### PR TITLE
feat: expr analyzer for buffer to filter table chunks

### DIFF
--- a/influxdb3_write/src/write_buffer/mod.rs
+++ b/influxdb3_write/src/write_buffer/mod.rs
@@ -12,8 +12,8 @@ use crate::write_buffer::queryable_buffer::QueryableBuffer;
 use crate::write_buffer::validator::WriteValidator;
 use crate::{chunk::ParquetChunk, DatabaseManager};
 use crate::{
-    BufferedWriteRequest, Bufferer, ChunkContainer, DistinctCacheManager, LastCacheManager,
-    ParquetFile, PersistedSnapshot, Precision, WriteBuffer, WriteLineError,
+    BufferFilter, BufferedWriteRequest, Bufferer, ChunkContainer, DistinctCacheManager,
+    LastCacheManager, ParquetFile, PersistedSnapshot, Precision, WriteBuffer, WriteLineError,
 };
 use async_trait::async_trait;
 use data_types::{
@@ -319,30 +319,35 @@ impl WriteBufferImpl {
             DataFusionError::Execution(format!("database {} not found", database_name))
         })?;
 
-        let (table_id, table_schema) =
-            db_schema.table_id_and_schema(table_name).ok_or_else(|| {
-                DataFusionError::Execution(format!(
-                    "table {} not found in db {}",
-                    table_name, database_name
-                ))
-            })?;
+        let table_def = db_schema.table_definition(table_name).ok_or_else(|| {
+            DataFusionError::Execution(format!(
+                "table {} not found in db {}",
+                table_name, database_name
+            ))
+        })?;
+
+        let buffer_filter = BufferFilter::new(&table_def, filters)
+            .inspect_err(|error| warn!(?error, "buffer filter generation failed"))
+            .map_err(|error| DataFusionError::External(Box::new(error)))?;
 
         let mut chunks = self.buffer.get_table_chunks(
             Arc::clone(&db_schema),
             table_name,
-            filters,
+            &buffer_filter,
             projection,
             ctx,
         )?;
 
