### PR TITLE
feat: only load wal files after most recent snapshot

### DIFF
--- a/influxdb3_write/src/write_buffer/persisted_files.rs
+++ b/influxdb3_write/src/write_buffer/persisted_files.rs
@@ -26,14 +26,6 @@ impl PersistedFiles {
         }
     }
 
-    /// Add a file to the list of persisted files
-    pub fn add_file(&self, db_id: DbId, table_id: TableId, file: ParquetFile) {
-        let mut inner = self.inner.write();
-        let tables = inner.files.entry(db_id).or_default();
-        let table_files = tables.entry(table_id).or_default();
-        table_files.push(file);
-    }
-
     /// Add all files from a persisted snapshot
     pub fn add_persisted_snapshot_files(&self, persisted_snapshot: PersistedSnapshot) {
         let mut inner = self.inner.write();


### PR DESCRIPTION
No issue for this.

This makes a change to the WAL replay whereby it takes into account the last WAL file sequence number from the most recent snapshot. It will use that number to ignore loading any WAL files from object store that were included or came before that snapshot.