### PR TITLE
feat: check mem and force snapshot

### DIFF
--- a/influxdb3/src/commands/serve.rs
+++ b/influxdb3/src/commands/serve.rs
@@ -28,7 +28,10 @@ use influxdb3_telemetry::store::TelemetryStore;
 use influxdb3_wal::{Gen1Duration, WalConfig};
 use influxdb3_write::{
     persister::Persister,
-    write_buffer::{persisted_files::PersistedFiles, WriteBufferImpl, WriteBufferImplArgs},
+    write_buffer::{
+        check_mem_and_force_snapshot_loop, persisted_files::PersistedFiles, WriteBufferImpl,
+        WriteBufferImplArgs,
+    },
     WriteBuffer,
 };
 use iox_query::exec::{DedicatedExecutor, Executor, ExecutorConfig};
@@ -37,7 +40,7 @@ use object_store::ObjectStore;
 use observability_deps::tracing::*;
 use panic_logging::SendPanicsToTracing;
 use parquet_file::storage::{ParquetStorage, StorageId};
-use std::{num::NonZeroUsize, sync::Arc};
+use std::{num::NonZeroUsize, sync::Arc, time::Duration};
 use std::{
     path::{Path, PathBuf},
     str::FromStr,
@@ -295,6 +298,16 @@ pub struct Config {
     /// The local directory that has python plugins and their test files.
     #[clap(long = "plugin-dir", env = "INFLUXDB3_PLUGIN_DIR", action)]
     pub plugin_dir: Option<PathBuf>,
+
+    /// Threshold for internal buffer, can be either percentage or absolute value.
+    /// eg: 70% or 100000
+    #[clap(
+        long = "force-snapshot-mem-threshold",
+        env = "INFLUXDB3_FORCE_SNAPSHOT_MEM_THRESHOLD",
+        default_value = "70%",
+        action
+    )]
+    pub force_snapshot_mem_threshold: MemorySize,
 }
 
 /// Specified size of the Parquet cache in megabytes (MB)
@@ -495,6 +508,14 @@ pub async fn command(config: Config) -> Result<()> {
     .await
     .map_err(|e| Error::WriteBufferInit(e.into()))?;
 
+    info!("setting up background mem check for query buffer");
+    background_buffer_checker(
+        config.force_snapshot_mem_threshold.bytes(),
+        &write_buffer_impl,
+    )
+    .await;
+
+    info!("setting up telemetry store");
     let telemetry_store = setup_telemetry_store(
         &config.object_store_config,
         catalog.instance_id(),
@@ -575,4 +596,17 @@ async fn setup_telemetry_store(
         telemetry_endpoint,
     )
     .await
+}
+
+async fn background_buffer_checker(
+    mem_threshold_bytes: usize,
+    write_buffer_impl: &Arc<WriteBufferImpl>,
+) {
+    debug!(mem_threshold_bytes, "setting up background buffer checker");
+    check_mem_and_force_snapshot_loop(
+        Arc::clone(write_buffer_impl),
+        mem_threshold_bytes,
+        Duration::from_secs(10),
+    )
+    .await;
 }

--- a/influxdb3_wal/src/lib.rs
+++ b/influxdb3_wal/src/lib.rs
@@ -891,10 +891,6 @@ impl WalContents {
     pub fn is_empty(&self) -> bool {
         self.ops.is_empty() && self.snapshot.is_none()
     }
-
-    pub fn has_only_no_op(&self) -> bool {
-        self.ops.len() == 1 && matches!(self.ops.first().unwrap(), WalOp::Noop(_))
-    }
 }
 
 #[derive(

--- a/influxdb3_write/src/write_buffer/queryable_buffer.rs
+++ b/influxdb3_write/src/write_buffer/queryable_buffer.rs
@@ -432,6 +432,11 @@ impl QueryableBuffer {
             }
         }
     }
+
+    pub fn get_total_size_bytes(&self) -> usize {
+        let buffer = self.buffer.read();
+        buffer.find_overall_buffer_size_bytes()
+    }
 }
 
 #[async_trait]
@@ -600,6 +605,16 @@ impl BufferState {
                 table_buffer.buffer_chunk(chunk_time, chunk.rows);
             }
         }
+    }
+
+    pub fn find_overall_buffer_size_bytes(&self) -> usize {
+        let mut total = 0;
+        for (_, all_tables) in &self.db_to_table {
+            for (_, table_buffer) in all_tables {
+                total += table_buffer.computed_size();
+            }
+        }
+        total
     }
 }
 


### PR DESCRIPTION
This commit allows checking memory in the background and force snapshotting if query buffer size is > mem threshold. This hooks into the function (`force_flush_buffer`) to achieve it.

closes: https://github.com/influxdata/influxdb/issues/25685
