### PR TITLE
feat: Update create plugin to use server file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2989,6 +2989,7 @@ dependencies = [
  "observability_deps",
  "parquet_file",
  "pyo3",
+ "tempfile",
  "thiserror 1.0.69",
  "tokio",
 ]

--- a/influxdb3/src/commands/create.rs
+++ b/influxdb3/src/commands/create.rs
@@ -13,7 +13,6 @@ use secrecy::Secret;
 use sha2::Digest;
 use sha2::Sha512;
 use std::error::Error;
-use std::fs;
 use std::num::NonZeroUsize;
 use std::str;
 use std::time::Duration;
@@ -206,9 +205,9 @@ pub struct DistinctCacheConfig {
 pub struct PluginConfig {
     #[clap(flatten)]
     influxdb3_config: InfluxDb3Config,
-    /// Python file containing the plugin code
-    #[clap(long = "code-filename")]
-    code_file: String,
+    /// Python file name of the file on the server's plugin-dir containing the plugin code
+    #[clap(long = "filename")]
+    file_name: String,
     /// Type of trigger the plugin processes. Options: wal_rows, scheduled
     #[clap(long = "plugin-type", default_value = "wal_rows")]
     plugin_type: String,
@@ -338,15 +337,14 @@ pub async fn command(config: Config) -> Result<(), Box<dyn Error>> {
         SubCommand::Plugin(PluginConfig {
             influxdb3_config: InfluxDb3Config { database_name, .. },
             plugin_name,
-            code_file,
+            file_name,
             plugin_type,
         }) => {
-            let code = fs::read_to_string(&code_file)?;
             client
                 .api_v3_configure_processing_engine_plugin_create(
                     database_name,
                     &plugin_name,
-                    code,
+                    file_name,
                     plugin_type,
                 )
                 .await?;

--- a/influxdb3_catalog/src/serialize.rs
+++ b/influxdb3_catalog/src/serialize.rs
@@ -103,7 +103,7 @@ impl From<DatabaseSnapshot> for DatabaseSchema {
                     TriggerDefinition {
                         trigger_name: trigger.trigger_name,
                         plugin_name: plugin.plugin_name.to_string(),
-                        plugin,
+                        plugin_file_name: plugin.file_name.clone(),
                         trigger: serde_json::from_str(&trigger.trigger_specification).unwrap(),
                         trigger_arguments: trigger.trigger_arguments,
                         disabled: trigger.disabled,
@@ -164,7 +164,7 @@ struct TableSnapshot {
 #[derive(Debug, Serialize, Deserialize)]
 struct ProcessingEnginePluginSnapshot {
     pub plugin_name: String,
-    pub code: String,
+    pub file_name: String,
     pub plugin_type: PluginType,
 }
 
@@ -414,7 +414,7 @@ impl From<&PluginDefinition> for ProcessingEnginePluginSnapshot {
     fn from(plugin: &PluginDefinition) -> Self {
         Self {
             plugin_name: plugin.plugin_name.to_string(),
-            code: plugin.code.to_string(),
+            file_name: plugin.file_name.to_string(),
             plugin_type: plugin.plugin_type,
         }
     }
@@ -424,7 +424,7 @@ impl From<ProcessingEnginePluginSnapshot> for PluginDefinition {
     fn from(plugin: ProcessingEnginePluginSnapshot) -> Self {
         Self {
             plugin_name: plugin.plugin_name.to_string(),
-            code: plugin.code.to_string(),
+            file_name: plugin.file_name.to_string(),
             plugin_type: plugin.plugin_type,
         }
     }

--- a/influxdb3_client/src/lib.rs
+++ b/influxdb3_client/src/lib.rs
@@ -481,7 +481,7 @@ impl Client {
         &self,
         db: impl Into<String> + Send,
         plugin_name: impl Into<String> + Send,
-        code: impl Into<String> + Send,
+        file_name: impl Into<String> + Send,
         plugin_type: impl Into<String> + Send,
     ) -> Result<()> {
         let api_path = "/api/v3/configure/processing_engine_plugin";
@@ -492,14 +492,14 @@ impl Client {
         struct Req {
             db: String,
             plugin_name: String,
-            code: String,
+            file_name: String,
             plugin_type: String,
         }
 
         let mut req = self.http_client.post(url).json(&Req {
             db: db.into(),
             plugin_name: plugin_name.into(),
-            code: code.into(),
+            file_name: file_name.into(),
             plugin_type: plugin_type.into(),
         });
 

--- a/influxdb3_processing_engine/Cargo.toml
+++ b/influxdb3_processing_engine/Cargo.toml
@@ -37,6 +37,7 @@ influxdb3_cache = { path = "../influxdb3_cache" }
 metric.workspace = true
 object_store.workspace = true
 parquet_file.workspace = true
+tempfile.workspace = true
 
 [lints]
 workspace = true

--- a/influxdb3_processing_engine/src/lib.rs
+++ b/influxdb3_processing_engine/src/lib.rs
@@ -114,9 +114,20 @@ impl ProcessingEngineManager for ProcessingEngineManagerImpl {
         &self,
         db: &str,
         plugin_name: String,
-        code: String,
+        file_name: String,
         plugin_type: PluginType,
     ) -> Result<(), ProcessingEngineError> {
+        // first verify that we can read the file
+        match &self.plugin_dir {
+            Some(plugin_dir) => {
+                let path = plugin_dir.join(&file_name);
+                if !path.exists() {
+                    return Err(ProcessingEngineError::PluginNotFound(file_name));
+                }
+            }
+            None => return Err(ProcessingEngineError::PluginDirNotSet),
+        }
+
         let (db_id, db_schema) = self
             .catalog
             .db_id_and_schema(db)
@@ -124,7 +135,7 @@ impl ProcessingEngineManager for ProcessingEngineManagerImpl {
 
         let catalog_op = CatalogOp::CreatePlugin(PluginDefinition {
             plugin_name,
-            code,
+            file_name,
             plugin_type,
         });
 
@@ -191,7 +202,7 @@ impl ProcessingEngineManager for ProcessingEngineManagerImpl {
         let catalog_op = CatalogOp::CreateTrigger(TriggerDefinition {
             trigger_name,
             plugin_name,
-            plugin: plugin.clone(),
+            plugin_file_name: plugin.file_name.clone(),
             trigger: trigger_specification,
             trigger_arguments,
             disabled,
@@ -287,7 +298,8 @@ impl ProcessingEngineManager for ProcessingEngineManagerImpl {
                 write_buffer,
                 query_executor,
             };
-            plugins::run_plugin(db_name.to_string(), trigger, plugin_context);
+            let plugin_code = self.read_plugin_code(&trigger.plugin_file_name)?;
+            plugins::run_plugin(db_name.to_string(), plugin_code, trigger, plugin_context);
         }
 
         Ok(())
@@ -463,9 +475,11 @@ mod tests {
     use object_store::memory::InMemory;
     use object_store::ObjectStore;
     use parquet_file::storage::{ParquetStorage, StorageId};
+    use std::io::Write;
     use std::num::NonZeroUsize;
     use std::sync::Arc;
     use std::time::Duration;
+    use tempfile::NamedTempFile;
 
     #[tokio::test]
     async fn test_create_plugin() -> influxdb3_write::write_buffer::Result<()> {
@@ -477,7 +491,14 @@ mod tests {
             flush_interval: Duration::from_millis(10),
             snapshot_size: 1,
         };
-        let pem = setup(start_time, test_store, wal_config).await;
+        let (pem, file) = setup(start_time, test_store, wal_config).await;
+        let file_name = file
+            .path()
+            .file_name()
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_string();
 
         pem._write_buffer
             .write_lp(
@@ -489,13 +510,10 @@ mod tests {
             )
             .await?;
 
-        let empty_udf = r#"def example(iterator, output):
-                                   return"#;
-
         pem.insert_plugin(
             "foo",
             "my_plugin".to_string(),
-            empty_udf.to_string(),
+            file_name.clone(),
             PluginType::WalRows,
         )
         .await
@@ -511,7 +529,7 @@ mod tests {
             .clone();
         let expected = PluginDefinition {
             plugin_name: "my_plugin".to_string(),
-            code: empty_udf.to_string(),
+            file_name: file_name.to_string(),
             plugin_type: PluginType::WalRows,
         };
         assert_eq!(expected, plugin);
@@ -520,7 +538,7 @@ mod tests {
         pem.insert_plugin(
             "foo",
             "my_plugin".to_string(),
-            empty_udf.to_string(),
+            file_name.clone(),
             PluginType::WalRows,
         )
         .await
@@ -530,7 +548,7 @@ mod tests {
         pem.insert_plugin(
             "foo",
             "my_second_plugin".to_string(),
-            empty_udf.to_string(),
+            file_name,
             PluginType::WalRows,
         )
         .await
@@ -547,7 +565,14 @@ mod tests {
             flush_interval: Duration::from_millis(10),
             snapshot_size: 1,
         };
-        let pem = setup(start_time, test_store, wal_config).await;
+        let (pem, file) = setup(start_time, test_store, wal_config).await;
+        let file_name = file
+            .path()
+            .file_name()
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_string();
 
         // Create the DB by inserting a line.
         pem._write_buffer
@@ -564,7 +589,7 @@ mod tests {
         pem.insert_plugin(
             "foo",
             "test_plugin".to_string(),
-            "def process(iterator, output): pass".to_string(),
+            file_name.clone(),
             PluginType::WalRows,
         )
         .await
@@ -581,7 +606,7 @@ mod tests {
         pem.insert_plugin(
             "foo",
             "test_plugin".to_string(),
-            "def new_process(iterator, output): pass".to_string(),
+            file_name.clone(),
             PluginType::WalRows,
         )
         .await
@@ -600,7 +625,14 @@ mod tests {
             flush_interval: Duration::from_millis(10),
             snapshot_size: 1,
         };
-        let pem = setup(start_time, test_store, wal_config).await;
+        let (pem, file) = setup(start_time, test_store, wal_config).await;
+        let file_name = file
+            .path()
+            .file_name()
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_string();
 
         // Create the DB by inserting a line.
         pem._write_buffer
@@ -617,7 +649,7 @@ mod tests {
         pem.insert_plugin(
             "foo",
             "test_plugin".to_string(),
-            "def process(iterator, output): pass".to_string(),
+            file_name.clone(),
             PluginType::WalRows,
         )
         .await
@@ -658,7 +690,14 @@ mod tests {
             flush_interval: Duration::from_millis(10),
             snapshot_size: 1,
         };
-        let pem = setup(start_time, test_store, wal_config).await;
+        let (pem, file) = setup(start_time, test_store, wal_config).await;
+        let file_name = file
+            .path()
+            .file_name()
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_string();
 
         // convert to Arc<WriteBuffer>
         let write_buffer: Arc<dyn WriteBuffer> = Arc::clone(&pem._write_buffer);
@@ -678,7 +717,7 @@ mod tests {
         pem.insert_plugin(
             "foo",
             "test_plugin".to_string(),
-            "def process(iterator, output): pass".to_string(),
+            file_name.clone(),
             PluginType::WalRows,
         )
         .await
@@ -748,7 +787,14 @@ mod tests {
             flush_interval: Duration::from_millis(10),
             snapshot_size: 1,
         };
-        let pem = setup(start_time, test_store, wal_config).await;
+        let (pem, file) = setup(start_time, test_store, wal_config).await;
+        let file_name = file
+            .path()
+            .file_name()
+            .unwrap()
+            .to_str()
+            .unwrap()
+            .to_string();
 
         // Create the DB by inserting a line.
         pem._write_buffer
@@ -765,7 +811,7 @@ mod tests {
         pem.insert_plugin(
             "foo",
             "test_plugin".to_string(),
-            "def process(iterator, output): pass".to_string(),
+            file_name.clone(),
             PluginType::WalRows,
         )
         .await
@@ -806,7 +852,7 @@ mod tests {
             flush_interval: Duration::from_millis(10),
             snapshot_size: 1,
         };
-        let pem = setup(start_time, test_store, wal_config).await;
+        let (pem, _file_name) = setup(start_time, test_store, wal_config).await;
 
         let write_buffer: Arc<dyn WriteBuffer> = Arc::clone(&pem._write_buffer);
 
@@ -844,7 +890,7 @@ mod tests {
         start: Time,
         object_store: Arc<dyn ObjectStore>,
         wal_config: WalConfig,
-    ) -> ProcessingEngineManagerImpl {
+    ) -> (ProcessingEngineManagerImpl, NamedTempFile) {
         let time_provider: Arc<dyn TimeProvider> = Arc::new(MockProvider::new(start));
         let metric_registry = Arc::new(Registry::new());
         let persister = Arc::new(Persister::new(Arc::clone(&object_store), "test_host"));
@@ -875,7 +921,18 @@ mod tests {
         let qe = Arc::new(UnimplementedQueryExecutor);
         let wal = wbuf.wal();
 
-        ProcessingEngineManagerImpl::new(None, catalog, wbuf, qe, time_provider, wal)
+        let mut file = NamedTempFile::new().unwrap();
+        let code = r#"
+def process_writes(influxdb3_local, table_batches, args=None):
+    influxdb3_local.info("done")
+"#;
+        writeln!(file, "{}", code).unwrap();
+        let plugin_dir = Some(file.path().parent().unwrap().to_path_buf());
+
+        (
+            ProcessingEngineManagerImpl::new(plugin_dir, catalog, wbuf, qe, time_provider, wal),
+            file,
+        )
     }
 
     pub(crate) fn make_exec() -> Arc<Executor> {

--- a/influxdb3_processing_engine/src/manager.rs
+++ b/influxdb3_processing_engine/src/manager.rs
@@ -20,6 +20,15 @@ pub enum ProcessingEngineError {
 
     #[error("wal error: {0}")]
     WalError(#[from] influxdb3_wal::Error),
+
+    #[error("server not started with --plugin-dir")]
+    PluginDirNotSet,
+
+    #[error("plugin not found: {0}")]
+    PluginNotFound(String),
+
+    #[error("plugin error: {0}")]
+    PluginError(#[from] crate::plugins::Error),
 }
 
 /// `[ProcessingEngineManager]` is used to interact with the processing engine,
@@ -32,7 +41,7 @@ pub trait ProcessingEngineManager: Debug + Send + Sync + 'static {
         &self,
         db: &str,
         plugin_name: String,
-        code: String,
+        file_name: String,
         plugin_type: PluginType,
     ) -> Result<(), ProcessingEngineError>;
 

--- a/influxdb3_processing_engine/src/plugins.rs
+++ b/influxdb3_processing_engine/src/plugins.rs
@@ -47,12 +47,14 @@ pub enum Error {
 #[cfg(feature = "system-py")]
 pub(crate) fn run_plugin(
     db_name: String,
+    plugin_code: String,
     trigger_definition: TriggerDefinition,
     context: PluginContext,
 ) {
     let trigger_plugin = TriggerPlugin {
         trigger_definition,
         db_name,
+        plugin_code,
         write_buffer: context.write_buffer,
         query_executor: context.query_executor,
     };
@@ -89,6 +91,7 @@ trait RunnablePlugin {
 #[derive(Debug)]
 struct TriggerPlugin {
     trigger_definition: TriggerDefinition,
+    plugin_code: String,
     db_name: String,
     write_buffer: Arc<dyn WriteBuffer>,
     query_executor: Arc<dyn QueryExecutor>,
@@ -170,7 +173,7 @@ mod python_plugin {
                                 };
 
                                 let result = execute_python_with_batch(
-                                    &self.trigger_definition.plugin.code,
+                                    &self.plugin_code,
                                     write_batch,
                                     Arc::clone(&schema),
                                     Arc::clone(&self.query_executor),

--- a/influxdb3_server/src/http.rs
+++ b/influxdb3_server/src/http.rs
@@ -995,7 +995,7 @@ where
         let ProcessingEnginePluginCreateRequest {
             db,
             plugin_name,
-            code,
+            file_name,
             plugin_type,
         } = if let Some(query) = req.uri().query() {
             serde_urlencoded::from_str(query)?
@@ -1003,7 +1003,7 @@ where
             self.read_body_json(req).await?
         };
         self.processing_engine
-            .insert_plugin(&db, plugin_name, code, plugin_type)
+            .insert_plugin(&db, plugin_name, file_name, plugin_type)
             .await?;
 
         Ok(Response::builder()
@@ -1596,7 +1596,7 @@ struct LastCacheDeleteRequest {
 struct ProcessingEnginePluginCreateRequest {
     db: String,
     plugin_name: String,
-    code: String,
+    file_name: String,
     plugin_type: PluginType,
 }
 

--- a/influxdb3_server/src/system_tables/python_call.rs
+++ b/influxdb3_server/src/system_tables/python_call.rs
@@ -17,7 +17,7 @@ pub(super) struct ProcessingEnginePluginTable {
 fn plugin_schema() -> SchemaRef {
     let columns = vec![
         Field::new("plugin_name", DataType::Utf8, false),
-        Field::new("code", DataType::Utf8, false),
+        Field::new("file_name", DataType::Utf8, false),
         Field::new("plugin_type", DataType::Utf8, false),
     ];
     Schema::new(columns).into()
@@ -53,7 +53,7 @@ impl IoxSystemTable for ProcessingEnginePluginTable {
             Arc::new(
                 self.plugins
                     .iter()
-                    .map(|p| Some(p.code.clone()))
+                    .map(|p| Some(p.file_name.clone()))
                     .collect::<StringArray>(),
             ),
             Arc::new(
@@ -111,7 +111,7 @@ impl IoxSystemTable for ProcessingEngineTriggerTable {
         let plugin_column = self
             .triggers
             .iter()
-            .map(|trigger| Some(trigger.plugin.plugin_name.clone()))
+            .map(|trigger| Some(trigger.plugin_name.clone()))
             .collect::<StringArray>();
         let specification_column = self
             .triggers

--- a/influxdb3_wal/src/lib.rs
+++ b/influxdb3_wal/src/lib.rs
@@ -622,7 +622,7 @@ pub struct DistinctCacheDelete {
 #[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Clone)]
 pub struct PluginDefinition {
     pub plugin_name: String,
-    pub code: String,
+    pub file_name: String,
     pub plugin_type: PluginType,
 }
 
@@ -641,11 +641,10 @@ pub enum PluginType {
 pub struct TriggerDefinition {
     pub trigger_name: String,
     pub plugin_name: String,
+    pub plugin_file_name: String,
     pub database_name: String,
     pub trigger: TriggerSpecificationDefinition,
     pub trigger_arguments: Option<HashMap<String, String>>,
-    // TODO: decide whether this should be populated from a reference rather than stored on its own.
-    pub plugin: PluginDefinition,
     pub disabled: bool,
 }
 


### PR DESCRIPTION
This updates the create plugin API and CLI so that it doesn't take the pugin code, but instead takes a file name of a file that must be in the plugin-dir of the server. It returns an error if the plugin-dir is not configured or if the file isn't there.

Also updates the WAL and catalog so that it doesn't store the plugin code directly. The code is read from disk one time when the plugin runs.

Closes #25797