### PR TITLE
feat: Wire up arguments to wal plugin trigger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2890,6 +2890,7 @@ name = "influxdb3_client"
 version = "0.1.0"
 dependencies = [
  "bytes",
+ "hashbrown 0.15.2",
  "iox_query_params",
  "mockito",
  "reqwest 0.11.27",
@@ -2998,6 +2999,7 @@ dependencies = [
  "arrow-array",
  "arrow-schema",
  "futures",
+ "hashbrown 0.15.2",
  "influxdb3_catalog",
  "influxdb3_id",
  "influxdb3_internal_api",
@@ -3030,6 +3032,7 @@ dependencies = [
  "datafusion_util",
  "flate2",
  "futures",
+ "hashbrown 0.15.2",
  "hex",
  "http 0.2.12",
  "humantime",

--- a/influxdb3/src/commands/create.rs
+++ b/influxdb3/src/commands/create.rs
@@ -1,6 +1,9 @@
-use crate::commands::common::{parse_key_val, DataType, InfluxDb3Config, SeparatedList};
+use crate::commands::common::{
+    parse_key_val, DataType, InfluxDb3Config, SeparatedKeyValue, SeparatedList,
+};
 use base64::engine::general_purpose::URL_SAFE_NO_PAD as B64;
 use base64::Engine as _;
+use hashbrown::HashMap;
 use influxdb3_client::Client;
 use influxdb3_wal::TriggerSpecificationDefinition;
 use rand::rngs::OsRng;
@@ -245,6 +248,9 @@ pub struct TriggerConfig {
           value_parser = TriggerSpecificationDefinition::from_string_rep,
           help = "Trigger specification format: 'table:<TABLE_NAME>' or 'all_tables'")]
     trigger_specification: TriggerSpecificationDefinition,
+    /// Comma separated list of key/value pairs to use as trigger arguments. Example: key1=val1,key2=val2
+    #[clap(long = "trigger-arguments")]
+    trigger_arguments: Option<SeparatedList<SeparatedKeyValue<String, String>>>,
     /// Create trigger in disabled state
     #[clap(long)]
     disabled: bool,
@@ -385,14 +391,22 @@ pub async fn command(config: Config) -> Result<(), Box<dyn Error>> {
             trigger_name,
             plugin_name,
             trigger_specification,
+            trigger_arguments,
             disabled,
         }) => {
+            let trigger_arguments: Option<HashMap<String, String>> = trigger_arguments.map(|a| {
+                a.into_iter()
+                    .map(|SeparatedKeyValue((k, v))| (k, v))
+                    .collect::<HashMap<String, String>>()
+            });
+
             client
                 .api_v3_configure_processing_engine_trigger_create(
                     database_name,
                     &trigger_name,
                     plugin_name,
                     trigger_specification.string_rep(),
+                    trigger_arguments,
                     disabled,
                 )
                 .await?;

--- a/influxdb3/src/commands/test.rs
+++ b/influxdb3/src/commands/test.rs
@@ -1,9 +1,9 @@
 use crate::commands::common::{InfluxDb3Config, SeparatedKeyValue, SeparatedList};
 use anyhow::Context;
+use hashbrown::HashMap;
 use influxdb3_client::plugin_development::WalPluginTestRequest;
 use influxdb3_client::Client;
 use secrecy::ExposeSecret;
-use std::collections::HashMap;
 use std::error::Error;
 
 #[derive(Debug, clap::Parser)]

--- a/influxdb3/tests/server/cli.rs
+++ b/influxdb3/tests/server/cli.rs
@@ -536,6 +536,11 @@ async fn test_create_trigger_and_run() {
 def process_writes(influxdb3_local, table_batches, args=None):
     for table_batch in table_batches:
         row_count = len(table_batch["rows"])
+
+        # Double row count if table name matches args table_name
+        if args and "double_count_table" in args and table_batch["table_name"] == args["double_count_table"]:
+            row_count *= 2
+
         line = LineBuilder("write_reports")\
             .tag("table_name", table_batch["table_name"])\
             .int64_field("row_count", row_count)
@@ -567,6 +572,8 @@ def process_writes(influxdb3_local, table_batches, args=None):
         plugin_name,
         "--trigger-spec",
         "all_tables",
+        "--trigger-arguments",
+        "double_count_table=cpu",
         trigger_name,
     ]);
     debug!(result = ?result, "create trigger");
@@ -610,7 +617,7 @@ def process_writes(influxdb3_local, table_batches, args=None):
         result,
         json!(
             [
-                {"table_name": "cpu", "row_count": 2},
+                {"table_name": "cpu", "row_count": 4},
                 {"table_name": "mem", "row_count": 1}
             ]
         )

--- a/influxdb3_catalog/src/serialize.rs
+++ b/influxdb3_catalog/src/serialize.rs
@@ -105,6 +105,7 @@ impl From<DatabaseSnapshot> for DatabaseSchema {
                         plugin_name: plugin.plugin_name.to_string(),
                         plugin,
                         trigger: serde_json::from_str(&trigger.trigger_specification).unwrap(),
+                        trigger_arguments: trigger.trigger_arguments,
                         disabled: trigger.disabled,
                         database_name: trigger.database_name,
                     },
@@ -173,6 +174,7 @@ struct ProcessingEngineTriggerSnapshot {
     pub plugin_name: String,
     pub database_name: String,
     pub trigger_specification: String,
+    pub trigger_arguments: Option<HashMap<String, String>>,
     pub disabled: bool,
 }
 
@@ -436,6 +438,7 @@ impl From<&TriggerDefinition> for ProcessingEngineTriggerSnapshot {
             database_name: trigger.database_name.to_string(),
             trigger_specification: serde_json::to_string(&trigger.trigger)
                 .expect("should be able to serialize trigger specification"),
+            trigger_arguments: trigger.trigger_arguments.clone(),
             disabled: trigger.disabled,
         }
     }

