### PR TITLE
feat: force snapshot under memory pressure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2863,6 +2863,7 @@ dependencies = [
  "secrecy",
  "serde_json",
  "sha2",
+ "sysinfo 0.30.13",
  "test-log",
  "test_helpers",
  "thiserror 1.0.69",

--- a/influxdb3/Cargo.toml
+++ b/influxdb3/Cargo.toml
@@ -51,6 +51,7 @@ rand.workspace = true
 secrecy.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
+sysinfo.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true

--- a/influxdb3_wal/src/lib.rs
+++ b/influxdb3_wal/src/lib.rs
@@ -17,7 +17,7 @@ use influxdb3_id::{ColumnId, DbId, SerdeVecMap, TableId};
 use influxdb_line_protocol::v3::SeriesValue;
 use influxdb_line_protocol::FieldValue;
 use iox_time::Time;
-use observability_deps::tracing::error;
+use observability_deps::tracing::{debug, error};
 use schema::{InfluxColumnType, InfluxFieldType};
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
@@ -97,8 +97,44 @@ pub trait Wal: Debug + Send + Sync + 'static {
     /// Returns the last persisted wal file sequence number
     async fn last_snapshot_sequence_number(&self) -> SnapshotSequenceNumber;
 
+    /// Returns the snapshot info, if force snapshot is set it avoids checking
+    /// certain cases and returns snapshot info leaving only the last wal period
+    async fn snapshot_info(
+        &self,
+        force_snapshot: bool,
+    ) -> Option<(SnapshotInfo, OwnedSemaphorePermit)>;
+
     /// Stop all writes to the WAL and flush the buffer to a WAL file.
     async fn shutdown(&self);
+
+    async fn flush_buffer_and_cleanup_snapshot(self: Arc<Self>) {
+        let cleanup_after_snapshot = self.flush_buffer().await;
+        self.cleanup_after_snapshot(cleanup_after_snapshot).await;
+    }
+
+    async fn cleanup_after_snapshot(
+        self: Arc<Self>,
+        cleanup_params: Option<(
+            oneshot::Receiver<SnapshotDetails>,
+            SnapshotInfo,
+            OwnedSemaphorePermit,
+        )>,
+    ) {
+        // handle snapshot cleanup outside of the flush loop
+        if let Some((snapshot_complete, snapshot_info, snapshot_permit)) = cleanup_params {
+            let arcd_wal = Arc::clone(&self);
+            tokio::spawn(async move {
+                let snapshot_details = snapshot_complete.await.expect("snapshot failed");
+                assert_eq!(snapshot_info.snapshot_details, snapshot_details);
+
+                arcd_wal
+                    .cleanup_snapshot(snapshot_info, snapshot_permit)
+                    .await;
+            });
+        } else {
+            debug!("not flushed the buffer, no snapshot");
+        }
+    }
 }
 
 /// When the WAL persists a file with buffered ops, the contents are sent to this
@@ -113,6 +149,12 @@ pub trait WalFileNotifier: Debug + Send + Sync + 'static {
     async fn notify_and_snapshot(
         &self,
         write: WalContents,
+        snapshot_details: SnapshotDetails,
+    ) -> oneshot::Receiver<SnapshotDetails>;
+
+    /// Snapshot only, currently used to force the snapshot
+    async fn snapshot(
+        &self,
         snapshot_details: SnapshotDetails,
     ) -> oneshot::Receiver<SnapshotDetails>;
 
@@ -181,6 +223,10 @@ impl Gen1Duration {
 
     pub fn as_nanos(&self) -> i64 {
         self.0.as_nanos() as i64
+    }
+
+    pub fn new_10s() -> Self {
+        Self(Duration::from_secs(10))
     }
 
     pub fn new_1m() -> Self {
@@ -890,23 +936,8 @@ pub fn background_wal_flush<W: Wal>(
 
         loop {
             interval.tick().await;
-
-            let cleanup_after_snapshot = wal.flush_buffer().await;
-
-            // handle snapshot cleanup outside of the flush loop
-            if let Some((snapshot_complete, snapshot_info, snapshot_permit)) =
-                cleanup_after_snapshot
-            {
-                let snapshot_wal = Arc::clone(&wal);
-                tokio::spawn(async move {
-                    let snapshot_details = snapshot_complete.await.expect("snapshot failed");
-                    assert_eq!(snapshot_info.snapshot_details, snapshot_details);
-
-                    snapshot_wal
-                        .cleanup_snapshot(snapshot_info, snapshot_permit)
-                        .await;
-                });
-            }
+            let wal = Arc::clone(&wal);
+            wal.flush_buffer_and_cleanup_snapshot().await;
         }
     })
 }

