### PR TITLE
fix: avoid panic if shard group has no shards

### DIFF
--- a/v1/coordinator/points_writer.go
+++ b/v1/coordinator/points_writer.go
@@ -255,6 +255,9 @@ func (w *PointsWriter) MapShards(wp *WritePointsRequest) (*ShardMapping, error) 
 			// scope of the RP.
 			mapping.Dropped = append(mapping.Dropped, p)
 			continue
+		} else if len(sg.Shards) <= 0 {
+			// Shard groups should have at least one shard.
+			return nil, fmt.Errorf("shard group %d covering %s to %s has no shards", sg.ID, sg.StartTime, sg.EndTime)
 		}
 
 		sh := sg.ShardFor(p)


### PR DESCRIPTION
Avoid panicking when mapping points to a shard group
that has no shards. This does not address the root problem,
how the shard group ended up with no shards.

helps: https://github.com/influxdata/influxdb/issues/25715