### PR TITLE
chore: use an unusable url instead of localhost for token create

### DIFF
--- a/influxdb3/src/commands/create.rs
+++ b/influxdb3/src/commands/create.rs
@@ -84,8 +84,8 @@ impl Config {
                 Ok(client)
             }
             // We don't need a client for this, so we're just creating a
-            // placeholder client
-            SubCommand::Token => Ok(Client::new("http://localhost")?),
+            // placeholder client with an unusable URL
+            SubCommand::Token => Ok(Client::new("http://recall.invalid")?),
         }
     }
 }


### PR DESCRIPTION
This is a followup to https://github.com/influxdata/influxdb/pull/25773/files#r1913406770.