### PR TITLE
refactor: porting changes in pro to oss

### DIFF
--- a/influxdb3_server/src/system_tables/mod.rs
+++ b/influxdb3_server/src/system_tables/mod.rs
@@ -1,6 +1,12 @@
-use std::{any::Any, collections::HashMap, sync::Arc};
+use std::{any::Any, collections::HashMap, ops::Deref, sync::Arc};
 
-use datafusion::{catalog::SchemaProvider, datasource::TableProvider, error::DataFusionError};
+use datafusion::{
+    catalog::SchemaProvider,
+    datasource::TableProvider,
+    error::DataFusionError,
+    logical_expr::{col, BinaryExpr, Expr, Operator},
+    scalar::ScalarValue,
+};
 use influxdb3_catalog::catalog::DatabaseSchema;
 use influxdb3_sys_events::SysEventStore;
 use influxdb3_write::WriteBuffer;
@@ -18,39 +24,68 @@ mod parquet_files;
 use crate::system_tables::python_call::{
     ProcessingEnginePluginTable, ProcessingEngineTriggerTable,
 };
-#[cfg(test)]
-pub(crate) use parquet_files::table_name_predicate_error;
 
 mod python_call;
 mod queries;
 
 pub const SYSTEM_SCHEMA_NAME: &str = "system";
+pub const TABLE_NAME_PREDICATE: &str = "table_name";
 
-const LAST_CACHES_TABLE_NAME: &str = "last_caches";
-const META_CACHES_TABLE_NAME: &str = "meta_caches";
-const PARQUET_FILES_TABLE_NAME: &str = "parquet_files";
-const QUERIES_TABLE_NAME: &str = "queries";
+pub(crate) const QUERIES_TABLE_NAME: &str = "queries";
+pub(crate) const LAST_CACHES_TABLE_NAME: &str = "last_caches";
+pub(crate) const META_CACHES_TABLE_NAME: &str = "meta_caches";
+pub(crate) const PARQUET_FILES_TABLE_NAME: &str = "parquet_files";
 
 const PROCESSING_ENGINE_PLUGINS_TABLE_NAME: &str = "processing_engine_plugins";
 
 const PROCESSING_ENGINE_TRIGGERS_TABLE_NAME: &str = "processing_engine_triggers";
 
