### PR TITLE
chore: add out of order tests

### DIFF
--- a/influxdb3_write/src/write_buffer/mod.rs
+++ b/influxdb3_write/src/write_buffer/mod.rs
@@ -2639,7 +2639,7 @@ mod tests {
             .await;
         }
 
-        // now introduce 20 - 50 timestamp data
+        // now introduce 20 - 30 timestamp data
         // this is similar to back filling
         for i in 20..=30 {
             do_writes(


### PR DESCRIPTION
- assertions for what remains in the queryable buffer when out of order timestamps are encountered. This could be true for back filling, and in that case back filled data takes over the queryable buffer and moving all the recent data into parquet files (as part of snapshotting)
- assertions to check last cache still retains the most recent values when out of order data is encountered