### PR TITLE
feat: Implement Deserialize for Catalog

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3689,6 +3689,7 @@ checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
 dependencies = [
  "autocfg",
  "scopeguard",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,7 +83,7 @@ mockito = { version = "1.4.0", default-features = false }
 mockall = { version = "0.13.0" }
 num_cpus = "1.16.0"
 object_store = "0.11.1"
-parking_lot = "0.12.1"
+parking_lot = { version = "0.12.1", features = ["serde"] }
 paste = "1.0.15"
 parquet = { version = "53.0.0", features = ["object_store"] }
 pbjson = "0.6.0"

--- a/influxdb3_catalog/src/catalog.rs
+++ b/influxdb3_catalog/src/catalog.rs
@@ -19,7 +19,7 @@ use iox_time::Time;
 use observability_deps::tracing::{debug, info};
 use parking_lot::RwLock;
 use schema::{InfluxColumnType, InfluxFieldType, Schema, SchemaBuilder};
-use serde::{Deserialize, Serialize, Serializer};
+use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 use std::cmp::Ordering;
 use std::collections::BTreeMap;
@@ -159,23 +159,15 @@ impl CatalogSequenceNumber {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct Catalog {
+    #[serde(flatten)]
     inner: RwLock<InnerCatalog>,
 }
 
 impl PartialEq for Catalog {
     fn eq(&self, other: &Self) -> bool {
         self.inner.read().eq(&other.inner.read())
-    }
-}
-
-impl Serialize for Catalog {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        self.inner.read().serialize(serializer)
     }
 }
 

--- a/influxdb3_catalog/src/snapshots/influxdb3_catalog__catalog__tests__catalog_serialization.snap
+++ b/influxdb3_catalog/src/snapshots/influxdb3_catalog__catalog__tests__catalog_serialization.snap
@@ -269,8 +269,8 @@ snapshot_kind: text
       }
     ]
   ],
-  "sequence": 0,
+  "db_map": [],
   "host_id": "sample-host-id",
   "instance_id": "instance-id",
-  "db_map": []
+  "sequence": 0
 }

--- a/influxdb3_catalog/src/snapshots/influxdb3_catalog__catalog__tests__serialize_last_cache.snap
+++ b/influxdb3_catalog/src/snapshots/influxdb3_catalog__catalog__tests__serialize_last_cache.snap
@@ -120,8 +120,8 @@ snapshot_kind: text
       }
     ]
   ],
-  "sequence": 0,
+  "db_map": [],
   "host_id": "sample-host-id",
   "instance_id": "instance-id",
-  "db_map": []
+  "sequence": 0
 }

--- a/influxdb3_catalog/src/snapshots/influxdb3_catalog__catalog__tests__serialize_series_keys.snap
+++ b/influxdb3_catalog/src/snapshots/influxdb3_catalog__catalog__tests__serialize_series_keys.snap
@@ -104,8 +104,8 @@ snapshot_kind: text
       }
     ]
   ],
-  "sequence": 0,
+  "db_map": [],
   "host_id": "sample-host-id",
   "instance_id": "instance-id",
-  "db_map": []
+  "sequence": 0
 }


### PR DESCRIPTION
This was fairly easy all things considered. We needed to turn on the serde feature for parking_lot, remove the Serialize impl, derive both it and Deserialize, and add the flatten attribute and we're all set. The output for the tests changed, but only the order of fields, not the actual content so it's fine that we updated them. This change will allow us to deserialize the Catalog in the future if need be without running into issues around the fact that it can't implement it.

Closes #25574