### PR TITLE
chore: merge to main should run release pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -580,7 +580,7 @@ workflows:
       - doc:
           <<: *any_filter
       - build-release:
-          <<: *release_filter
+          <<: *main_filter
           name: build-release-<< matrix.target >>
           matrix:
             parameters:
@@ -592,15 +592,15 @@ workflows:
                 - x86_64-unknown-linux-gnu
                 - x86_64-unknown-linux-musl
       - build-packages:
-          <<: *release_filter
+          <<: *main_filter
           requires:
             - build-release
       - check_package_deb_arm64:
-          <<: *release_filter
+          <<: *main_filter
           requires:
             - build-packages
       - check_package_deb_amd64:
-          <<: *release_filter
+          <<: *main_filter
           requires:
             - build-packages
       - check_package_rpm:
@@ -613,7 +613,7 @@ workflows:
           requires:
             - build-packages
       - sign-packages:
-          <<: *release_filter
+          <<: *main_filter
           requires:
             - build-packages
             - check_package_rpm
@@ -621,7 +621,7 @@ workflows:
             - check_package_deb_amd64
             - test
       - publish-packages:
-          <<: *release_filter
+          <<: *main_filter
           matrix:
             parameters:
               destination: [ releases ]


### PR DESCRIPTION
No issue for this - noticed merges to main run release pipeline only for docker images but not for binaries. This commit allows releasing every time code is merged to main again. This would mean both docker images and binaries are in sync.
