### PR TITLE
feat(processing_engine): Add CLI support for plugins and triggers

### DIFF
--- a/influxdb3/src/commands/processing_engine/mod.rs
+++ b/influxdb3/src/commands/processing_engine/mod.rs
@@ -1,0 +1,30 @@
+mod plugin;
+mod trigger;
+
+use std::error::Error;
+
+#[derive(Debug, clap::Parser)]
+pub(crate) struct Config {
+    #[clap(subcommand)]
+    command: Command,
+}
+
+#[derive(Debug, clap::Parser)]
+enum Command {
+    /// Manage plugins (create, delete, update, etc.)
+    Plugin(plugin::Config),
+    /// Manage triggers (create, delete, activate, deactivate, etc.)
+    Trigger(trigger::Config),
+}
+
+pub(crate) async fn command(config: Config) -> Result<(), Box<dyn Error>> {
+    match config.command {
+        Command::Plugin(plugin_config) => {
+            plugin::command(plugin_config).await?;
+        }
+        Command::Trigger(trigger_config) => {
+            trigger::command(trigger_config).await?;
+        }
+    }
+    Ok(())
+}

--- a/influxdb3/src/commands/processing_engine/plugin.rs
+++ b/influxdb3/src/commands/processing_engine/plugin.rs
@@ -1,0 +1,97 @@
+use crate::commands::common::InfluxDb3Config;
+use secrecy::ExposeSecret;
+use std::error::Error;
+use std::fs::File;
+use std::io::Read;
+
+#[derive(Debug, clap::Parser)]
+pub struct Config {
+    #[clap(subcommand)]
+    action: PluginAction,
+}
+
+#[derive(Debug, clap::Subcommand)]
+enum PluginAction {
+    /// Create a new processing engine plugin
+    Create(CreateConfig),
+    /// Delete an existing processing engine plugin
+    Delete(DeleteConfig),
+}
+
+impl PluginAction {
+    pub fn get_influxdb3_config(&self) -> &InfluxDb3Config {
+        match self {
+            Self::Create(create) => &create.influxdb3_config,
+            Self::Delete(delete) => &delete.influxdb3_config,
+        }
+    }
+}
+
+#[derive(Debug, clap::Parser)]
+struct CreateConfig {
+    #[clap(flatten)]
+    influxdb3_config: InfluxDb3Config,
+
+    /// Name of the plugin to create
+    #[clap(long = "plugin-name")]
+    plugin_name: String,
+    /// Python file containing the plugin code
+    #[clap(long = "code-filename")]
+    code_file: String,
+    /// Entry point function for the plugin
+    #[clap(long = "entry-point")]
+    function_name: String,
+    /// Type of trigger the plugin processes
+    #[clap(long = "plugin-type", default_value = "wal_rows")]
+    plugin_type: String,
+}
+
+#[derive(Debug, clap::Parser)]
+struct DeleteConfig {
+    #[clap(flatten)]
+    influxdb3_config: InfluxDb3Config,
+
+    /// Name of the plugin to delete
+    #[clap(long = "plugin-name")]
+    plugin_name: String,
+}
+
+pub(super) async fn command(config: Config) -> Result<(), Box<dyn Error>> {
+    let influxdb3_config = config.action.get_influxdb3_config();
+    let mut client = influxdb3_client::Client::new(influxdb3_config.host_url.clone())?;
+    if let Some(token) = &influxdb3_config.auth_token {
+        client = client.with_auth_token(token.expose_secret());
+    }
+    match config.action {
+        PluginAction::Create(create_config) => {
+            let code = open_file(&create_config.code_file)?;
+            client
+                .api_v3_configure_processing_engine_plugin_create(
+                    create_config.influxdb3_config.database_name,
+                    &create_config.plugin_name,
+                    code,
+                    create_config.function_name,
+                    create_config.plugin_type,
+                )
+                .await?;
+            println!("Plugin {} created successfully", create_config.plugin_name);
+        }
+        PluginAction::Delete(delete_config) => {
+            client
+                .api_v3_configure_processing_engine_plugin_delete(
+                    delete_config.influxdb3_config.database_name,
+                    &delete_config.plugin_name,
+                )
+                .await?;
+            println!("Plugin {} deleted successfully", delete_config.plugin_name);
+        }
+    }
+    Ok(())
+}
+
+fn open_file(file: &str) -> Result<String, Box<dyn Error>> {
+    let mut file = File::open(file)?;
+    let mut contents = String::new();
+    file.read_to_string(&mut contents)?;
+    Ok(contents)
+}

