### PR TITLE
fix: get create token subcommand to work again 

### DIFF
--- a/influxdb3/src/commands/create.rs
+++ b/influxdb3/src/commands/create.rs
@@ -81,7 +81,9 @@ impl Config {
                 }
                 Ok(client)
             }
-            SubCommand::Token => unreachable!(),
+            // We don't need a client for this, so we're just creating a
+            // placeholder client
+            SubCommand::Token => Ok(Client::new("http://localhost")?),
         }
     }
 }
@@ -375,7 +377,7 @@ pub async fn command(config: Config) -> Result<(), Box<dyn Error>> {
                 "\
                 Token: {token}\n\
                 Hashed Token: {hashed}\n\n\
-                Start the server with `influxdb3 serve --bearer-token {hashed}`\n\n\
+                Start the server with `influxdb3 serve --bearer-token {hashed} --object-store file --data-dir ~/.influxdb3 --host-id YOUR_HOST_NAME`\n\n\
                 HTTP requests require the following header: \"Authorization: Bearer {token}\"\n\
                 This will grant you access to every HTTP endpoint or deny it otherwise
             ",

--- a/influxdb3/tests/server/cli.rs
+++ b/influxdb3/tests/server/cli.rs
@@ -800,3 +800,52 @@ fn test_create_token() {
         "This will grant you access to every HTTP endpoint or deny it otherwise"
     );
 }
+
+#[tokio::test]
+async fn meta_cache_create_and_delete() {
+    let server = TestServer::spawn().await;
+    let db_name = "foo";
+    let server_addr = server.client_addr();
+    server
+        .write_lp_to_db(
+            db_name,
+            "cpu,t1=a,t2=b,t3=c f1=true,f2=\"hello\",f3=4i,f4=4u,f5=5 1000",
+            influxdb3_client::Precision::Second,
+        )
+        .await
+        .expect("write to db");
+
+    let result = run_with_confirmation(&[
+        "create",
+        "meta_cache",
+        "-H",
+        &server_addr,
+        "-d",
+        db_name,
+        "-t",
+        "cpu",
+        "--columns",
+        "t1,t2",
+        "--max-cardinality",
+        "20000",
+        "--max-age",
+        "200s",
+        "cache_money",
+    ]);
+
+    insta::assert_yaml_snapshot!(result);
+
+    let result = run_with_confirmation(&[
+        "delete",
+        "meta_cache",
+        "-H",
+        &server_addr,
+        "-d",
+        db_name,
+        "-t",
+        "cpu",
+        "cache_money",
+    ]);
+
+    insta::assert_yaml_snapshot!(result);
+}

--- a/influxdb3/tests/server/cli.rs
+++ b/influxdb3/tests/server/cli.rs
@@ -791,3 +791,12 @@ def process_rows(iterator, output):
     debug!(result = ?result, "create table-specific trigger");
     assert_contains!(&result, "Trigger test_trigger created successfully");
 }
+
+#[test]
+fn test_create_token() {
+    let result = run_with_confirmation(&["create", "token"]);
+    assert_contains!(
+        &result,
+        "This will grant you access to every HTTP endpoint or deny it otherwise"
+    );
+}

--- a/influxdb3/tests/server/snapshots/server__cli__meta_cache_create_and_delete-2.snap
+++ b/influxdb3/tests/server/snapshots/server__cli__meta_cache_create_and_delete-2.snap
@@ -1,0 +1,6 @@
+---
+source: influxdb3/tests/server/cli.rs
+expression: result
+snapshot_kind: text
+---
+meta cache deleted successfully

--- a/influxdb3/tests/server/snapshots/server__cli__meta_cache_create_and_delete.snap
+++ b/influxdb3/tests/server/snapshots/server__cli__meta_cache_create_and_delete.snap
@@ -1,0 +1,6 @@
+---
+source: influxdb3/tests/server/cli.rs
+expression: result
+snapshot_kind: text
+---
+"new cache created: {\n  \"table_id\": 0,\n  \"table_name\": \"cpu\",\n  \"cache_name\": \"cache_money\",\n  \"column_ids\": [\n    0,\n    1\n  ],\n  \"max_cardinality\": 20000,\n  \"max_age_seconds\": 200\n}"

--- a/influxdb3_client/src/lib.rs
+++ b/influxdb3_client/src/lib.rs
@@ -1272,7 +1272,7 @@ pub struct CreateMetaCacheRequestBuilder<'c> {
     #[serde(skip_serializing_if = "Option::is_none")]
     max_cardinality: Option<NonZeroUsize>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    max_age: Option<Duration>,
+    max_age: Option<u64>,
 }
 
 impl<'c> CreateMetaCacheRequestBuilder<'c> {
@@ -1307,7 +1307,7 @@ impl<'c> CreateMetaCacheRequestBuilder<'c> {
 
     /// Specify the maximum age for entries in the cache
     pub fn max_age(mut self, max_age: Duration) -> Self {
-        self.max_age = Some(max_age);
+        self.max_age = Some(max_age.as_secs());
         self
     }
 


### PR DESCRIPTION
In https://github.com/influxdata/influxdb/pull/25737 token creation was broken as a client would attempt to be
made, but hit an unreachable branch. The fix was to just make the branch
create a Client that won't do anything. We also add a test to make sure
that if there is a regression we'll catch it in the future.

Closes https://github.com/influxdata/influxdb/issues/25764

fix: make client turn a duration into seconds/u64

This commit fixes the creation of a metadata cache made via the cli by
actually sending a time in seconds as a u64 and not as a duration. With
that we can now make metadata caches again when the `--max-age` flag is
specified.

This commit also adds a regression test for the CLI so that we can catch
this again in the future.