### PR TITLE
feat: Finish wiring up WAL plugin with trigger

### DIFF
--- a/influxdb3_processing_engine/src/plugins.rs
+++ b/influxdb3_processing_engine/src/plugins.rs
@@ -104,13 +104,15 @@ mod python_plugin {
     use influxdb3_wal::WalOp;
     use influxdb3_write::Precision;
     use iox_time::Time;
-    use observability_deps::tracing::warn;
+    use observability_deps::tracing::{info, warn};
     use std::time::SystemTime;
     use tokio::sync::mpsc::Receiver;
 
     #[async_trait::async_trait]
     impl RunnablePlugin for TriggerPlugin {
         async fn run_plugin(&self, mut receiver: Receiver<PluginEvent>) -> Result<(), Error> {
+            info!(?self.trigger_definition.trigger_name, ?self.trigger_definition.database_name, ?self.trigger_definition.plugin_name, "starting trigger plugin");
+
             loop {
                 let event = match receiver.recv().await {
                     Some(event) => event,

--- a/influxdb3_server/src/builder.rs
+++ b/influxdb3_server/src/builder.rs
@@ -160,6 +160,10 @@ impl<T: TimeProvider>
             Arc::clone(&self.time_provider.0) as _,
             self.write_buffer.0.wal(),
         ));
+        self.write_buffer
+            .0
+            .wal()
+            .add_file_notifier(Arc::clone(&processing_engine) as _);
         let http = Arc::new(HttpApi::new(
             self.common_state.clone(),
             Arc::clone(&self.time_provider.0),

--- a/influxdb3_server/src/http.rs
+++ b/influxdb3_server/src/http.rs
@@ -1036,6 +1036,7 @@ where
         } else {
             self.read_body_json(req).await?
         };
+        debug!(%db, %plugin_name, %trigger_name, %trigger_specification, %disabled, "configure_processing_engine_trigger");
         let Ok(trigger_spec) =
             TriggerSpecificationDefinition::from_string_rep(&trigger_specification)
         else {

--- a/influxdb3_wal/src/lib.rs
+++ b/influxdb3_wal/src/lib.rs
@@ -113,6 +113,12 @@ pub trait Wal: Debug + Send + Sync + 'static {
 
     /// Stop all writes to the WAL and flush the buffer to a WAL file.
     async fn shutdown(&self);
+
+    /// Adds a new file notifier listener to the WAL (for use by the processing engine). The WAL
+    /// will send new file notifications to the listener, but ignore any snapshot receiver.
+    /// Only the notifier passed in the WAL constructor should be used for snapshots (i.e. the
+    /// `QueryableBuffer`).
+    fn add_file_notifier(&self, notifier: Arc<dyn WalFileNotifier>);
 }
 
 /// When the WAL persists a file with buffered ops, the contents are sent to this


### PR DESCRIPTION
This updates the WAL so that it can have new file notifiers added that will get updated when the wal flushes. The processing engine now implements the WALNotifier trait.

I've updated the CLI test for creating a trigger to run and end-to-end test that defines a plugin, creates a trigger, writes data into the database, triggering the plugin, which writes summary statistics back into the database in a different table. The test queries the destination table to confirm that the plugin worked.