### PR TITLE
feat: track lines rejected in prometheus metrics

### DIFF
--- a/influxdb3_write/src/write_buffer/metrics.rs
+++ b/influxdb3_write/src/write_buffer/metrics.rs
@@ -4,9 +4,9 @@ use metric::{Metric, Registry, U64Counter};
 
 #[derive(Debug)]
 pub(super) struct WriteMetrics {
-    write_lines_count: Metric<U64Counter>,
-    write_lines_rejected_count: Metric<U64Counter>,
-    write_bytes_count: Metric<U64Counter>,
+    write_lines_total: Metric<U64Counter>,
+    write_lines_rejected_total: Metric<U64Counter>,
+    write_bytes_total: Metric<U64Counter>,
 }
 
 pub(super) const WRITE_LINES_METRIC_NAME: &str = "influxdb3_write_lines";
@@ -15,40 +15,40 @@ pub(super) const WRITE_BYTES_METRIC_NAME: &str = "influxdb3_write_bytes";
 
 impl WriteMetrics {
     pub(super) fn new(metric_registry: &Registry) -> Self {
-        let write_lines_count = metric_registry.register_metric::<U64Counter>(
+        let write_lines_total = metric_registry.register_metric::<U64Counter>(
             WRITE_LINES_METRIC_NAME,
             "track total number of lines written to the database",
         );
-        let write_lines_rejected_count = metric_registry.register_metric::<U64Counter>(
+        let write_lines_rejected_total = metric_registry.register_metric::<U64Counter>(
             WRITE_LINES_REJECTED_METRIC_NAME,
             "track total number of lines written to the database that were rejected",
         );
-        let write_bytes_count = metric_registry.register_metric::<U64Counter>(
+        let write_bytes_total = metric_registry.register_metric::<U64Counter>(
             WRITE_BYTES_METRIC_NAME,
             "track total number of bytes written to the database",
         );
         Self {
-            write_lines_count,
-            write_lines_rejected_count,
-            write_bytes_count,
+            write_lines_total,
+            write_lines_rejected_total,
+            write_bytes_total,
         }
     }
 
     pub(super) fn record_lines<D: Into<String>>(&self, db: D, lines: u64) {
         let db: Cow<'static, str> = Cow::from(db.into());
-        self.write_lines_count.recorder([("db", db)]).inc(lines);
+        self.write_lines_total.recorder([("db", db)]).inc(lines);
     }
 
     pub(super) fn record_lines_rejected<D: Into<String>>(&self, db: D, lines: u64) {
         let db: Cow<'static, str> = Cow::from(db.into());
-        self.write_lines_rejected_count
+        self.write_lines_rejected_total
             .recorder([("db", db)])
             .inc(lines);
     }
 
     pub(super) fn record_bytes<D: Into<String>>(&self, db: D, bytes: u64) {
         let db: Cow<'static, str> = Cow::from(db.into());
-        self.write_bytes_count.recorder([("db", db)]).inc(bytes);
+        self.write_bytes_total.recorder([("db", db)]).inc(bytes);
     }
 }
 
@@ -67,7 +67,7 @@ mod tests {
         assert_eq!(
             64,
             metrics
-                .write_lines_count
+                .write_lines_total
                 .get_observer(&Attributes::from(&[("db", "foo")]))
                 .unwrap()
                 .fetch()
@@ -75,7 +75,7 @@ mod tests {
         assert_eq!(
             256,
             metrics
-                .write_lines_count
+                .write_lines_total
                 .get_observer(&Attributes::from(&[("db", "bar")]))
                 .unwrap()
                 .fetch()
@@ -91,7 +91,7 @@ mod tests {
         assert_eq!(
             64,
             metrics
-                .write_lines_rejected_count
+                .write_lines_rejected_total
                 .get_observer(&Attributes::from(&[("db", "foo")]))
                 .unwrap()
                 .fetch()
@@ -99,7 +99,7 @@ mod tests {
         assert_eq!(
             256,
             metrics
-                .write_lines_rejected_count
+                .write_lines_rejected_total
                 .get_observer(&Attributes::from(&[("db", "bar")]))
                 .unwrap()
                 .fetch()
@@ -115,7 +115,7 @@ mod tests {
         assert_eq!(
             64,
             metrics
-                .write_bytes_count
+                .write_bytes_total
                 .get_observer(&Attributes::from(&[("db", "foo")]))
                 .unwrap()
                 .fetch()
@@ -123,7 +123,7 @@ mod tests {
         assert_eq!(
             256,
             metrics
-                .write_bytes_count
+                .write_bytes_total
                 .get_observer(&Attributes::from(&[("db", "bar")]))
                 .unwrap()
                 .fetch()

--- a/influxdb3_write/src/write_buffer/metrics.rs
+++ b/influxdb3_write/src/write_buffer/metrics.rs
@@ -4,37 +4,51 @@ use metric::{Metric, Registry, U64Counter};
 
 #[derive(Debug)]
 pub(super) struct WriteMetrics {
-    write_lines_total: Metric<U64Counter>,
-    write_bytes_total: Metric<U64Counter>,
+    write_lines_count: Metric<U64Counter>,
+    write_lines_rejected_count: Metric<U64Counter>,
+    write_bytes_count: Metric<U64Counter>,
 }
 
-pub(super) const WRITE_LINES_TOTAL_NAME: &str = "influxdb3_write_lines_total";
-pub(super) const WRITE_BYTES_TOTAL_NAME: &str = "influxdb3_write_bytes_total";
+pub(super) const WRITE_LINES_METRIC_NAME: &str = "influxdb3_write_lines";
+pub(super) const WRITE_LINES_REJECTED_METRIC_NAME: &str = "influxdb3_write_lines_rejected";
+pub(super) const WRITE_BYTES_METRIC_NAME: &str = "influxdb3_write_bytes";
 
 impl WriteMetrics {
     pub(super) fn new(metric_registry: &Registry) -> Self {
-        let write_lines_total = metric_registry.register_metric::<U64Counter>(
-            WRITE_LINES_TOTAL_NAME,
+        let write_lines_count = metric_registry.register_metric::<U64Counter>(
+            WRITE_LINES_METRIC_NAME,
             "track total number of lines written to the database",
         );
-        let write_bytes_total = metric_registry.register_metric::<U64Counter>(
-            WRITE_BYTES_TOTAL_NAME,
+        let write_lines_rejected_count = metric_registry.register_metric::<U64Counter>(
+            WRITE_LINES_REJECTED_METRIC_NAME,
+            "track total number of lines written to the database that were rejected",
+        );
+        let write_bytes_count = metric_registry.register_metric::<U64Counter>(
+            WRITE_BYTES_METRIC_NAME,
             "track total number of bytes written to the database",
         );
         Self {
-            write_lines_total,
-            write_bytes_total,
+            write_lines_count,
+            write_lines_rejected_count,
+            write_bytes_count,
         }
     }
 
     pub(super) fn record_lines<D: Into<String>>(&self, db: D, lines: u64) {
         let db: Cow<'static, str> = Cow::from(db.into());
-        self.write_lines_total.recorder([("db", db)]).inc(lines);
+        self.write_lines_count.recorder([("db", db)]).inc(lines);
+    }
+
+    pub(super) fn record_lines_rejected<D: Into<String>>(&self, db: D, lines: u64) {
+        let db: Cow<'static, str> = Cow::from(db.into());
+        self.write_lines_rejected_count
+            .recorder([("db", db)])
+            .inc(lines);
     }
 
     pub(super) fn record_bytes<D: Into<String>>(&self, db: D, bytes: u64) {
         let db: Cow<'static, str> = Cow::from(db.into());
-        self.write_bytes_total.recorder([("db", db)]).inc(bytes);
+        self.write_bytes_count.recorder([("db", db)]).inc(bytes);
     }
 }
 
@@ -53,7 +67,7 @@ mod tests {
         assert_eq!(
             64,
             metrics
-                .write_lines_total
+                .write_lines_count
                 .get_observer(&Attributes::from(&[("db", "foo")]))
                 .unwrap()
                 .fetch()
@@ -61,7 +75,31 @@ mod tests {
         assert_eq!(
             256,
             metrics
-                .write_lines_total
+                .write_lines_count
+                .get_observer(&Attributes::from(&[("db", "bar")]))
+                .unwrap()
+                .fetch()
+        );
+    }
+
+    #[test]
+    fn record_lines_rejected() {
+        let metric_registry = Registry::new();
+        let metrics = WriteMetrics::new(&metric_registry);
+        metrics.record_lines_rejected("foo", 64);
+        metrics.record_lines_rejected(String::from("bar"), 256);
+        assert_eq!(
+            64,
+            metrics
+                .write_lines_rejected_count
+                .get_observer(&Attributes::from(&[("db", "foo")]))
+                .unwrap()
+                .fetch()
+        );
+        assert_eq!(
+            256,
+            metrics
+                .write_lines_rejected_count
                 .get_observer(&Attributes::from(&[("db", "bar")]))
                 .unwrap()
                 .fetch()
@@ -77,7 +115,7 @@ mod tests {
         assert_eq!(
             64,
             metrics
-                .write_bytes_total
+                .write_bytes_count
                 .get_observer(&Attributes::from(&[("db", "foo")]))
                 .unwrap()
                 .fetch()
@@ -85,7 +123,7 @@ mod tests {
         assert_eq!(
             256,
             metrics
-                .write_bytes_total
+                .write_bytes_count
                 .get_observer(&Attributes::from(&[("db", "bar")]))
                 .unwrap()
                 .fetch()


### PR DESCRIPTION
This adds the metric `influxdb3_write_lines_rejected_total` metric which tracks the total number of lines rejected from incoming writes.

Note, that this only tacks the number of rejected lines when the default `accept_partial` of `true` is provided to incoming write requests.

This also changes the names of the `influxdb3_write_lines_total` and `influxdb3_write_bytes_total` internally to `influxdb3_write_lines` and `influxdb3_write_bytes`, respectively. Since the Prometheus exporter adds the `_total` for counter metrics for us see [here](https://github.com/influxdata/influxdb3_core/blob/db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64/metric_exporters/src/lib.rs#L54), these were previously being exported as `influxdb3_write_lines_total_total` and `influxdb3_write_bytes_total_total` - FYI @saraghds.

Closes #25696
