### PR TITLE
feat: Add request plugin capability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2996,11 +2996,13 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
+ "bytes",
  "chrono",
  "cron 0.15.0",
  "data_types",
  "datafusion_util",
  "hashbrown 0.15.2",
+ "hyper 0.14.32",
  "influxdb3_cache",
  "influxdb3_catalog",
  "influxdb3_client",
@@ -3016,6 +3018,7 @@ dependencies = [
  "parquet_file",
  "pyo3",
  "reqwest 0.11.27",
+ "serde_json",
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
@@ -3028,6 +3031,7 @@ dependencies = [
  "anyhow",
  "arrow-array",
  "arrow-schema",
+ "bytes",
  "chrono",
  "futures",
  "hashbrown 0.15.2",
@@ -3123,6 +3127,7 @@ dependencies = [
  "trace_http",
  "tracker",
  "unicode-segmentation",
+ "url",
  "urlencoding",
 ]
 

--- a/influxdb3/src/commands/create.rs
+++ b/influxdb3/src/commands/create.rs
@@ -208,8 +208,8 @@ pub struct PluginConfig {
     /// Python file name of the file on the server's plugin-dir containing the plugin code
     #[clap(long = "filename")]
     file_name: String,
-    /// Type of trigger the plugin processes. Options: wal_rows, scheduled
-    #[clap(long = "plugin-type", default_value = "wal_rows")]
+    /// Type of trigger the plugin processes. Options: wal_rows, scheduled, request
+    #[clap(long = "plugin-type")]
     plugin_type: String,
     /// Name of the plugin to create
     plugin_name: String,

--- a/influxdb3_processing_engine/Cargo.toml
+++ b/influxdb3_processing_engine/Cargo.toml
@@ -11,10 +11,12 @@ license.workspace = true
 [dependencies]
 anyhow.workspace = true
 async-trait.workspace = true
+bytes.workspace = true
 chrono.workspace = true
 cron.workspace =  true
 data_types.workspace = true
 hashbrown.workspace = true
+hyper.workspace = true
 iox_time.workspace = true
 influxdb3_catalog = { path = "../influxdb3_catalog" }
 influxdb3_client = { path = "../influxdb3_client" }
@@ -24,6 +26,7 @@ influxdb3_wal = { path = "../influxdb3_wal" }
 influxdb3_write = { path = "../influxdb3_write" }
 observability_deps.workspace = true
 reqwest.workspace = true
+serde_json.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 

--- a/influxdb3_processing_engine/src/manager.rs
+++ b/influxdb3_processing_engine/src/manager.rs
@@ -1,4 +1,6 @@
+use bytes::Bytes;
 use hashbrown::HashMap;
+use hyper::{Body, Response};
 use influxdb3_client::plugin_development::{
     SchedulePluginTestRequest, SchedulePluginTestResponse, WalPluginTestRequest,
     WalPluginTestResponse,
@@ -38,6 +40,12 @@ pub enum ProcessingEngineError {
         database: String,
         trigger_name: String,
     },
+
+    #[error("request trigger not found")]
+    RequestTriggerNotFound,
+
+    #[error("request handler for trigger down")]
+    RequestHandlerDown,
 }
 
 /// `[ProcessingEngineManager]` is used to interact with the processing engine,
@@ -110,4 +118,12 @@ pub trait ProcessingEngineManager: Debug + Send + Sync + 'static {
         request: SchedulePluginTestRequest,
         query_executor: Arc<dyn QueryExecutor>,
     ) -> Result<SchedulePluginTestResponse, crate::plugins::Error>;
+
+    async fn request_trigger(
+        &self,
+        trigger_path: &str,
+        query_params: HashMap<String, String>,
+        request_headers: HashMap<String, String>,
+        request_body: Bytes,
+    ) -> Result<Response<Body>, ProcessingEngineError>;
 }

--- a/influxdb3_py_api/Cargo.toml
+++ b/influxdb3_py_api/Cargo.toml
@@ -12,6 +12,7 @@ system-py = ["pyo3"]
 anyhow.workspace = true
 arrow-array.workspace = true
 arrow-schema.workspace = true
+bytes.workspace = true
 chrono.workspace = true
 hashbrown.workspace = true
 influxdb3_id = { path = "../influxdb3_id" }

--- a/influxdb3_py_api/src/lib.rs
+++ b/influxdb3_py_api/src/lib.rs
@@ -3,6 +3,12 @@ pub enum ExecutePluginError {
     #[error("the process_writes function is not present in the plugin. Should be defined as: process_writes(influxdb3_local, table_batches, args=None)")]
     MissingProcessWritesFunction,
 
+    #[error("the process_request function is not present in the plugin. Should be defined as: process_request(influxdb3_local, query_parameters, request_headers, request_body, args=None) -> Tuple[str, Optional[Dict[str, str]]]")]
+    MissingProcessRequestFunction,
+
+    #[error("the process_scheduled_call function is not present in the plugin. Should be defined as: process_scheduled_call(influxdb3_local, call_time, args=None)")]
+    MissingProcessScheduledCallFunction,
+
     #[error("{0}")]
     PluginError(#[from] anyhow::Error),
 }

--- a/influxdb3_py_api/src/system_py.rs
+++ b/influxdb3_py_api/src/system_py.rs
@@ -644,7 +644,7 @@ pub fn execute_request_trigger(
         let py_headers_dict = headers_binding
             .downcast::<PyDict>()
             .map_err(|e| anyhow::anyhow!("Failed to downcast to PyDict: {}", e))?;
-        let body_binding = result.get_item(2).context("Python reqeust function didn't return a tuple of (status_code, response_headers, body)")?;
+        let body_binding = result.get_item(2).context("Python request function didn't return a tuple of (status_code, response_headers, body)")?;
         let response_body: &str = body_binding.extract().context(
             "unable to convert the third tuple element from Python request function to a string",
         )?;

--- a/influxdb3_py_api/src/system_py.rs
+++ b/influxdb3_py_api/src/system_py.rs
@@ -6,6 +6,7 @@ use arrow_array::{
     TimestampNanosecondArray, UInt64Array,
 };
 use arrow_schema::DataType;
+use bytes::Bytes;
 use chrono::{DateTime, Utc};
 use futures::TryStreamExt;
 use hashbrown::HashMap;
@@ -18,7 +19,7 @@ use observability_deps::tracing::{error, info, warn};
 use parking_lot::Mutex;
 use pyo3::exceptions::{PyException, PyValueError};
 use pyo3::prelude::{PyAnyMethods, PyModule};
-use pyo3::types::{PyDateTime, PyDict, PyList, PyTuple};
+use pyo3::types::{PyBytes, PyDateTime, PyDict, PyList, PyTuple};
 use pyo3::{
     create_exception, pyclass, pymethods, pymodule, Bound, IntoPyObject, Py, PyAny, PyObject,
     PyResult, Python,
@@ -260,6 +261,8 @@ const PROCESS_WRITES_CALL_SITE: &str = "process_writes";
 
 const PROCESS_SCHEDULED_CALL_SITE: &str = "process_scheduled_call";
 
+const PROCESS_REQUEST_CALL_SITE: &str = "process_request";
+
 const LINE_BUILDER_CODE: &str = r#"
 from typing import Optional
 from collections import OrderedDict
@@ -377,14 +380,17 @@ fn args_to_py_object<'py>(
     py: Python<'py>,
     args: &Option<HashMap<String, String>>,
 ) -> Option<Bound<'py, PyDict>> {
-    args.as_ref().map(|args| {
-        let dict = PyDict::new(py);
-        for (key, value) in args {
-            dict.set_item(key, value).unwrap();
-        }
-        dict
-    })
+    args.as_ref().map(|args| map_to_py_object(py, args))
 }
+
+fn map_to_py_object<'py>(py: Python<'py>, map: &HashMap<String, String>) -> Bound<'py, PyDict> {
+    let dict = PyDict::new(py);
+    for (key, value) in map {
+        dict.set_item(key, value).unwrap();
+    }
+    dict
+}
+
 pub fn execute_python_with_batch(
     code: &str,
     write_batch: &WriteBatch,
@@ -526,18 +532,22 @@ pub fn execute_schedule_trigger(
     schema: Arc<DatabaseSchema>,
     query_executor: Arc<dyn QueryExecutor>,
     args: &Option<HashMap<String, String>>,
-) -> PyResult<PluginReturnState> {
+) -> Result<PluginReturnState, ExecutePluginError> {
     Python::with_gil(|py| {
         // import the LineBuilder for use in the python code
         let globals = PyDict::new(py);
 
-        let py_datetime = PyDateTime::from_timestamp(py, schedule_time.timestamp() as f64, None)?;
+        let py_datetime = PyDateTime::from_timestamp(py, schedule_time.timestamp() as f64, None)
+            .map_err(|e| {
+                anyhow::Error::new(e).context("error converting the schedule time to Python time")
+            })?;
 
         py.run(
             &CString::new(LINE_BUILDER_CODE).unwrap(),
             Some(&globals),
             None,
-        )?;
+        )
+        .map_err(|e| anyhow::Error::new(e).context("failed to eval the LineBuilder API code"))?;
 
         let api = PyPluginCallApi {
             db_schema: schema,
@@ -545,26 +555,127 @@ pub fn execute_schedule_trigger(
             return_state: Default::default(),
         };
         let return_state = Arc::clone(&api.return_state);
-        let local_api = api.into_pyobject(py)?;
+        let local_api = api.into_pyobject(py).map_err(anyhow::Error::from)?;
 
         // turn args into an optional dict to pass into python
         let args = args_to_py_object(py, args);
 
         // run the code and get the python function to call
-        py.run(&CString::new(code).unwrap(), Some(&globals), None)?;
-        let py_func = py.eval(
-            &CString::new(PROCESS_SCHEDULED_CALL_SITE).unwrap(),
-            Some(&globals),
-            None,
-        )?;
+        py.run(&CString::new(code).unwrap(), Some(&globals), None)
+            .map_err(anyhow::Error::from)?;
 
-        py_func.call1((local_api, py_datetime, args))?;
+        let py_func = py
+            .eval(
+                &CString::new(PROCESS_SCHEDULED_CALL_SITE).unwrap(),
+                Some(&globals),
+                None,
+            )
+            .map_err(|_| ExecutePluginError::MissingProcessScheduledCallFunction)?;
+
+        py_func
+            .call1((local_api, py_datetime, args))
+            .map_err(anyhow::Error::from)?;
 
         // swap with an empty return state to avoid cloning
         let empty_return_state = PluginReturnState::default();
         let ret = std::mem::replace(&mut *return_state.lock(), empty_return_state);
 
         Ok(ret)
+    })
+}
+
+pub fn execute_request_trigger(
+    code: &str,
+    db_schema: Arc<DatabaseSchema>,
+    query_executor: Arc<dyn QueryExecutor>,
+    args: &Option<HashMap<String, String>>,
+    query_params: HashMap<String, String>,
+    request_headers: HashMap<String, String>,
+    request_body: Bytes,
+) -> Result<(u16, HashMap<String, String>, String, PluginReturnState), ExecutePluginError> {
+    Python::with_gil(|py| {
+        // import the LineBuilder for use in the python code
+        let globals = PyDict::new(py);
+
+        py.run(
+            &CString::new(LINE_BUILDER_CODE).unwrap(),
+            Some(&globals),
+            None,
+        )
+        .map_err(|e| anyhow::Error::new(e).context("failed to eval the LineBuilder API code"))?;
+
+        let api = PyPluginCallApi {
+            db_schema,
+            query_executor,
+            return_state: Default::default(),
+        };
+        let return_state = Arc::clone(&api.return_state);
+        let local_api = api.into_pyobject(py).map_err(anyhow::Error::from)?;
+
+        // turn args into an optional dict to pass into python
+        let args = args_to_py_object(py, args);
+
+        let query_params = map_to_py_object(py, &query_params);
+        let request_params = map_to_py_object(py, &request_headers);
+
+        // run the code and get the python function to call
+        py.run(&CString::new(code).unwrap(), Some(&globals), None)
+            .map_err(anyhow::Error::from)?;
+
+        let py_func = py
+            .eval(
+                &CString::new(PROCESS_REQUEST_CALL_SITE).unwrap(),
+                Some(&globals),
+                None,
+            )
+            .map_err(|_| ExecutePluginError::MissingProcessRequestFunction)?;
+
+        // convert the body bytes into python bytes blob
+        let request_body = PyBytes::new(py, &request_body[..]);
+
+        // get the result from calling the python function
+        let result = py_func
+            .call1((local_api, query_params, request_params, request_body, args))
+            .map_err(|e| anyhow::anyhow!("Python function call failed: {}", e))?;
+
+        // the return from the process_request function should be a tuple of (status_code, response_headers, body)
+        let response_code: i64 = result.get_item(0).context("Python request function didn't return a tuple of (status_code, response_headers, body)")?.extract().context("unable to convert first tuple element from Python request function return to integer")?;
+        let headers_binding = result.get_item(1).context("Python request function didn't return a tuple of (status_code, response_headers, body)")?;
+        let py_headers_dict = headers_binding
+            .downcast::<PyDict>()
+            .map_err(|e| anyhow::anyhow!("Failed to downcast to PyDict: {}", e))?;
+        let body_binding = result.get_item(2).context("Python reqeust function didn't return a tuple of (status_code, response_headers, body)")?;
+        let response_body: &str = body_binding.extract().context(
+            "unable to convert the third tuple element from Python request function to a string",
+        )?;
+
+        // Then convert the dict to HashMap
+        let response_headers: std::collections::HashMap<String, String> = py_headers_dict
+            .extract()
+            .map_err(|e| anyhow::anyhow!("error converting response headers into hashmap {}", e))?;
+
+        // convert the returned i64 to a u16 or it's a 500
+        let response_code: u16 = response_code.try_into().unwrap_or_else(|_| {
+            warn!(
+                "Invalid response code from Python request trigger: {}",
+                response_code
+            );
+
+            500
+        });
+
+        let response_headers: HashMap<String, String> = response_headers.into_iter().collect();
+
+        // swap with an empty return state to avoid cloning
+        let empty_return_state = PluginReturnState::default();
+        let ret = std::mem::replace(&mut *return_state.lock(), empty_return_state);
+
+        Ok((
+            response_code,
+            response_headers,
+            response_body.to_string(),
+            ret,
+        ))
     })
 }
 

--- a/influxdb3_server/Cargo.toml
+++ b/influxdb3_server/Cargo.toml
@@ -80,6 +80,7 @@ tokio-util.workspace = true
 tonic.workspace = true
 tower.workspace = true
 unicode-segmentation.workspace = true
+url.workspace = true
 
 [dependencies.pyo3]
 version = "0.23.3"

--- a/influxdb3_server/src/http.rs
+++ b/influxdb3_server/src/http.rs
@@ -1195,9 +1195,62 @@ where
             .body(Body::from(body))?)
     }
 