--- a/influxdb3_wal/src/object_store.rs
+++ b/influxdb3_wal/src/object_store.rs
@@ -416,12 +416,12 @@ impl Wal for WalObjectStore {
             .last_snapshot_sequence_number()
     }
 
-    async fn snapshot_info(
+    async fn snapshot_info_and_permit(
         &self,
         force_snapshot: bool,
     ) -> Option<(SnapshotInfo, OwnedSemaphorePermit)> {
         let mut buff = self.flush_buffer.lock().await;
-        buff.get_snapshot_info(force_snapshot).await
+        buff.get_snapshot_info_and_permit(force_snapshot).await
     }
 
     async fn shutdown(&self) {
@@ -456,7 +456,7 @@ impl FlushBuffer {
         self.snapshot_tracker.add_wal_period(wal_period);
     }
 
-    async fn get_snapshot_info(
+    async fn get_snapshot_info_and_permit(
         &mut self,
         force_snapshot: bool,
     ) -> Option<(SnapshotInfo, OwnedSemaphorePermit)> {
@@ -489,7 +489,7 @@ impl FlushBuffer {
             max_time: Timestamp::new(wal_contents.max_timestamp_ns),
         });
 
-        let snapshot = match self.get_snapshot_info(false).await {
+        let snapshot = match self.get_snapshot_info_and_permit(false).await {
             Some(info) => {
                 wal_contents.snapshot = Some(info.0.snapshot_details);
                 Some(info)

--- a/influxdb3_write/src/write_buffer/table_buffer.rs
+++ b/influxdb3_write/src/write_buffer/table_buffer.rs
@@ -187,6 +187,9 @@ impl TableBuffer {
             .filter(|k| **k < older_than_chunk_time)
             .copied()
             .collect::<Vec<_>>();
+
+        debug!(?self.chunk_time_to_chunks, ">>> snapshot chunk_time_to_chunks");
+        debug!(?keys_to_remove, ">>> snapshot keys_to_remove");
         self.snapshotting_chunks = keys_to_remove
             .into_iter()
             .map(|chunk_time| {
@@ -203,6 +206,8 @@ impl TableBuffer {
             })
             .collect::<Vec<_>>();
 
+        debug!(?self.snapshotting_chunks, ">>> snapshotting_chunks");
+        debug!(?self.chunk_time_to_chunks, ">>> snapshot chunk_time_to_chunks after removal and snapshotting");
         self.snapshotting_chunks.clone()
     }
 


### PR DESCRIPTION
- The main change is to detach wal and snapshot, in a way all 3 of the following things can happen   
  - flush the wal buffer only (already handled, before this commit)   
  - flush wal buffer and snapshot (already handled, before this commit)   
  - snapshot without flushing wal buffer (introduced in this commit) 
  This is achieved by introducing another method `snapshot` in `WalFileNotifier` trait. The main dependency between wal and snapshot is the `wal_file_number`, since this is tracked in `SnapshotTracker` separately we can switch to using `SnapshotTracker`'s `last_wal_sequence_number` instead of the one that comes through the `WalContents`. 
- A higher level background loop is introduced that checks the overall table buffer size every `N` seconds and if it is greater than a threshold (`X`) then it calls `snapshot` method. Both `N` and `X` are configurable through cli. `N` defaults to 10s and `X` defaults to 70% 
- Some refactoring of code so that existing methods can be reused when only snapshotting 

closes: https://github.com/influxdata/influxdb/issues/25685

This [comment](https://github.com/influxdata/influxdb/pull/25727#discussion_r1900856276) explains the reasoning behind why I thought `last_wal_sequence_number` from snapshot tracker can be used. If this reasoning is not sound, then this approach doesn't quite work.