### PR TITLE
chore: add helix config dir to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ perf.svg
 perf.txt
 valgrind-out.txt
 *.pending-snap
+# Helix editor configuration directory:
+**/.helix


### PR DESCRIPTION
No issue.

This adds an entry to `.gitignore` to ignore the `.helix` directory, which can store repo-local configuration for the [Helix editor](https://helix-editor.com/).

This is useful for enabling feature flags as needed in the `.helix/languages.toml` file like so:
```toml
[language-server.rust-analyzer.config.cargo]
features = ["system-py"]
```
In order that `rust-analyzer` will compile/check parts of the codebase flagged by a given feature.