### PR TITLE
feat: force snapshot under memory pressure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3110,6 +3110,7 @@ dependencies = [
  "secrecy",
  "serde_json",
  "sha2",
+ "sysinfo 0.30.13",
  "test-log",
  "test_helpers",
  "thiserror 1.0.69",

--- a/influxdb3/Cargo.toml
+++ b/influxdb3/Cargo.toml
@@ -51,6 +51,7 @@ rand.workspace = true
 secrecy.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
+sysinfo.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true

--- a/influxdb3_wal/src/lib.rs
+++ b/influxdb3_wal/src/lib.rs
@@ -17,7 +17,7 @@ use influxdb3_id::{ColumnId, DbId, SerdeVecMap, TableId};
 use influxdb_line_protocol::v3::SeriesValue;
 use influxdb_line_protocol::FieldValue;
 use iox_time::Time;
-use observability_deps::tracing::error;
+use observability_deps::tracing::{debug, error};
 use schema::{InfluxColumnType, InfluxFieldType};
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
@@ -84,6 +84,15 @@ pub trait Wal: Debug + Send + Sync + 'static {
         OwnedSemaphorePermit,
     )>;
 
+    /// Forces the flush buffer
+    async fn force_flush_buffer(
+        &self,
+    ) -> Option<(
+        oneshot::Receiver<SnapshotDetails>,
+        SnapshotInfo,
+        OwnedSemaphorePermit,
+    )>;
+
     /// Removes any snapshot wal files
     async fn cleanup_snapshot(
         &self,
@@ -99,6 +108,40 @@ pub trait Wal: Debug + Send + Sync + 'static {
 
     /// Stop all writes to the WAL and flush the buffer to a WAL file.
     async fn shutdown(&self);
+
+    async fn flush_buffer_and_cleanup_snapshot(self: Arc<Self>) {
+        let cleanup_after_snapshot = self.flush_buffer().await;
+        self.cleanup_after_snapshot(cleanup_after_snapshot).await;
+    }
+
+    async fn force_flush_buffer_and_cleanup_snapshot(self: Arc<Self>) {
+        let cleanup_after_snapshot = self.force_flush_buffer().await;
+        self.cleanup_after_snapshot(cleanup_after_snapshot).await;
+    }
+
+    async fn cleanup_after_snapshot(
+        self: Arc<Self>,
+        cleanup_params: Option<(
+            oneshot::Receiver<SnapshotDetails>,
+            SnapshotInfo,
+            OwnedSemaphorePermit,
+        )>,
+    ) {
+        // handle snapshot cleanup outside of the flush loop
+        if let Some((snapshot_complete, snapshot_info, snapshot_permit)) = cleanup_params {
+            let arcd_wal = Arc::clone(&self);
+            tokio::spawn(async move {
+                let snapshot_details = snapshot_complete.await.expect("snapshot failed");
+                assert_eq!(snapshot_info.snapshot_details, snapshot_details);
+
+                arcd_wal
+                    .cleanup_snapshot(snapshot_info, snapshot_permit)
+                    .await;
+            });
+        } else {
+            debug!("not flushed the buffer, no snapshot");
+        }
+    }
 }
 
 /// When the WAL persists a file with buffered ops, the contents are sent to this
