### PR TITLE
fix: update CI to use a new version of the Ubuntu image as the old one has been deprecated by CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,7 +169,7 @@ jobs:
     machine:
       enabled: true
       docker_layer_caching: true
-      image: ubuntu-2004:202107-02
+      image: ubuntu-2204:current
     steps:
       - attach_workspace:
           at: /tmp/workspace


### PR DESCRIPTION
Related to https://github.com/orgs/influxdata/projects/108/views/1?pane=issue&itemId=91339068

The CI image has been removed. For more information, see [this discussion](https://discuss.circleci.com/t/linux-image-deprecations-and-eol-for-2024/50177). The `ubuntu-2204:current` image is the same as used in the 1.11 branch.

We need to fix the CI before releasing the new version of Plutonium.

![image](https://github.com/user-attachments/assets/f27d8d37-f078-429f-b422-317e680db958)
![image](https://github.com/user-attachments/assets/1db0d966-9d53-454a-8c29-94a51bb1a839)

https://app.circleci.com/pipelines/github/influxdata/influxdb/43361/workflows/6c772afa-d2ed-423b-ab83-157ce0d1b298/jobs/407782

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