--- a/influxdb3_client/Cargo.toml
+++ b/influxdb3_client/Cargo.toml
@@ -11,6 +11,7 @@ iox_query_params.workspace = true
 
 # crates.io dependencies
 bytes.workspace = true
+hashbrown.workspace = true
 reqwest.workspace = true
 secrecy.workspace = true
 serde.workspace = true

--- a/influxdb3_client/src/lib.rs
+++ b/influxdb3_client/src/lib.rs
@@ -1,15 +1,13 @@
 pub mod plugin_development;
 
-use std::{
-    collections::HashMap, fmt::Display, num::NonZeroUsize, string::FromUtf8Error, time::Duration,
-};
-
 use crate::plugin_development::{WalPluginTestRequest, WalPluginTestResponse};
 use bytes::Bytes;
+use hashbrown::HashMap;
 use iox_query_params::StatementParam;
 use reqwest::{Body, IntoUrl, Method, StatusCode};
 use secrecy::{ExposeSecret, Secret};
 use serde::{Deserialize, Serialize};
+use std::{fmt::Display, num::NonZeroUsize, string::FromUtf8Error, time::Duration};
 use url::Url;
 
 /// Primary error type for the [`Client`]
@@ -565,6 +563,7 @@ impl Client {
         trigger_name: impl Into<String> + Send,
         plugin_name: impl Into<String> + Send,
         trigger_spec: impl Into<String> + Send,
+        trigger_arguments: Option<HashMap<String, String>>,
         disabled: bool,
     ) -> Result<()> {
         let api_path = "/api/v3/configure/processing_engine_trigger";
@@ -577,6 +576,7 @@ impl Client {
             trigger_name: String,
             plugin_name: String,
             trigger_specification: String,
+            trigger_arguments: Option<HashMap<String, String>>,
             disabled: bool,
         }
         let mut req = self.http_client.post(url).json(&Req {
@@ -584,6 +584,7 @@ impl Client {
             trigger_name: trigger_name.into(),
             plugin_name: plugin_name.into(),
             trigger_specification: trigger_spec.into(),
+            trigger_arguments,
             disabled,
         });
 

--- a/influxdb3_client/src/plugin_development.rs
+++ b/influxdb3_client/src/plugin_development.rs
@@ -1,7 +1,7 @@
 //! Request structs for the /api/v3/plugin_test API
 
+use hashbrown::HashMap;
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
 
 /// Request definition for `POST /api/v3/plugin_test/wal` API
 #[derive(Debug, Serialize, Deserialize)]

--- a/influxdb3_processing_engine/src/lib.rs
+++ b/influxdb3_processing_engine/src/lib.rs
@@ -175,6 +175,7 @@ impl ProcessingEngineManager for ProcessingEngineManagerImpl {
         trigger_name: String,
         plugin_name: String,
         trigger_specification: TriggerSpecificationDefinition,
+        trigger_arguments: Option<HashMap<String, String>>,
         disabled: bool,
     ) -> Result<(), ProcessingEngineError> {
         let Some((db_id, db_schema)) = self.catalog.db_id_and_schema(db_name) else {
@@ -192,6 +193,7 @@ impl ProcessingEngineManager for ProcessingEngineManagerImpl {
             plugin_name,
             plugin: plugin.clone(),
             trigger: trigger_specification,
+            trigger_arguments,
             disabled,
             database_name: db_name.to_string(),
         });
@@ -627,6 +629,7 @@ mod tests {
             "test_trigger".to_string(),
             "test_plugin".to_string(),
             TriggerSpecificationDefinition::AllTablesWalWrite,
+            None,
             false,
         )
         .await
@@ -687,6 +690,7 @@ mod tests {
             "test_trigger".to_string(),
             "test_plugin".to_string(),
             TriggerSpecificationDefinition::AllTablesWalWrite,
+            None,
             false,
         )
         .await
@@ -773,6 +777,7 @@ mod tests {
             "test_trigger".to_string(),
             "test_plugin".to_string(),
             TriggerSpecificationDefinition::AllTablesWalWrite,
+            None,
             true,
         )
         .await

--- a/influxdb3_processing_engine/src/manager.rs
+++ b/influxdb3_processing_engine/src/manager.rs
@@ -1,3 +1,4 @@
+use hashbrown::HashMap;
 use influxdb3_client::plugin_development::{WalPluginTestRequest, WalPluginTestResponse};
 use influxdb3_internal_api::query_executor::QueryExecutor;
 use influxdb3_wal::{PluginType, TriggerSpecificationDefinition};
@@ -44,6 +45,7 @@ pub trait ProcessingEngineManager: Debug + Send + Sync + 'static {
         trigger_name: String,
         plugin_name: String,
         trigger_specification: TriggerSpecificationDefinition,
+        trigger_arguments: Option<HashMap<String, String>>,
         disabled: bool,
     ) -> Result<(), ProcessingEngineError>;
 

--- a/influxdb3_processing_engine/src/plugins.rs
+++ b/influxdb3_processing_engine/src/plugins.rs
@@ -175,7 +175,7 @@ mod python_plugin {
                                     Arc::clone(&schema),
                                     Arc::clone(&self.query_executor),
                                     table_filter,
-                                    None,
+                                    &self.trigger_definition.trigger_arguments,
                                 )?;
 
                                 // write the output lines to the appropriate database
@@ -260,7 +260,7 @@ pub(crate) fn run_test_wal_plugin(
         db,
         query_executor,
         None,
-        request.input_arguments,
+        &request.input_arguments,
     )?;
 
     // validate the generated output lines
@@ -348,12 +348,12 @@ pub(crate) fn run_test_wal_plugin(
 mod tests {
     use super::*;
     use data_types::NamespaceName;
+    use hashbrown::HashMap;
     use influxdb3_catalog::catalog::Catalog;
     use influxdb3_internal_api::query_executor::UnimplementedQueryExecutor;
     use influxdb3_write::write_buffer::validator::WriteValidator;
     use influxdb3_write::Precision;
     use iox_time::Time;
-    use std::collections::HashMap;
 
     #[test]
     fn test_wal_plugin() {

--- a/influxdb3_py_api/Cargo.toml
+++ b/influxdb3_py_api/Cargo.toml
@@ -11,6 +11,7 @@ system-py = ["pyo3"]
 [dependencies]
 arrow-array.workspace = true
 arrow-schema.workspace = true
+hashbrown.workspace = true
 influxdb3_id = { path = "../influxdb3_id" }
 influxdb3_wal = { path = "../influxdb3_wal" }
 influxdb3_catalog = {path = "../influxdb3_catalog"}

--- a/influxdb3_py_api/src/system_py.rs
+++ b/influxdb3_py_api/src/system_py.rs
@@ -5,6 +5,7 @@ use arrow_array::{
 };
 use arrow_schema::DataType;
 use futures::TryStreamExt;
+use hashbrown::HashMap;
 use influxdb3_catalog::catalog::DatabaseSchema;
 use influxdb3_id::TableId;
 use influxdb3_internal_api::query_executor::{QueryExecutor, QueryKind};
@@ -17,7 +18,6 @@ use pyo3::types::{PyDict, PyList};
 use pyo3::{
     pyclass, pymethods, pymodule, Bound, IntoPyObject, Py, PyAny, PyObject, PyResult, Python,
 };
-use std::collections::HashMap;
 use std::ffi::CString;
 use std::sync::Arc;
 
@@ -119,7 +119,7 @@ impl PyPluginCallApi {
     fn query_rows(
         &self,
         query: String,
-        args: Option<HashMap<String, String>>,
+        args: Option<std::collections::HashMap<String, String>>,
     ) -> PyResult<Py<PyList>> {
         let query_executor = Arc::clone(&self.query_executor);
         let db_schema_name = Arc::clone(&self.db_schema.name);
@@ -341,7 +341,7 @@ pub fn execute_python_with_batch(
     schema: Arc<DatabaseSchema>,
     query_executor: Arc<dyn QueryExecutor>,
     table_filter: Option<TableId>,
-    args: Option<HashMap<String, String>>,
+    args: &Option<HashMap<String, String>>,
 ) -> PyResult<PluginReturnState> {
     Python::with_gil(|py| {
         // import the LineBuilder for use in the python code
@@ -424,7 +424,7 @@ pub fn execute_python_with_batch(
         let local_api = api.into_pyobject(py)?;
 
         // turn args into an optional dict to pass into python
-        let args = args.map(|args| {
+        let args = args.as_ref().map(|args| {
             let dict = PyDict::new(py);
             for (key, value) in args {
                 dict.set_item(key, value).unwrap();

--- a/influxdb3_server/Cargo.toml
+++ b/influxdb3_server/Cargo.toml
@@ -59,6 +59,7 @@ csv.workspace = true
 datafusion.workspace = true
 flate2.workspace = true
 futures.workspace = true
+hashbrown.workspace = true
 hex.workspace = true
 hyper.workspace = true
 humantime.workspace = true

--- a/influxdb3_server/src/http.rs
+++ b/influxdb3_server/src/http.rs
@@ -12,6 +12,7 @@ use datafusion::execution::memory_pool::UnboundedMemoryPool;
 use datafusion::execution::RecordBatchStream;
 use datafusion::physical_plan::SendableRecordBatchStream;
 use futures::{StreamExt, TryStreamExt};
+use hashbrown::HashMap;
 use hyper::header::ACCEPT;
 use hyper::header::AUTHORIZATION;
 use hyper::header::CONTENT_ENCODING;
@@ -1030,6 +1031,7 @@ where
             plugin_name,
             trigger_name,
             trigger_specification,
+            trigger_arguments,
             disabled,
         } = if let Some(query) = req.uri().query() {
             serde_urlencoded::from_str(query)?
@@ -1052,6 +1054,7 @@ where
                 trigger_name.clone(),
                 plugin_name,
                 trigger_spec,
+                trigger_arguments,
                 disabled,
             )
             .await?;
@@ -1609,6 +1612,7 @@ struct ProcessEngineTriggerCreateRequest {
     plugin_name: String,
     trigger_name: String,
     trigger_specification: String,
+    trigger_arguments: Option<HashMap<String, String>>,
     disabled: bool,
 }
 

--- a/influxdb3_wal/src/lib.rs
+++ b/influxdb3_wal/src/lib.rs
@@ -640,6 +640,7 @@ pub struct TriggerDefinition {
     pub plugin_name: String,
     pub database_name: String,
     pub trigger: TriggerSpecificationDefinition,
+    pub trigger_arguments: Option<HashMap<String, String>>,
     // TODO: decide whether this should be populated from a reference rather than stored on its own.
     pub plugin: PluginDefinition,
     pub disabled: bool,


### PR DESCRIPTION
This allows the user to specify arguments that will be passed to each execution of a wal plugin trigger. The CLI test was updated to check this end to end.

Closes #25655