### PR TITLE
chore: patch enterprise back to core

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2832,6 +2832,7 @@ dependencies = [
 name = "influxdb3_catalog"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "arrow",
  "bimap",
  "chrono",
@@ -3202,6 +3203,7 @@ dependencies = [
  "influxdb3_id",
  "influxdb3_internal_api",
  "influxdb3_py_api",
+ "influxdb3_sys_events",
  "influxdb3_telemetry",
  "influxdb3_test_helpers",
  "influxdb3_wal",

--- a/deny.toml
+++ b/deny.toml
@@ -1,7 +1,8 @@
 # Configuration documentation:
-#   https://embarkstudios.github.io/cargo-deny/index.html
+#   https://embarkstudios.github.io/cargo-deny/index.html
 
 [advisories]
+version = 2
 yanked = "deny"
 ignore = [
     # dependent on datafusion-common moving away from instant
@@ -11,6 +12,8 @@ ignore = [
 git-fetch-with-cli = true
 
 [licenses]
+version = 2
+unused-allowed-license = "warn"
 allow = [
     "Apache-2.0",
     "BSD-2-Clause",
@@ -22,7 +25,6 @@ allow = [
     "Unicode-3.0",
     "Zlib",
 ]
-
 exceptions = [
     # We should probably NOT bundle CA certs but use the OS ones.
     { name = "webpki-roots", allow = ["MPL-2.0"] },
@@ -41,10 +43,10 @@ license-files = [
 github = ["influxdata"]
 
 [bans]
-multiple-versions = "warn"
+multiple-versions = "allow"
 deny = [
-    # We are using rustls as the TLS implementation, so we shouldn't be linking
-    # in OpenSSL too.
+    # We are using rustls as the TLS implementation, so we shouldn't be linking
+    # in OpenSSL too.
     #
     # If you're hitting this, you might want to take a look at what new
     # dependencies you have introduced and check if there's a way to depend on
@@ -53,4 +55,6 @@ deny = [
     # We've decided to use the `humantime` crate to parse and generate friendly time formats; use
     # that rather than chrono-english.
     { name = "chrono-english" },
+    # Use stdlib ( https://doc.rust-lang.org/stable/std/io/trait.IsTerminal.html )
+    { name = "atty" },
 ]

--- a/influxdb3_cache/src/distinct_cache/cache.rs
+++ b/influxdb3_cache/src/distinct_cache/cache.rs
@@ -473,7 +473,7 @@ impl Node {
                         let block = builder.append_block(value.0.as_bytes().into());
                         for _ in 0..count {
                             builder
-                                .try_append_view(block, 0u32, value.0.as_bytes().len() as u32)
+                                .try_append_view(block, 0u32, value.0.len() as u32)
                                 .expect("append view for known valid block, offset and length");
                         }
                     }

--- a/influxdb3_catalog/Cargo.toml
+++ b/influxdb3_catalog/Cargo.toml
@@ -17,6 +17,7 @@ influxdb3_id = { path = "../influxdb3_id" }
 influxdb3_wal = { path = "../influxdb3_wal" }
 
 # crates.io dependencies
+anyhow.workspace = true
 arrow.workspace = true
 bimap.workspace = true
 chrono.workspace = true

--- a/influxdb3_clap_blocks/src/datafusion.rs
+++ b/influxdb3_clap_blocks/src/datafusion.rs
@@ -4,7 +4,7 @@ use datafusion::config::ConfigExtension;
 use iox_query::config::IoxConfigExt;
 
 /// Extends the standard [`HashMap`] based DataFusion config option in the CLI with specific
-/// options (along with defaults) for InfluxDB 3 OSS/Pro. This is intended for customization of
+/// options (along with defaults) for InfluxDB 3 Core/Enterprise. This is intended for customization of
 /// options that are defined in the `iox_query` crate, e.g., those defined in [`IoxConfigExt`]
 /// that are relevant to the monolithinc versions of InfluxDB 3.
 #[derive(Debug, clap::Parser, Clone)]

--- a/influxdb3_client/src/lib.rs
+++ b/influxdb3_client/src/lib.rs
@@ -852,7 +852,7 @@ impl<'c> WriteRequestBuilder<'c, NoBody> {
     }
 }
 
-impl<'c> WriteRequestBuilder<'c, Body> {
+impl WriteRequestBuilder<'_, Body> {
     /// Send the request to the server
     pub async fn send(self) -> Result<()> {
         let url = self.client.base_url.join("/api/v3/write_lp")?;
@@ -900,7 +900,7 @@ pub struct QueryRequestBuilder<'c> {
 // TODO - for now the send method just returns the bytes from the response.
 //   It may be nicer to have the format parameter dictate how we return from
 //   send, e.g., using types more specific to the format selected.
-impl<'c> QueryRequestBuilder<'c> {
+impl QueryRequestBuilder<'_> {
     /// Specify the format, `json`, `csv`, `pretty`, or `parquet`
     pub fn format(mut self, format: Format) -> Self {
         self.format = Some(format);
@@ -1101,7 +1101,7 @@ pub struct ShowDatabasesRequestBuilder<'c> {
     show_deleted: bool,
 }
 
-impl<'c> ShowDatabasesRequestBuilder<'c> {
+impl ShowDatabasesRequestBuilder<'_> {
     /// Specify whether or not to show deleted databases in the output
     pub fn with_show_deleted(mut self, show_deleted: bool) -> Self {
         self.show_deleted = show_deleted;

--- a/influxdb3_internal_api/src/query_executor.rs
+++ b/influxdb3_internal_api/src/query_executor.rs
@@ -24,6 +24,8 @@ pub enum QueryExecutorError {
     DatabasesToRecordBatch(#[source] ArrowError),
     #[error("unable to compose record batches from retention policies: {0}")]
     RetentionPoliciesToRecordBatch(#[source] ArrowError),
+    #[error("invokded a method that is not implemented: {0}")]
+    MethodNotImplemented(&'static str),
 }
 
 #[async_trait]

--- a/influxdb3_server/src/lib.rs
+++ b/influxdb3_server/src/lib.rs
@@ -1,4 +1,4 @@
-//! InfluxDB 3 Core server implementation
+//! InfluxDB 3 Enterprise server implementation
 //!
 //! The server is responsible for handling the HTTP API
 #![deny(rustdoc::broken_intra_doc_links, rustdoc::bare_urls, rust_2018_idioms)]
@@ -789,7 +789,7 @@ mod tests {
         let parquet_metrics_provider: Arc<PersistedFiles> =
             Arc::clone(&write_buffer_impl.persisted_files());
         let sample_telem_store =
-            TelemetryStore::new_without_background_runners(parquet_metrics_provider);
+            TelemetryStore::new_without_background_runners(Some(parquet_metrics_provider));
         let write_buffer: Arc<dyn WriteBuffer> = write_buffer_impl;
         let common_state = crate::CommonServerState::new(
             Arc::clone(&metrics),

--- a/influxdb3_telemetry/src/sampler.rs
+++ b/influxdb3_telemetry/src/sampler.rs
@@ -125,7 +125,8 @@ mod tests {
     #[test]
     fn test_sample_all_metrics() {
         let mut mock_sys_info_provider = MockSystemInfoProvider::new();
-        let store = TelemetryStore::new_without_background_runners(Arc::from(MockParquetMetrics));
+        let store =
+            TelemetryStore::new_without_background_runners(Some(Arc::from(MockParquetMetrics)));
 
         mock_sys_info_provider
             .expect_get_pid()
@@ -145,7 +146,8 @@ mod tests {
     #[test]
     fn test_sample_all_metrics_with_call_failure() {
         let mut mock_sys_info_provider = MockSystemInfoProvider::new();
-        let store = TelemetryStore::new_without_background_runners(Arc::from(MockParquetMetrics));
+        let store =
+            TelemetryStore::new_without_background_runners(Some(Arc::from(MockParquetMetrics)));
 
         mock_sys_info_provider
             .expect_get_pid()

--- a/influxdb3_telemetry/src/store.rs
+++ b/influxdb3_telemetry/src/store.rs
@@ -71,7 +71,9 @@ impl TelemetryStore {
         store
     }
 
-    pub fn new_without_background_runners(persisted_files: Arc<dyn ParquetMetrics>) -> Arc<Self> {
+    pub fn new_without_background_runners(
+        persisted_files: Option<Arc<dyn ParquetMetrics>>,
+    ) -> Arc<Self> {
         let instance_id = Arc::from("sample-instance-id");
         let os = Arc::from("Linux");
         let influx_version = Arc::from("influxdb3-0.1.0");
@@ -80,7 +82,7 @@ impl TelemetryStore {
         let inner = TelemetryStoreInner::new(instance_id, os, influx_version, storage_type, cores);
         Arc::new(TelemetryStore {
             inner: parking_lot::Mutex::new(inner),
-            persisted_files: Some(persisted_files),
+            persisted_files,
         })
     }
 
@@ -191,7 +193,7 @@ impl TelemetryStoreInner {
             instance_id: self.instance_id.clone(),
             storage_type: self.storage_type.clone(),
             cores: self.cores,
-            product_type: "OSS",
+            product_type: "Core",
             uptime_secs: self.start_timer.elapsed().as_secs(),
 
             cpu_utilization_percent_min_1m: self.cpu.utilization.min,
@@ -316,7 +318,7 @@ mod tests {
         let store: Arc<TelemetryStore> = TelemetryStore::new(
             Arc::from("some-instance-id"),
             Arc::from("Linux"),
-            Arc::from("OSS-v3.0"),
+            Arc::from("Core-v3.0"),
             Arc::from("Memory"),
             10,
             Some(parqet_file_metrics),

--- a/influxdb3_wal/src/create.rs
+++ b/influxdb3_wal/src/create.rs
@@ -43,6 +43,19 @@ pub fn write_batch_op(write_batch: WriteBatch) -> WalOp {
     WalOp::Write(write_batch)
 }
 
+pub fn catalog_batch_op(
+    db_id: DbId,
+    db_name: impl Into<Arc<str>>,
+    time_ns: i64,
+    ops: impl IntoIterator<Item = CatalogOp>,
+    sequence_number: u32,
+) -> WalOp {
+    WalOp::Catalog(OrderedCatalogBatch::new(
+        catalog_batch(db_id, db_name, time_ns, ops),
+        sequence_number,
+    ))
+}
+
 pub fn catalog_batch(
     db_id: DbId,
     db_name: impl Into<Arc<str>>,

--- a/influxdb3_wal/src/lib.rs
+++ b/influxdb3_wal/src/lib.rs
@@ -16,7 +16,6 @@ use influxdb3_id::{ColumnId, DbId, SerdeVecMap, TableId};
 use influxdb_line_protocol::v3::SeriesValue;
 use influxdb_line_protocol::FieldValue;
 use iox_time::Time;
-use observability_deps::tracing::error;
 use schema::{InfluxColumnType, InfluxFieldType};
 use serde::{Deserialize, Serialize};
 use serde_with::serde_as;
@@ -319,6 +318,10 @@ impl OrderedCatalogBatch {
 
     pub fn batch(&self) -> &CatalogBatch {
         &self.catalog
+    }
+
+    pub fn into_batch(self) -> CatalogBatch {
+        self.catalog
     }
 }
 

--- a/influxdb3_wal/src/object_store.rs
+++ b/influxdb3_wal/src/object_store.rs
@@ -252,6 +252,7 @@ impl WalObjectStore {
                 .await
         };
         info!(
+            host = self.host_identifier_prefix,
             n_ops = %wal_contents.ops.len(),
             min_timestamp_ns = %wal_contents.min_timestamp_ns,
             max_timestamp_ns = %wal_contents.max_timestamp_ns,

--- a/influxdb3_write/Cargo.toml
+++ b/influxdb3_write/Cargo.toml
@@ -32,6 +32,7 @@ influxdb3_internal_api = { path = "../influxdb3_internal_api" }
 influxdb3_test_helpers = { path = "../influxdb3_test_helpers" }
 influxdb3_wal = { path = "../influxdb3_wal" }
 influxdb3_telemetry = { path = "../influxdb3_telemetry" }
+influxdb3_sys_events = { path = "../influxdb3_sys_events" }
 influxdb3_py_api = {path = "../influxdb3_py_api"}
 
 # crates.io dependencies

--- a/influxdb3_write/src/chunk.rs
+++ b/influxdb3_write/src/chunk.rs
@@ -64,13 +64,13 @@ impl QueryChunk for BufferChunk {
 
 #[derive(Debug)]
 pub struct ParquetChunk {
-    pub(crate) schema: Schema,
-    pub(crate) stats: Arc<ChunkStatistics>,
-    pub(crate) partition_id: TransitionPartitionId,
-    pub(crate) sort_key: Option<SortKey>,
-    pub(crate) id: ChunkId,
-    pub(crate) chunk_order: ChunkOrder,
-    pub(crate) parquet_exec: ParquetExecInput,
+    pub schema: Schema,
+    pub stats: Arc<ChunkStatistics>,
+    pub partition_id: TransitionPartitionId,
+    pub sort_key: Option<SortKey>,
+    pub id: ChunkId,
+    pub chunk_order: ChunkOrder,
+    pub parquet_exec: ParquetExecInput,
 }
 
 impl QueryChunk for ParquetChunk {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.83.0"
+channel = "1.84.0"
 components = ["rustfmt", "clippy", "rust-analyzer"]


### PR DESCRIPTION
This PR patches changes from enterprise back into core so they are as in-sync as possible, and to pull back changes that have been made to core code in the enterprise repo.