--- a/influxdb3/src/commands/processing_engine/trigger.rs
+++ b/influxdb3/src/commands/processing_engine/trigger.rs
@@ -1,0 +1,146 @@
+use crate::commands::common::InfluxDb3Config;
+use influxdb3_client::Client;
+use influxdb3_wal::TriggerSpecificationDefinition;
+use secrecy::ExposeSecret;
+use std::error::Error;
+
+#[derive(Debug, clap::Parser)]
+pub struct Config {
+    #[clap(subcommand)]
+    action: TriggerAction,
+}
+
+impl Config {
+    fn get_client(&self) -> Result<Client, Box<dyn Error>> {
+        let influxdb3_config = match &self.action {
+            TriggerAction::Create(create) => &create.influxdb3_config,
+            TriggerAction::Activate(manage) | TriggerAction::Deactivate(manage) => {
+                &manage.influxdb3_config
+            }
+            TriggerAction::Delete(delete) => &delete.influxdb3_config,
+        };
+        let mut client = Client::new(influxdb3_config.host_url.clone())?;
+        if let Some(token) = &influxdb3_config.auth_token {
+            client = client.with_auth_token(token.expose_secret());
+        }
+        Ok(client)
+    }
+}
+
+#[derive(Debug, clap::Subcommand)]
+enum TriggerAction {
+    /// Create a new trigger using an existing plugin
+    Create(CreateConfig),
+    /// Activate a trigger to enable plugin execution
+    Activate(ManageConfig),
+    /// Deactivate a trigger to disable plugin execution
+    Deactivate(ManageConfig),
+    /// Delete a trigger
+    Delete(DeleteConfig),
+}
+
+#[derive(Debug, clap::Parser)]
+struct CreateConfig {
+    #[clap(flatten)]
+    influxdb3_config: InfluxDb3Config,
+
+    /// Name for the new trigger
+    #[clap(long = "trigger-name")]
+    trigger_name: String,
+    /// Plugin to execute when trigger fires
+    #[clap(long = "plugin-name")]
+    plugin_name: String,
+    /// When the trigger should fire
+    #[clap(long = "trigger-spec",
+          value_parser = TriggerSpecificationDefinition::from_string_rep,
+          help = "Trigger specification format: 'table:<TABLE_NAME>' or 'all_tables'")]
+    trigger_specification: TriggerSpecificationDefinition,
+    /// Create trigger in disabled state
+    #[clap(long)]
+    disabled: bool,
+}
+
+#[derive(Debug, clap::Parser)]
+struct ManageConfig {
+    #[clap(flatten)]
+    influxdb3_config: InfluxDb3Config,
+
+    /// Name of trigger to manage
+    #[clap(long = "trigger-name")]
+    trigger_name: String,
+}
+
+#[derive(Debug, clap::Parser)]
+struct DeleteConfig {
+    #[clap(flatten)]
+    influxdb3_config: InfluxDb3Config,
+
+    /// Name of trigger to delete
+    #[clap(long = "trigger-name")]
+    trigger_name: String,
+
+    /// Force deletion even if trigger is active
+    #[clap(long)]
+    force: bool,
+}
+
+// [Previous CreateConfig and ManageConfig structs remain unchanged]
+
+pub(super) async fn command(config: Config) -> Result<(), Box<dyn Error>> {
+    let client = config.get_client()?;
+    match config.action {
+        TriggerAction::Create(create_config) => {
+            client
+                .api_v3_configure_processing_engine_trigger_create(
+                    create_config.influxdb3_config.database_name,
+                    &create_config.trigger_name,
+                    &create_config.plugin_name,
+                    create_config.trigger_specification.string_rep(),
+                    create_config.disabled,
+                )
+                .await?;
+            println!(
+                "Trigger {} created successfully",
+                create_config.trigger_name
+            );
+        }
+        TriggerAction::Activate(manage_config) => {
+            client
+                .api_v3_configure_processing_engine_trigger_activate(
+                    manage_config.influxdb3_config.database_name,
+                    &manage_config.trigger_name,
+                )
+                .await?;
+            println!(
+                "Trigger {} activated successfully",
+                manage_config.trigger_name
+            );
+        }
+        TriggerAction::Deactivate(manage_config) => {
+            client
+                .api_v3_configure_processing_engine_trigger_deactivate(
+                    manage_config.influxdb3_config.database_name,
+                    &manage_config.trigger_name,
+                )
+                .await?;
+            println!(
+                "Trigger {} deactivated successfully",
+                manage_config.trigger_name
+            );
+        }
+        TriggerAction::Delete(delete_config) => {
+            client
+                .api_v3_configure_processing_engine_trigger_delete(
+                    delete_config.influxdb3_config.database_name,
+                    &delete_config.trigger_name,
+                    delete_config.force,
+                )
+                .await?;
+            println!(
+                "Trigger {} deleted successfully",
+                delete_config.trigger_name
+            );
+        }
+    }
+    Ok(())
+}

