### PR TITLE
feat: allow n/u for precision in v1/v2 write apis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -382,7 +382,7 @@ dependencies = [
 [[package]]
 name = "arrow_util"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64#db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=a5f6076c966f4940a67998e0b85d12c3e8596715#a5f6076c966f4940a67998e0b85d12c3e8596715"
 dependencies = [
  "ahash",
  "arrow",
@@ -468,18 +468,18 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.94",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.83"
+version = "0.1.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
+checksum = "1b1244b10dcd56c92219da4e14caa97e312079e185f04ba3eea25061561dc0a0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.94",
 ]
 
 [[package]]
@@ -500,7 +500,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 [[package]]
 name = "authz"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64#db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=a5f6076c966f4940a67998e0b85d12c3e8596715#a5f6076c966f4940a67998e0b85d12c3e8596715"
 dependencies = [
  "async-trait",
  "backoff",
@@ -544,7 +544,7 @@ dependencies = [
  "rustversion",
  "serde",
  "sync_wrapper 0.1.2",
- "tower",
+ "tower 0.4.13",
  "tower-layer",
  "tower-service",
 ]
@@ -569,7 +569,7 @@ dependencies = [
 [[package]]
 name = "backoff"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64#db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=a5f6076c966f4940a67998e0b85d12c3e8596715#a5f6076c966f4940a67998e0b85d12c3e8596715"
 dependencies = [
  "observability_deps",
  "rand",
@@ -653,7 +653,7 @@ checksum = "a539389a13af092cd345a2b47ae7dec12deb306d660b2223d25cd3419b253ebe"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.94",
 ]
 
 [[package]]
@@ -734,9 +734,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.11.1"
+version = "1.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "786a307d683a5bf92e6fd5fd69a7eb613751668d1d8d67d802846dfe367c62c8"
+checksum = "531a9155a481e2ee699d4f98f43c0ca4ff8ee1bfd55c31e9e98fb29d2b176fe0"
 dependencies = [
  "memchr",
  "regex-automata 0.4.9",
@@ -797,7 +797,7 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 [[package]]
 name = "catalog_cache"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64#db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=a5f6076c966f4940a67998e0b85d12c3e8596715#a5f6076c966f4940a67998e0b85d12c3e8596715"
 dependencies = [
  "bytes",
  "dashmap",
@@ -816,9 +816,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.5"
+version = "1.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31a0499c1dc64f458ad13872de75c0eb7e3fdb0e67964610c914b034fc5956e"
+checksum = "a012a0df96dd6d06ba9a1b29d6402d1a5d77c6befd2566afdc26e10603dc93d7"
 dependencies = [
  "jobserver",
  "libc",
@@ -913,7 +913,7 @@ dependencies = [
 [[package]]
 name = "clap_blocks"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64#db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=a5f6076c966f4940a67998e0b85d12c3e8596715#a5f6076c966f4940a67998e0b85d12c3e8596715"
 dependencies = [
  "async-trait",
  "clap",
@@ -931,7 +931,7 @@ dependencies = [
  "observability_deps",
  "paste",
  "snafu",
- "sysinfo 0.33.0",
+ "sysinfo 0.33.1",
  "tokio",
  "trace_exporters",
  "trogging",
@@ -960,7 +960,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.94",
 ]
 
 [[package]]
@@ -972,13 +972,13 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 [[package]]
 name = "client_util"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64#db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=a5f6076c966f4940a67998e0b85d12c3e8596715#a5f6076c966f4940a67998e0b85d12c3e8596715"
 dependencies = [
  "http 0.2.12",
  "reqwest 0.11.27",
  "thiserror 2.0.9",
  "tonic 0.11.0",
- "tower",
+ "tower 0.4.13",
  "workspace-hack",
 ]
 
@@ -1306,7 +1306,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.94",
 ]
 
 [[package]]
@@ -1330,7 +1330,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.91",
+ "syn 2.0.94",
 ]
 
 [[package]]
@@ -1341,7 +1341,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.94",
 ]
 
 [[package]]
@@ -1361,7 +1361,7 @@ dependencies = [
 [[package]]
 name = "data_types"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64#db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=a5f6076c966f4940a67998e0b85d12c3e8596715#a5f6076c966f4940a67998e0b85d12c3e8596715"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -1776,7 +1776,7 @@ dependencies = [
 [[package]]
 name = "datafusion_util"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64#db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=a5f6076c966f4940a67998e0b85d12c3e8596715#a5f6076c966f4940a67998e0b85d12c3e8596715"
 dependencies = [
  "async-trait",
  "datafusion",
@@ -1855,7 +1855,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.94",
 ]
 
 [[package]]
@@ -1964,7 +1964,7 @@ dependencies = [
 [[package]]
 name = "error_reporting"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64#db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=a5f6076c966f4940a67998e0b85d12c3e8596715#a5f6076c966f4940a67998e0b85d12c3e8596715"
 dependencies = [
  "workspace-hack",
 ]
@@ -1994,7 +1994,7 @@ dependencies = [
 [[package]]
 name = "executor"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64#db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=a5f6076c966f4940a67998e0b85d12c3e8596715#a5f6076c966f4940a67998e0b85d12c3e8596715"
 dependencies = [
  "futures",
  "metric",
@@ -2048,7 +2048,7 @@ dependencies = [
 [[package]]
 name = "flightsql"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64#db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=a5f6076c966f4940a67998e0b85d12c3e8596715#a5f6076c966f4940a67998e0b85d12c3e8596715"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -2171,7 +2171,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.94",
 ]
 
 [[package]]
@@ -2207,7 +2207,7 @@ dependencies = [
 [[package]]
 name = "generated_types"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64#db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=a5f6076c966f4940a67998e0b85d12c3e8596715#a5f6076c966f4940a67998e0b85d12c3e8596715"
 dependencies = [
  "observability_deps",
  "pbjson",
@@ -2261,9 +2261,9 @@ checksum = "dc46dd3ec48fdd8e693a98d2b8bafae273a2d54c1de02a2a7e3d57d501f39677"
 
 [[package]]
 name = "glob"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "h2"
@@ -2742,7 +2742,7 @@ checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.94",
 ]
 
 [[package]]
@@ -2803,7 +2803,7 @@ checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
 [[package]]
 name = "influxdb-line-protocol"
 version = "1.0.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64#db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=a5f6076c966f4940a67998e0b85d12c3e8596715#a5f6076c966f4940a67998e0b85d12c3e8596715"
 dependencies = [
  "bytes",
  "log",
@@ -2870,7 +2870,7 @@ dependencies = [
  "tokio-util",
  "tokio_metrics_bridge",
  "tonic 0.11.0",
- "tower",
+ "tower 0.4.13",
  "trace",
  "trace_exporters",
  "trace_http",
@@ -3098,7 +3098,7 @@ dependencies = [
  "tokio",
  "tokio-util",
  "tonic 0.11.0",
- "tower",
+ "tower 0.4.13",
  "trace",
  "trace_exporters",
  "trace_http",
@@ -3248,7 +3248,7 @@ dependencies = [
 [[package]]
 name = "influxdb_influxql_parser"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64#db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=a5f6076c966f4940a67998e0b85d12c3e8596715#a5f6076c966f4940a67998e0b85d12c3e8596715"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -3263,7 +3263,7 @@ dependencies = [
 [[package]]
 name = "influxdb_iox_client"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64#db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=a5f6076c966f4940a67998e0b85d12c3e8596715#a5f6076c966f4940a67998e0b85d12c3e8596715"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -3324,7 +3324,7 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 [[package]]
 name = "iox_catalog"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64#db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=a5f6076c966f4940a67998e0b85d12c3e8596715#a5f6076c966f4940a67998e0b85d12c3e8596715"
 dependencies = [
  "async-trait",
  "backoff",
@@ -3362,7 +3362,7 @@ dependencies = [
 [[package]]
 name = "iox_http"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64#db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=a5f6076c966f4940a67998e0b85d12c3e8596715#a5f6076c966f4940a67998e0b85d12c3e8596715"
 dependencies = [
  "async-trait",
  "authz",
@@ -3378,13 +3378,14 @@ dependencies = [
 [[package]]
 name = "iox_query"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64#db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=a5f6076c966f4940a67998e0b85d12c3e8596715#a5f6076c966f4940a67998e0b85d12c3e8596715"
 dependencies = [
  "arrow",
  "arrow_util",
  "async-trait",
  "bytes",
  "chrono",
+ "dashmap",
  "data_types",
  "datafusion",
  "datafusion_util",
@@ -3415,7 +3416,7 @@ dependencies = [
 [[package]]
 name = "iox_query_influxql"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64#db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=a5f6076c966f4940a67998e0b85d12c3e8596715#a5f6076c966f4940a67998e0b85d12c3e8596715"
 dependencies = [
  "arrow",
  "assert_matches",
@@ -3448,7 +3449,7 @@ dependencies = [
 [[package]]
 name = "iox_query_params"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64#db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=a5f6076c966f4940a67998e0b85d12c3e8596715#a5f6076c966f4940a67998e0b85d12c3e8596715"
 dependencies = [
  "arrow",
  "datafusion",
@@ -3463,7 +3464,7 @@ dependencies = [
 [[package]]
 name = "iox_system_tables"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64#db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=a5f6076c966f4940a67998e0b85d12c3e8596715#a5f6076c966f4940a67998e0b85d12c3e8596715"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3475,7 +3476,7 @@ dependencies = [
 [[package]]
 name = "iox_time"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64#db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=a5f6076c966f4940a67998e0b85d12c3e8596715#a5f6076c966f4940a67998e0b85d12c3e8596715"
 dependencies = [
  "chrono",
  "parking_lot",
@@ -3700,7 +3701,7 @@ checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 [[package]]
 name = "logfmt"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64#db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=a5f6076c966f4940a67998e0b85d12c3e8596715#a5f6076c966f4940a67998e0b85d12c3e8596715"
 dependencies = [
  "humantime",
  "observability_deps",
@@ -3771,7 +3772,7 @@ dependencies = [
 [[package]]
 name = "meta_data_cache"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64#db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=a5f6076c966f4940a67998e0b85d12c3e8596715#a5f6076c966f4940a67998e0b85d12c3e8596715"
 dependencies = [
  "arrow",
  "data_types",
@@ -3787,7 +3788,7 @@ dependencies = [
 [[package]]
 name = "metric"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64#db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=a5f6076c966f4940a67998e0b85d12c3e8596715#a5f6076c966f4940a67998e0b85d12c3e8596715"
 dependencies = [
  "parking_lot",
  "workspace-hack",
@@ -3796,7 +3797,7 @@ dependencies = [
 [[package]]
 name = "metric_exporters"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64#db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=a5f6076c966f4940a67998e0b85d12c3e8596715#a5f6076c966f4940a67998e0b85d12c3e8596715"
 dependencies = [
  "metric",
  "observability_deps",
@@ -3869,7 +3870,7 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.94",
 ]
 
 [[package]]
@@ -4095,7 +4096,7 @@ dependencies = [
  "percent-encoding",
  "quick-xml",
  "rand",
- "reqwest 0.12.9",
+ "reqwest 0.12.12",
  "ring",
  "rustls-pemfile 2.2.0",
  "serde",
@@ -4110,7 +4111,7 @@ dependencies = [
 [[package]]
 name = "object_store_mem_cache"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64#db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=a5f6076c966f4940a67998e0b85d12c3e8596715#a5f6076c966f4940a67998e0b85d12c3e8596715"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4122,7 +4123,6 @@ dependencies = [
  "metric",
  "object_store",
  "observability_deps",
- "paste",
  "tokio",
  "tracker",
  "workspace-hack",
@@ -4131,7 +4131,7 @@ dependencies = [
 [[package]]
 name = "observability_deps"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64#db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=a5f6076c966f4940a67998e0b85d12c3e8596715#a5f6076c966f4940a67998e0b85d12c3e8596715"
 dependencies = [
  "tracing",
  "workspace-hack",
@@ -4182,7 +4182,7 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 [[package]]
 name = "panic_logging"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64#db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=a5f6076c966f4940a67998e0b85d12c3e8596715#a5f6076c966f4940a67998e0b85d12c3e8596715"
 dependencies = [
  "metric",
  "observability_deps",
@@ -4256,7 +4256,7 @@ dependencies = [
 [[package]]
 name = "parquet_file"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64#db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=a5f6076c966f4940a67998e0b85d12c3e8596715#a5f6076c966f4940a67998e0b85d12c3e8596715"
 dependencies = [
  "arrow",
  "arrow_util",
@@ -4382,7 +4382,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.94",
 ]
 
 [[package]]
@@ -4461,7 +4461,7 @@ checksum = "3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.94",
 ]
 
 [[package]]
@@ -4555,7 +4555,7 @@ dependencies = [
 [[package]]
 name = "predicate"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64#db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=a5f6076c966f4940a67998e0b85d12c3e8596715#a5f6076c966f4940a67998e0b85d12c3e8596715"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4614,7 +4614,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64d1ec885c64d0457d564db4ec299b2dae3f9c02808b8ad9c3a089c591b18033"
 dependencies = [
  "proc-macro2",
- "syn 2.0.91",
+ "syn 2.0.94",
 ]
 
 [[package]]
@@ -4719,7 +4719,7 @@ dependencies = [
  "prost 0.12.6",
  "prost-types 0.12.6",
  "regex",
- "syn 2.0.91",
+ "syn 2.0.94",
  "tempfile",
 ]
 
@@ -4746,7 +4746,7 @@ dependencies = [
  "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.94",
 ]
 
 [[package]]
@@ -4759,7 +4759,7 @@ dependencies = [
  "itertools 0.13.0",
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.94",
 ]
 
 [[package]]
@@ -4827,7 +4827,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.94",
 ]
 
 [[package]]
@@ -4840,13 +4840,13 @@ dependencies = [
  "proc-macro2",
  "pyo3-build-config",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.94",
 ]
 
 [[package]]
 name = "query_functions"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64#db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=a5f6076c966f4940a67998e0b85d12c3e8596715#a5f6076c966f4940a67998e0b85d12c3e8596715"
 dependencies = [
  "arrow",
  "chrono",
@@ -4866,9 +4866,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
-version = "0.37.1"
+version = "0.37.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f22f29bdff3987b4d8632ef95fd6424ec7e4e0a57e2f4fc63e489e75357f6a03"
+checksum = "165859e9e55f79d67b96c5d96f4e88b6f2695a1972849c15a6a3f5c59fc2c003"
 dependencies = [
  "memchr",
  "serde",
@@ -4928,9 +4928,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
 ]
@@ -5093,9 +5093,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.9"
+version = "0.12.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a77c62af46e79de0a562e1a9849205ffcb7fc1238876e9bd743357570e04046f"
+checksum = "43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da"
 dependencies = [
  "async-compression",
  "base64 0.22.1",
@@ -5129,6 +5129,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.1",
  "tokio-util",
+ "tower 0.5.2",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -5336,9 +5337,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e819f2bc632f285be6d7cd36e25940d45b2391dd6d9b939e79de557f7014248"
+checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
 
 [[package]]
 name = "rusty-fork"
@@ -5379,7 +5380,7 @@ dependencies = [
 [[package]]
 name = "schema"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64#db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=a5f6076c966f4940a67998e0b85d12c3e8596715#a5f6076c966f4940a67998e0b85d12c3e8596715"
 dependencies = [
  "arrow",
  "hashbrown 0.14.5",
@@ -5464,22 +5465,22 @@ checksum = "a3f0bf26fd526d2a95683cd0f87bf103b8539e2ca1ef48ce002d67aad59aa0b4"
 
 [[package]]
 name = "serde"
-version = "1.0.216"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b9781016e935a97e8beecf0c933758c97a5520d32930e460142b4cd80c6338e"
+checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.216"
+version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46f859dbbf73865c6627ed570e78961cd3ac92407a2d117204c49232485da55e"
+checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.94",
 ]
 
 [[package]]
@@ -5508,9 +5509,9 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.11.0"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e28bdad6db2b8340e449f7108f020b3b092e8583a9e3fb82713e1d4e71fe817"
+checksum = "d6b6f7f2fcb69f747921f79f3926bd1e203fce4fef62c268dd3abfb6d86029aa"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -5526,20 +5527,20 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.11.0"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d846214a9854ef724f3da161b426242d8de7c1fc7de2f89bb1efcb154dca79d"
+checksum = "8d00caa5193a3c8362ac2b73be6b9e768aa5a4b2f721d8f4b339600c3cb51f8e"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.94",
 ]
 
 [[package]]
 name = "service_common"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64#db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=a5f6076c966f4940a67998e0b85d12c3e8596715#a5f6076c966f4940a67998e0b85d12c3e8596715"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -5553,7 +5554,7 @@ dependencies = [
 [[package]]
 name = "service_grpc_flight"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64#db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=a5f6076c966f4940a67998e0b85d12c3e8596715#a5f6076c966f4940a67998e0b85d12c3e8596715"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -5694,7 +5695,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.94",
 ]
 
 [[package]]
@@ -5760,7 +5761,7 @@ checksum = "01b2e185515564f15375f593fb966b5718bc624ba77fe49fa4616ad619690554"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.94",
 ]
 
 [[package]]
@@ -5822,7 +5823,7 @@ dependencies = [
 [[package]]
 name = "sqlx-hotswap-pool"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64#db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=a5f6076c966f4940a67998e0b85d12c3e8596715#a5f6076c966f4940a67998e0b85d12c3e8596715"
 dependencies = [
  "either",
  "futures",
@@ -5840,7 +5841,7 @@ dependencies = [
  "quote",
  "sqlx-core",
  "sqlx-macros-core",
- "syn 2.0.91",
+ "syn 2.0.94",
 ]
 
 [[package]]
@@ -5863,7 +5864,7 @@ dependencies = [
  "sqlx-mysql",
  "sqlx-postgres",
  "sqlx-sqlite",
- "syn 2.0.91",
+ "syn 2.0.94",
  "tempfile",
  "tokio",
  "url",
@@ -6023,7 +6024,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.91",
+ "syn 2.0.94",
 ]
 
 [[package]]
@@ -6045,9 +6046,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.91"
+version = "2.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53cbcb5a243bd33b7858b1d7f4aca2153490815872d86d955d6ea29f743c035"
+checksum = "987bc0be1cdea8b10216bd06e2ca407d40b9543468fafd3ddfb02f36e77f71f3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6077,7 +6078,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.94",
 ]
 
 [[package]]
@@ -6097,9 +6098,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.33.0"
+version = "0.33.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "948512566b1895f93b1592c7574baeb2de842f224f2aab158799ecadb8ebbb46"
+checksum = "4fc858248ea01b66f19d8e8a6d55f41deaf91e9d495246fd01368d99935c6c01"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -6138,12 +6139,13 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tempfile"
-version = "3.14.0"
+version = "3.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c"
+checksum = "9a8a559c81686f576e8cd0290cd2a24a2a9ad80c98b3478856500fcbd7acd704"
 dependencies = [
  "cfg-if",
  "fastrand",
+ "getrandom",
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
@@ -6174,13 +6176,13 @@ checksum = "5999e24eaa32083191ba4e425deb75cdf25efefabe5aaccb7446dd0d4122a3f5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.94",
 ]
 
 [[package]]
 name = "test_helpers"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64#db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=a5f6076c966f4940a67998e0b85d12c3e8596715#a5f6076c966f4940a67998e0b85d12c3e8596715"
 dependencies = [
  "async-trait",
  "dotenvy",
@@ -6223,7 +6225,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.94",
 ]
 
 [[package]]
@@ -6234,7 +6236,7 @@ checksum = "7b50fa271071aae2e6ee85f842e2e28ba8cd2c5fb67f11fcb1fd70b276f9e7d4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.94",
 ]
 
 [[package]]
@@ -6412,7 +6414,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.94",
 ]
 
 [[package]]
@@ -6486,7 +6488,7 @@ dependencies = [
 [[package]]
 name = "tokio_metrics_bridge"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64#db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=a5f6076c966f4940a67998e0b85d12c3e8596715#a5f6076c966f4940a67998e0b85d12c3e8596715"
 dependencies = [
  "metric",
  "parking_lot",
@@ -6497,7 +6499,7 @@ dependencies = [
 [[package]]
 name = "tokio_watchdog"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64#db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=a5f6076c966f4940a67998e0b85d12c3e8596715#a5f6076c966f4940a67998e0b85d12c3e8596715"
 dependencies = [
  "metric",
  "observability_deps",
@@ -6527,7 +6529,7 @@ dependencies = [
  "prost 0.11.9",
  "tokio",
  "tokio-stream",
- "tower",
+ "tower 0.4.13",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -6558,7 +6560,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.25.0",
  "tokio-stream",
- "tower",
+ "tower 0.4.13",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -6574,7 +6576,7 @@ dependencies = [
  "proc-macro2",
  "prost-build",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.94",
 ]
 
 [[package]]
@@ -6611,6 +6613,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper 1.0.2",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "tower-layer"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6625,21 +6642,21 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 [[package]]
 name = "tower_trailer"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64#db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=a5f6076c966f4940a67998e0b85d12c3e8596715#a5f6076c966f4940a67998e0b85d12c3e8596715"
 dependencies = [
  "futures",
  "http 0.2.12",
  "http-body 0.4.6",
  "parking_lot",
  "pin-project",
- "tower",
+ "tower 0.4.13",
  "workspace-hack",
 ]
 
 [[package]]
 name = "trace"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64#db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=a5f6076c966f4940a67998e0b85d12c3e8596715#a5f6076c966f4940a67998e0b85d12c3e8596715"
 dependencies = [
  "chrono",
  "observability_deps",
@@ -6651,7 +6668,7 @@ dependencies = [
 [[package]]
 name = "trace_exporters"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64#db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=a5f6076c966f4940a67998e0b85d12c3e8596715#a5f6076c966f4940a67998e0b85d12c3e8596715"
 dependencies = [
  "async-trait",
  "clap",
@@ -6669,7 +6686,7 @@ dependencies = [
 [[package]]
 name = "trace_http"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64#db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=a5f6076c966f4940a67998e0b85d12c3e8596715#a5f6076c966f4940a67998e0b85d12c3e8596715"
 dependencies = [
  "bytes",
  "futures",
@@ -6682,7 +6699,7 @@ dependencies = [
  "parking_lot",
  "pin-project",
  "snafu",
- "tower",
+ "tower 0.4.13",
  "trace",
  "workspace-hack",
 ]
@@ -6707,7 +6724,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.94",
 ]
 
 [[package]]
@@ -6766,7 +6783,7 @@ dependencies = [
 [[package]]
 name = "tracker"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64#db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=a5f6076c966f4940a67998e0b85d12c3e8596715#a5f6076c966f4940a67998e0b85d12c3e8596715"
 dependencies = [
  "futures",
  "hashbrown 0.14.5",
@@ -6776,7 +6793,7 @@ dependencies = [
  "observability_deps",
  "parking_lot",
  "pin-project",
- "sysinfo 0.33.0",
+ "sysinfo 0.33.1",
  "tokio",
  "tokio-util",
  "trace",
@@ -6786,7 +6803,7 @@ dependencies = [
 [[package]]
 name = "trogging"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64#db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=a5f6076c966f4940a67998e0b85d12c3e8596715#a5f6076c966f4940a67998e0b85d12c3e8596715"
 dependencies = [
  "clap",
  "logfmt",
@@ -6832,9 +6849,9 @@ checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
 name = "unicase"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e51b68083f157f853b6379db119d1c1be0e6e4dec98101079dec41f6f5cf6df"
+checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
 name = "unicode-bidi"
@@ -7017,7 +7034,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.94",
  "wasm-bindgen-shared",
 ]
 
@@ -7052,7 +7069,7 @@ checksum = "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.94",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -7201,7 +7218,7 @@ checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.94",
 ]
 
 [[package]]
@@ -7212,7 +7229,7 @@ checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.94",
 ]
 
 [[package]]
@@ -7415,7 +7432,7 @@ dependencies = [
 [[package]]
 name = "workspace-hack"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64#db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=a5f6076c966f4940a67998e0b85d12c3e8596715#a5f6076c966f4940a67998e0b85d12c3e8596715"
 dependencies = [
  "ahash",
  "arrayvec",
@@ -7483,7 +7500,7 @@ dependencies = [
  "regex-automata 0.4.9",
  "regex-syntax 0.8.5",
  "reqwest 0.11.27",
- "reqwest 0.12.9",
+ "reqwest 0.12.12",
  "ring",
  "rustls 0.23.20",
  "serde",
@@ -7503,14 +7520,14 @@ dependencies = [
  "sqlx-sqlite",
  "strum",
  "subtle",
- "syn 2.0.91",
+ "syn 2.0.94",
  "thrift",
  "tokio",
  "tokio-metrics",
  "tokio-rustls 0.26.1",
  "tokio-stream",
  "tokio-util",
- "tower",
+ "tower 0.4.13",
  "tracing",
  "tracing-core",
  "tracing-log",
@@ -7576,7 +7593,7 @@ checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.94",
  "synstructure",
 ]
 
@@ -7598,7 +7615,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.94",
 ]
 
 [[package]]
@@ -7618,7 +7635,7 @@ checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.94",
  "synstructure",
 ]
 
@@ -7639,7 +7656,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.94",
 ]
 
 [[package]]
@@ -7661,7 +7678,7 @@ checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.91",
+ "syn 2.0.94",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,37 +124,37 @@ uuid = { version = "1", features = ["v4"] }
 num = { version = "0.4.3" }
 
 # Core.git crates we depend on
-arrow_util = { git = "https://github.com/influxdata/influxdb3_core", rev = "db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64" }
-authz = { git = "https://github.com/influxdata/influxdb3_core", rev = "db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64" }
-clap_blocks = { git = "https://github.com/influxdata/influxdb3_core", rev = "db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64" }
-data_types = { git = "https://github.com/influxdata/influxdb3_core", rev = "db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64" }
-datafusion_util = { git = "https://github.com/influxdata/influxdb3_core", rev = "db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64" }
-executor = { git = "https://github.com/influxdata/influxdb3_core", rev = "db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64" }
-influxdb-line-protocol = { git = "https://github.com/influxdata/influxdb3_core", rev = "db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64", features = ["v3"]}
-influxdb_influxql_parser = { git = "https://github.com/influxdata/influxdb3_core", rev = "db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64" }
-influxdb_iox_client = { git = "https://github.com/influxdata/influxdb3_core", rev = "db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64" }
-iox_catalog = { git = "https://github.com/influxdata/influxdb3_core", rev = "db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64" }
-iox_http = { git = "https://github.com/influxdata/influxdb3_core", rev = "db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64" }
-iox_query = { git = "https://github.com/influxdata/influxdb3_core", rev = "db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64" }
-iox_query_params = { git = "https://github.com/influxdata/influxdb3_core", rev = "db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64" }
-iox_query_influxql = { git = "https://github.com/influxdata/influxdb3_core", rev = "db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64" }
-iox_system_tables = { git = "https://github.com/influxdata/influxdb3_core", rev = "db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64" }
-iox_time = { git = "https://github.com/influxdata/influxdb3_core", rev = "db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64" }
-metric = { git = "https://github.com/influxdata/influxdb3_core", rev = "db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64" }
-metric_exporters = { git = "https://github.com/influxdata/influxdb3_core", rev = "db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64" }
-observability_deps = { git = "https://github.com/influxdata/influxdb3_core", rev = "db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64" }
-panic_logging = { git = "https://github.com/influxdata/influxdb3_core", rev = "db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64" }
-parquet_file = { git = "https://github.com/influxdata/influxdb3_core", rev = "db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64" }
-schema = { git = "https://github.com/influxdata/influxdb3_core", rev = "db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64", features = ["v3"]  }
-service_common = { git = "https://github.com/influxdata/influxdb3_core", rev = "db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64" }
-service_grpc_flight = { git = "https://github.com/influxdata/influxdb3_core", rev = "db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64" }
-test_helpers = { git = "https://github.com/influxdata/influxdb3_core", rev = "db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64" }
-tokio_metrics_bridge = { git = "https://github.com/influxdata/influxdb3_core", rev = "db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64" }
-trace = { git = "https://github.com/influxdata/influxdb3_core", rev = "db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64" }
-trace_exporters = { git = "https://github.com/influxdata/influxdb3_core", rev = "db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64" }
-trace_http = { git = "https://github.com/influxdata/influxdb3_core", rev = "db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64" }
-tracker = { git = "https://github.com/influxdata/influxdb3_core", rev = "db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64" }
-trogging = { git = "https://github.com/influxdata/influxdb3_core", rev = "db48a4f721086ffdb65b8c6b5d7d1bcbf61b5c64" }
+arrow_util = { git = "https://github.com/influxdata/influxdb3_core", rev = "a5f6076c966f4940a67998e0b85d12c3e8596715" }
+authz = { git = "https://github.com/influxdata/influxdb3_core", rev = "a5f6076c966f4940a67998e0b85d12c3e8596715" }
+clap_blocks = { git = "https://github.com/influxdata/influxdb3_core", rev = "a5f6076c966f4940a67998e0b85d12c3e8596715" }
+data_types = { git = "https://github.com/influxdata/influxdb3_core", rev = "a5f6076c966f4940a67998e0b85d12c3e8596715" }
+datafusion_util = { git = "https://github.com/influxdata/influxdb3_core", rev = "a5f6076c966f4940a67998e0b85d12c3e8596715" }
+executor = { git = "https://github.com/influxdata/influxdb3_core", rev = "a5f6076c966f4940a67998e0b85d12c3e8596715" }
+influxdb-line-protocol = { git = "https://github.com/influxdata/influxdb3_core", rev = "a5f6076c966f4940a67998e0b85d12c3e8596715", features = ["v3"]}
+influxdb_influxql_parser = { git = "https://github.com/influxdata/influxdb3_core", rev = "a5f6076c966f4940a67998e0b85d12c3e8596715" }
+influxdb_iox_client = { git = "https://github.com/influxdata/influxdb3_core", rev = "a5f6076c966f4940a67998e0b85d12c3e8596715" }
+iox_catalog = { git = "https://github.com/influxdata/influxdb3_core", rev = "a5f6076c966f4940a67998e0b85d12c3e8596715" }
+iox_http = { git = "https://github.com/influxdata/influxdb3_core", rev = "a5f6076c966f4940a67998e0b85d12c3e8596715" }
+iox_query = { git = "https://github.com/influxdata/influxdb3_core", rev = "a5f6076c966f4940a67998e0b85d12c3e8596715" }
+iox_query_params = { git = "https://github.com/influxdata/influxdb3_core", rev = "a5f6076c966f4940a67998e0b85d12c3e8596715" }
+iox_query_influxql = { git = "https://github.com/influxdata/influxdb3_core", rev = "a5f6076c966f4940a67998e0b85d12c3e8596715" }
+iox_system_tables = { git = "https://github.com/influxdata/influxdb3_core", rev = "a5f6076c966f4940a67998e0b85d12c3e8596715" }
+iox_time = { git = "https://github.com/influxdata/influxdb3_core", rev = "a5f6076c966f4940a67998e0b85d12c3e8596715" }
+metric = { git = "https://github.com/influxdata/influxdb3_core", rev = "a5f6076c966f4940a67998e0b85d12c3e8596715" }
+metric_exporters = { git = "https://github.com/influxdata/influxdb3_core", rev = "a5f6076c966f4940a67998e0b85d12c3e8596715" }
+observability_deps = { git = "https://github.com/influxdata/influxdb3_core", rev = "a5f6076c966f4940a67998e0b85d12c3e8596715" }
+panic_logging = { git = "https://github.com/influxdata/influxdb3_core", rev = "a5f6076c966f4940a67998e0b85d12c3e8596715" }
+parquet_file = { git = "https://github.com/influxdata/influxdb3_core", rev = "a5f6076c966f4940a67998e0b85d12c3e8596715" }
+schema = { git = "https://github.com/influxdata/influxdb3_core", rev = "a5f6076c966f4940a67998e0b85d12c3e8596715", features = ["v3"]  }
+service_common = { git = "https://github.com/influxdata/influxdb3_core", rev = "a5f6076c966f4940a67998e0b85d12c3e8596715" }
+service_grpc_flight = { git = "https://github.com/influxdata/influxdb3_core", rev = "a5f6076c966f4940a67998e0b85d12c3e8596715" }
+test_helpers = { git = "https://github.com/influxdata/influxdb3_core", rev = "a5f6076c966f4940a67998e0b85d12c3e8596715" }
+tokio_metrics_bridge = { git = "https://github.com/influxdata/influxdb3_core", rev = "a5f6076c966f4940a67998e0b85d12c3e8596715" }
+trace = { git = "https://github.com/influxdata/influxdb3_core", rev = "a5f6076c966f4940a67998e0b85d12c3e8596715" }
+trace_exporters = { git = "https://github.com/influxdata/influxdb3_core", rev = "a5f6076c966f4940a67998e0b85d12c3e8596715" }
+trace_http = { git = "https://github.com/influxdata/influxdb3_core", rev = "a5f6076c966f4940a67998e0b85d12c3e8596715" }
+tracker = { git = "https://github.com/influxdata/influxdb3_core", rev = "a5f6076c966f4940a67998e0b85d12c3e8596715" }
+trogging = { git = "https://github.com/influxdata/influxdb3_core", rev = "a5f6076c966f4940a67998e0b85d12c3e8596715" }
 
 [workspace.lints.rust]
 missing_copy_implementations = "deny"

--- a/influxdb3/tests/server/write.rs
+++ b/influxdb3/tests/server/write.rs
@@ -46,8 +46,20 @@ async fn api_v1_write_request_parsing() {
         },
         TestCase {
             db: Some("foo"),
+            precision: Some("u"),
+            rp: Some("autogen"),
+            expected: StatusCode::NO_CONTENT,
+        },
+        TestCase {
+            db: Some("foo"),
             precision: Some("us"),
             rp: None,
+            expected: StatusCode::NO_CONTENT,
+        },
+        TestCase {
+            db: Some("foo"),
+            precision: Some("n"),
+            rp: Some("autogen"),
             expected: StatusCode::NO_CONTENT,
         },
         TestCase {
@@ -198,6 +210,18 @@ async fn api_v2_write_request_parsing() {
             org: None,
             bucket: Some("foo"),
             precision: Some("us"),
+            expected: StatusCode::NO_CONTENT,
+        },
+        TestCase {
+            org: None,
+            bucket: Some("foo"),
+            precision: Some("u"),
+            expected: StatusCode::NO_CONTENT,
+        },
+        TestCase {
+            org: None,
+            bucket: Some("foo"),
+            precision: Some("n"),
             expected: StatusCode::NO_CONTENT,
         },
         TestCase {


### PR DESCRIPTION
Prior to this change we would deny writes that used n and u for the precision argument when doing writes. We only accepted ns and us for those apis. However, to be backwards compatible we would need to enable accepting writes with n and u. This is mostly just upgrading our deps as this was a change that landed in IOx first. We test that it works for our code by adding test cases for their precision in this repo.

Closes #25734