-        let parquet_files = self.persisted_files.get_files(db_schema.id, table_id);
+        let parquet_files =
+            self.persisted_files
+                .get_files(db_schema.id, table_def.table_id, &buffer_filter);
 
         let mut chunk_order = chunks.len() as i64;
 
         for parquet_file in parquet_files {
             let parquet_chunk = parquet_chunk_from_file(
                 &parquet_file,
-                &table_schema,
+                &table_def.schema,
                 self.persister.object_store_url().clone(),
                 self.persister.object_store(),
                 chunk_order,
@@ -427,8 +432,13 @@ impl Bufferer for WriteBufferImpl {
         Arc::clone(&self.wal)
     }
 
-    fn parquet_files(&self, db_id: DbId, table_id: TableId) -> Vec<ParquetFile> {
-        self.buffer.persisted_parquet_files(db_id, table_id)
+    fn parquet_files_filtered(
+        &self,
+        db_id: DbId,
+        table_id: TableId,
+        filter: &BufferFilter,
+    ) -> Vec<ParquetFile> {
+        self.buffer.persisted_parquet_files(db_id, table_id, filter)
     }
 
     fn watch_persisted_snapshots(&self) -> Receiver<Option<PersistedSnapshot>> {
@@ -2092,7 +2102,9 @@ mod tests {
         verify_snapshot_count(1, &wbuf.persister).await;
 
         // get the path for the created parquet file:
-        let persisted_files = wbuf.persisted_files().get_files(db_id, tbl_id);
+        let persisted_files =
+            wbuf.persisted_files()
+                .get_files(db_id, tbl_id, &BufferFilter::default());
         assert_eq!(1, persisted_files.len());
         let path = ObjPath::from(persisted_files[0].path.as_str());
 
@@ -2198,7 +2210,9 @@ mod tests {
         verify_snapshot_count(1, &wbuf.persister).await;
 
         // get the path for the created parquet file:
-        let persisted_files = wbuf.persisted_files().get_files(db_id, tbl_id);
+        let persisted_files =
+            wbuf.persisted_files()
+                .get_files(db_id, tbl_id, &BufferFilter::default());
         assert_eq!(1, persisted_files.len());
         let path = ObjPath::from(persisted_files[0].path.as_str());
 

--- a/influxdb3_write/src/write_buffer/persisted_files.rs
+++ b/influxdb3_write/src/write_buffer/persisted_files.rs
@@ -48,7 +48,14 @@ impl PersistedFiles {
     }
 
     /// Get the list of files for a given database and table, always return in descending order of min_time
-    pub fn get_files(
+    pub fn get_files(&self, db_id: DbId, table_id: TableId) -> Vec<ParquetFile> {
+        self.get_files_filtered(db_id, table_id, &BufferFilter::default())
+    }
+
+    /// Get the list of files for a given database and table, using the provided filter to filter results.
+    ///
+    /// Always return in descending order of min_time
+    pub fn get_files_filtered(
         &self,
         db_id: DbId,
         table_id: TableId,
@@ -383,7 +390,7 @@ mod tests {
         for t in test_cases {
             let filter = BufferFilter::new(&table_def, t.filter).unwrap();
             let filtered_files =
-                persisted_files.get_files(DbId::from(0), TableId::from(0), &filter);
+                persisted_files.get_files_filtered(DbId::from(0), TableId::from(0), &filter);
             assert_eq!(
                 t.expected_n_files,
                 filtered_files.len(),

--- a/influxdb3_write/src/write_buffer/persisted_files.rs
+++ b/influxdb3_write/src/write_buffer/persisted_files.rs
@@ -2,6 +2,7 @@
 //! When queries come in they will combine whatever chunks exist from `QueryableBuffer` with
 //! the persisted files to get the full set of data to query.
 
+use crate::BufferFilter;
 use crate::{ParquetFile, PersistedSnapshot};
 use hashbrown::HashMap;
 use influxdb3_id::DbId;
@@ -47,7 +48,12 @@ impl PersistedFiles {
     }
 
     /// Get the list of files for a given database and table, always return in descending order of min_time
-    pub fn get_files(&self, db_id: DbId, table_id: TableId) -> Vec<ParquetFile> {
+    pub fn get_files(
+        &self,
+        db_id: DbId,
+        table_id: TableId,
+        filter: &BufferFilter,
+    ) -> Vec<ParquetFile> {
         let three_days_ago = (self.time_provider.now() - crate::THREE_DAYS).timestamp_nanos();
         let mut files = {
             let inner = self.inner.read();
@@ -58,7 +64,8 @@ impl PersistedFiles {
                 .cloned()
                 .unwrap_or_default()
                 .into_iter()
-                .filter(|file| dbg!(file.min_time) > dbg!(three_days_ago))
+                .filter(|file| filter.test_time_stamp_min_max(file.min_time, file.max_time))
+                .filter(|file| file.min_time > three_days_ago)
                 .collect::<Vec<_>>()
         };
 
@@ -169,12 +176,18 @@ fn update_persisted_files_with_snapshot(
 #[cfg(test)]
 mod tests {
 
+    use datafusion::prelude::col;
+    use datafusion::prelude::lit_timestamp_nano;
+    use datafusion::prelude::Expr;
     use influxdb3_catalog::catalog::CatalogSequenceNumber;
+    use influxdb3_catalog::catalog::TableDefinition;
+    use influxdb3_id::ColumnId;
     use influxdb3_wal::{SnapshotSequenceNumber, WalFileSequenceNumber};
     use iox_time::MockProvider;
     use iox_time::Time;
     use observability_deps::tracing::info;
     use pretty_assertions::assert_eq;
+    use schema::InfluxColumnType;
 
     use crate::ParquetFileId;
 
@@ -260,6 +273,125 @@ mod tests {
         //       doesn't check for duplicates
         assert_eq!(0.75, size_in_mb);
         assert_eq!(150, row_count);
+    }
+
+    #[test]
+    fn test_get_files_with_filters() {
+        let parquet_files = (0..100)
+            .step_by(10)
+            .map(|i| {
+                let chunk_time = i;
+                ParquetFile {
+                    id: ParquetFileId::new(),
+                    path: format!("/path/{i:03}.parquet"),
+                    size_bytes: 1,
+                    row_count: 1,
+                    chunk_time,
+                    min_time: chunk_time,
+                    max_time: chunk_time + 10,
+                }
+            })
+            .collect();
+        let persisted_snapshots = vec![build_snapshot(parquet_files, 0, 0, 0)];
+        let persisted_files = PersistedFiles::new_from_persisted_snapshots(
+            Arc::new(MockProvider::new(Time::from_timestamp_nanos(0))),
+            persisted_snapshots,
+        );
+
+        struct TestCase<'a> {
+            filter: &'a [Expr],
+            expected_n_files: usize,
+        }
+
+        let test_cases = [
+            TestCase {
+                filter: &[],
+                expected_n_files: 10,
+            },
+            TestCase {
+                filter: &[col("time").gt(lit_timestamp_nano(0))],
+                expected_n_files: 10,
+            },
+            TestCase {
+                filter: &[col("time").gt(lit_timestamp_nano(50))],
+                expected_n_files: 5,
+            },
+            TestCase {
+                filter: &[col("time").gt(lit_timestamp_nano(90))],
+                expected_n_files: 1,
+            },
+            TestCase {
+                filter: &[col("time").gt(lit_timestamp_nano(100))],
+                expected_n_files: 0,
+            },
+            TestCase {
+                filter: &[col("time").lt(lit_timestamp_nano(100))],
+                expected_n_files: 10,
+            },
+            TestCase {
+                filter: &[col("time").lt(lit_timestamp_nano(50))],
+                expected_n_files: 5,
+            },
+            TestCase {
+                filter: &[col("time").lt(lit_timestamp_nano(10))],
+                expected_n_files: 1,
+            },
+            TestCase {
+                filter: &[col("time").lt(lit_timestamp_nano(0))],
+                expected_n_files: 0,
+            },
+            TestCase {
+                filter: &[col("time")
+                    .gt(lit_timestamp_nano(20))
+                    .and(col("time").lt(lit_timestamp_nano(40)))],
+                expected_n_files: 2,
+            },
+            TestCase {
+                filter: &[col("time")
+                    .gt(lit_timestamp_nano(20))
+                    .and(col("time").lt(lit_timestamp_nano(30)))],
+                expected_n_files: 1,
+            },
+            TestCase {
+                filter: &[col("time")
+                    .gt(lit_timestamp_nano(21))
+                    .and(col("time").lt(lit_timestamp_nano(29)))],
+                expected_n_files: 1,
+            },
+            TestCase {
+                filter: &[col("time")
+                    .gt(lit_timestamp_nano(0))
+                    .and(col("time").lt(lit_timestamp_nano(100)))],
+                expected_n_files: 10,
+            },
+        ];
+
+        let table_def = Arc::new(
+            TableDefinition::new(
+                TableId::from(0),
+                "test-tbl".into(),
+                vec![(
+                    ColumnId::from(0),
+                    "time".into(),
+                    InfluxColumnType::Timestamp,
+                )],
+                vec![],
+            )
+            .unwrap(),
+        );
+
+        for t in test_cases {
+            let filter = BufferFilter::new(&table_def, t.filter).unwrap();
+            let filtered_files =
+                persisted_files.get_files(DbId::from(0), TableId::from(0), &filter);
+            assert_eq!(
+                t.expected_n_files,
+                filtered_files.len(),
+                "wrong number of filtered files:\n\
+                result: {filtered_files:?}\n\
+                filter provided: {filter:?}"
+            );
+        }
     }
 
     fn build_persisted_snapshots() -> Vec<PersistedSnapshot> {

--- a/influxdb3_write/src/write_buffer/queryable_buffer.rs
+++ b/influxdb3_write/src/write_buffer/queryable_buffer.rs
@@ -421,7 +421,8 @@ impl QueryableBuffer {
         table_id: TableId,
         filter: &BufferFilter,
     ) -> Vec<ParquetFile> {
-        self.persisted_files.get_files(db_id, table_id, filter)
+        self.persisted_files
+            .get_files_filtered(db_id, table_id, filter)
     }
 
     pub fn persisted_snapshot_notify_rx(
@@ -881,11 +882,9 @@ mod tests {
         // validate we have a single persisted file
         let db = catalog.db_schema("testdb").unwrap();
         let table = db.table_definition("foo").unwrap();
-        let files = queryable_buffer.persisted_files.get_files(
-            db.id,
-            table.table_id,
-            &BufferFilter::default(),
-        );
+        let files = queryable_buffer
+            .persisted_files
+            .get_files(db.id, table.table_id);
         assert_eq!(files.len(), 1);
 
         // now force another snapshot, persisting the data to parquet file
@@ -914,11 +913,9 @@ mod tests {
             .unwrap();
 
         // validate we have two persisted files
-        let files = queryable_buffer.persisted_files.get_files(
-            db.id,
-            table.table_id,
-            &BufferFilter::default(),
-        );
+        let files = queryable_buffer
+            .persisted_files
+            .get_files(db.id, table.table_id);
         assert_eq!(files.len(), 2);
     }
 }


### PR DESCRIPTION
Related to https://github.com/influxdata/influxdb_pro/issues/436

This PR updates the filter handling in the `WriteBuffer` so that sets of `Expr`s provided in a query will better prune both chunks from the in-memory buffer, as well as the set of parquet file chunks that are forwarded to DataFusion, for query execution.

### New `BufferFilter` type

This introduces the [`BufferFilter`](https://github.com/influxdata/influxdb/blob/bab428f0eb5ec6a59882a71a2f7b807c85db8122/influxdb3_write/src/lib.rs#L496) type. This converts a set of `Expr`s from a logical query plan into a filter that can be used to:
* prune chunks based on a provided lower/upper `time` boundary from both the buffer and parquet
* prune chunks from the buffer based on any literal guarantees predicated on tag columns in the query, e.g., `WHERE tag = 'a'` or `WHERE tag IN ['a', 'b']`

This type is exposed such that it will be easy to use from replicated buffers and from the compactor when producing `Arc<dyn QueryChunk>`s in Enterprise.

### Tests

* Tests in the [`table_buffer`](https://github.com/influxdata/influxdb/blob/bab428f0eb5ec6a59882a71a2f7b807c85db8122/influxdb3_write/src/write_buffer/table_buffer.rs) module were updated to use the `WriteValidator`. This allows construction of rows based on line protocol directly, and in cleaning up the tests a bit, allowed me to extend some of the test cases in [this test](https://github.com/influxdata/influxdb/blob/bab428f0eb5ec6a59882a71a2f7b807c85db8122/influxdb3_write/src/write_buffer/table_buffer.rs#L979).
* I added [a test](https://github.com/influxdata/influxdb/blob/bab428f0eb5ec6a59882a71a2f7b807c85db8122/influxdb3_write/src/write_buffer/table_buffer.rs#L1243) that checks the buffer chunk index filtering for expressions against multiple tag columns. 
* Added [a test](https://github.com/influxdata/influxdb/blob/bab428f0eb5ec6a59882a71a2f7b807c85db8122/influxdb3_write/src/write_buffer/table_buffer.rs#L1153) that checks time pruning
* Added [a test](https://github.com/influxdata/influxdb/blob/bab428f0eb5ec6a59882a71a2f7b807c85db8122/influxdb3_write/src/write_buffer/persisted_files.rs#L279) that checks time pruning in `PersistedFiles`
* I renamed several tests to start with `test_`.