### PR TITLE
fix: allow default browser header

### DIFF
--- a/influxdb3/tests/server/main.rs
+++ b/influxdb3/tests/server/main.rs
@@ -290,6 +290,23 @@ impl TestServer {
             .await
     }
 
+    pub async fn api_v3_query_sql_with_header(
+        &self,
+        params: &[(&str, &str)],
+        headers: HeaderMap<HeaderValue>,
+    ) -> Response {
+        self.http_client
+            .get(format!(
+                "{base}/api/v3/query_sql",
+                base = self.client_addr()
+            ))
+            .query(params)
+            .headers(headers)
+            .send()
+            .await
+            .expect("send /api/v3/query_sql request to server")
+    }
+
     pub async fn api_v3_query_sql(&self, params: &[(&str, &str)]) -> Response {
         self.http_client
             .get(format!(


### PR DESCRIPTION
Although the `format` in the request is used, the value coming through the header is parsed earlier. So, when that lookup in the header fails an error is returned (`InvalidMimeType`).

In this commit, there are extra checks to allow the default `Accept` header values that come from the browser by defaulting it to `json`

closes: https://github.com/influxdata/influxdb/issues/25874