### PR TITLE
feat: Add query API to Python plugins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -473,9 +473,9 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.84"
+version = "0.1.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1244b10dcd56c92219da4e14caa97e312079e185f04ba3eea25061561dc0a0"
+checksum = "3f934833b4b7233644e5848f235df3f57ed8c80f1528a26c3dfa13d2147fa056"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2911,6 +2911,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "influxdb3_internal_api"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "datafusion",
+ "iox_query",
+ "iox_query_params",
+ "thiserror 1.0.69",
+ "trace",
+ "trace_http",
+ "tracker",
+]
+
+[[package]]
 name = "influxdb3_load_generator"
 version = "0.1.0"
 dependencies = [
@@ -2954,12 +2968,17 @@ dependencies = [
 name = "influxdb3_py_api"
 version = "0.1.0"
 dependencies = [
- "async-trait",
+ "arrow-array",
+ "arrow-schema",
+ "futures",
  "influxdb3_catalog",
+ "influxdb3_internal_api",
  "influxdb3_wal",
+ "iox_query_params",
  "parking_lot",
  "pyo3",
  "schema",
+ "tokio",
 ]
 
 [[package]]
@@ -2993,6 +3012,7 @@ dependencies = [
  "influxdb3_catalog",
  "influxdb3_client",
  "influxdb3_id",
+ "influxdb3_internal_api",
  "influxdb3_process",
  "influxdb3_sys_events",
  "influxdb3_telemetry",
@@ -3149,6 +3169,7 @@ dependencies = [
  "influxdb3_catalog",
  "influxdb3_client",
  "influxdb3_id",
+ "influxdb3_internal_api",
  "influxdb3_py_api",
  "influxdb3_telemetry",
  "influxdb3_test_helpers",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "influxdb3_clap_blocks",
     "influxdb3_client",
     "influxdb3_id",
+    "influxdb3_internal_api",
     "influxdb3_load_generator",
     "influxdb3_process",
     "influxdb3_py_api",

--- a/influxdb3/tests/server/cli.rs
+++ b/influxdb3/tests/server/cli.rs
@@ -849,3 +849,105 @@ async fn meta_cache_create_and_delete() {
 
     insta::assert_yaml_snapshot!(result);
 }
+
+#[cfg(feature = "system-py")]
+#[test_log::test(tokio::test)]
+async fn test_wal_plugin_test() {
+    use crate::ConfigProvider;
+    use influxdb3_client::Precision;
+
+    // Create plugin file
+    let plugin_file = create_plugin_file(
+        r#"
+def process_writes(influxdb3_local, table_batches, args=None):
+    influxdb3_local.info("arg1: " + args["arg1"])
+
+    query_params = {"host": args["host"]}
+    query_result = influxdb3_local.query_rows("SELECT * FROM cpu where host = $host", query_params)
+    influxdb3_local.info("query result: " + str(query_result))
+
+    for table_batch in table_batches:
+        influxdb3_local.info("table: " + table_batch["table_name"])
+
+        for row in table_batch["rows"]:
+            influxdb3_local.info("row: " + str(row))
+
+    line = LineBuilder("some_table")\
+        .tag("tag1", "tag1_value")\
+        .tag("tag2", "tag2_value")\
+        .int64_field("field1", 1)\
+        .float64_field("field2", 2.0)\
+        .string_field("field3", "number three")
+    influxdb3_local.write(line)
+
+    other_line = LineBuilder("other_table")
+    other_line.int64_field("other_field", 1)
+    other_line.float64_field("other_field2", 3.14)
+    other_line.time_ns(1302)
+
+    influxdb3_local.write_to_db("mytestdb", other_line)
+
+    influxdb3_local.info("done")"#,
+    );
+
+    let plugin_dir = plugin_file.path().parent().unwrap().to_str().unwrap();
+    let plugin_name = plugin_file.path().file_name().unwrap().to_str().unwrap();
+
+    let server = TestServer::configure()
+        .with_plugin_dir(plugin_dir)
+        .spawn()
+        .await;
+    let server_addr = server.client_addr();
+
+    server
+        .write_lp_to_db(
+            "foo",
+            "cpu,host=s1,region=us-east usage=0.9 1\n\
+            cpu,host=s2,region=us-east usage=0.89 2\n\
+            cpu,host=s1,region=us-east usage=0.85 3",
+            Precision::Nanosecond,
+        )
+        .await
+        .unwrap();
+
+    let db_name = "foo";
+
+    // Run the test
+    let result = run_with_confirmation(&[
+        "test",
+        "wal_plugin",
+        "--database",
+        db_name,
+        "--host",
+        &server_addr,
+        "--lp",
+        "test_input,tag1=tag1_value,tag2=tag2_value field1=1i 500",
+        "--input-arguments",
+        "arg1=arg1_value,host=s2",
+        plugin_name,
+    ]);
+    debug!(result = ?result, "test wal plugin");
+
+    let res = serde_json::from_str::<serde_json::Value>(&result).unwrap();
+
+    let expected_result = r#"{
+  "log_lines": [
+    "INFO: arg1: arg1_value",
+    "INFO: query result: [{'host': 's2', 'region': 'us-east', 'time': 2, 'usage': 0.89}]",
+    "INFO: table: test_input",
+    "INFO: row: {'tag1': 'tag1_value', 'tag2': 'tag2_value', 'field1': 1, 'time': 500}",
+    "INFO: done"
+  ],
+  "database_writes": {
+    "mytestdb": [
+      "other_table other_field=1i,other_field2=3.14 1302"
+    ],
+    "foo": [
+      "some_table,tag1=tag1_value,tag2=tag2_value field1=1i,field2=2.0,field3=\"number three\""
+    ]
+  },
+  "errors": []
+}"#;
+    let expected_result = serde_json::from_str::<serde_json::Value>(expected_result).unwrap();
+    assert_eq!(res, expected_result);
+}

--- a/influxdb3/tests/server/main.rs
+++ b/influxdb3/tests/server/main.rs
@@ -48,6 +48,7 @@ trait ConfigProvider {
 pub struct TestConfig {
     auth_token: Option<(String, String)>,
     host_id: Option<String>,
+    plugin_dir: Option<String>,
 }
 
 impl TestConfig {
@@ -66,6 +67,12 @@ impl TestConfig {
         self.host_id = Some(host_id.into());
         self
     }
+
+    /// Set the plugin dir for this [`TestServer`]
+    pub fn with_plugin_dir<S: Into<String>>(mut self, plugin_dir: S) -> Self {
+        self.plugin_dir = Some(plugin_dir.into());
+        self
+    }
 }
 
 impl ConfigProvider for TestConfig {
@@ -73,6 +80,9 @@ impl ConfigProvider for TestConfig {
         let mut args = vec![];
         if let Some((token, _)) = &self.auth_token {
             args.append(&mut vec!["--bearer-token".to_string(), token.to_owned()]);
+        }
+        if let Some(plugin_dir) = &self.plugin_dir {
+            args.append(&mut vec!["--plugin-dir".to_string(), plugin_dir.to_owned()]);
         }
         args.push("--host-id".to_string());
         if let Some(host) = &self.host_id {

--- a/influxdb3_client/src/plugin_development.rs
+++ b/influxdb3_client/src/plugin_development.rs
@@ -6,9 +6,9 @@ use std::collections::HashMap;
 /// Request definition for `POST /api/v3/plugin_test/wal` API
 #[derive(Debug, Serialize, Deserialize)]
 pub struct WalPluginTestRequest {
-    pub name: String,
-    pub input_lp: Option<String>,
-    pub input_file: Option<String>,
+    pub filename: String,
+    pub database: String,
+    pub input_lp: String,
     pub input_arguments: Option<HashMap<String, String>>,
 }
 

--- a/influxdb3_internal_api/Cargo.toml
+++ b/influxdb3_internal_api/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "influxdb3_internal_api"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+# Core Crates
+iox_query.workspace = true
+iox_query_params.workspace = true
+trace.workspace = true
+trace_http.workspace = true
+tracker.workspace = true
+
+# Local Crates
+
+# Crates.io dependencies
+async-trait.workspace = true
+datafusion.workspace = true
+thiserror.workspace = true
+
+[lints]
+workspace = true

--- a/influxdb3_internal_api/src/lib.rs
+++ b/influxdb3_internal_api/src/lib.rs
@@ -1,0 +1,4 @@
+//! This crate contains the internal API for use across the crates in this code base, mainly
+//! to get around circular dependency issues.
+
+pub mod query_executor;

--- a/influxdb3_internal_api/src/query_executor.rs
+++ b/influxdb3_internal_api/src/query_executor.rs
@@ -1,0 +1,134 @@
+use async_trait::async_trait;
+use datafusion::arrow::error::ArrowError;
+use datafusion::common::DataFusionError;
+use datafusion::execution::SendableRecordBatchStream;
+use iox_query::query_log::QueryLogEntries;
+use iox_query::{QueryDatabase, QueryNamespace};
+use iox_query_params::StatementParams;
+use std::fmt::Debug;
+use std::sync::Arc;
+use trace::ctx::SpanContext;
+use trace::span::Span;
+use trace_http::ctx::RequestLogContext;
+use tracker::InstrumentedAsyncOwnedSemaphorePermit;
+
+#[derive(Debug, thiserror::Error)]
+pub enum QueryExecutorError {
+    #[error("database not found: {db_name}")]
+    DatabaseNotFound { db_name: String },
+    #[error("error while planning query: {0}")]
+    QueryPlanning(#[source] DataFusionError),
+    #[error("error while executing plan: {0}")]
+    ExecuteStream(#[source] DataFusionError),
+    #[error("unable to compose record batches from databases: {0}")]
+    DatabasesToRecordBatch(#[source] ArrowError),
+    #[error("unable to compose record batches from retention policies: {0}")]
+    RetentionPoliciesToRecordBatch(#[source] ArrowError),
+}
+
+#[async_trait]
+pub trait QueryExecutor: QueryDatabase + Debug + Send + Sync + 'static {
+    async fn query(
+        &self,
+        database: &str,
+        q: &str,
+        params: Option<StatementParams>,
+        kind: QueryKind,
+        span_ctx: Option<SpanContext>,
+        external_span_ctx: Option<RequestLogContext>,
+    ) -> Result<SendableRecordBatchStream, QueryExecutorError>;
+
+    fn show_databases(
+        &self,
+        include_deleted: bool,
+    ) -> Result<SendableRecordBatchStream, QueryExecutorError>;
+
+    async fn show_retention_policies(
+        &self,
+        database: Option<&str>,
+        span_ctx: Option<SpanContext>,
+    ) -> Result<SendableRecordBatchStream, QueryExecutorError>;
+
+    fn upcast(&self) -> Arc<(dyn QueryDatabase + 'static)>;
+}
+
+#[derive(Debug, Clone, Copy)]
+pub enum QueryKind {
+    Sql,
+    InfluxQl,
+}
+
+impl QueryKind {
+    pub fn query_type(&self) -> &'static str {
+        match self {
+            Self::Sql => "sql",
+            Self::InfluxQl => "influxql",
+        }
+    }
+}
+
+#[derive(Debug, Copy, Clone)]
+pub struct UnimplementedQueryExecutor;
+
+#[async_trait]
+impl QueryDatabase for UnimplementedQueryExecutor {
+    async fn namespace(
+        &self,
+        _name: &str,
+        _span: Option<Span>,
+        _include_debug_info_tables: bool,
+    ) -> Result<Option<Arc<dyn QueryNamespace>>, DataFusionError> {
+        unimplemented!()
+    }
+
+    async fn acquire_semaphore(
+        &self,
+        _span: Option<Span>,
+    ) -> InstrumentedAsyncOwnedSemaphorePermit {
+        unimplemented!()
+    }
+
+    fn query_log(&self) -> QueryLogEntries {
+        unimplemented!()
+    }
+}
+
+#[async_trait]
+impl QueryExecutor for UnimplementedQueryExecutor {
+    async fn query(
+        &self,
+        _database: &str,
+        _q: &str,
+        _params: Option<StatementParams>,
+        _kind: QueryKind,
+        _span_ctx: Option<SpanContext>,
+        _external_span_ctx: Option<RequestLogContext>,
+    ) -> Result<SendableRecordBatchStream, QueryExecutorError> {
+        Err(QueryExecutorError::DatabaseNotFound {
+            db_name: "unimplemented".to_string(),
+        })
+    }
+
+    fn show_databases(
+        &self,
+        _include_deleted: bool,
+    ) -> Result<SendableRecordBatchStream, QueryExecutorError> {
+        Err(QueryExecutorError::DatabaseNotFound {
+            db_name: "unimplemented".to_string(),
+        })
+    }
+
+    async fn show_retention_policies(
+        &self,
+        _database: Option<&str>,
+        _span_ctx: Option<SpanContext>,
+    ) -> Result<SendableRecordBatchStream, QueryExecutorError> {
+        Err(QueryExecutorError::DatabaseNotFound {
+            db_name: "unimplemented".to_string(),
+        })
+    }
+
+    fn upcast(&self) -> Arc<(dyn QueryDatabase + 'static)> {
+        Arc::new(UnimplementedQueryExecutor) as _
+    }
+}

--- a/influxdb3_py_api/Cargo.toml
+++ b/influxdb3_py_api/Cargo.toml
@@ -5,20 +5,25 @@ authors.workspace = true
 edition.workspace = true
 license.workspace = true
 
-
 [features]
 system-py = ["pyo3"]
+
 [dependencies]
+arrow-array.workspace = true
+arrow-schema.workspace = true
 influxdb3_wal = { path = "../influxdb3_wal" }
 influxdb3_catalog = {path = "../influxdb3_catalog"}
-async-trait.workspace = true
+influxdb3_internal_api = { path = "../influxdb3_internal_api" }
+iox_query_params.workspace = true
 schema.workspace = true
 parking_lot.workspace = true
+futures.workspace = true
+tokio.workspace = true
 
 [dependencies.pyo3]
 version = "0.23.3"
 # this is necessary to automatically initialize the Python interpreter
-features = ["auto-initialize"]
+features = ["auto-initialize", "experimental-async"]
 optional = true
 
 

--- a/influxdb3_server/Cargo.toml
+++ b/influxdb3_server/Cargo.toml
@@ -34,6 +34,7 @@ influxdb3_cache = { path = "../influxdb3_cache" }
 influxdb3_catalog = { path = "../influxdb3_catalog" }
 influxdb3_client = { path = "../influxdb3_client" }
 influxdb3_id = { path = "../influxdb3_id" }
+influxdb3_internal_api = { path = "../influxdb3_internal_api" }
 influxdb3_process = { path = "../influxdb3_process", default-features = false }
 influxdb3_wal = { path = "../influxdb3_wal"}
 influxdb3_write = { path = "../influxdb3_write" }

--- a/influxdb3_server/src/builder.rs
+++ b/influxdb3_server/src/builder.rs
@@ -1,13 +1,10 @@
 use std::sync::Arc;
 
+use crate::{auth::DefaultAuthorizer, http::HttpApi, CommonServerState, Server};
 use authz::Authorizer;
+use influxdb3_internal_api::query_executor::QueryExecutor;
 use influxdb3_write::{persister::Persister, WriteBuffer};
 use tokio::net::TcpListener;
-
-use crate::{
-    auth::DefaultAuthorizer, http::HttpApi, query_executor, CommonServerState, QueryExecutor,
-    Server,
-};
 
 #[derive(Debug)]
 pub struct ServerBuilder<W, Q, P, T, L> {
@@ -55,7 +52,7 @@ pub struct WithWriteBuf(Arc<dyn WriteBuffer>);
 #[derive(Debug)]
 pub struct NoQueryExec;
 #[derive(Debug)]
-pub struct WithQueryExec(Arc<dyn QueryExecutor<Error = query_executor::Error>>);
+pub struct WithQueryExec(Arc<dyn QueryExecutor>);
 #[derive(Debug)]
 pub struct NoPersister;
 #[derive(Debug)]
@@ -87,7 +84,7 @@ impl<Q, P, T, L> ServerBuilder<NoWriteBuf, Q, P, T, L> {
 impl<W, P, T, L> ServerBuilder<W, NoQueryExec, P, T, L> {
     pub fn query_executor(
         self,
-        qe: Arc<dyn QueryExecutor<Error = query_executor::Error>>,
+        qe: Arc<dyn QueryExecutor>,
     ) -> ServerBuilder<W, WithQueryExec, P, T, L> {
         ServerBuilder {
             common_state: self.common_state,

--- a/influxdb3_server/src/grpc.rs
+++ b/influxdb3_server/src/grpc.rs
@@ -4,11 +4,10 @@ use arrow_flight::flight_service_server::{
     FlightService as Flight, FlightServiceServer as FlightServer,
 };
 use authz::Authorizer;
-
-use crate::{query_executor, QueryExecutor};
+use influxdb3_internal_api::query_executor::QueryExecutor;
 
 pub(crate) fn make_flight_server(
-    server: Arc<dyn QueryExecutor<Error = query_executor::Error>>,
+    server: Arc<dyn QueryExecutor>,
     authz: Option<Arc<dyn Authorizer>>,
 ) -> FlightServer<impl Flight> {
     let query_db = server.upcast();

--- a/influxdb3_server/src/query_executor/mod.rs
+++ b/influxdb3_server/src/query_executor/mod.rs
@@ -1,12 +1,10 @@
 //! module for query executor
 use crate::system_tables::{SystemSchemaProvider, SYSTEM_SCHEMA_NAME};
 use crate::{query_planner::Planner, system_tables::AllSystemSchemaTablesProvider};
-use crate::{QueryExecutor, QueryKind};
 use arrow::array::{ArrayRef, Int64Builder, StringBuilder, StructArray};
 use arrow::datatypes::SchemaRef;
 use arrow::record_batch::RecordBatch;
 use arrow_array::{Array, BooleanArray};
-use arrow_schema::ArrowError;
 use async_trait::async_trait;
 use data_types::NamespaceId;
 use datafusion::catalog::{CatalogProvider, SchemaProvider, Session};
@@ -23,6 +21,7 @@ use datafusion_util::MemoryStream;
 use influxdb3_cache::last_cache::{LastCacheFunction, LAST_CACHE_UDTF_NAME};
 use influxdb3_cache::meta_cache::{MetaCacheFunction, META_CACHE_UDTF_NAME};
 use influxdb3_catalog::catalog::{Catalog, DatabaseSchema};
+use influxdb3_internal_api::query_executor::{QueryExecutor, QueryExecutorError, QueryKind};
 use influxdb3_sys_events::SysEventStore;
 use influxdb3_telemetry::store::TelemetryStore;
 use influxdb3_write::WriteBuffer;
@@ -114,8 +113,6 @@ impl QueryExecutorImpl {
 
 #[async_trait]
 impl QueryExecutor for QueryExecutorImpl {
-    type Error = Error;
-
     async fn query(
         &self,
         database: &str,
@@ -124,15 +121,15 @@ impl QueryExecutor for QueryExecutorImpl {
         kind: QueryKind,
         span_ctx: Option<SpanContext>,
         external_span_ctx: Option<RequestLogContext>,
-    ) -> Result<SendableRecordBatchStream, Self::Error> {
+    ) -> Result<SendableRecordBatchStream, QueryExecutorError> {
         info!(%database, %query, ?params, ?kind, "QueryExecutorImpl as QueryExecutor::query");
         let db = self
             .namespace(database, span_ctx.child_span("get database"), false)
             .await
-            .map_err(|_| Error::DatabaseNotFound {
+            .map_err(|_| QueryExecutorError::DatabaseNotFound {
                 db_name: database.to_string(),
             })?
-            .ok_or_else(|| Error::DatabaseNotFound {
+            .ok_or_else(|| QueryExecutorError::DatabaseNotFound {
                 db_name: database.to_string(),
             })?;
 
@@ -161,7 +158,7 @@ impl QueryExecutor for QueryExecutorImpl {
             })
             .await;
 
-        let plan = match plan.map_err(Error::QueryPlanning) {
+        let plan = match plan.map_err(QueryExecutorError::QueryPlanning) {
             Ok(plan) => plan,
             Err(e) => {
                 token.fail();
@@ -182,7 +179,7 @@ impl QueryExecutor for QueryExecutorImpl {
             }
             Err(err) => {
                 token.fail();
-                Err(Error::ExecuteStream(err))
+                Err(QueryExecutorError::ExecuteStream(err))
             }
         }
     }
@@ -190,7 +187,7 @@ impl QueryExecutor for QueryExecutorImpl {
     fn show_databases(
         &self,
         include_deleted: bool,
-    ) -> Result<SendableRecordBatchStream, Self::Error> {
+    ) -> Result<SendableRecordBatchStream, QueryExecutorError> {
         let mut databases = self.catalog.list_db_schema();
         // sort them to ensure consistent order, first by deleted, then by name:
         databases.sort_unstable_by(|a, b| match a.deleted.cmp(&b.deleted) {
@@ -222,7 +219,7 @@ impl QueryExecutor for QueryExecutorImpl {
         }
         let schema = DatafusionSchema::new(fields);
         let batch = RecordBatch::try_new(Arc::new(schema), arrays)
-            .map_err(Error::DatabasesToRecordBatch)?;
+            .map_err(QueryExecutorError::DatabasesToRecordBatch)?;
         Ok(Box::pin(MemoryStream::new(vec![batch])))
     }
 
@@ -230,7 +227,7 @@ impl QueryExecutor for QueryExecutorImpl {
         &self,
         database: Option<&str>,
         span_ctx: Option<SpanContext>,
-    ) -> Result<SendableRecordBatchStream, Self::Error> {
+    ) -> Result<SendableRecordBatchStream, QueryExecutorError> {
         let mut databases = if let Some(db) = database {
             vec![db.to_owned()]
         } else {
@@ -244,10 +241,10 @@ impl QueryExecutor for QueryExecutorImpl {
             let db = self
                 .namespace(&database, span_ctx.child_span("get database"), false)
                 .await
-                .map_err(|_| Error::DatabaseNotFound {
+                .map_err(|_| QueryExecutorError::DatabaseNotFound {
                     db_name: database.to_string(),
                 })?
-                .ok_or_else(|| Error::DatabaseNotFound {
+                .ok_or_else(|| QueryExecutorError::DatabaseNotFound {
                     db_name: database.to_string(),
                 })?;
             let duration = db.retention_time_ns();
@@ -337,20 +334,6 @@ fn split_database_name(db_name: &str) -> (String, String) {
     )
 }
 
-#[derive(Debug, thiserror::Error)]
-pub enum Error {
-    #[error("database not found: {db_name}")]
-    DatabaseNotFound { db_name: String },
-    #[error("error while planning query: {0}")]
-    QueryPlanning(#[source] DataFusionError),
-    #[error("error while executing plan: {0}")]
-    ExecuteStream(#[source] DataFusionError),
-    #[error("unable to compose record batches from databases: {0}")]
-    DatabasesToRecordBatch(#[source] ArrowError),
-    #[error("unable to compose record batches from retention policies: {0}")]
-    RetentionPoliciesToRecordBatch(#[source] ArrowError),
-}
-
 // This implementation is for the Flight service
 #[async_trait]
 impl QueryDatabase for QueryExecutorImpl {
@@ -364,7 +347,7 @@ impl QueryDatabase for QueryExecutorImpl {
         let _span_recorder = SpanRecorder::new(span);
 
         let db_schema = self.catalog.db_schema(name).ok_or_else(|| {
-            DataFusionError::External(Box::new(Error::DatabaseNotFound {
+            DataFusionError::External(Box::new(QueryExecutorError::DatabaseNotFound {
                 db_name: name.into(),
             }))
         })?;
@@ -647,6 +630,7 @@ impl TableProvider for QueryTable {
 mod tests {
     use std::{num::NonZeroUsize, sync::Arc, time::Duration};
 
+    use crate::query_executor::QueryExecutorImpl;
     use arrow::array::RecordBatch;
     use data_types::NamespaceName;
     use datafusion::assert_batches_sorted_eq;
@@ -656,6 +640,7 @@ mod tests {
         parquet_cache::test_cached_obj_store_and_oracle,
     };
     use influxdb3_catalog::catalog::Catalog;
+    use influxdb3_internal_api::query_executor::{QueryExecutor, QueryKind};
     use influxdb3_sys_events::SysEventStore;
     use influxdb3_telemetry::store::TelemetryStore;
     use influxdb3_wal::{Gen1Duration, WalConfig};
@@ -669,8 +654,6 @@ mod tests {
     use metric::Registry;
     use object_store::{local::LocalFileSystem, ObjectStore};
     use parquet_file::storage::{ParquetStorage, StorageId};
-
-    use crate::{query_executor::QueryExecutorImpl, QueryExecutor};
 
     use super::CreateQueryExecutorArgs;
 
@@ -860,7 +843,7 @@ mod tests {
 
         for t in test_cases {
             let batch_stream = query_executor
-                .query(db_name, t.query, None, crate::QueryKind::Sql, None, None)
+                .query(db_name, t.query, None, QueryKind::Sql, None, None)
                 .await
                 .unwrap();
             let batches: Vec<RecordBatch> = batch_stream.try_collect().await.unwrap();

--- a/influxdb3_write/Cargo.toml
+++ b/influxdb3_write/Cargo.toml
@@ -28,6 +28,7 @@ influxdb3_cache = { path = "../influxdb3_cache" }
 influxdb3_catalog = { path = "../influxdb3_catalog" }
 influxdb3_client = { path = "../influxdb3_client" }
 influxdb3_id = { path = "../influxdb3_id" }
+influxdb3_internal_api = { path = "../influxdb3_internal_api" }
 influxdb3_test_helpers = { path = "../influxdb3_test_helpers" }
 influxdb3_wal = { path = "../influxdb3_wal" }
 influxdb3_telemetry = { path = "../influxdb3_telemetry" }


### PR DESCRIPTION
This ended up being a couple things rolled into one. In order to add a query API to the Python plugin, I had to pull the QueryExecutor trait out of server into a place so that the python crate could use it.

This implements the query API, but also fixes up the WAL plugin test CLI a bit. I've added a test in the CLI section so that it shows end-to-end operation of the WAL plugin test API and exercise of the entire Plugin API.

Closes #25757