### PR TITLE
fix(processing_engine): start triggers when server is started.

### DIFF
--- a/influxdb3/src/commands/serve.rs
+++ b/influxdb3/src/commands/serve.rs
@@ -579,8 +579,9 @@ pub async fn command(config: Config) -> Result<()> {
         builder
             .authorizer(Arc::new(AllOrNothingAuthorizer::new(token)))
             .build()
+            .await
     } else {
-        builder.build()
+        builder.build().await
     };
     serve(server, frontend_shutdown, startup_timer).await?;
 

--- a/influxdb3/tests/server/main.rs
+++ b/influxdb3/tests/server/main.rs
@@ -49,6 +49,8 @@ pub struct TestConfig {
     auth_token: Option<(String, String)>,
     writer_id: Option<String>,
     plugin_dir: Option<String>,
+    // If None, use memory object store.
+    object_store_dir: Option<String>,
 }
 
 impl TestConfig {
@@ -73,6 +75,12 @@ impl TestConfig {
         self.plugin_dir = Some(plugin_dir.into());
         self
     }
+
+    // Set the object store dir for this [`TestServer`]
+    pub fn with_object_store_dir<S: Into<String>>(mut self, object_store_dir: S) -> Self {
+        self.object_store_dir = Some(object_store_dir.into());
+        self
+    }
 }
 
 impl ConfigProvider for TestConfig {
@@ -90,10 +98,19 @@ impl ConfigProvider for TestConfig {
         } else {
             args.push("test-server".to_string());
         }
-        args.append(&mut vec![
-            "--object-store".to_string(),
-            "memory".to_string(),
-        ]);
+        if let Some(object_store_dir) = &self.object_store_dir {
+            args.append(&mut vec![
+                "--object-store".to_string(),
+                "file".to_string(),
+                "--data-dir".to_string(),
+                object_store_dir.to_owned(),
+            ]);
+        } else {
+            args.append(&mut vec![
+                "--object-store".to_string(),
+                "memory".to_string(),
+            ]);
+        }
         args
     }
 

--- a/influxdb3_catalog/src/catalog.rs
+++ b/influxdb3_catalog/src/catalog.rs
@@ -332,7 +332,7 @@ impl Catalog {
         }
     }
 
-    pub fn triggers(&self) -> Vec<(String, String)> {
+    pub fn active_triggers(&self) -> Vec<(String, String)> {
         let inner = self.inner.read();
         let result = inner
             .databases

--- a/influxdb3_processing_engine/src/lib.rs
+++ b/influxdb3_processing_engine/src/lib.rs
@@ -422,6 +422,20 @@ impl ProcessingEngineManager for ProcessingEngineManagerImpl {
         Ok(())
     }
 
+    async fn start_triggers(&self) -> Result<(), ProcessingEngineError> {
+        let triggers = self.catalog.active_triggers();
+        for (db_name, trigger_name) in triggers {
+            self.run_trigger(
+                Arc::clone(&self._write_buffer),
+                Arc::clone(&self._query_executor),
+                &db_name,
+                &trigger_name,
+            )
+            .await?;
+        }
+        Ok(())
+    }
+
     #[cfg_attr(not(feature = "system-py"), allow(unused))]
     async fn test_wal_plugin(
         &self,
@@ -870,7 +884,7 @@ mod tests {
         assert!(trigger.disabled);
 
         // Verify trigger is not in active triggers list
-        assert!(pem.catalog.triggers().is_empty());
+        assert!(pem.catalog.active_triggers().is_empty());
         Ok(())
     }
 

--- a/influxdb3_processing_engine/src/manager.rs
+++ b/influxdb3_processing_engine/src/manager.rs
@@ -94,6 +94,8 @@ pub trait ProcessingEngineManager: Debug + Send + Sync + 'static {
         trigger_name: &str,
     ) -> Result<(), ProcessingEngineError>;
 
+    async fn start_triggers(&self) -> Result<(), ProcessingEngineError>;
+
     async fn test_wal_plugin(
         &self,
         request: WalPluginTestRequest,

--- a/influxdb3_server/src/lib.rs
+++ b/influxdb3_server/src/lib.rs
@@ -825,7 +825,8 @@ mod tests {
             .authorizer(Arc::new(DefaultAuthorizer))
             .time_provider(Arc::clone(&time_provider))
             .tcp_listener(listener)
-            .build();
+            .build()
+            .await;
         let frontend_shutdown = CancellationToken::new();
         let shutdown = frontend_shutdown.clone();
 


### PR DESCRIPTION
In an earlier change we dropped the logic that started running triggers when the database runs. Adds it back in with a `start_triggers()` call on ProcessingEngineManager.