### PR TITLE
chore: add cargo check to circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,6 +146,23 @@ jobs:
           command: |
             go install github.com/jdstrand/language-checker@latest
             language-checker --exit-1-on-failure .
+  check:
+    docker:
+      - image: quay.io/influxdb/rust:ci
+    environment:
+      # Disable incremental compilation to avoid overhead. We are not preserving these files anyway.
+      CARGO_INCREMENTAL: "0"
+      # Disable full debug symbol generation to speed up CI build
+      # "1" means line tables only, which is useful for panic tracebacks.
+      CARGO_PROFILE_DEV_DEBUG: "1"
+      # https://github.com/rust-lang/cargo/issues/10280
+      CARGO_NET_GIT_FETCH_WITH_CLI: "true"
+    steps:
+      - checkout
+      - rust_components
+      - run:
+          name: Cargo check
+          command: cargo check --future-incompat-report
   cargo-audit:
     docker:
       - image: quay.io/influxdb/rust:ci
@@ -555,6 +572,8 @@ workflows:
           <<: *any_filter
       - lint:
           <<: *any_filter
+      - check:
+          <<: *any_filter
       - inclusivity:
           <<: *any_filter
       - cargo-audit:
@@ -631,6 +650,7 @@ workflows:
             - test
             - doc
             - lint
+            - check
             - fmt
             - cargo-audit
       - build-docker:


### PR DESCRIPTION
After rebasing https://github.com/influxdata/influxdb/pull/25849 onto main branch I started noticing the following `cargo check` failure:

```
zsh/5 13152  (git)-[feat/add-flag-to-disable-telemetry]-% git commit -m "chore: remove explicit predicates dependency"
running hook: cargo fmt                                succeeded
running hook: cargo check                                 failed
    Blocking waiting for file lock on build directory
    Checking influxdb3_telemetry v0.1.0 (/home/wayne/projects/github.com/influxdata/influxdb/influxdb3_telemetry)
    Checking influxdb3_internal_api v0.1.0 (/home/wayne/projects/github.com/influxdata/influxdb/influxdb3_internal_api)
    Checking influxdb3_py_api v0.1.0 (/home/wayne/projects/github.com/influxdata/influxdb/influxdb3_py_api)
    Checking influxdb3_write v0.1.0 (/home/wayne/projects/github.com/influxdata/influxdb/influxdb3_write)
    Checking influxdb3_processing_engine v0.1.0 (/home/wayne/projects/github.com/influxdata/influxdb/influxdb3_processing_engine)
error[E0599]: no method named `active_triggers` found for struct `Arc<influxdb3_catalog::catalog::Catalog>` in the current scope
   --> influxdb3_processing_engine/src/lib.rs:427:37
    |
427 |         let triggers = self.catalog.active_triggers();
    |                                     ^^^^^^^^^^^^^^^
    |
help: there is a method `triggers` with a similar name
    |
427 |         let triggers = self.catalog.triggers();
    |                                     ~~~~~~~~

error[E0277]: the size for values of type `str` cannot be known at compilation time
   --> influxdb3_processing_engine/src/lib.rs:428:14
    |
428 |         for (db_name, trigger_name) in triggers {
    |              ^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `str`
    = note: all local variables must have a statically known size
    = help: unsized locals are gated as an unstable feature

error[E0277]: the size for values of type `str` cannot be known at compilation time
   --> influxdb3_processing_engine/src/lib.rs:428:23
    |
428 |         for (db_name, trigger_name) in triggers {
    |                       ^^^^^^^^^^^^ doesn't have a size known at compile-time
    |
    = help: the trait `Sized` is not implemented for `str`
    = note: all local variables must have a statically known size
    = help: unsized locals are gated as an unstable feature

error[E0277]: the size for values of type `str` cannot be known at compilation time
   --> influxdb3_processing_engine/src/lib.rs:428:9
    |
428 | /         for (db_name, trigger_name) in triggers {
429 | |             self.run_trigger(
430 | |                 Arc::clone(&self.write_buffer),
431 | |                 Arc::clone(&self.query_executor),
...   |
435 | |             .await?;
436 | |         }
    | |_________^ doesn't have a size known at compile-time
    |
    = help: within `(str, str)`, the trait `Sized` is not implemented for `str`
    = note: required because it appears within the type `(str, str)`
note: required by a bound in `None`
   --> /home/wayne/.rustup/toolchains/1.84.0-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/option.rs:572:17
    |
572 | pub enum Option<T> {
    |                 ^ required by this bound in `None`
...
576 |     None,
    |     ---- required by a bound in this variant

Some errors have detailed explanations: E0277, E0599.
For more information about an error, try `rustc --explain E0277`.
error: could not compile `influxdb3_processing_engine` (lib) due to 4 previous errors
```

It's not clear to me if this is meant to be tolerated as an artifact of the enterprise<->core sync process or if it was accidental due to the `influxdb3_processing_engine` crate not being included in default/CI builds due to being excluded by a feature flag somewhere so I'm opening this PR to surface the issue to others on the team more suited to making that judgement call and (potentially) fixing it.
