### PR TITLE
fix: create S3 client with from_env() instead of new() to allow eks and fargate container builds

### DIFF
--- a/influxdb3_clap_blocks/src/object_store.rs
+++ b/influxdb3_clap_blocks/src/object_store.rs
@@ -544,7 +544,7 @@ macro_rules! object_store_config_inner {
                 pub fn s3_builder(&self) -> object_store::aws::AmazonS3Builder {
                     use object_store::aws::AmazonS3Builder;
 
-                    let mut builder = AmazonS3Builder::new()
+                    let mut builder = AmazonS3Builder::from_env()
                         .with_client_options(self.client_options())
                         .with_allow_http(self.aws_allow_http)
                         .with_region(&self.aws_default_region)
@@ -623,7 +623,7 @@ macro_rules! object_store_config_inner {
                         return Ok(None);
                     };
 
-                    let store = object_store::aws::AmazonS3Builder::new()
+                    let store = object_store::aws::AmazonS3Builder::from_env()
                         // bucket name is ignored by our cache server
                         .with_bucket_name(self.bucket.as_deref().unwrap_or("placeholder"))
                         .with_client_options(


### PR DESCRIPTION
Creates AmazonS3 object using all environmental variables for additional cases where command line parameters are not appropriate.

This makes step 4 here possible - https://docs.aws.amazon.com/sdk-for-rust/latest/dg/credproviders.html

Alternative approach may have been to add a similar command line option for AWS_CONTAINER_CREDENTIALS_RELATIVE_URI but this makes no sense to provide on a CLI given it is only to be set automatically on Fargate and EKS containers.

As from_env() looks up all relevant environmental variables, it no longer makes sense to look for them as part of the CLI option parsing, so those relevant env options are removed.

Closes #25828

Describe your proposed changes here.

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
