### PR TITLE
refactor: change host-id to writer-id

### DIFF
--- a/influxdb3/src/commands/create.rs
+++ b/influxdb3/src/commands/create.rs
@@ -377,7 +377,7 @@ pub async fn command(config: Config) -> Result<(), Box<dyn Error>> {
                 "\
                 Token: {token}\n\
                 Hashed Token: {hashed}\n\n\
-                Start the server with `influxdb3 serve --bearer-token {hashed} --object-store file --data-dir ~/.influxdb3 --host-id YOUR_HOST_NAME`\n\n\
+                Start the server with `influxdb3 serve --bearer-token {hashed} --object-store file --data-dir ~/.influxdb3 --writer-id YOUR_HOST_NAME`\n\n\
                 HTTP requests require the following header: \"Authorization: Bearer {token}\"\n\
                 This will grant you access to every HTTP endpoint or deny it otherwise
             ",

--- a/influxdb3/src/commands/serve.rs
+++ b/influxdb3/src/commands/serve.rs
@@ -240,10 +240,17 @@ pub struct Config {
     )]
     pub buffer_mem_limit_mb: usize,
 
-    /// The host idendifier used as a prefix in all object store file paths. This should be unique
-    /// for any hosts that share the same object store configuration, i.e., the same bucket.
-    #[clap(long = "host-id", env = "INFLUXDB3_HOST_IDENTIFIER_PREFIX", action)]
-    pub host_identifier_prefix: String,
+    /// The writer idendifier used as a prefix in all object store file paths. This should be unique
+    /// for any InfluxDB 3 Core servers that share the same object store configuration, i.e., the
+    /// same bucket.
+    #[clap(
+        long = "writer-id",
+        // TODO: deprecate this alias in future version
+        alias = "host-id",
+        env = "INFLUXDB3_WRITER_IDENTIFIER_PREFIX",
+        action
+    )]
+    pub writer_identifier_prefix: String,
 
     /// The size of the in-memory Parquet cache in megabytes (MB).
     #[clap(