-pub(crate) struct SystemSchemaProvider {
+#[derive(Debug)]
+pub(crate) enum SystemSchemaProvider {
+    AllSystemSchemaTables(AllSystemSchemaTablesProvider),
+}
+
+#[async_trait]
+impl SchemaProvider for SystemSchemaProvider {
+    fn as_any(&self) -> &dyn Any {
+        self as &dyn Any
+    }
+
+    fn table_names(&self) -> Vec<String> {
+        match self {
+            Self::AllSystemSchemaTables(all_system_tables) => all_system_tables.table_names(),
+        }
+    }
+
+    async fn table(&self, name: &str) -> Result<Option<Arc<dyn TableProvider>>, DataFusionError> {
+        match self {
+            Self::AllSystemSchemaTables(all_system_tables) => all_system_tables.table(name).await,
+        }
+    }
+
+    fn table_exist(&self, name: &str) -> bool {
+        match self {
+            Self::AllSystemSchemaTables(all_system_tables) => all_system_tables.table_exist(name),
+        }
+    }
+}
+
+pub(crate) struct AllSystemSchemaTablesProvider {
     tables: HashMap<&'static str, Arc<dyn TableProvider>>,
 }
 
-impl std::fmt::Debug for SystemSchemaProvider {
+impl std::fmt::Debug for AllSystemSchemaTablesProvider {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut keys = self.tables.keys().copied().collect::<Vec<_>>();
         keys.sort_unstable();
 
-        f.debug_struct("SystemSchemaProvider")
+        f.debug_struct("AllSystemSchemaTablesProvider")
             .field("tables", &keys.join(", "))
             .finish()
     }
 }
 
-impl SystemSchemaProvider {
+impl AllSystemSchemaTablesProvider {
     pub(crate) fn new(
         db_schema: Arc<DatabaseSchema>,
         query_log: Arc<QueryLog>,
@@ -106,7 +141,7 @@ impl SystemSchemaProvider {
 }
 
 #[async_trait]
-impl SchemaProvider for SystemSchemaProvider {
+impl SchemaProvider for AllSystemSchemaTablesProvider {
     fn as_any(&self) -> &dyn Any {
         self as &dyn Any
     }
@@ -128,4 +163,39 @@ impl SchemaProvider for SystemSchemaProvider {
     fn table_exist(&self, name: &str) -> bool {
         self.tables.contains_key(name)
     }
+}
+
+/// Used in queries to the system.{table_name} table
+///
+/// # Example
+/// ```sql
+/// SELECT * FROM system.parquet_files WHERE table_name = 'foo'
+/// ```
+pub(crate) fn find_table_name_in_filter(filters: Option<Vec<Expr>>) -> Option<String> {
+    filters.map(|all_filters| {
+        all_filters.iter().find_map(|f| match f {
+            Expr::BinaryExpr(BinaryExpr { left, op, right }) => {
+                if left.deref() == &col(TABLE_NAME_PREDICATE) && op == &Operator::Eq {
+                    match right.deref() {
+                        Expr::Literal(
+                            ScalarValue::Utf8(Some(s))
+                            | ScalarValue::LargeUtf8(Some(s))
+                            | ScalarValue::Utf8View(Some(s)),
+                        ) => Some(s.to_owned()),
+                        _ => None,
+                    }
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        })
+    })?
+}
+
+pub(crate) fn table_name_predicate_error(table_name: &str) -> DataFusionError {
+    DataFusionError::Plan(format!(
+        "must provide a {TABLE_NAME_PREDICATE} = '<table_name>' predicate in queries to \
+            {SYSTEM_SCHEMA_NAME}.{table_name}"
+    ))
 }

--- a/influxdb3_server/src/system_tables/parquet_files.rs
+++ b/influxdb3_server/src/system_tables/parquet_files.rs
@@ -1,18 +1,16 @@
-use std::{ops::Deref, sync::Arc};
+use std::sync::Arc;
 
 use arrow_array::{ArrayRef, Int64Array, RecordBatch, StringArray, UInt64Array};
 use arrow_schema::{DataType, Field, Schema, SchemaRef};
 use async_trait::async_trait;
-use datafusion::{
-    error::DataFusionError,
-    logical_expr::{col, BinaryExpr, Expr, Operator},
-    scalar::ScalarValue,
-};
+use datafusion::{error::DataFusionError, logical_expr::Expr};
 use influxdb3_id::DbId;
 use influxdb3_write::{ParquetFile, WriteBuffer};
 use iox_system_tables::IoxSystemTable;
 
-use super::{PARQUET_FILES_TABLE_NAME, SYSTEM_SCHEMA_NAME};
+use crate::system_tables::{find_table_name_in_filter, table_name_predicate_error};
+
+use super::PARQUET_FILES_TABLE_NAME;
 
 #[derive(Debug)]
 pub(super) struct ParquetFilesTable {
@@ -43,21 +41,6 @@ fn parquet_files_schema() -> SchemaRef {
     Arc::new(Schema::new(columns))
 }
 
-/// Used in queries to the system.parquet_files table
-///
-/// # Example
-/// ```sql
-/// SELECT * FROM system.parquet_files WHERE table_name = 'foo'
-/// ```
-const TABLE_NAME_PREDICATE: &str = "table_name";
-
-pub(crate) fn table_name_predicate_error() -> DataFusionError {
-    DataFusionError::Plan(format!(
-        "must provide a {TABLE_NAME_PREDICATE} = '<table_name>' predicate in queries to \
-            {SYSTEM_SCHEMA_NAME}.{PARQUET_FILES_TABLE_NAME}"
-    ))
-}
-
 #[async_trait]
 impl IoxSystemTable for ParquetFilesTable {
     fn schema(&self) -> SchemaRef {
@@ -72,25 +55,8 @@ impl IoxSystemTable for ParquetFilesTable {
         let schema = self.schema();
 
         // extract `table_name` from filters
-        let table_name = filters
-            .ok_or_else(table_name_predicate_error)?
-            .iter()
-            .find_map(|f| match f {
-                Expr::BinaryExpr(BinaryExpr { left, op, right }) => {
-                    if left.deref() == &col(TABLE_NAME_PREDICATE) && op == &Operator::Eq {
-                        match right.deref() {
-                            Expr::Literal(
-                                ScalarValue::Utf8(Some(s)) | ScalarValue::LargeUtf8(Some(s)),
-                            ) => Some(s.to_owned()),
-                            _ => None,
-                        }
-                    } else {
-                        None
-                    }
-                }
-                _ => None,
-            })
-            .ok_or_else(table_name_predicate_error)?;
+        let table_name = find_table_name_in_filter(filters)
+            .ok_or_else(|| table_name_predicate_error(PARQUET_FILES_TABLE_NAME))?;
 
         let parquet_files: Vec<ParquetFile> = self.buffer.parquet_files(
             self.db_id,

--- a/influxdb3_sys_events/src/lib.rs
+++ b/influxdb3_sys_events/src/lib.rs
@@ -124,6 +124,19 @@ impl<T> RingBufferVec<T> {
         }
     }
 
+    pub fn in_order(&self) -> impl Iterator<Item = &T> {
+        let (head, tail) = self.buf.split_at(self.write_index);
+        tail.iter().chain(head.iter())
+    }
+
+    pub fn len(&self) -> usize {
+        self.buf.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.buf.is_empty()
+    }
+
     fn push(&mut self, val: T) {
         if !self.is_at_max() {
             self.buf.push(val);
@@ -135,11 +148,6 @@ impl<T> RingBufferVec<T> {
 
     fn is_at_max(&mut self) -> bool {
         self.buf.len() >= self.max
-    }
-
-    pub fn in_order(&self) -> impl Iterator<Item = &T> {
-        let (head, tail) = self.buf.split_at(self.write_index);
-        tail.iter().chain(head.iter())
     }
 }
 


### PR DESCRIPTION
- query_executor is moved to it's own module so that it's easier to swap the setup for pro.
- system_tables setup is also modified

(no issue)