+    #[cfg(feature = "system-py")]
+    async fn processing_engine_request_plugin(
+        &self,
+        trigger_path: &str,
+        req: Request<Body>,
+    ) -> Result<Response<Body>> {
+        // pull out the query params into a hashmap
+        let uri = req.uri();
+        let query_str = uri.query().unwrap_or("");
+
+        let parsed_url = url::Url::parse(&format!("http://influxdata.com?{}", query_str)).unwrap();
+        let params: HashMap<String, String> = parsed_url
+            .query_pairs()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect();
+
+        // pull out the request headers into a hashmap
+        let headers = req
+            .headers()
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_str().unwrap().to_string()))
+            .collect();
+
+        // pull out the request body
+        let body = self.read_body(req).await?;
+
+        match self
+            .processing_engine
+            .request_trigger(trigger_path, params, headers, body)
+            .await
+        {
+            Ok(response) => Ok(response),
+            Err(
+                influxdb3_processing_engine::manager::ProcessingEngineError::RequestTriggerNotFound,
+            ) => {
+                let body = "{error: \"not found\"}";
+                Ok(Response::builder()
+                    .status(StatusCode::NOT_FOUND)
+                    .body(Body::from(body))?)
+            }
+            Err(e) => Err(e.into()),
+        }
+    }
+
     #[cfg(not(feature = "system-py"))]
     async fn test_processing_engine_schedule_plugin(
         &self,
+        _req: Request<Body>,
+    ) -> Result<Response<Body>> {
+        Err(Error::PythonPluginsNotEnabled)
+    }
+
+    #[cfg(not(feature = "system-py"))]
+    async fn processing_engine_request_plugin(
+        &self,
+        _trigger_path: &str,
         _req: Request<Body>,
     ) -> Result<Response<Body>> {
         Err(Error::PythonPluginsNotEnabled)
@@ -1764,6 +1817,12 @@ pub(crate) async fn route_request<T: TimeProvider>(
         (Method::GET, "/health" | "/api/v1/health") => http_server.health(),
         (Method::GET | Method::POST, "/ping") => http_server.ping(),
         (Method::GET, "/metrics") => http_server.handle_metrics(),
+        (Method::GET | Method::POST, path) if path.starts_with("/api/v3/engine/") => {
+            let path = path.strip_prefix("/api/v3/engine/").unwrap();
+            http_server
+                .processing_engine_request_plugin(path, req)
+                .await
+        }
         (Method::POST, "/api/v3/configure/distinct_cache") => {
             http_server.configure_distinct_cache_create(req).await
         }


### PR DESCRIPTION
Adds the request plugin type. Triggers can be bound to an API endpoint at /api/v3/engine/<path>. Requests will get yielded to the plugin with the query parameters, request parameters, and request body.

I didn't implement the test endpoint for this plugin type as it seems much more natural for users to save the file and make a new request. Once #25863 is done it'll make it very easy.

Closes #25862