### PR TITLE
fix: do not leak file handles from Compactor.write

### DIFF
--- a/tsdb/engine/tsm1/compact.go
+++ b/tsdb/engine/tsm1/compact.go
@@ -1068,7 +1068,7 @@ func (c *Compactor) writeNewFiles(generation, sequence int, src []string, iter K
 			files = append(files, fileName)
 			logger.Debug("file size or block count exceeded, opening another output file", zap.String("output_file", fileName))
 			continue
-		} else if err == ErrNoValues {
+		} else if errors.Is(err, ErrNoValues) {
 			logger.Debug("Dropping empty file", zap.String("output_file", fileName))
 			// If the file only contained tombstoned entries, then it would be a 0 length
 			// file that we can drop.
@@ -1180,7 +1180,7 @@ func (c *Compactor) write(path string, iter KeyIterator, throttle bool, logger *
 		}
 
 		// Write the key and value
-		if err := w.WriteBlock(key, minTime, maxTime, block); err == ErrMaxBlocksExceeded {
+		if err := w.WriteBlock(key, minTime, maxTime, block); errors.Is(err, ErrMaxBlocksExceeded) {
 			if err := w.WriteIndex(); err != nil {
 				return err
 			}
@@ -1189,7 +1189,7 @@ func (c *Compactor) write(path string, iter KeyIterator, throttle bool, logger *
 			return err
 		}
 
-		// If we have a max file size configured and we're over it, close out the file
+		// If we're over maxTSMFileSize, close out the file
 		// and return the error.
 		if w.Size() > maxTSMFileSize {
 			if err := w.WriteIndex(); err != nil {

--- a/tsdb/engine/tsm1/compact.go
+++ b/tsdb/engine/tsm1/compact.go
@@ -17,6 +17,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"math"
 	"os"
 	"path/filepath"
@@ -1082,7 +1083,7 @@ func (c *Compactor) writeNewFiles(generation, sequence int, src []string, iter K
 			}
 			break
 		} else if errors.As(err, &eInProgress) {
-			if !os.IsExist(eInProgress.err) {
+			if !errors.Is(eInProgress.err, fs.ErrExist) {
 				logger.Error("error creating compaction file", zap.String("output_file", fileName), zap.Error(err))
 			} else {
 				// Don't clean up the file as another compaction is using it.  This should not happen as the
@@ -1154,7 +1155,7 @@ func (c *Compactor) write(path string, iter KeyIterator, throttle bool, logger *
 		errs = append(errs, closeErr)
 
 		// Check for conditions where we should not remove the file
-		inProgress := errors.As(err, &eInProgress) && os.IsExist(eInProgress.err)
+		inProgress := errors.As(err, &eInProgress) && errors.Is(eInProgress.err, fs.ErrExist)
 		if (closeErr == nil) && (inProgress || rollToNext) {
 			// do not join errors, there is only the one.
 			return

--- a/tsdb/engine/tsm1/compact.go
+++ b/tsdb/engine/tsm1/compact.go
@@ -65,6 +65,10 @@ func (e errCompactionInProgress) Error() string {
 	return "compaction in progress"
 }
 
+func (e errCompactionInProgress) Unwrap() error {
+	return e.err
+}
+
 type errCompactionAborted struct {
 	err error
 }
@@ -1078,7 +1082,7 @@ func (c *Compactor) writeNewFiles(generation, sequence int, src []string, iter K
 			}
 			break
 		} else if errors.As(err, &eInProgress) {
-			if !errors.Is(eInProgress, os.ErrExist) {
+			if !os.IsExist(eInProgress.err) {
 				logger.Error("error creating compaction file", zap.String("output_file", fileName), zap.Error(err))
 			} else {
 				// Don't clean up the file as another compaction is using it.  This should not happen as the


### PR DESCRIPTION
There are a number of code paths in Compactor.write which on error can lead to leaked file handles to temporary files. This, in turn, prevents the removal of the temporary files until InfluxDB is rebooted, releasing the file handles.

closes https://github.com/influxdata/influxdb/issues/25724
