### PR TITLE
feat: improve plugin logging interface

### DIFF
--- a/influxdb3/tests/server/cli.rs
+++ b/influxdb3/tests/server/cli.rs
@@ -949,6 +949,9 @@ def process_writes(influxdb3_local, table_batches, args=None):
     query_params = {"host": args["host"]}
     query_result = influxdb3_local.query("SELECT host, region, usage FROM cpu where host = $host", query_params)
     influxdb3_local.info("query result: " + str(query_result))
+    influxdb3_local.info("i", query_result, args["host"])
+    influxdb3_local.warn("w:", query_result)
+    influxdb3_local.error("err", query_result)
 
     for table_batch in table_batches:
         influxdb3_local.info("table: " + table_batch["table_name"])
@@ -1018,6 +1021,9 @@ def process_writes(influxdb3_local, table_batches, args=None):
   "log_lines": [
     "INFO: arg1: arg1_value",
     "INFO: query result: [{'host': 's2', 'region': 'us-east', 'usage': 0.89}]",
+    "INFO: i [{'host': 's2', 'region': 'us-east', 'usage': 0.89}] s2",
+    "WARN: w: [{'host': 's2', 'region': 'us-east', 'usage': 0.89}]",
+    "ERROR: err [{'host': 's2', 'region': 'us-east', 'usage': 0.89}]",
     "INFO: table: test_input",
     "INFO: row: {'tag1': 'tag1_value', 'tag2': 'tag2_value', 'field1': 1, 'time': 500}",
     "INFO: done"

--- a/influxdb3_py_api/src/system_py.rs
+++ b/influxdb3_py_api/src/system_py.rs
@@ -17,7 +17,7 @@ use observability_deps::tracing::{error, info, warn};
 use parking_lot::Mutex;
 use pyo3::exceptions::{PyException, PyValueError};
 use pyo3::prelude::{PyAnyMethods, PyModule};
-use pyo3::types::{PyDict, PyList};
+use pyo3::types::{PyDict, PyList, PyTuple};
 use pyo3::{
     create_exception, pyclass, pymethods, pymodule, Bound, IntoPyObject, Py, PyAny, PyObject,
     PyResult, Python,
@@ -72,16 +72,27 @@ impl std::fmt::Debug for LogLine {
 
 #[pymethods]
 impl PyPluginCallApi {
-    fn info(&self, line: &str) -> PyResult<()> {
+    #[pyo3(signature = (*args))]
+    fn info(&self, args: &Bound<'_, PyTuple>) -> PyResult<()> {
+        let line = args
+            .try_iter()?
+            .map(|arg| arg?.str()?.extract::<String>())
+            .collect::<Result<Vec<String>, _>>()?
+            .join(" ");
+
         info!("processing engine: {}", line);
-        self.return_state
-            .lock()
-            .log_lines
-            .push(LogLine::Info(line.to_string()));
+        self.return_state.lock().log_lines.push(LogLine::Info(line));
         Ok(())
     }
 
-    fn warn(&self, line: &str) -> PyResult<()> {
+    #[pyo3(signature = (*args))]
+    fn warn(&self, args: &Bound<'_, PyTuple>) -> PyResult<()> {
+        let line = args
+            .try_iter()?
+            .map(|arg| arg?.str()?.extract::<String>())
+            .collect::<Result<Vec<String>, _>>()?
+            .join(" ");
+
         warn!("processing engine: {}", line);
         self.return_state
             .lock()
@@ -90,7 +101,14 @@ impl PyPluginCallApi {
         Ok(())
     }
 
-    fn error(&self, line: &str) -> PyResult<()> {
+    #[pyo3(signature = (*args))]
+    fn error(&self, args: &Bound<'_, PyTuple>) -> PyResult<()> {
+        let line = args
+            .try_iter()?
+            .map(|arg| arg?.str()?.extract::<String>())
+            .collect::<Result<Vec<String>, _>>()?
+            .join(" ");
+
         error!("processing engine: {}", line);
         self.return_state
             .lock()

--- a/influxdb3_py_api/src/system_py.rs
+++ b/influxdb3_py_api/src/system_py.rs
@@ -74,11 +74,7 @@ impl std::fmt::Debug for LogLine {
 impl PyPluginCallApi {
     #[pyo3(signature = (*args))]
     fn info(&self, args: &Bound<'_, PyTuple>) -> PyResult<()> {
-        let line = args
-            .try_iter()?
-            .map(|arg| arg?.str()?.extract::<String>())
-            .collect::<Result<Vec<String>, _>>()?
-            .join(" ");
+        let line = self.log_args_to_string(args)?;
 
         info!("processing engine: {}", line);
         self.return_state.lock().log_lines.push(LogLine::Info(line));
@@ -87,11 +83,7 @@ impl PyPluginCallApi {
 
     #[pyo3(signature = (*args))]
     fn warn(&self, args: &Bound<'_, PyTuple>) -> PyResult<()> {
-        let line = args
-            .try_iter()?
-            .map(|arg| arg?.str()?.extract::<String>())
-            .collect::<Result<Vec<String>, _>>()?
-            .join(" ");
+        let line = self.log_args_to_string(args)?;
 
         warn!("processing engine: {}", line);
         self.return_state
@@ -103,11 +95,7 @@ impl PyPluginCallApi {
 
     #[pyo3(signature = (*args))]
     fn error(&self, args: &Bound<'_, PyTuple>) -> PyResult<()> {
-        let line = args
-            .try_iter()?
-            .map(|arg| arg?.str()?.extract::<String>())
-            .collect::<Result<Vec<String>, _>>()?
-            .join(" ");
+        let line = self.log_args_to_string(args)?;
 
         error!("processing engine: {}", line);
         self.return_state
@@ -115,6 +103,15 @@ impl PyPluginCallApi {
             .log_lines
             .push(LogLine::Error(line.to_string()));
         Ok(())
+    }
+
+    fn log_args_to_string(&self, args: &Bound<'_, PyTuple>) -> PyResult<String> {
+        let line = args
+            .try_iter()?
+            .map(|arg| arg?.str()?.extract::<String>())
+            .collect::<Result<Vec<String>, _>>()?
+            .join(" ");
+        Ok(line)
     }
 
     fn write(&self, line_builder: &Bound<'_, PyAny>) -> PyResult<()> {


### PR DESCRIPTION
Updates the plugin log functions so they can take any number of Python objects which will be converted into a single log line string.

Closes #25847