@@ -383,7 +390,7 @@ pub async fn command(config: Config) -> Result<()> {
     let num_cpus = num_cpus::get();
     let build_malloc_conf = build_malloc_conf();
     info!(
-        host_id = %config.host_identifier_prefix,
+        writer_id = %config.writer_identifier_prefix,
         git_hash = %INFLUXDB3_GIT_HASH as &str,
         version = %INFLUXDB3_VERSION.as_ref() as &str,
         uuid = %PROCESS_UUID.as_ref() as &str,
@@ -473,7 +480,7 @@ pub async fn command(config: Config) -> Result<()> {
 
     let persister = Arc::new(Persister::new(
         Arc::clone(&object_store),
-        config.host_identifier_prefix,
+        config.writer_identifier_prefix,
     ));
     let wal_config = WalConfig {
         gen1_duration: config.gen1_duration,

--- a/influxdb3/src/main.rs
+++ b/influxdb3/src/main.rs
@@ -55,7 +55,7 @@ long_about = r#"InfluxDB 3 Core server and command line tools
 
 Examples:
     # Run the InfluxDB 3 Core server
-    influxdb3 serve --object-store file --data-dir ~/.influxdb3 --host_id my_host_name
+    influxdb3 serve --object-store file --data-dir ~/.influxdb3 --writer_id my_writer_name
 
     # Display all commands short form
     influxdb3 -h
@@ -64,10 +64,10 @@ Examples:
     influxdb3 --help
 
     # Run the InfluxDB 3 Core server with extra verbose logging
-    influxdb3 serve -v --object-store file --data-dir ~/.influxdb3 --host_id my_host_name
+    influxdb3 serve -v --object-store file --data-dir ~/.influxdb3 --writer_id my_writer_name
 
     # Run InfluxDB 3 Core with full debug logging specified with LOG_FILTER
-    LOG_FILTER=debug influxdb3 serve --object-store file --data-dir ~/.influxdb3 --host_id my_host_name
+    LOG_FILTER=debug influxdb3 serve --object-store file --data-dir ~/.influxdb3 --writer_id my_writer_name
 "#
 )]
 struct Config {

--- a/influxdb3/tests/server/main.rs
+++ b/influxdb3/tests/server/main.rs
@@ -47,7 +47,7 @@ trait ConfigProvider {
 #[derive(Debug, Default)]
 pub struct TestConfig {
     auth_token: Option<(String, String)>,
-    host_id: Option<String>,
+    writer_id: Option<String>,
     plugin_dir: Option<String>,
 }
 
@@ -63,8 +63,8 @@ impl TestConfig {
     }
 
     /// Set a host identifier prefix on the spawned [`TestServer`]
-    pub fn with_host_id<S: Into<String>>(mut self, host_id: S) -> Self {
-        self.host_id = Some(host_id.into());
+    pub fn with_writer_id<S: Into<String>>(mut self, writer_id: S) -> Self {
+        self.writer_id = Some(writer_id.into());
         self
     }
 
@@ -84,8 +84,8 @@ impl ConfigProvider for TestConfig {
         if let Some(plugin_dir) = &self.plugin_dir {
             args.append(&mut vec!["--plugin-dir".to_string(), plugin_dir.to_owned()]);
         }
-        args.push("--host-id".to_string());
-        if let Some(host) = &self.host_id {
+        args.push("--writer-id".to_string());
+        if let Some(host) = &self.writer_id {
             args.push(host.to_owned());
         } else {
             args.push("test-server".to_string());

--- a/influxdb3_cache/src/last_cache/mod.rs
+++ b/influxdb3_cache/src/last_cache/mod.rs
@@ -1349,9 +1349,9 @@ mod tests {
             .insert(table_def.table_id, Arc::new(table_def));
         // Create the catalog and clone its InnerCatalog (which is what the LastCacheProvider is
         // initialized from):
-        let host_id = Arc::from("sample-host-id");
+        let writer_id = Arc::from("sample-host-id");
         let instance_id = Arc::from("sample-instance-id");
-        let catalog = Catalog::new(host_id, instance_id);
+        let catalog = Catalog::new(writer_id, instance_id);
         let db_id = database.id;
         catalog.insert_database(database);
         let catalog = Arc::new(catalog);

--- a/influxdb3_catalog/src/snapshots/influxdb3_catalog__catalog__tests__catalog_serialization.snap
+++ b/influxdb3_catalog/src/snapshots/influxdb3_catalog__catalog__tests__catalog_serialization.snap
@@ -2,7 +2,6 @@
 source: influxdb3_catalog/src/catalog.rs
 description: catalog serialization to help catch breaking changes
 expression: catalog
-snapshot_kind: text
 ---
 {
   "databases": [
@@ -270,7 +269,7 @@ snapshot_kind: text
     ]
   ],
   "sequence": 0,
-  "host_id": "sample-host-id",
+  "writer_id": "sample-host-id",
   "instance_id": "instance-id",
   "db_map": []
 }

--- a/influxdb3_catalog/src/snapshots/influxdb3_catalog__catalog__tests__serialize_last_cache.snap
+++ b/influxdb3_catalog/src/snapshots/influxdb3_catalog__catalog__tests__serialize_last_cache.snap
@@ -2,7 +2,6 @@
 source: influxdb3_catalog/src/catalog.rs
 description: catalog serialization to help catch breaking changes
 expression: catalog
-snapshot_kind: text
 ---
 {
   "databases": [
@@ -121,7 +120,7 @@ snapshot_kind: text
     ]
   ],
   "sequence": 0,
-  "host_id": "sample-host-id",
+  "writer_id": "sample-host-id",
   "instance_id": "instance-id",
   "db_map": []
 }

--- a/influxdb3_catalog/src/snapshots/influxdb3_catalog__catalog__tests__serialize_series_keys.snap
+++ b/influxdb3_catalog/src/snapshots/influxdb3_catalog__catalog__tests__serialize_series_keys.snap
@@ -2,7 +2,6 @@
 source: influxdb3_catalog/src/catalog.rs
 description: catalog serialization to help catch breaking changes
 expression: catalog
-snapshot_kind: text
 ---
 {
   "databases": [
@@ -105,7 +104,7 @@ snapshot_kind: text
     ]
   ],
   "sequence": 0,
-  "host_id": "sample-host-id",
+  "writer_id": "sample-host-id",
   "instance_id": "instance-id",
   "db_map": []
 }

--- a/influxdb3_server/src/lib.rs
+++ b/influxdb3_server/src/lib.rs
@@ -760,9 +760,9 @@ mod tests {
             DedicatedExecutor::new_testing(),
         ));
         let persister = Arc::new(Persister::new(Arc::clone(&object_store), "test_host"));
-        let sample_host_id = Arc::from("sample-host-id");
+        let sample_writer_id = Arc::from("sample-host-id");
         let instance_id = Arc::from("sample-instance-id");
-        let catalog = Arc::new(Catalog::new(sample_host_id, instance_id));
+        let catalog = Arc::new(Catalog::new(sample_writer_id, instance_id));
         let write_buffer_impl = influxdb3_write::write_buffer::WriteBufferImpl::new(
             influxdb3_write::write_buffer::WriteBufferImplArgs {
                 persister: Arc::clone(&persister),

--- a/influxdb3_server/src/query_executor/mod.rs
+++ b/influxdb3_server/src/query_executor/mod.rs
@@ -738,9 +738,9 @@ mod tests {
         );
         let persister = Arc::new(Persister::new(Arc::clone(&object_store), "test_host"));
         let exec = make_exec(Arc::clone(&object_store));
-        let host_id = Arc::from("sample-host-id");
+        let writer_id = Arc::from("sample-host-id");
         let instance_id = Arc::from("instance-id");
-        let catalog = Arc::new(Catalog::new(host_id, instance_id));
+        let catalog = Arc::new(Catalog::new(writer_id, instance_id));
         let write_buffer_impl = WriteBufferImpl::new(WriteBufferImplArgs {
             persister,
             catalog: Arc::clone(&catalog),

--- a/influxdb3_write/src/lib.rs
+++ b/influxdb3_write/src/lib.rs
@@ -186,8 +186,8 @@ pub struct BufferedWriteRequest {
 /// The collection of Parquet files that were persisted in a snapshot
 #[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Clone)]
 pub struct PersistedSnapshot {
-    /// The host identifier that persisted this snapshot
-    pub host_id: String,
+    /// The writer identifier that persisted this snapshot
+    pub writer_id: String,
     /// The next file id to be used with `ParquetFile`s when the snapshot is loaded
     pub next_file_id: ParquetFileId,
     /// The next db id to be used for databases when the snapshot is loaded
@@ -217,13 +217,13 @@ pub struct PersistedSnapshot {
 
 impl PersistedSnapshot {
     pub fn new(
-        host_id: String,
+        writer_id: String,
         snapshot_sequence_number: SnapshotSequenceNumber,
         wal_file_sequence_number: WalFileSequenceNumber,
         catalog_sequence_number: CatalogSequenceNumber,
     ) -> Self {
         Self {
-            host_id,
+            writer_id,
             next_file_id: ParquetFileId::next_id(),
             next_db_id: DbId::next_id(),
             next_table_id: TableId::next_id(),
@@ -500,7 +500,7 @@ mod tests {
 
         // add dbs_1 to snapshot
         let persisted_snapshot_1 = PersistedSnapshot {
-            host_id: host.to_string(),
+            writer_id: host.to_string(),
             next_file_id: ParquetFileId::from(0),
             next_db_id: DbId::from(1),
             next_table_id: TableId::from(1),
@@ -545,7 +545,7 @@ mod tests {
 
         // add dbs_2 to snapshot
         let persisted_snapshot_2 = PersistedSnapshot {
-            host_id: host.to_string(),
+            writer_id: host.to_string(),
             next_file_id: ParquetFileId::from(5),
             next_db_id: DbId::from(2),
             next_table_id: TableId::from(22),

--- a/influxdb3_write/src/snapshots/influxdb3_write__persister__tests__persisted_snapshot_structure.snap
+++ b/influxdb3_write/src/snapshots/influxdb3_write__persister__tests__persisted_snapshot_structure.snap
@@ -3,7 +3,7 @@ source: influxdb3_write/src/persister.rs
 expression: snapshot
 ---
 {
-  "host_id": "host",
+  "writer_id": "host",
   "next_file_id": 8,
   "next_db_id": 2,
   "next_table_id": 4,

--- a/influxdb3_write/src/write_buffer/mod.rs
+++ b/influxdb3_write/src/write_buffer/mod.rs
@@ -216,7 +216,7 @@ impl WriteBufferImpl {
         let wal = WalObjectStore::new(
             Arc::clone(&time_provider),
             persister.object_store(),
-            persister.host_identifier_prefix(),
+            persister.writer_identifier_prefix(),
             Arc::clone(&queryable_buffer) as Arc<dyn WalFileNotifier>,
             wal_config,
             last_wal_sequence_number,
@@ -883,9 +883,9 @@ mod tests {
 
     #[test]
     fn parse_lp_into_buffer() {
-        let host_id = Arc::from("sample-host-id");
+        let writer_id = Arc::from("sample-host-id");
         let instance_id = Arc::from("sample-instance-id");
-        let catalog = Arc::new(Catalog::new(host_id, instance_id));
+        let catalog = Arc::new(Catalog::new(writer_id, instance_id));
         let db_name = NamespaceName::new("foo").unwrap();
         let lp = "cpu,region=west user=23.2 100\nfoo f1=1i";
         WriteValidator::initialize(db_name, Arc::clone(&catalog), 0)

--- a/influxdb3_write/src/write_buffer/queryable_buffer.rs
+++ b/influxdb3_write/src/write_buffer/queryable_buffer.rs
@@ -209,7 +209,7 @@ impl QueryableBuffer {
                             table_name: Arc::clone(&table_name),
                             chunk_time: chunk.chunk_time,
                             path: ParquetFilePath::new(
-                                self.persister.host_identifier_prefix(),
+                                self.persister.writer_identifier_prefix(),
                                 db_schema.name.as_ref(),
                                 database_id.as_u32(),
                                 table_name.as_ref(),
@@ -277,7 +277,7 @@ impl QueryableBuffer {
             );
             // persist the individual files, building the snapshot as we go
             let mut persisted_snapshot = PersistedSnapshot::new(
-                persister.host_identifier_prefix().to_string(),
+                persister.writer_identifier_prefix().to_string(),
                 snapshot_details.snapshot_sequence_number,
                 snapshot_details.last_wal_sequence_number,
                 catalog.sequence_number(),

--- a/influxdb3_write/src/write_buffer/snapshots/influxdb3_write__write_buffer__tests__catalog-after-last-cache-create-and-new-field.snap
+++ b/influxdb3_write/src/write_buffer/snapshots/influxdb3_write__write_buffer__tests__catalog-after-last-cache-create-and-new-field.snap
@@ -1,7 +1,6 @@
 ---
 source: influxdb3_write/src/write_buffer/mod.rs
 expression: catalog_json
-snapshot_kind: text
 ---
 {
   "databases": [
@@ -100,7 +99,7 @@ snapshot_kind: text
       "name": "db"
     }
   ],
-  "host_id": "test_host",
   "instance_id": "[uuid]",
-  "sequence": 3
+  "sequence": 3,
+  "writer_id": "test_host"
 }

--- a/influxdb3_write/src/write_buffer/snapshots/influxdb3_write__write_buffer__tests__catalog-immediately-after-last-cache-create.snap
+++ b/influxdb3_write/src/write_buffer/snapshots/influxdb3_write__write_buffer__tests__catalog-immediately-after-last-cache-create.snap
@@ -1,7 +1,6 @@
 ---
 source: influxdb3_write/src/write_buffer/mod.rs
 expression: catalog_json
-snapshot_kind: text
 ---
 {
   "databases": [
@@ -90,7 +89,7 @@ snapshot_kind: text
       "name": "db"
     }
   ],
-  "host_id": "test_host",
   "instance_id": "[uuid]",
-  "sequence": 2
+  "sequence": 2,
+  "writer_id": "test_host"
 }

--- a/influxdb3_write/src/write_buffer/snapshots/influxdb3_write__write_buffer__tests__catalog-immediately-after-last-cache-delete.snap
+++ b/influxdb3_write/src/write_buffer/snapshots/influxdb3_write__write_buffer__tests__catalog-immediately-after-last-cache-delete.snap
@@ -1,7 +1,6 @@
 ---
 source: influxdb3_write/src/write_buffer/mod.rs
 expression: catalog_json
-snapshot_kind: text
 ---
 {
   "databases": [
@@ -87,7 +86,7 @@ snapshot_kind: text
       "name": "db"
     }
   ],
-  "host_id": "test_host",
   "instance_id": "[uuid]",
-  "sequence": 4
+  "sequence": 4,
+  "writer_id": "test_host"
 }

--- a/influxdb3_write/src/write_buffer/validator.rs
+++ b/influxdb3_write/src/write_buffer/validator.rs
@@ -508,10 +508,10 @@ mod tests {
 
     #[test]
     fn write_validator_v1() -> Result<(), Error> {
-        let host_id = Arc::from("sample-host-id");
+        let writer_id = Arc::from("sample-host-id");
         let instance_id = Arc::from("sample-instance-id");
         let namespace = NamespaceName::new("test").unwrap();
-        let catalog = Arc::new(Catalog::new(host_id, instance_id));
+        let catalog = Arc::new(Catalog::new(writer_id, instance_id));
         let result = WriteValidator::initialize(namespace.clone(), Arc::clone(&catalog), 0)
             .unwrap()
             .v1_parse_lines_and_update_schema(


### PR DESCRIPTION
* [**BREAKING**] This changes the CLI arg `host-id` to `writer-id` to more accurately indicate meaning.
* This changes also goes through the codebase and changes struct fields, methods, and variables to use the term `writer_id` or `writer_identifier_prefix` instead of `host_id` etc., to make the meaning clear and consistent in the code.
* [**BREAKING**] This also changes the catalog serialization to use the field `writer_id` instead of `host_id`, which is breaking change.

Here is the section from the updated `influxdb3 serve --help`:
```
Run the InfluxDB 3 Core server

Usage: influxdb3 serve [OPTIONS] --writer-id <WRITER_IDENTIFIER_PREFIX>

Options:
[...]
      --writer-id <WRITER_IDENTIFIER_PREFIX>
          The writer idendifier used as a prefix in all object store file paths. This should be unique for any InfluxDB 3 Core servers that share the same object store configuration, i.e., the same bucket

          [env: INFLUXDB3_WRITER_IDENTIFIER_PREFIX=]
```

Closes #25790