### PR TITLE
test: do not pass TEST_LOG to log filter in e2e tests

### DIFF
--- a/influxdb3/tests/server/main.rs
+++ b/influxdb3/tests/server/main.rs
@@ -134,10 +134,10 @@ impl TestServer {
             .args(config.as_args())
             .stdout(Stdio::piped());
 
-        // If TEST_LOG env var is not defined, discard stdout/stderr, otherwise, pass it to the
-        // inner binary in the "LOG_FILTER" env var:
-        let emit_logs = if let Ok(val) = std::env::var("TEST_LOG") {
-            command.env("LOG_FILTER", if val.is_empty() { "info" } else { &val });
+        // Use the TEST_LOG env var to determine if logs are emitted from the spawned process
+        let emit_logs = if std::env::var("TEST_LOG").is_ok() {
+            // use "info" filter, as would be used in production:
+            command.env("LOG_FILTER", "info");
             true
         } else {
             false


### PR DESCRIPTION
Closes #25760

This changes the E2E tests so that the `TEST_LOG` env var does not pass its value forward to the log filter on the running process. We need the process to use an `info` log filter so that the server's local address can be scraped from the logs (see https://github.com/influxdata/influxdb/pull/25758).