### PR TITLE
fix: Return a 422 for limits on a partial write

### DIFF
--- a/influxdb3/tests/server/limits.rs
+++ b/influxdb3/tests/server/limits.rs
@@ -76,7 +76,7 @@ async fn limits() -> Result<(), Error> {
     else {
         panic!("Did not error when adding 501st column");
     };
-    assert_eq!(code, StatusCode::BAD_REQUEST);
+    assert_eq!(code, StatusCode::UNPROCESSABLE_ENTITY);
 
     Ok(())
 }


### PR DESCRIPTION
Prior to this change we would error correctly with a 422 if a limit was hit. However, we would not send back the correct error in the case of a limit being hit that caused a partial write. This change fixes that by checking the error messages for failed lines and if one is found that caused a limit to be hit, then a 422 is returned rather than a 400 as we would have been able to process the line otherwise, but the limit was hit instead

Closes #25208