### PR TITLE
chore: Remove references to IOx in docs/comments

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ For features we don't plan to support we will close the feature request ticket (
 
 ## Contributing Changes
 
-InfluxDB IOx is written mostly in idiomatic Rust—please see the [Style Guide] for more details.
+InfluxDB 3 is written mostly in idiomatic Rust—please see the [Style Guide] for more details.
 All code must adhere to the `rustfmt` format, and pass all of the `clippy` checks we run in CI (there are more details further down this README).
 
 [Style Guide]: docs/style_guide.md
@@ -54,7 +54,7 @@ If you're planning to submit significant changes, even if it relates to existing
 The easiest way to do this is to open up a new ticket, describing the changes you plan to make and *why* you plan to make them. Changes that may seem obviously good to you, are not always obvious to everyone else.
 Example of changes where we would encourage up-front communication:
 
-* new IOx features;
+* new InfluxDB 3 features;
 * significant refactors that move code between modules/crates etc;
 * performance improvements involving new concurrency patterns or the use of `unsafe` code;
 * API-breaking changes, or changes that require a data migration;
@@ -68,7 +68,7 @@ Further, please don't expect us to accept significant changes without new test c
 
 To open a PR you will need to have a Github account.
 Fork the `influxdb` repo and work on a branch on your fork.
-When you have completed your changes, or you want some incremental feedback make a Pull Request to InfluxDB IOx [here].
+When you have completed your changes, or you want some incremental feedback make a Pull Request to InfluxDB [here].
 
 If you want to discuss some work in progress then please prefix `[WIP]` to the
 PR title.
@@ -197,4 +197,4 @@ cargo clippy --all-targets --workspace -- -D warnings
 
 ## Distributed Tracing
 
-See [tracing.md](docs/tracing.md) for more information on the distributed tracing functionality within IOx
+See [tracing.md](docs/tracing.md) for more information on the distributed tracing functionality within InfluxDB 3

--- a/docker/Dockerfile.ci
+++ b/docker/Dockerfile.ci
@@ -1,11 +1,10 @@
 ###
-# Dockerfile for the image used in the InfluxDB IOx CI tests
-# As of October 2020, it is rebuilt each night
+# Dockerfile for the image used in the InfluxDB 3 CI tests
 #
 # It expects to be run with the repo checked out locally.
 # for example:
 #
-# cd influxdb_iox
+# cd influxdb
 # docker build -f docker/Dockerfile.ci \
 #   --build-arg RUST_VERSION=$(sed -E -ne 's/channel = "(.*)"/\1/p' rust-toolchain.toml) .
 ##

--- a/influxdb3/src/commands/serve.rs
+++ b/influxdb3/src/commands/serve.rs
@@ -46,7 +46,7 @@ use trace_exporters::TracingConfig;
 use trace_http::ctx::TraceHeaderParser;
 use trogging::cli::LoggingConfig;
 
-/// The default name of the influxdb_iox data directory
+/// The default name of the influxdb data directory
 #[allow(dead_code)]
 pub const DEFAULT_DATA_DIRECTORY_NAME: &str = ".influxdb3";
 

--- a/influxdb3/src/main.rs
+++ b/influxdb3/src/main.rs
@@ -1,4 +1,4 @@
-//! Entrypoint of InfluxDB IOx binary
+//! Entrypoint of the influxdb3 binary
 #![recursion_limit = "512"] // required for print_cpu
 #![deny(rustdoc::broken_intra_doc_links, rustdoc::bare_urls, rust_2018_idioms)]
 #![warn(

--- a/influxdb3_load_generator/src/main.rs
+++ b/influxdb3_load_generator/src/main.rs
@@ -1,4 +1,4 @@
-//! Entrypoint of InfluxDB IOx binary
+//! Entrypoint of the influxdb3_load_generator binary
 #![recursion_limit = "512"] // required for print_cpu
 #![deny(rustdoc::broken_intra_doc_links, rustdoc::bare_urls, rust_2018_idioms)]
 #![warn(
@@ -148,7 +148,10 @@ fn get_runtime(num_threads: Option<usize>) -> Result<Runtime, std::io::Error> {
                 _ => Builder::new_multi_thread()
                     .enable_all()
                     .thread_name_fn(move || {
-                        format!("IOx main {}", thread_counter.fetch_add(1, Ordering::SeqCst))
+                        format!(
+                            "inflxudb3_load_generator main {}",
+                            thread_counter.fetch_add(1, Ordering::SeqCst)
+                        )
                     })
                     .worker_threads(num_threads)
                     .build(),


### PR DESCRIPTION
This removes references to IOx in our docs and comments as when we started making Monolith last year it was a fork of influxdb_iox. This was something that we changed in some places, but not all as time went on. To avoid confusion whenever we more broadly release this software I've removed references to IOx in our code and docs. Note however that we still use a lot of IOx code and our system tables also return iox as part of the name. This is a separate issue namely #25227. Some things like env vars will also be cleaned up in #25646

Closes #25662
