### PR TITLE
feat: remove required field restriction for tables

### DIFF
--- a/influxdb3/src/commands/manage/table.rs
+++ b/influxdb3/src/commands/manage/table.rs
@@ -33,7 +33,7 @@ pub struct CreateTableConfig {
     #[clap(long = "tags", required = true, num_args=0..)]
     tags: Vec<String>,
 
-    #[clap(short = 'f', long = "fields", value_parser = parse_key_val::<String, DataType>, required = true, num_args=0..)]
+    #[clap(short = 'f', long = "fields", value_parser = parse_key_val::<String, DataType>, num_args=0..)]
     fields: Vec<(String, DataType)>,
 
     #[clap(flatten)]

--- a/influxdb3/tests/server/configure.rs
+++ b/influxdb3/tests/server/configure.rs
@@ -1111,7 +1111,45 @@ async fn api_v3_configure_table_create_no_fields() {
         .send()
         .await
         .expect("create table call failed");
-    assert_eq!(StatusCode::UNPROCESSABLE_ENTITY, resp.status());
+    assert_eq!(StatusCode::OK, resp.status());
+    let result = server
+        .api_v3_query_sql(&[
+            ("db", "foo"),
+            ("q", "SELECT * FROM bar"),
+            ("format", "json"),
+        ])
+        .await
+        .json::<Value>()
+        .await
+        .unwrap();
+    assert_eq!(result, json!([]));
+    server
+        .write_lp_to_db(
+            "foo",
+            "bar,one=1,two=2 new_field=0 1000",
+            influxdb3_client::Precision::Second,
+        )
+        .await
+        .expect("write to db");
+    let result = server
+        .api_v3_query_sql(&[
+            ("db", "foo"),
+            ("q", "SELECT * FROM bar"),
+            ("format", "json"),
+        ])
+        .await
+        .json::<Value>()
+        .await
+        .unwrap();
+    assert_eq!(
+        result,
+        json!([{
+            "one": "1",
+            "two": "2",
+            "new_field": 0.0,
+            "time": "1970-01-01T00:16:40"
+        }])
+    );
 }
 
 #[test_log::test(tokio::test)]

--- a/influxdb3_server/src/http.rs
+++ b/influxdb3_server/src/http.rs
@@ -251,10 +251,6 @@ impl Error {
                 .status(StatusCode::BAD_REQUEST)
                 .body(Body::from(err.to_string()))
                 .unwrap(),
-            Self::WriteBuffer(err @ WriteBufferError::EmptyFields) => Response::builder()
-                .status(StatusCode::UNPROCESSABLE_ENTITY)
-                .body(Body::from(err.to_string()))
-                .unwrap(),
             Self::WriteBuffer(WriteBufferError::CatalogUpdateError(
                 err @ (CatalogError::TooManyDbs
                 | CatalogError::TooManyColumns

--- a/influxdb3_write/src/write_buffer/mod.rs
+++ b/influxdb3_write/src/write_buffer/mod.rs
@@ -102,10 +102,6 @@ pub enum Error {
     #[error("table not found {table_name:?} in db {db_name:?}")]
     TableNotFound { db_name: String, table_name: String },
 
-    // This error is exclusive to the table creation API
-    #[error("table creation failed due to no fields")]
-    EmptyFields,
-
     #[error("tried accessing database that does not exist")]
     DbDoesNotExist,
 
@@ -682,9 +678,6 @@ impl DatabaseManager for WriteBufferImpl {
         tags: Vec<String>,
         fields: Vec<(String, String)>,
     ) -> Result<(), self::Error> {
-        if fields.is_empty() {
-            return Err(self::Error::EmptyFields);
-        }
         let (db_id, db_schema) =
             self.catalog
                 .db_id_and_schema(&db)


### PR DESCRIPTION
This commit removes the required fields restriction when using the CLI or the API to create a new table. As users can't write via the line protocol without a field this is fine and the schema will be updated on write. This expands the test to check for the correct response code now and make sure that we can both query the empty table and write new data to it.

Closes #25735