### PR TITLE
feat: reloads plugins if modified

### DIFF
--- a/influxdb3/tests/server/cli.rs
+++ b/influxdb3/tests/server/cli.rs
@@ -1660,4 +1660,33 @@ def process_request(influxdb3_local, query_parameters, request_headers, request_
         .unwrap();
 
     assert_eq!(val, json!([{"tag1": "tag1_value", "field1": 1}]));
+
+    // now update it to make sure that it reloads
+    let plugin_code = r#"
+import json
+
+def process_request(influxdb3_local, query_parameters, request_headers, request_body, args=None):
+    return 200, {"Content-Type": "application/json"}, json.dumps({"status": "updated"})
+"#;
+    // clear all bytes from the plugin file
+    plugin_file.reopen().unwrap().set_len(0).unwrap();
+    plugin_file
+        .reopen()
+        .unwrap()
+        .write_all(plugin_code.as_bytes())
+        .unwrap();
+
+    // send an HTTP request to the server
+    let response = client
+        .post(format!("{}/api/v3/engine/foo", server_addr))
+        .header("Content-Type", "application/json")
+        .query(&[("q1", "whatevs")])
+        .body(r#"{"hello": "world"}"#)
+        .send()
+        .await
+        .unwrap();
+
+    let body = response.text().await.unwrap();
+    let body = serde_json::from_str::<serde_json::Value>(&body).unwrap();
+    assert_eq!(body, json!({"status": "updated"}));
 }


### PR DESCRIPTION
This updates plugins so that they will reload the code if the local file is modified. Github pugins continue to be loaded only once when they are initially created or loaded on startup.

This will make iterating on plugin development locally much easier.
    
Closes #25863

Leaving this in draft until #25864 gets merged in as this builds on top of that.