### PR TITLE
feat: 1h sum fields for telem writes/queries

### DIFF
--- a/influxdb3_telemetry/src/bucket.rs
+++ b/influxdb3_telemetry/src/bucket.rs
@@ -42,13 +42,20 @@ impl EventsBucket {
 #[derive(Debug, Default)]
 pub(crate) struct PerMinuteWrites {
     pub lines: Stats<u64>,
+    pub total_lines: u64,
     pub size_bytes: Stats<u64>,
+    pub total_size_bytes: u64,
 }
 
 impl PerMinuteWrites {
     pub fn add_sample(&mut self, num_lines: usize, size_bytes: usize) -> Option<()> {
-        self.lines.update(num_lines as u64);
-        self.size_bytes.update(size_bytes as u64)?;
+        let new_num_lines = num_lines as u64;
+        self.lines.update(new_num_lines);
+        self.total_lines += new_num_lines;
+
+        let new_size_bytes = size_bytes as u64;
+        self.size_bytes.update(new_size_bytes)?;
+        self.total_size_bytes += new_size_bytes;
         Some(())
     }
 }
@@ -56,11 +63,13 @@ impl PerMinuteWrites {
 #[derive(Debug, Default)]
 pub(crate) struct PerMinuteReads {
     pub num_queries: Stats<u64>,
+    pub total_num_queries: u64,
 }
 
 impl PerMinuteReads {
     pub fn add_sample(&mut self) -> Option<()> {
         self.num_queries.update(1);
+        self.total_num_queries += 1;
         Some(())
     }
 }

--- a/influxdb3_telemetry/src/metrics.rs
+++ b/influxdb3_telemetry/src/metrics.rs
@@ -6,24 +6,35 @@ use crate::{
 #[derive(Debug, Default)]
 pub(crate) struct Writes {
     pub lines: RollingStats<u64>,
+    pub total_lines: u64,
     pub size_bytes: RollingStats<u64>,
+    pub total_size_bytes: u64,
     // num_writes is just Stats and not RollingStats as we don't
     // aggregate num_writes at the per minute interval, it can
     // just be taken from the events bucket.
     pub num_writes: Stats<u64>,
+    pub total_num_writes: u64,
 }
 
 impl Writes {
     pub fn add_sample(&mut self, events_bucket: &EventsBucket) -> Option<()> {
+        let num_writes = events_bucket.num_writes as u64;
         self.lines.update(&events_bucket.writes.lines);
         self.size_bytes.update(&events_bucket.writes.size_bytes);
-        self.num_writes.update(events_bucket.num_writes as u64);
+        self.num_writes.update(num_writes);
+        self.total_lines += events_bucket.writes.total_lines;
+        self.total_size_bytes += events_bucket.writes.total_size_bytes;
+        self.total_num_writes += num_writes;
         Some(())
     }
 
     pub fn reset(&mut self) {
         self.lines.reset();
         self.size_bytes.reset();
+        self.num_writes.reset();
+        self.total_lines = 0;
+        self.total_size_bytes = 0;
+        self.total_num_writes = 0;
     }
 }
 
@@ -31,16 +42,19 @@ impl Writes {
 pub(crate) struct Queries {
     // We don't aggregate the num_queries at 1 min intervals
     pub num_queries: Stats<u64>,
+    pub total_num_queries: u64,
 }
 
 impl Queries {
     pub fn add_sample(&mut self, events_bucket: &EventsBucket) -> Option<()> {
         self.num_queries.update(events_bucket.num_queries as u64);
+        self.total_num_queries += events_bucket.queries.total_num_queries;
         Some(())
     }
 
     pub fn reset(&mut self) {
         self.num_queries.reset();
+        self.total_num_queries = 0;
     }
 }
 

--- a/influxdb3_telemetry/src/sampler.rs
+++ b/influxdb3_telemetry/src/sampler.rs
@@ -103,7 +103,7 @@ fn sample_all_metrics(sampler: &mut CpuAndMemorySampler, store: &Arc<TelemetrySt
     } else {
         debug!("Cannot get cpu/mem usage stats for this process");
     }
-    store.rollup_events();
+    store.rollup_events_1m();
 }
 
 #[cfg(test)]

--- a/influxdb3_telemetry/src/sender.rs
+++ b/influxdb3_telemetry/src/sender.rs
@@ -62,18 +62,22 @@ pub(crate) struct TelemetryPayload {
     pub write_requests_min_1m: u64,
     pub write_requests_max_1m: u64,
     pub write_requests_avg_1m: u64,
+    pub write_requests_sum_1h: u64,
 
     pub write_lines_min_1m: u64,
     pub write_lines_max_1m: u64,
     pub write_lines_avg_1m: u64,
+    pub write_lines_sum_1h: u64,
 
     pub write_mb_min_1m: u64,
     pub write_mb_max_1m: u64,
     pub write_mb_avg_1m: u64,
+    pub write_mb_sum_1h: u64,
     // reads
     pub query_requests_min_1m: u64,
     pub query_requests_max_1m: u64,
     pub query_requests_avg_1m: u64,
+    pub query_requests_sum_1h: u64,
     // parquet files
     pub parquet_file_count: u64,
     pub parquet_file_size_mb: f64,
@@ -108,7 +112,7 @@ async fn send_telemetry(store: &Arc<TelemetryStore>, telem_sender: &mut Telemetr
     }
     // if we tried sending and failed, we currently still reset the
     // metrics, it is ok to miss few samples
-    store.reset_metrics();
+    store.reset_metrics_1h();
 }
 
 #[cfg(test)]
@@ -183,6 +187,10 @@ mod tests {
             parquet_file_size_mb: 100.0,
             parquet_row_count: 100,
             uptime_secs: 100,
+            write_requests_sum_1h: 200,
+            write_lines_sum_1h: 200,
+            write_mb_sum_1h: 200,
+            query_requests_sum_1h: 200,
         }
     }
 }


### PR DESCRIPTION
closes: https://github.com/influxdata/influxdb/issues/25713

New fields end with `..sum_1h`

```javascript
{
  "os": "linux",
  "version": "influxdb3-0.1.0",
  "storage_type": "file",
  "instance_id": "08c62980-603c-4dec-9034-47d0bf69fcc7",
  "cores": 14,
  "product_type": "OSS",
  "uptime_secs": 0,
  "cpu_utilization_percent_min_1m": 0.0,
  "cpu_utilization_percent_max_1m": 0.0,
  "cpu_utilization_percent_avg_1m": 0.0,
  "memory_used_mb_min_1m": 0,
  "memory_used_mb_max_1m": 0,
  "memory_used_mb_avg_1m": 0,
  "write_requests_min_1m": 0,
  "write_requests_max_1m": 0,
  "write_requests_avg_1m": 0,
  // newly added
  "write_requests_sum_1h": 0,
  "write_lines_min_1m": 0,
  "write_lines_max_1m": 0,
  "write_lines_avg_1m": 0,
  // newly added
  "write_lines_sum_1h": 0,
  "write_mb_min_1m": 0,
  "write_mb_max_1m": 0,
  "write_mb_avg_1m": 0,
  // newly added
  "write_mb_sum_1h": 0,
  "query_requests_min_1m": 0,
  "query_requests_max_1m": 0,
  "query_requests_avg_1m": 0,
  // newly added
  "query_requests_sum_1h": 0,
  "parquet_file_count": 0,
  "parquet_file_size_mb": 0.0,
  "parquet_row_count": 0
}

```

