### PR TITLE
feat(processing_engine): standalone python dependency

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,10 @@
+[env]
+PYO3_PYTHON = { value = "python_embedded/python/bin/python3", relative = true }
+PYTHONHOME = { value = "python_embedded/python", relative = true }
+# TODO: figure out how to make the python version tunable. 
+# Would like to avoid manual editing of this file.
+PYTHONPATH = { value = "python_embedded/python/lib/python3.12", relative = true }
+
 [build]
 # enable tokio-console and some other goodies
 rustflags = [

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,6 +78,14 @@ commands:
             rustup show
             cargo fmt --version
             cargo clippy --version
+  install_python:
+    description: Install Python
+    steps:
+      - run:
+          name: Install Python
+          command: |
+            apt-get update
+            apt-get install -y python3 python3-dev
   gcloud-docker-login:
     steps:
       - run:
@@ -197,6 +205,7 @@ jobs:
     steps:
       - checkout
       - rust_components
+      - install_python
       - run:
           name: cargo nextest
           command: TEST_LOG= RUST_LOG=info RUST_LOG_SPAN_EVENTS=full RUST_BACKTRACE=1 cargo nextest run --workspace --failure-output immediate-final --no-fail-fast
@@ -225,11 +234,14 @@ jobs:
       # The `2xlarge` resource class that we use has 32GB RAM but also 16 CPUs. This means we have 2GB RAM per core on
       # avarage. At peak this is a bit tight, so lower the CPU count for cargo a bit.
       CARGO_BUILD_JOBS: "12"
+      # for cross compilation we need to specify the python version
+      PYO3_CROSS_PYTHON_VERSION: "3.11"
     parameters:
       target:
         type: string
     steps:
       - checkout
+      - install_python
       - run:
           name: Install Target
           command: rustup target add << parameters.target >>

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ perf.svg
 perf.txt
 valgrind-out.txt
 *.pending-snap
+python_embedded/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2016,21 +2016,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
 
 [[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
-
-[[package]]
 name = "form_urlencoded"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2527,22 +2512,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper 1.5.2",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
-]
-
-[[package]]
 name = "hyper-util"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3002,7 +2971,7 @@ dependencies = [
  "log",
  "parking_lot",
  "pyo3",
- "reqwest 0.12.12",
+ "reqwest 0.11.27",
  "schema",
  "tar",
 ]
@@ -3899,23 +3868,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9252111cf132ba0929b6f8e030cac2a24b507f3a4d6db6fb2896f27b354c714b"
 
 [[package]]
-name = "native-tls"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework 2.11.1",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4157,48 +4109,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
 
 [[package]]
-name = "openssl"
-version = "0.10.68"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6174bc48f102d208783c2c84bf931bb75927a617866870de8a4ea85597f871f5"
-dependencies = [
- "bitflags 2.6.0",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.95",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.104"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45abf306cbf99debc8195b66b7346498d7b10c210de50418b5ccd7ceba08c741"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "ordered-float"
@@ -5122,7 +5036,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 0.1.2",
- "system-configuration 0.5.1",
+ "system-configuration",
  "tokio",
  "tokio-rustls 0.24.1",
  "tokio-util",
@@ -5145,8 +5059,6 @@ dependencies = [
  "async-compression",
  "base64 0.22.1",
  "bytes",
- "encoding_rs",
- "futures-channel",
  "futures-core",
  "futures-util",
  "h2 0.4.7",
@@ -5155,14 +5067,12 @@ dependencies = [
  "http-body-util",
  "hyper 1.5.2",
  "hyper-rustls 0.27.5",
- "hyper-tls",
  "hyper-util",
  "ipnet",
  "js-sys",
  "log",
  "mime",
  "mime_guess",
- "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -5175,9 +5085,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 1.0.2",
- "system-configuration 0.6.1",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls 0.26.1",
  "tokio-util",
  "tower 0.5.2",
@@ -6169,18 +6077,7 @@ checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation 0.9.4",
- "system-configuration-sys 0.5.0",
-]
-
-[[package]]
-name = "system-configuration"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
-dependencies = [
- "bitflags 2.6.0",
- "core-foundation 0.9.4",
- "system-configuration-sys 0.6.0",
+ "system-configuration-sys",
 ]
 
 [[package]]
@@ -6188,16 +6085,6 @@ name = "system-configuration-sys"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -6510,16 +6397,6 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-stream",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1934,6 +1934,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "filetime"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35c0522e981e68cbfa8c3f978441a5f34b30b96e146b33cd3359176b50fe8586"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "fixedbitset"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2002,6 +2014,21 @@ name = "foldhash"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -2500,6 +2527,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper 1.5.2",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2952,12 +2995,16 @@ dependencies = [
 name = "influxdb3_py_api"
 version = "0.1.0"
 dependencies = [
- "async-trait",
+ "anyhow",
+ "flate2",
  "influxdb3_catalog",
  "influxdb3_wal",
+ "log",
  "parking_lot",
  "pyo3",
+ "reqwest 0.12.12",
  "schema",
+ "tar",
 ]
 
 [[package]]
@@ -3586,6 +3633,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
 
 [[package]]
+name = "libredox"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
+dependencies = [
+ "bitflags 2.6.0",
+ "libc",
+ "redox_syscall",
+]
+
+[[package]]
 name = "libsqlite3-sys"
 version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3841,6 +3899,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9252111cf132ba0929b6f8e030cac2a24b507f3a4d6db6fb2896f27b354c714b"
 
 [[package]]
+name = "native-tls"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework 2.11.1",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4082,10 +4157,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
 
 [[package]]
+name = "openssl"
+version = "0.10.68"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6174bc48f102d208783c2c84bf931bb75927a617866870de8a4ea85597f871f5"
+dependencies = [
+ "bitflags 2.6.0",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.95",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45abf306cbf99debc8195b66b7346498d7b10c210de50418b5ccd7ceba08c741"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "ordered-float"
@@ -5009,7 +5122,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 0.1.2",
- "system-configuration",
+ "system-configuration 0.5.1",
  "tokio",
  "tokio-rustls 0.24.1",
  "tokio-util",
@@ -5032,6 +5145,8 @@ dependencies = [
  "async-compression",
  "base64 0.22.1",
  "bytes",
+ "encoding_rs",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "h2 0.4.7",
@@ -5040,12 +5155,14 @@ dependencies = [
  "http-body-util",
  "hyper 1.5.2",
  "hyper-rustls 0.27.5",
+ "hyper-tls",
  "hyper-util",
  "ipnet",
  "js-sys",
  "log",
  "mime",
  "mime_guess",
+ "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -5058,7 +5175,9 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 1.0.2",
+ "system-configuration 0.6.1",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls 0.26.1",
  "tokio-util",
  "tower 0.5.2",
@@ -6050,7 +6169,18 @@ checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation 0.9.4",
- "system-configuration-sys",
+ "system-configuration-sys 0.5.0",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+dependencies = [
+ "bitflags 2.6.0",
+ "core-foundation 0.9.4",
+ "system-configuration-sys 0.6.0",
 ]
 
 [[package]]
@@ -6061,6 +6191,27 @@ checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c65998313f8e17d0d553d28f91a0df93e4dbbbf770279c7bc21ca0f09ea1a1f6"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -6359,6 +6510,16 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-stream",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]
@@ -7489,6 +7650,17 @@ name = "writeable"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+
+[[package]]
+name = "xattr"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e105d177a3871454f754b33bb0ee637ecaaac997446375fd3e5d43a2ed00c909"
+dependencies = [
+ "libc",
+ "linux-raw-sys",
+ "rustix",
+]
 
 [[package]]
 name = "xz2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,7 +99,7 @@ prost-build = "0.12.6"
 prost-types = "0.12.6"
 proptest = { version = "1", default-features = false, features = ["std"] }
 rand = "0.8.5"
-reqwest = { version = "0.11.27", default-features = false, features = ["rustls-tls", "stream", "json"] }
+reqwest = { version = "0.11.27", default-features = false, features = ["rustls-tls", "stream", "json", "blocking"] }
 secrecy = "0.8.0"
 serde = { version = "1.0", features = ["derive"] }
 # serde_json is set to 1.0.127 to prevent a conflict with core, if that gets updated upstream, this

--- a/influxdb3_py_api/Cargo.toml
+++ b/influxdb3_py_api/Cargo.toml
@@ -5,22 +5,34 @@ authors.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[lib]
+name = "influxdb3_py_api"
+crate-type = ["cdylib", "rlib"]
 
 [features]
 system-py = ["pyo3"]
 [dependencies]
 influxdb3_wal = { path = "../influxdb3_wal" }
 influxdb3_catalog = {path = "../influxdb3_catalog"}
-async-trait.workspace = true
 schema.workspace = true
 parking_lot.workspace = true
+anyhow = "1.0.95"
+reqwest = { version = "0.12", features = ["blocking"] }
+flate2 = "1.0.35"
+tar = "0.4.43"
+log = "0.4.22"
+
 
 [dependencies.pyo3]
 version = "0.23.3"
-# this is necessary to automatically initialize the Python interpreter
-features = ["auto-initialize"]
+features = ["extension-module"]
 optional = true
 
 
+[build-dependencies]
+anyhow = "1.0"
+reqwest = { version = "0.12", features = ["blocking"] }
+flate2 = "1.0"
+tar = "0.4"
 [lints]
 workspace = true

--- a/influxdb3_py_api/Cargo.toml
+++ b/influxdb3_py_api/Cargo.toml
@@ -17,7 +17,7 @@ influxdb3_catalog = {path = "../influxdb3_catalog"}
 schema.workspace = true
 parking_lot.workspace = true
 anyhow = "1.0.95"
-reqwest = { version = "0.12", features = ["blocking"] }
+reqwest.workspace = true
 flate2 = "1.0.35"
 tar = "0.4.43"
 log = "0.4.22"
@@ -31,7 +31,7 @@ optional = true
 
 [build-dependencies]
 anyhow = "1.0"
-reqwest = { version = "0.12", features = ["blocking"] }
+reqwest.workspace =  true
 flate2 = "1.0"
 tar = "0.4"
 [lints]

--- a/influxdb3_py_api/build.rs
+++ b/influxdb3_py_api/build.rs
@@ -1,0 +1,118 @@
+use anyhow::{Context, Result};
+use std::env;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+fn main() -> Result<()> {
+    // Read configuration from environment or use defaults
+    let python_version = env::var("PYTHON_VERSION").unwrap_or_else(|_| "3.12.8".to_string());
+    let release_date = env::var("PYTHON_RELEASE_DATE").unwrap_or_else(|_| "20250106".to_string());
+    let major_minor = python_version
+        .split('.')
+        .take(2)
+        .collect::<Vec<_>>()
+        .join(".");
+
+    // Get target platform info
+    let target_os = env::var("CARGO_CFG_TARGET_OS")?;
+    let target_arch = env::var("CARGO_CFG_TARGET_ARCH")?;
+
+    // Get the manifest directory and set up paths
+    let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR")?);
+    let python_dir = manifest_dir.join("../python_embedded/python");
+    let python_lib_dir = python_dir.join("lib");
+
+    // Part 1: Download and install Python if needed
+    if !python_dir.join("bin").exists() || env::var("FORCE_PYTHON_DOWNLOAD").is_ok() {
+        let url = get_python_url(&python_version, &release_date, &target_os, &target_arch)?;
+        println!("cargo:warning=Python download URL: {}", url);
+        download_python(&url, &python_dir)?;
+    }
+
+    // Part 2: Set up linking configuration
+    println!(
+        "cargo:rustc-link-search=native={}",
+        python_lib_dir.display()
+    );
+
+    match target_os.as_str() {
+        "macos" => {
+            println!("cargo:rustc-link-lib=python{}", major_minor);
+            println!("cargo:rustc-link-lib=dylib=python{}", major_minor);
+
+            let config_dir = python_lib_dir.join(format!(
+                "python{}/config-{}-darwin",
+                major_minor, major_minor
+            ));
+            println!("cargo:rustc-link-search=native={}", config_dir.display());
+
+            println!(
+                "cargo:rustc-link-arg=-Wl,-rpath,@loader_path/../../python_embedded/python/lib"
+            );
+        }
+        "linux" => {
+            println!("cargo:rustc-link-lib=python{}", major_minor);
+            println!("cargo:rustc-link-arg=-Wl,-rpath,$ORIGIN/../../python_embedded/python/lib");
+        }
+        "windows" => {
+            println!("cargo:rustc-link-lib=python{}", major_minor);
+            // TODO: Windows linking
+        }
+        _ => anyhow::bail!("Unsupported platform: {}", target_os),
+    }
+
+    // Make sure we rebuild if relevant environment variables change
+    println!("cargo:rerun-if-env-changed=PYTHON_VERSION");
+    println!("cargo:rerun-if-env-changed=PYTHON_RELEASE_DATE");
+    println!("cargo:rerun-if-env-changed=FORCE_PYTHON_DOWNLOAD");
+
+    Ok(())
+}
+
+fn get_python_url(version: &str, date: &str, os: &str, arch: &str) -> Result<String> {
+    let (arch_str, os_str, platform_str) = match (os, arch) {
+        ("macos", "aarch64") => ("aarch64", "apple", "darwin"),
+        ("macos", "x86_64") => ("x86_64", "apple", "darwin"),
+        ("linux", "aarch64") => ("aarch64", "unknown", "linux-gnu"),
+        ("linux", "x86_64") => ("x86_64", "unknown", "linux-gnu"),
+        ("windows", "x86_64") => ("x86_64", "pc", "windows-msvc"),
+        ("windows", "x86") => ("x86", "pc", "windows-msvc"),
+        _ => anyhow::bail!("Unsupported platform: {}-{}", os, arch),
+    };
+
+    Ok(format!(
+        "https://github.com/astral-sh/python-build-standalone/releases/download/{}/cpython-{}+{}-{}-{}-{}-install_only.tar.gz",
+        date, version, date, arch_str, os_str, platform_str
+    ))
+}
+
+fn download_python(url: &str, target_dir: &Path) -> Result<()> {
+    println!(
+        "cargo:warning=Downloading Python to {}",
+        target_dir.display()
+    );
+
+    // Download the archive
+    let response =
+        reqwest::blocking::get(url).with_context(|| format!("Failed to download from {}", url))?;
+    let archive_bytes = response.bytes()?;
+
+    // Extract the archive
+    let tar_gz = flate2::read::GzDecoder::new(&archive_bytes[..]);
+    let mut archive = tar::Archive::new(tar_gz);
+    archive.unpack(target_dir.parent().unwrap())?;
+
+    // Fix permissions on Unix systems
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let python_bin = target_dir.join("bin/python3");
+        if python_bin.exists() {
+            let mut perms = fs::metadata(&python_bin)?.permissions();
+            perms.set_mode(0o755);
+            fs::set_permissions(&python_bin, perms)?;
+        }
+    }
+
+    Ok(())
+}

--- a/influxdb3_py_api/build.rs
+++ b/influxdb3_py_api/build.rs
@@ -55,9 +55,16 @@ fn main() -> Result<()> {
             println!("cargo:rustc-link-arg=-Wl,-rpath,$ORIGIN/../../python_embedded/python/lib");
         }
         "windows" => {
+            // On Windows, we need both the import library and the DLL
             println!("cargo:rustc-link-lib=python{}", major_minor);
-            // TODO: Windows linking
-        }
+
+            // Add the Python DLL directory to the DLL search path
+            println!("cargo:rustc-link-arg=/LIBPATH:{}", python_lib_dir.display());
+
+            // Ensure the DLL can be found at runtime relative to the executable
+            // Using delayload allows the DLL to be loaded at runtime from our custom path
+            println!("cargo:rustc-link-arg=/DELAYLOAD:python{}.dll", major_minor);
+        },
         _ => anyhow::bail!("Unsupported platform: {}", target_os),
     }
 

--- a/influxdb3_server/Cargo.toml
+++ b/influxdb3_server/Cargo.toml
@@ -78,8 +78,6 @@ unicode-segmentation.workspace = true
 
 [dependencies.pyo3]
 version = "0.23.3"
-# this is necessary to automatically initialize the Python interpreter
-features = ["auto-initialize"]
 optional = true
 
 [features]

--- a/influxdb3_write/Cargo.toml
+++ b/influxdb3_write/Cargo.toml
@@ -65,8 +65,6 @@ uuid.workspace = true
 
 [dependencies.pyo3]
 version = "0.23.3"
-# this is necessary to automatically initialize the Python interpreter
-features = ["auto-initialize"]
 optional = true
 
 [dev-dependencies]


### PR DESCRIPTION
downloads a local copy of python from python-standalone-build, routes dependencies to it.


This is where I've landed. Haven't had a chance to test it on other architectures yet. I'd say it currently "mostly works". More specifically, running the following on an arm64 Mac should work:
* Run `cargo build` without the system-py feature. This should create a folder `python_embedded/` that contains a recent version of python3.12.
* Run `cargo build  --profile quick-release  --features system-py`. This should trigger a build of pyo3 that finds your newly installed python. I spent a while trying to have the dependencies ordered in some way but am stumped.
* Set the linker path with `export DYLD_LIBRARY_PATH="$PWD/python_embedded/python/lib"` before you run the server. Otherwise you'll get a `Library not loaded: /install/lib/libpython3.12.dylib` error.
* Install any dependencies to the embedded python by directly calling pip, e.g. `./python_embedded/python/bin/pip install influxdb3-python`.
* Run your server, create plugins, everything should work. I was able to test with a plugin that tagged the line protocol with the python version to ensure it wasn't using the system python.

Things I'd like to improve
* Build other architectures.
* Automatically support other python versions. Right now the minor version is hard-coded in .cargo/config.toml.
* Eliminate the system-py feature flag. I mainly left it in because without it I couldn't run the build.rs to install python before pyo3 is compiled.
* Add support for virtualenvs.
* Add support for managing python dependencies.