### PR TITLE
fix: change trigger shutdown implementation to avoid deadlock.

### DIFF
--- a/influxdb3_processing_engine/src/manager.rs
+++ b/influxdb3_processing_engine/src/manager.rs
@@ -29,6 +29,12 @@ pub enum ProcessingEngineError {
 
     #[error("plugin error: {0}")]
     PluginError(#[from] crate::plugins::Error),
+
+    #[error("failed to shutdown trigger {trigger_name} in database {database}")]
+    TriggerShutdownError {
+        database: String,
+        trigger_name: String,
+    },
 }
 
 /// `[ProcessingEngineManager]` is used to interact with the processing engine,


### PR DESCRIPTION
Closes #25786 

Holding the lock on the PluginChannels caused a deadlock. Instead we only take the lock to send down the shutdown signal, and then wait for the plugin to exit.