@@ -181,6 +224,10 @@ impl Gen1Duration {
 
     pub fn as_nanos(&self) -> i64 {
         self.0.as_nanos() as i64
+    }
+
+    pub fn new_10s() -> Self {
+        Self(Duration::from_secs(10))
     }
 
     pub fn new_1m() -> Self {
@@ -809,6 +856,10 @@ impl WalContents {
     pub fn is_empty(&self) -> bool {
         self.ops.is_empty() && self.snapshot.is_none()
     }
+
+    pub fn is_default(&self) -> bool {
+        self.min_timestamp_ns == i64::MAX && self.max_timestamp_ns == i64::MIN
+    }
 }
 
 #[derive(
@@ -890,23 +941,8 @@ pub fn background_wal_flush<W: Wal>(
 
         loop {
             interval.tick().await;
-
-            let cleanup_after_snapshot = wal.flush_buffer().await;
-
-            // handle snapshot cleanup outside of the flush loop
-            if let Some((snapshot_complete, snapshot_info, snapshot_permit)) =
-                cleanup_after_snapshot
-            {
-                let snapshot_wal = Arc::clone(&wal);
-                tokio::spawn(async move {
-                    let snapshot_details = snapshot_complete.await.expect("snapshot failed");
-                    assert_eq!(snapshot_info.snapshot_details, snapshot_details);
-
-                    snapshot_wal
-                        .cleanup_snapshot(snapshot_info, snapshot_permit)
-                        .await;
-                });
-            }
+            let wal = Arc::clone(&wal);
+            wal.flush_buffer_and_cleanup_snapshot().await;
         }
     })
 }

--- a/influxdb3_wal/src/snapshot_tracker.rs
+++ b/influxdb3_wal/src/snapshot_tracker.rs
@@ -6,6 +6,7 @@
 
 use crate::{Gen1Duration, SnapshotDetails, SnapshotSequenceNumber, WalFileSequenceNumber};
 use data_types::Timestamp;
+use observability_deps::tracing::debug;
 
 /// A struct that tracks the WAL periods (files if using object store) and decides when to snapshot the WAL.
 #[derive(Debug)]