--- a/influxdb3/src/main.rs
+++ b/influxdb3/src/main.rs
@@ -25,6 +25,7 @@ mod commands {
     pub mod last_cache;
     pub mod manage;
     pub mod meta_cache;
+    pub mod processing_engine;
     pub mod query;
     pub mod serve;
     pub mod token;
@@ -96,6 +97,9 @@ enum Command {
     /// Manage metadata caches
     MetaCache(commands::meta_cache::Config),
 
+    /// Manage processing engine plugins and triggers
+    ProcessingEngine(commands::processing_engine::Config),
+
     /// Manage database (delete only for the moment)
     Database(commands::manage::database::Config),
 
@@ -162,6 +166,12 @@ fn main() -> Result<(), std::io::Error> {
             Some(Command::MetaCache(config)) => {
                 if let Err(e) = commands::meta_cache::command(config).await {
                     eprintln!("Metadata Cache command faild: {e}");
+                    std::process::exit(ReturnCode::Failure as _)
+                }
+            }
+            Some(Command::ProcessingEngine(config)) => {
+                if let Err(e) = commands::processing_engine::command(config).await {
+                    eprintln!("Processing engine command failed: {e}");
                     std::process::exit(ReturnCode::Failure as _)
                 }
             }

--- a/influxdb3_catalog/src/catalog.rs
+++ b/influxdb3_catalog/src/catalog.rs
@@ -2,7 +2,7 @@
 
 use crate::catalog::Error::{
     CatalogUpdatedElsewhere, ProcessingEngineCallExists, ProcessingEngineTriggerExists,
-    TableNotFound,
+    ProcessingEngineTriggerRunning, TableNotFound,
 };
 use bimap::{BiHashMap, Overwritten};
 use hashbrown::HashMap;
@@ -10,13 +10,13 @@ use indexmap::IndexMap;
 use influxdb3_id::{ColumnId, DbId, SerdeVecMap, TableId};
 use influxdb3_wal::{
     CatalogBatch, CatalogOp, DeleteDatabaseDefinition, DeletePluginDefinition,
-    DeleteTableDefinition, FieldAdditions, FieldDefinition, LastCacheDefinition, LastCacheDelete,
-    MetaCacheDefinition, MetaCacheDelete, OrderedCatalogBatch, PluginDefinition, TriggerDefinition,
-    TriggerIdentifier,
+    DeleteTableDefinition, DeleteTriggerDefinition, FieldAdditions, FieldDefinition,
+    LastCacheDefinition, LastCacheDelete, MetaCacheDefinition, MetaCacheDelete,
+    OrderedCatalogBatch, PluginDefinition, TriggerDefinition, TriggerIdentifier,
 };
 use influxdb_line_protocol::FieldValue;
 use iox_time::Time;
-use observability_deps::tracing::{debug, info};
+use observability_deps::tracing::{debug, info, warn};
 use parking_lot::RwLock;
 use schema::{InfluxColumnType, InfluxFieldType, Schema, SchemaBuilder};
 use serde::{Deserialize, Serialize, Serializer};
@@ -101,6 +101,12 @@ pub enum Error {
     },
 
     #[error(
+        "Cannot delete running plugin {}. Disable it first or use --force.",
+        trigger_name
+    )]
+    ProcessingEngineTriggerRunning { trigger_name: String },
+
+    #[error(
         "Cannot delete plugin {} in database {} because it is used by trigger {}",
         plugin_name,
         database_name,
@@ -133,6 +139,8 @@ pub enum Error {
         database_name: String,
         trigger_name: String,
     },
+    #[error("failed to parse trigger from {}", trigger_spec)]
+    ProcessingEngineTriggerSpecParseError { trigger_spec: String },
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -714,6 +722,7 @@ impl UpdateDatabaseSchema for CatalogOp {
             CatalogOp::DeletePlugin(delete_plugin) => delete_plugin.update_schema(schema),
             CatalogOp::CreatePlugin(create_plugin) => create_plugin.update_schema(schema),
             CatalogOp::CreateTrigger(create_trigger) => create_trigger.update_schema(schema),
+            CatalogOp::DeleteTrigger(delete_trigger) => delete_trigger.update_schema(schema),
             CatalogOp::EnableTrigger(trigger_identifier) => {
                 EnableTrigger(trigger_identifier.clone()).update_schema(schema)
             }
@@ -903,6 +912,33 @@ impl UpdateDatabaseSchema for TriggerDefinition {
             .to_mut()
             .processing_engine_triggers
             .insert(self.trigger_name.to_string(), self.clone());
+        Ok(schema)
+    }
+}
+
+impl UpdateDatabaseSchema for DeleteTriggerDefinition {
+    fn update_schema<'a>(
+        &self,
+        mut schema: Cow<'a, DatabaseSchema>,
+    ) -> Result<Cow<'a, DatabaseSchema>> {
+        let Some(trigger) = schema.processing_engine_triggers.get(&self.trigger_name) else {
+            // deleting a non-existent trigger is a no-op to make it idempotent.
+            return Ok(schema);
+        };
+        if !trigger.disabled && !self.force {
+            if self.force {
+                warn!("deleting running trigger {}", self.trigger_name);
+            } else {
+                return Err(ProcessingEngineTriggerRunning {
+                    trigger_name: self.trigger_name.to_string(),
+                });
+            }
+        }
+        schema
+            .to_mut()
+            .processing_engine_triggers
+            .remove(&self.trigger_name);
+
         Ok(schema)
     }
 }

