### PR TITLE
feat(processing_engine): Add REST API endpoints for activating and deactivating triggers.

### DIFF
--- a/influxdb3_catalog/src/serialize.rs
+++ b/influxdb3_catalog/src/serialize.rs
@@ -105,6 +105,7 @@ impl From<DatabaseSnapshot> for DatabaseSchema {
                         plugin_name: plugin.plugin_name.to_string(),
                         plugin,
                         trigger: serde_json::from_str(&trigger.trigger_specification).unwrap(),
+                        disabled: trigger.disabled,
                     },
                 )
             })
@@ -171,6 +172,7 @@ struct ProcessingEngineTriggerSnapshot {
     pub trigger_name: String,
     pub plugin_name: String,
     pub trigger_specification: String,
+    pub disabled: bool,
 }
 
 /// Representation of Arrow's `DataType` for table snapshots.
@@ -434,6 +436,7 @@ impl From<&TriggerDefinition> for ProcessingEngineTriggerSnapshot {
             plugin_name: trigger.plugin_name.to_string(),
             trigger_specification: serde_json::to_string(&trigger.trigger)
                 .expect("should be able to serialize trigger specification"),
+            disabled: trigger.disabled,
         }
     }
 }

--- a/influxdb3_wal/src/lib.rs
+++ b/influxdb3_wal/src/lib.rs
@@ -106,7 +106,7 @@ pub trait Wal: Debug + Send + Sync + 'static {
 #[async_trait]
 pub trait WalFileNotifier: Debug + Send + Sync + 'static {
     /// Notify the handler that a new WAL file has been persisted with the given contents.
-    fn notify(&self, write: WalContents);
+    async fn notify(&self, write: WalContents);
 
     /// Notify the handler that a new WAL file has been persisted with the given contents and tell
     /// it to snapshot the data. The returned receiver will be signalled when the snapshot is complete.
@@ -301,7 +301,10 @@ pub enum CatalogOp {
     DeleteDatabase(DeleteDatabaseDefinition),
     DeleteTable(DeleteTableDefinition),
     CreatePlugin(PluginDefinition),
+    DeletePlugin(DeletePluginDefinition),
     CreateTrigger(TriggerDefinition),
+    EnableTrigger(TriggerIdentifier),
+    DisableTrigger(TriggerIdentifier),
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
@@ -587,6 +590,16 @@ pub struct PluginDefinition {
     pub plugin_type: PluginType,
 }
 
+#[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Clone)]
+pub struct DeletePluginDefinition {
+    pub plugin_name: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Clone)]
+pub struct DeletePlugin {
+    pub plugin_name: String,
+}
+
 #[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize, Copy)]
 #[serde(rename_all = "snake_case")]
 pub enum PluginType {
@@ -600,6 +613,13 @@ pub struct TriggerDefinition {
     pub trigger: TriggerSpecificationDefinition,
     // TODO: decide whether this should be populated from a reference rather than stored on its own.
     pub plugin: PluginDefinition,
+    pub disabled: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Clone)]
+pub struct TriggerIdentifier {
+    pub db_name: String,
+    pub trigger_name: String,
 }
 
 #[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Clone)]

--- a/influxdb3_wal/src/lib.rs
+++ b/influxdb3_wal/src/lib.rs
@@ -595,11 +595,6 @@ pub struct DeletePluginDefinition {
     pub plugin_name: String,
 }
 
-#[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Clone)]
-pub struct DeletePlugin {
-    pub plugin_name: String,
-}
-
 #[derive(Debug, Eq, PartialEq, Clone, Serialize, Deserialize, Copy)]
 #[serde(rename_all = "snake_case")]
 pub enum PluginType {

--- a/influxdb3_wal/src/object_store.rs
+++ b/influxdb3_wal/src/object_store.rs
@@ -134,7 +134,7 @@ impl WalObjectStore {
 
             match wal_contents.snapshot {
                 // This branch uses so much time
-                None => self.file_notifier.notify(wal_contents),
+                None => self.file_notifier.notify(wal_contents).await,
                 Some(snapshot_details) => {
                     let snapshot_info = {
                         let mut buffer = self.flush_buffer.lock().await;
@@ -151,7 +151,7 @@ impl WalObjectStore {
                     if snapshot_details.snapshot_sequence_number <= last_snapshot_sequence_number {
                         // Instead just notify about the WAL, as this snapshot has already been taken
                         // and WAL files may have been cleared.
-                        self.file_notifier.notify(wal_contents);
+                        self.file_notifier.notify(wal_contents).await;
                     } else {
                         let snapshot_done = self
                             .file_notifier
@@ -297,7 +297,7 @@ impl WalObjectStore {
                     "notify sent to buffer for wal file {}",
                     wal_contents.wal_file_number.as_u64()
                 );
-                self.file_notifier.notify(wal_contents);
+                self.file_notifier.notify(wal_contents).await;
                 None
             }
         };
@@ -1100,7 +1100,7 @@ mod tests {
 
     #[async_trait]
     impl WalFileNotifier for TestNotifier {
-        fn notify(&self, write: WalContents) {
+        async fn notify(&self, write: WalContents) {
             self.notified_writes.lock().push(write);
         }
 


### PR DESCRIPTION
I've also added support for deleting plugins. In particular, a plugin can't be deleted if it is associated with a trigger. I plan on adding deletes for triggers shortly.

In order to do this I needed to use a separate channel per trigger, rather than them all looking at a broadcast channel.  This in turn caused `notify()` to need to be async. This should be fine as notify_and_snapshot() already was.

Tests should pass both with and without the system-py feature.