@@ -56,43 +57,46 @@ impl SnapshotTracker {
     /// In the case of data coming in for future times, we will be unable to snapshot older data.
     /// Over time this will back up the WAL. To guard against this, if the number of WAL periods
     /// is >= 3x the snapshot size, snapshot everything up to the last period.
-    pub(crate) fn snapshot(&mut self) -> Option<SnapshotInfo> {
-        if self.wal_periods.is_empty()
-            || self.wal_periods.len() < self.number_of_periods_to_snapshot_after()
-        {
+    pub(crate) fn snapshot(&mut self, force_snapshot: bool) -> Option<SnapshotInfo> {
+        debug!(
+            wal_periods = ?self.wal_periods,
+            wal_periods_len = ?self.wal_periods.len(),
+            num_snapshots_after = ?self.number_of_periods_to_snapshot_after(),
+            ">>> wal periods and snapshots"
+        );
+
+        if !self.should_run_snapshot(force_snapshot) {
             return None;
         }
 
         // if the number of wal periods is >= 3x the snapshot size, snapshot everything up to, but
         // not including, the last period:
         if self.wal_periods.len() >= 3 * self.snapshot_size {
-            let n_periods_to_take = self.wal_periods.len() - 1;
-            let wal_periods: Vec<WalPeriod> =
-                self.wal_periods.drain(0..n_periods_to_take).collect();
-            let max_time = wal_periods
-                .iter()
-                .map(|period| period.max_time)
-                .max()
-                .unwrap();
-            let t = max_time - (max_time.get() % self.gen1_duration.as_nanos())
-                + self.gen1_duration.as_nanos();
-            let last_wal_sequence_number = wal_periods.last().unwrap().wal_file_number;
-
-            let snapshot_details = SnapshotDetails {
-                snapshot_sequence_number: self.increment_snapshot_sequence_number(),
-                end_time_marker: t.get(),
-                last_wal_sequence_number,
-            };
-
-            return Some(SnapshotInfo {
-                snapshot_details,
-                wal_periods,
-            });
+            return self.snapshot_up_to_last_wal_period();
         }
 
+        self.snapshot_including_last_wal_period()
+    }
+
+    fn should_run_snapshot(&mut self, force_snapshot: bool) -> bool {
+        if self.wal_periods.is_empty() {
+            return false;
+        }
+
+        // if force_snapshot is set, we don't need to check wal periods len or num periods we
+        // snapshot immediately
+        if !force_snapshot && self.wal_periods.len() < self.number_of_periods_to_snapshot_after() {
+            return false;
+        }
+
+        true
+    }
+
+    pub(crate) fn snapshot_including_last_wal_period(&mut self) -> Option<SnapshotInfo> {
         let t = self.wal_periods.last().unwrap().max_time;
         // round the last timestamp down to the gen1_duration
         let t = t - (t.get() % self.gen1_duration.as_nanos());
+        debug!(timestamp_ns = ?t, gen1_duration_ns = ?self.gen1_duration.as_nanos(), ">>> last timestamp");
 
         // any wal period that has data before this time can be snapshot
         let periods_to_snapshot = self
@@ -101,6 +105,7 @@ impl SnapshotTracker {
             .take_while(|period| period.max_time < t)
             .cloned()
             .collect::<Vec<_>>();
+        debug!(?periods_to_snapshot, ">>> periods to snapshot");
 
         periods_to_snapshot.last().cloned().map(|period| {
             // remove the wal periods and return the snapshot details
@@ -115,6 +120,29 @@ impl SnapshotTracker {
                 },
                 wal_periods: periods_to_snapshot,
             }
+        })
+    }
+
+    fn snapshot_up_to_last_wal_period(&mut self) -> Option<SnapshotInfo> {
+        let n_periods_to_take = self.wal_periods.len() - 1;
+        let wal_periods: Vec<WalPeriod> = self.wal_periods.drain(0..n_periods_to_take).collect();
+        let max_time = wal_periods
+            .iter()
+            .map(|period| period.max_time)
+            .max()
+            .unwrap();
+        let t = max_time - (max_time.get() % self.gen1_duration.as_nanos())
+            + self.gen1_duration.as_nanos();
+        let last_wal_sequence_number = wal_periods.last().unwrap().wal_file_number;
+        let snapshot_details = SnapshotDetails {
+            snapshot_sequence_number: self.increment_snapshot_sequence_number(),
+            end_time_marker: t.get(),
+            last_wal_sequence_number,
+        };
+
+        Some(SnapshotInfo {
+            snapshot_details,
+            wal_periods,
         })
     }
 
@@ -209,14 +237,14 @@ mod tests {
             Timestamp::new(360_100000000),
         );
 
-        assert!(tracker.snapshot().is_none());
+        assert!(tracker.snapshot(false).is_none());
         tracker.add_wal_period(p1.clone());
-        assert!(tracker.snapshot().is_none());
+        assert!(tracker.snapshot(false).is_none());
         tracker.add_wal_period(p2.clone());
-        assert!(tracker.snapshot().is_none());
+        assert!(tracker.snapshot(false).is_none());
         tracker.add_wal_period(p3.clone());
         assert_eq!(
-            tracker.snapshot(),
+            tracker.snapshot(false),
             Some(SnapshotInfo {
                 snapshot_details: SnapshotDetails {
                     snapshot_sequence_number: SnapshotSequenceNumber::new(1),
@@ -227,10 +255,10 @@ mod tests {
             })
         );
         tracker.add_wal_period(p4.clone());
-        assert_eq!(tracker.snapshot(), None);
+        assert_eq!(tracker.snapshot(false), None);
         tracker.add_wal_period(p5.clone());
         assert_eq!(
-            tracker.snapshot(),
+            tracker.snapshot(false),
             Some(SnapshotInfo {
                 snapshot_details: SnapshotDetails {
                     snapshot_sequence_number: SnapshotSequenceNumber::new(2),
@@ -245,7 +273,7 @@ mod tests {
 
         tracker.add_wal_period(p6.clone());
         assert_eq!(
-            tracker.snapshot(),
+            tracker.snapshot(false),
             Some(SnapshotInfo {
                 snapshot_details: SnapshotDetails {
                     snapshot_sequence_number: SnapshotSequenceNumber::new(3),
@@ -256,7 +284,7 @@ mod tests {
             })
         );
 
-        assert!(tracker.snapshot().is_none());
+        assert!(tracker.snapshot(false).is_none());
     }
 
     #[test]
@@ -296,15 +324,15 @@ mod tests {
         tracker.add_wal_period(p1.clone());
         tracker.add_wal_period(p2.clone());
         tracker.add_wal_period(p3.clone());
-        assert!(tracker.snapshot().is_none());
+        assert!(tracker.snapshot(false).is_none());
         tracker.add_wal_period(p4.clone());
-        assert!(tracker.snapshot().is_none());
+        assert!(tracker.snapshot(false).is_none());
         tracker.add_wal_period(p5.clone());
-        assert!(tracker.snapshot().is_none());
+        assert!(tracker.snapshot(false).is_none());
         tracker.add_wal_period(p6.clone());
 
         assert_eq!(
-            tracker.snapshot(),
+            tracker.snapshot(false),
             Some(SnapshotInfo {
                 snapshot_details: SnapshotDetails {
                     snapshot_sequence_number: SnapshotSequenceNumber::new(1),

--- a/influxdb3_write/src/write_buffer/queryable_buffer.rs
+++ b/influxdb3_write/src/write_buffer/queryable_buffer.rs
@@ -22,7 +22,10 @@ use influxdb3_cache::meta_cache::MetaCacheProvider;
 use influxdb3_cache::parquet_cache::{CacheRequest, ParquetCacheOracle};
 use influxdb3_catalog::catalog::{Catalog, DatabaseSchema};
 use influxdb3_id::{DbId, TableId};
-use influxdb3_wal::{CatalogOp, SnapshotDetails, WalContents, WalFileNotifier, WalOp, WriteBatch};
+use influxdb3_wal::{
+    CatalogOp, SnapshotDetails, WalContents, WalFileNotifier, WalFileSequenceNumber, WalOp,
+    WriteBatch,
+};
 use iox_query::chunk_statistics::{create_chunk_statistics, NoColumnRanges};
 use iox_query::exec::Executor;
 use iox_query::frontend::reorg::ReorgPlanner;
@@ -93,6 +96,11 @@ impl QueryableBuffer {
             persisted_snapshot_notify_tx,
             plugin_event_tx: Mutex::new(None),
         }
+    }
+
+    pub fn get_total_size_bytes(&self) -> usize {
+        let buffer = self.buffer.read();
+        buffer.find_overall_buffer_size_bytes()
     }
 
     pub fn get_table_chunks(
@@ -180,56 +188,11 @@ impl QueryableBuffer {
         );
         self.write_wal_contents_to_caches(&write);
         let persist_jobs = {
-            let mut buffer = self.buffer.write();
-
-            let mut persisting_chunks = vec![];
-            let catalog = Arc::clone(&buffer.catalog);
-            for (database_id, table_map) in buffer.db_to_table.iter_mut() {
-                let db_schema = catalog.db_schema_by_id(database_id).expect("db exists");
-                for (table_id, table_buffer) in table_map.iter_mut() {
-                    let table_def = db_schema
-                        .table_definition_by_id(table_id)
-                        .expect("table exists");
-                    let snapshot_chunks =
-                        table_buffer.snapshot(table_def, snapshot_details.end_time_marker);
-
-                    for chunk in snapshot_chunks {
-                        let table_name =
-                            db_schema.table_id_to_name(table_id).expect("table exists");
-                        let persist_job = PersistJob {
-                            database_id: *database_id,
-                            table_id: *table_id,
-                            table_name: Arc::clone(&table_name),
-                            chunk_time: chunk.chunk_time,
-                            path: ParquetFilePath::new(
-                                self.persister.host_identifier_prefix(),
-                                db_schema.name.as_ref(),
-                                database_id.as_u32(),
-                                table_name.as_ref(),
-                                table_id.as_u32(),
-                                chunk.chunk_time,
-                                write.wal_file_number,
-                            ),
-                            batch: chunk.record_batch,
-                            schema: chunk.schema,
-                            timestamp_min_max: chunk.timestamp_min_max,
-                            sort_key: table_buffer.sort_key.clone(),
-                        };
-
-                        persisting_chunks.push(persist_job);
-                    }
-                }
-            }
-
-            // we must buffer the ops after the snapshotting as this data should not be persisted
-            // with this set of wal files
-            buffer.buffer_ops(
-                write.ops,
-                &self.last_cache_provider,
-                &self.meta_cache_provider,
-            );
-
-            persisting_chunks
+            self.prepare_persist_jobs_from_chunks(
+                snapshot_details.end_time_marker,
+                write.wal_file_number,
+                Some(write.ops),
+            )
         };
 
         let (sender, receiver) = oneshot::channel();
@@ -276,77 +239,18 @@ impl QueryableBuffer {
                 persist_jobs.len(),
                 wal_file_number.as_u64(),
             );
-            // persist the individual files, building the snapshot as we go
-            let mut persisted_snapshot = PersistedSnapshot::new(
-                persister.host_identifier_prefix().to_string(),
-                snapshot_details.snapshot_sequence_number,
+            let (persisted_snapshot, cache_notifiers) = persist_parquet_files_and_get_summary(
+                &persister,
+                snapshot_details,
                 wal_file_number,
-                catalog.sequence_number(),
-            );
-            let mut cache_notifiers = vec![];
-            for persist_job in persist_jobs {
-                let path = persist_job.path.to_string();
-                let database_id = persist_job.database_id;
-                let table_id = persist_job.table_id;
-                let chunk_time = persist_job.chunk_time;
-                let min_time = persist_job.timestamp_min_max.min;
-                let max_time = persist_job.timestamp_min_max.max;
+                catalog,
+                persist_jobs,
+                executor,
+                parquet_cache,
+            )
+            .await;
 
-                let SortDedupePersistSummary {
-                    file_size_bytes,
-                    file_meta_data,
-                    parquet_cache_rx,
-                } = sort_dedupe_persist(
-                    persist_job,
-                    Arc::clone(&persister),
-                    Arc::clone(&executor),
-                    parquet_cache.clone(),
-                )
-                .await
-                .inspect_err(|error| {
-                    error!(
-                        %error,
-                        debug = ?error,
-                        "error during sort, deduplicate, and persist of buffer data as parquet"
-                    );
-                })
-                // for now, we are still panicking in this case, see:
-                // https://github.com/influxdata/influxdb/issues/25676
-                // https://github.com/influxdata/influxdb/issues/25677
-                .expect("sort, deduplicate, and persist buffer data as parquet");
-
-                cache_notifiers.push(parquet_cache_rx);
-                persisted_snapshot.add_parquet_file(
-                    database_id,
-                    table_id,
-                    ParquetFile {
-                        id: ParquetFileId::new(),
-                        path,
-                        size_bytes: file_size_bytes,
-                        row_count: file_meta_data.num_rows as u64,
-                        chunk_time,
-                        min_time,
-                        max_time,
-                    },
-                )
-            }
-
-            // persist the snapshot file
-            loop {
-                match persister.persist_snapshot(&persisted_snapshot).await {
-                    Ok(_) => {
-                        let persisted_snapshot = Some(persisted_snapshot.clone());
-                        notify_snapshot_tx
-                            .send(persisted_snapshot)
-                            .expect("persisted snapshot notify tx should not be closed");
-                        break;
-                    }
-                    Err(e) => {
-                        error!(%e, "Error persisting snapshot, sleeping and retrying...");
-                        tokio::time::sleep(Duration::from_secs(1)).await;
-                    }
-                }
-            }
+            persist_snapshot_file(persister, &persisted_snapshot, notify_snapshot_tx).await;
 
             // clear out the write buffer and add all the persisted files to the persisted files
             // on a background task to ensure that the cache has been populated before we clear
@@ -370,6 +274,62 @@ impl QueryableBuffer {
         });
 
         receiver
+    }
+
+    fn prepare_persist_jobs_from_chunks(
+        &self,
+        end_time_marker: i64,
+        wal_file_number: WalFileSequenceNumber,
+        write_ops: Option<Vec<WalOp>>,
+    ) -> Vec<PersistJob> {
+        let mut persisting_chunks = vec![];
+        let mut buffer = self.buffer.write();
+        let catalog = Arc::clone(&buffer.catalog);
+        for (database_id, table_map) in buffer.db_to_table.iter_mut() {
+            let db_schema = catalog.db_schema_by_id(database_id).expect("db exists");
+            for (table_id, table_buffer) in table_map.iter_mut() {
+                let table_def = db_schema
+                    .table_definition_by_id(table_id)
+                    .expect("table exists");
+                let snapshot_chunks = table_buffer.snapshot(table_def, end_time_marker);
+                let table_name = db_schema.table_id_to_name(table_id).expect("table exists");
+
+                for chunk in snapshot_chunks {
+                    let path = ParquetFilePath::new(
+                        self.persister.host_identifier_prefix(),
+                        db_schema.name.as_ref(),
+                        database_id.as_u32(),
+                        table_name.as_ref(),
+                        table_id.as_u32(),
+                        chunk.chunk_time,
+                        wal_file_number,
+                    );
+                    let persist_job = PersistJob {
+                        database_id: *database_id,
+                        table_id: *table_id,
+                        table_name: Arc::clone(&table_name),
+                        chunk_time: chunk.chunk_time,
+                        path,
+                        batch: chunk.record_batch,
+                        schema: chunk.schema,
+                        timestamp_min_max: chunk.timestamp_min_max,
+                        sort_key: table_buffer.sort_key.clone(),
+                    };
+
+                    persisting_chunks.push(persist_job);
+                }
+            }
+        }
+        if let Some(write_ops) = write_ops {
+            // we must buffer the ops after the snapshotting as this data should not be persisted
+            // with this set of wal files
+            buffer.buffer_ops(
+                write_ops,
+                &self.last_cache_provider,
+                &self.meta_cache_provider,
+            );
+        }
+        persisting_chunks
     }
 
     pub fn persisted_parquet_files(&self, db_id: DbId, table_id: TableId) -> Vec<ParquetFile> {
@@ -398,6 +358,95 @@ impl QueryableBuffer {
         }
         sender.as_ref().unwrap().subscribe()
     }
+}
+
+async fn persist_snapshot_file(
+    persister: Arc<Persister>,
+    persisted_snapshot: &PersistedSnapshot,
+    notify_snapshot_tx: tokio::sync::watch::Sender<Option<PersistedSnapshot>>,
+) {
+    // persist the snapshot file
+    loop {
+        match persister.persist_snapshot(persisted_snapshot).await {
+            Ok(_) => {
+                let persisted_snapshot = Some(persisted_snapshot.clone());
+                notify_snapshot_tx
+                    .send(persisted_snapshot)
+                    .expect("persisted snapshot notify tx should not be closed");
+                break;
+            }
+            Err(e) => {
+                error!(%e, "Error persisting snapshot, sleeping and retrying...");
+                tokio::time::sleep(Duration::from_secs(1)).await;
+            }
+        }
+    }
+}
+
+async fn persist_parquet_files_and_get_summary(
+    persister: &Arc<Persister>,
+    snapshot_details: SnapshotDetails,
+    wal_file_number: WalFileSequenceNumber,
+    catalog: Arc<Catalog>,
+    persist_jobs: Vec<PersistJob>,
+    executor: Arc<Executor>,
+    parquet_cache: Option<Arc<dyn ParquetCacheOracle>>,
+) -> (PersistedSnapshot, Vec<Option<Receiver<()>>>) {
+    // persist the individual files, building the snapshot as we go
+    let mut persisted_snapshot = PersistedSnapshot::new(
+        persister.host_identifier_prefix().to_string(),
+        snapshot_details.snapshot_sequence_number,
+        wal_file_number,
+        catalog.sequence_number(),
+    );
+    let mut cache_notifiers = vec![];
+    for persist_job in persist_jobs {
+        let path = persist_job.path.to_string();
+        let database_id = persist_job.database_id;
+        let table_id = persist_job.table_id;
+        let chunk_time = persist_job.chunk_time;
+        let min_time = persist_job.timestamp_min_max.min;
+        let max_time = persist_job.timestamp_min_max.max;
+
+        let SortDedupePersistSummary {
+            file_size_bytes,
+            file_meta_data,
+            parquet_cache_rx,
+        } = sort_dedupe_persist(
+            persist_job,
+            Arc::clone(persister),
+            Arc::clone(&executor),
+            parquet_cache.clone(),
+        )
+        .await
+        .inspect_err(|error| {
+            error!(
+                %error,
+                debug = ?error,
+                "error during sort, deduplicate, and persist of buffer data as parquet"
+            );
+        })
+        // for now, we are still panicking in this case, see:
+        // https://github.com/influxdata/influxdb/issues/25676
+        // https://github.com/influxdata/influxdb/issues/25677
+        .expect("sort, deduplicate, and persist buffer data as parquet");
+
+        cache_notifiers.push(parquet_cache_rx);
+        persisted_snapshot.add_parquet_file(
+            database_id,
+            table_id,
+            ParquetFile {
+                id: ParquetFileId::new(),
+                path,
+                size_bytes: file_size_bytes,
+                row_count: file_meta_data.num_rows as u64,
+                chunk_time,
+                min_time,
+                max_time,
+            },
+        )
+    }
+    (persisted_snapshot, cache_notifiers)
 }
 
 #[async_trait]
@@ -542,6 +591,16 @@ impl BufferState {
                 }
             }
         }
+    }
+
+    pub fn find_overall_buffer_size_bytes(&self) -> usize {
+        let mut total = 0;
+        for (_, all_tables) in &self.db_to_table {
+            for (_, table_buffer) in all_tables {
+                total += table_buffer.computed_size();
+            }
+        }
+        total
     }
 
     fn add_write_batch(&mut self, write_batch: WriteBatch) {
@@ -716,6 +775,7 @@ mod tests {
     use iox_time::{MockProvider, Time, TimeProvider};
     use object_store::memory::InMemory;
     use object_store::ObjectStore;
+    use observability_deps::tracing::debug;
     use parquet_file::storage::{ParquetStorage, StorageId};
     use std::num::NonZeroUsize;
 
@@ -857,5 +917,17 @@ mod tests {
             .persisted_files
             .get_files(db.id, table.table_id);
         assert_eq!(files.len(), 2);
+    }
+
+    #[test_log::test(test)]
+    fn test_sizes() {
+        let size_provider = size_of::<LastCacheProvider>();
+        debug!(?size_provider, "last cache provider size");
+
+        let size_buffer_state = size_of::<BufferState>();
+        debug!(?size_buffer_state, "buffer state size");
+
+        // let size_buffer_state = size_of::<>();
+        // debug!(?size_buffer_state, "buffer state size");
     }
 }


### PR DESCRIPTION
- The core of the change is to introduce another method `force_flush_buffer` in `Wal` trait. This gives a handle to choose when to kick off snapshot.
- A higher level background loop is introduced that checks the overall table buffer size every `N` seconds and if it is greater than a threshold (`X`) then it calls `force_flush_buffer`. Both `N` and `X` are configurable through cli. `N` defaults to 10s and `X` defaults to 70%
- Some refactoring of the code went on to make sure the calls made via `Wal` trait to flush buffer and cleanup any snapshot is reused across both branches (forcing snapshot and normal wal buffer flush)

closes: https://github.com/influxdata/influxdb/issues/25685