--- a/influxdb3_client/src/lib.rs
+++ b/influxdb3_client/src/lib.rs
@@ -466,6 +466,237 @@ impl Client {
         }
     }
 
+    /// Make a request to the `POST /api/v3/configure/processing_engine_plugin` API
+    pub async fn api_v3_configure_processing_engine_plugin_create(
+        &self,
+        db: impl Into<String> + Send,
+        plugin_name: impl Into<String> + Send,
+        code: impl Into<String> + Send,
+        function_name: impl Into<String> + Send,
+        plugin_type: impl Into<String> + Send,
+    ) -> Result<()> {
+        let api_path = "/api/v3/configure/processing_engine_plugin";
+
+        let url = self.base_url.join(api_path)?;
+
+        #[derive(Serialize)]
+        struct Req {
+            db: String,
+            plugin_name: String,
+            code: String,
+            function_name: String,
+            plugin_type: String,
+        }
+
+        let mut req = self.http_client.post(url).json(&Req {
+            db: db.into(),
+            plugin_name: plugin_name.into(),
+            code: code.into(),
+            function_name: function_name.into(),
+            plugin_type: plugin_type.into(),
+        });
+
+        if let Some(token) = &self.auth_token {
+            req = req.bearer_auth(token.expose_secret());
+        }
+        let resp = req
+            .send()
+            .await
+            .map_err(|src| Error::request_send(Method::POST, api_path, src))?;
+        let status = resp.status();
+        match status {
+            StatusCode::OK => Ok(()),
+            code => Err(Error::ApiError {
+                code,
+                message: resp.text().await.map_err(Error::Text)?,
+            }),
+        }
+    }
+    /// Make a request to the `DELETE /api/v3/configure/processing_engine_plugin` API
+    pub async fn api_v3_configure_processing_engine_plugin_delete(
+        &self,
+        db: impl Into<String> + Send,
+        plugin_name: impl Into<String> + Send,
+    ) -> Result<()> {
+        let api_path = "/api/v3/configure/processing_engine_plugin";
+
+        let url = self.base_url.join(api_path)?;
+
+        #[derive(Serialize)]
+        struct Req {
+            db: String,
+            plugin_name: String,
+        }
+
+        let mut req = self.http_client.delete(url).json(&Req {
+            db: db.into(),
+            plugin_name: plugin_name.into(),
+        });
+
+        if let Some(token) = &self.auth_token {
+            req = req.bearer_auth(token.expose_secret());
+        }
+        let resp = req
+            .send()
+            .await
+            .map_err(|src| Error::request_send(Method::DELETE, api_path, src))?;
+        let status = resp.status();
+        match status {
+            StatusCode::OK => Ok(()),
+            code => Err(Error::ApiError {
+                code,
+                message: resp.text().await.map_err(Error::Text)?,
+            }),
+        }
+    }
+    /// Make a request to `POST /api/v3/configure/processing_engine_trigger`
+    pub async fn api_v3_configure_processing_engine_trigger_create(
+        &self,
+        db: impl Into<String> + Send,
+        trigger_name: impl Into<String> + Send,
+        plugin_name: impl Into<String> + Send,
+        trigger_spec: impl Into<String> + Send,
+        disabled: bool,
+    ) -> Result<()> {
+        let api_path = "/api/v3/configure/processing_engine_trigger";
+
+        let url = self.base_url.join(api_path)?;
+
+        #[derive(Serialize)]
+        struct Req {
+            db: String,
+            trigger_name: String,
+            plugin_name: String,
+            trigger_specification: String,
+            disabled: bool,
+        }
+        let mut req = self.http_client.post(url).json(&Req {
+            db: db.into(),
+            trigger_name: trigger_name.into(),
+            plugin_name: plugin_name.into(),
+            trigger_specification: trigger_spec.into(),
+            disabled,
+        });
+
+        if let Some(token) = &self.auth_token {
+            req = req.bearer_auth(token.expose_secret());
+        }
+        let resp = req
+            .send()
+            .await
+            .map_err(|src| Error::request_send(Method::POST, api_path, src))?;
+        let status = resp.status();
+        match status {
+            StatusCode::OK => Ok(()),
+            code => Err(Error::ApiError {
+                code,
+                message: resp.text().await.map_err(Error::Text)?,
+            }),
+        }
+    }
+    /// Make a request to `DELETE /api/v3/configure/processing_engine_trigger`
+    pub async fn api_v3_configure_processing_engine_trigger_delete(
+        &self,
+        db: impl Into<String> + Send,
+        trigger_name: impl Into<String> + Send,
+        force: bool,
+    ) -> Result<()> {
+        let api_path = "/api/v3/configure/processing_engine_trigger";
+
+        let url = self.base_url.join(api_path)?;
+
+        #[derive(Serialize)]
+        struct Req {
+            db: String,
+            trigger_name: String,
+            force: bool,
+        }
+
+        let mut req = self.http_client.delete(url).json(&Req {
+            db: db.into(),
+            trigger_name: trigger_name.into(),
+            force,
+        });
+
+        if let Some(token) = &self.auth_token {
+            req = req.bearer_auth(token.expose_secret());
+        }
+        let resp = req
+            .send()
+            .await
+            .map_err(|src| Error::request_send(Method::DELETE, api_path, src))?;
+        let status = resp.status();
+        match status {
+            StatusCode::OK => Ok(()),
+            code => Err(Error::ApiError {
+                code,
+                message: resp.text().await.map_err(Error::Text)?,
+            }),
+        }
+    }
+
+    /// Make a request to `POST /api/v3/configure/processing_engine_trigger/activate`
+    pub async fn api_v3_configure_processing_engine_trigger_activate(
+        &self,
+        db: impl Into<String> + Send,
+        trigger_name: impl Into<String> + Send,
+    ) -> Result<()> {
+        let api_path = "/api/v3/configure/processing_engine_trigger/activate";
+        let url = self.base_url.join(api_path)?;
+
+        let mut req = self
+            .http_client
+            .post(url)
+            .query(&[("db", db.into()), ("trigger_name", trigger_name.into())]);
+
+        if let Some(token) = &self.auth_token {
+            req = req.bearer_auth(token.expose_secret());
+        }
+        let resp = req
+            .send()
+            .await
+            .map_err(|src| Error::request_send(Method::POST, api_path, src))?;
+
+        match resp.status() {
+            StatusCode::OK => Ok(()),
+            code => Err(Error::ApiError {
+                code,
+                message: resp.text().await.map_err(Error::Text)?,
+            }),
+        }
+    }
+
+    /// Make a request to `POST /api/v3/configure/processing_engine_trigger/deactivate`
+    pub async fn api_v3_configure_processing_engine_trigger_deactivate(
+        &self,
+        db: impl Into<String> + Send,
+        trigger_name: impl Into<String> + Send,
+    ) -> Result<()> {
+        let api_path = "/api/v3/configure/processing_engine_trigger/deactivate";
+        let url = self.base_url.join(api_path)?;
+
+        let mut req = self
+            .http_client
+            .post(url)
+            .query(&[("db", db.into()), ("trigger_name", trigger_name.into())]);
+
+        if let Some(token) = &self.auth_token {
+            req = req.bearer_auth(token.expose_secret());
+        }
+        let resp = req
+            .send()
+            .await
+            .map_err(|src| Error::request_send(Method::POST, api_path, src))?;
+
+        match resp.status() {
+            StatusCode::OK => Ok(()),
+            code => Err(Error::ApiError {
+                code,
+                message: resp.text().await.map_err(Error::Text)?,
+            }),
+        }
+    }
+
     /// Send a `/ping` request to the target `influxdb3` server to check its
     /// status and gather `version` and `revision` information
     pub async fn ping(&self) -> Result<PingResponse> {

--- a/influxdb3_write/src/write_buffer/plugins.rs
+++ b/influxdb3_write/src/write_buffer/plugins.rs
@@ -52,6 +52,13 @@ pub trait ProcessingEngineManager: Debug + Send + Sync + 'static {
         disabled: bool,
     ) -> crate::Result<(), write_buffer::Error>;
 
+    async fn delete_trigger(
+        &self,
+        db_name: &str,
+        trigger_name: &str,
+        force: bool,
+    ) -> crate::Result<(), write_buffer::Error>;
+
     /// Starts running the trigger, which will run in the background.
     async fn run_trigger(
         &self,

--- a/influxdb3_write/src/write_buffer/queryable_buffer.rs
+++ b/influxdb3_write/src/write_buffer/queryable_buffer.rs
@@ -561,10 +561,11 @@ impl BufferState {
                                 }
                             }
                             CatalogOp::CreatePlugin(_) => {}
+                            CatalogOp::DeletePlugin(_) => {}
                             CatalogOp::CreateTrigger(_) => {}
+                            CatalogOp::DeleteTrigger(_) => {}
                             CatalogOp::EnableTrigger(_) => {}
                             CatalogOp::DisableTrigger(_) => {}
-                            CatalogOp::DeletePlugin(_) => {}
                         }
                     }
                 }


### PR DESCRIPTION
Closes #25697.

All of the new CLI commands are under the `processing-engine` subcommand, split further into `plugin` and `trigger` subcommands.