### PR TITLE
feat: loosen 72 hour query/write restriction

### DIFF
--- a/influxdb3/src/commands/serve.rs
+++ b/influxdb3/src/commands/serve.rs
@@ -345,6 +345,15 @@ pub struct Config {
         action
     )]
     pub telemetry_endpoint: String,
+
+    /// Set the limit for number of parquet files allowed in a query. Defaults
+    /// to 432 which is about 3 days worth of files using default settings.
+    /// This number can be increased to allow more files to be queried, but
+    /// query performance will likely suffer, RAM usage will spike, and the
+    /// process might be OOM killed as a result. It would be better to specify
+    /// smaller time ranges if possible in a query.
+    #[clap(long = "query-file-limit", env = "INFLUXDB3_QUERY_FILE_LIMIT", action)]
+    pub query_file_limit: Option<usize>,
 }
 
 /// Specified size of the Parquet cache in megabytes (MB)
@@ -541,6 +550,7 @@ pub async fn command(config: Config) -> Result<()> {
         parquet_cache,
         metric_registry: Arc::clone(&metrics),
         snapshotted_wal_files_to_keep: config.snapshotted_wal_files_to_keep,
+        query_file_limit: config.query_file_limit,
     })
     .await
     .map_err(|e| Error::WriteBufferInit(e.into()))?;

--- a/influxdb3_processing_engine/src/lib.rs
+++ b/influxdb3_processing_engine/src/lib.rs
@@ -1042,6 +1042,7 @@ mod tests {
             parquet_cache: None,
             metric_registry: Arc::clone(&metric_registry),
             snapshotted_wal_files_to_keep: 10,
+            query_file_limit: None,
         })
         .await
         .unwrap();

--- a/influxdb3_server/src/lib.rs
+++ b/influxdb3_server/src/lib.rs
@@ -779,6 +779,7 @@ mod tests {
                 parquet_cache: Some(parquet_cache),
                 metric_registry: Arc::clone(&metrics),
                 snapshotted_wal_files_to_keep: 100,
+                query_file_limit: None,
             },
         )
         .await

--- a/influxdb3_server/src/query_executor/mod.rs
+++ b/influxdb3_server/src/query_executor/mod.rs
@@ -773,6 +773,7 @@ mod tests {
     use metric::Registry;
     use object_store::{local::LocalFileSystem, ObjectStore};
     use parquet_file::storage::{ParquetStorage, StorageId};
+    use pretty_assertions::assert_eq;
 
     use super::CreateQueryExecutorArgs;
 
@@ -798,7 +799,9 @@ mod tests {
         ))
     }
 
-    pub(crate) async fn setup() -> (
+    pub(crate) async fn setup(
+        query_file_limit: Option<usize>,
+    ) -> (
         Arc<dyn WriteBuffer>,
         QueryExecutorImpl,
         Arc<MockProvider>,
@@ -838,6 +841,7 @@ mod tests {
             parquet_cache: Some(parquet_cache),
             metric_registry: Default::default(),
             snapshotted_wal_files_to_keep: 1,
+            query_file_limit,
         })
         .await
         .unwrap();
@@ -871,7 +875,7 @@ mod tests {
 
     #[test_log::test(tokio::test)]
     async fn system_parquet_files_success() {
-        let (write_buffer, query_executor, time_provider, _) = setup().await;
+        let (write_buffer, query_executor, time_provider, _) = setup(None).await;
         // Perform some writes to multiple tables
         let db_name = "test_db";
         // perform writes over time to generate WAL files and some snapshots
@@ -978,5 +982,233 @@ mod tests {
             let batches: Vec<RecordBatch> = batch_stream.try_collect().await.unwrap();
             assert_batches_sorted_eq!(t.expected, &batches);
         }
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn query_file_limits_default() {
+        let (write_buffer, query_executor, time_provider, _) = setup(None).await;
+        // Perform some writes to multiple tables
+        let db_name = "test_db";
+        // perform writes over time to generate WAL files and some snapshots
+        // the time provider is bumped to trick the system into persisting files:
+        for i in 0..1298 {
+            let time = i * 10;
+            let _ = write_buffer
+                .write_lp(
+                    NamespaceName::new(db_name).unwrap(),
+                    "\
+                cpu,host=a,region=us-east usage=250\n\
+                mem,host=a,region=us-east usage=150000\n\
+                ",
+                    Time::from_timestamp_nanos(time),
+                    false,
+                    influxdb3_write::Precision::Nanosecond,
+                )
+                .await
+                .unwrap();
+
+            time_provider.set(Time::from_timestamp(time + 1, 0).unwrap());
+        }
+
+        // bump time again and sleep briefly to ensure time to persist things
+        time_provider.set(Time::from_timestamp(20, 0).unwrap());
+        tokio::time::sleep(Duration::from_millis(500)).await;
+
+        struct TestCase<'a> {
+            query: &'a str,
+            expected: &'a [&'a str],
+        }
+
+        let test_cases = [
+            TestCase {
+                query: "\
+                    SELECT COUNT(*) \
+                    FROM system.parquet_files \
+                    WHERE table_name = 'cpu'",
+                expected: &[
+                    "+----------+",
+                    "| count(*) |",
+                    "+----------+",
+                    "| 432      |",
+                    "+----------+",
+                ],
+            },
+            TestCase {
+                query: "\
+                    SELECT Count(host) \
+                    FROM cpu",
+                expected: &[
+                    "+-----------------+",
+                    "| count(cpu.host) |",
+                    "+-----------------+",
+                    "| 1298            |",
+                    "+-----------------+",
+                ],
+            },
+        ];
+
+        for t in test_cases {
+            let batch_stream = query_executor
+                .query_sql(db_name, t.query, None, None, None)
+                .await
+                .unwrap();
+            let batches: Vec<RecordBatch> = batch_stream.try_collect().await.unwrap();
+            assert_batches_sorted_eq!(t.expected, &batches);
+        }
+
+        // put us over the parquet limit
+        let time = 12990;
+        let _ = write_buffer
+            .write_lp(
+                NamespaceName::new(db_name).unwrap(),
+                "\
+                cpu,host=a,region=us-east usage=250\n\
+                mem,host=a,region=us-east usage=150000\n\
+                ",
+                Time::from_timestamp_nanos(time),
+                false,
+                influxdb3_write::Precision::Nanosecond,
+            )
+            .await
+            .unwrap();
+
+        time_provider.set(Time::from_timestamp(time + 1, 0).unwrap());
+
+        // bump time again and sleep briefly to ensure time to persist things
+        time_provider.set(Time::from_timestamp(20, 0).unwrap());
+        tokio::time::sleep(Duration::from_millis(500)).await;
+
+        match query_executor
+            .query_sql(db_name, "SELECT COUNT(host) FROM CPU", None, None, None)
+            .await {
+            Ok(_) => panic!("expected to exceed parquet file limit, yet query succeeded"),
+            Err(err) => assert_eq!(err.to_string(), "error while planning query: External error: Query would exceed file limit of 432 parquet files. Please specify a smaller time range for your query. You can increase the file limit with the `--query-file-limit` option in the serve command, however, query performance will be slower and the server may get OOM killed or become unstable as a result".to_string())
+        }
+
+        // Make sure if we specify a smaller time range that queries will still work
+        query_executor
+            .query_sql(
+                db_name,
+                "SELECT COUNT(host) FROM CPU WHERE time < '1970-01-01T00:00:00.000000010Z'",
+                None,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn query_file_limits_configured() {
+        let (write_buffer, query_executor, time_provider, _) = setup(Some(3)).await;
+        // Perform some writes to multiple tables
+        let db_name = "test_db";
+        // perform writes over time to generate WAL files and some snapshots
+        // the time provider is bumped to trick the system into persisting files:
+        for i in 0..11 {
+            let time = i * 10;
+            let _ = write_buffer
+                .write_lp(
+                    NamespaceName::new(db_name).unwrap(),
+                    "\
+                cpu,host=a,region=us-east usage=250\n\
+                mem,host=a,region=us-east usage=150000\n\
+                ",
+                    Time::from_timestamp_nanos(time),
+                    false,
+                    influxdb3_write::Precision::Nanosecond,
+                )
+                .await
+                .unwrap();
+
+            time_provider.set(Time::from_timestamp(time + 1, 0).unwrap());
+        }
+
+        // bump time again and sleep briefly to ensure time to persist things
+        time_provider.set(Time::from_timestamp(20, 0).unwrap());
+        tokio::time::sleep(Duration::from_millis(500)).await;
+
+        struct TestCase<'a> {
+            query: &'a str,
+            expected: &'a [&'a str],
+        }
+
+        let test_cases = [
+            TestCase {
+                query: "\
+                    SELECT COUNT(*) \
+                    FROM system.parquet_files \
+                    WHERE table_name = 'cpu'",
+                expected: &[
+                    "+----------+",
+                    "| count(*) |",
+                    "+----------+",
+                    "| 3        |",
+                    "+----------+",
+                ],
+            },
+            TestCase {
+                query: "\
+                    SELECT Count(host) \
+                    FROM cpu",
+                expected: &[
+                    "+-----------------+",
+                    "| count(cpu.host) |",
+                    "+-----------------+",
+                    "| 11              |",
+                    "+-----------------+",
+                ],
+            },
+        ];
+
+        for t in test_cases {
+            let batch_stream = query_executor
+                .query_sql(db_name, t.query, None, None, None)
+                .await
+                .unwrap();
+            let batches: Vec<RecordBatch> = batch_stream.try_collect().await.unwrap();
+            assert_batches_sorted_eq!(t.expected, &batches);
+        }
+
+        // put us over the parquet limit
+        let time = 120;
+        let _ = write_buffer
+            .write_lp(
+                NamespaceName::new(db_name).unwrap(),
+                "\
+                cpu,host=a,region=us-east usage=250\n\
+                mem,host=a,region=us-east usage=150000\n\
+                ",
+                Time::from_timestamp_nanos(time),
+                false,
+                influxdb3_write::Precision::Nanosecond,
+            )
+            .await
+            .unwrap();
+
+        time_provider.set(Time::from_timestamp(time + 1, 0).unwrap());
+
+        // bump time again and sleep briefly to ensure time to persist things
+        time_provider.set(Time::from_timestamp(20, 0).unwrap());
+        tokio::time::sleep(Duration::from_millis(500)).await;
+
+        match query_executor
+            .query_sql(db_name, "SELECT COUNT(host) FROM CPU", None, None, None)
+            .await {
+            Ok(_) => panic!("expected to exceed parquet file limit, yet query succeeded"),
+            Err(err) => assert_eq!(err.to_string(), "error while planning query: External error: Query would exceed file limit of 3 parquet files. Please specify a smaller time range for your query. You can increase the file limit with the `--query-file-limit` option in the serve command, however, query performance will be slower and the server may get OOM killed or become unstable as a result".to_string())
+        }
+
+        // Make sure if we specify a smaller time range that queries will still work
+        query_executor
+            .query_sql(
+                db_name,
+                "SELECT COUNT(host) FROM CPU WHERE time < '1970-01-01T00:00:00.000000010Z'",
+                None,
+                None,
+                None,
+            )
+            .await
+            .unwrap();
     }
 }

--- a/influxdb3_write/src/lib.rs
+++ b/influxdb3_write/src/lib.rs
@@ -47,9 +47,6 @@ use thiserror::Error;
 use twox_hash::XxHash64;
 use write_buffer::INDEX_HASH_SEED;
 
-/// Used to determine if writes are older than what we can accept or query
-pub const THREE_DAYS: Duration = Duration::from_secs(60 * 60 * 24 * 3);
-
 #[derive(Debug, Error)]
 pub enum Error {
     #[error("object store path error: {0}")]

--- a/influxdb3_write/src/write_buffer/mod.rs
+++ b/influxdb3_write/src/write_buffer/mod.rs
@@ -147,6 +147,8 @@ pub struct WriteBufferImpl {
     metrics: WriteMetrics,
     distinct_cache: Arc<DistinctCacheProvider>,
     last_cache: Arc<LastCacheProvider>,
+    /// The number of files we will accept for a query
+    query_file_limit: usize,
 }
 
 /// The maximum number of snapshots to load on start
@@ -164,6 +166,7 @@ pub struct WriteBufferImplArgs {
     pub parquet_cache: Option<Arc<dyn ParquetCacheOracle>>,
     pub metric_registry: Arc<Registry>,
     pub snapshotted_wal_files_to_keep: u64,
+    pub query_file_limit: Option<usize>,
 }
 
 impl WriteBufferImpl {
@@ -179,6 +182,7 @@ impl WriteBufferImpl {
             parquet_cache,
             metric_registry,
             snapshotted_wal_files_to_keep,
+            query_file_limit,
         }: WriteBufferImplArgs,
     ) -> Result<Arc<Self>> {
         // load snapshots and replay the wal into the in memory buffer
@@ -200,7 +204,6 @@ impl WriteBufferImpl {
         }
 
         let persisted_files = Arc::new(PersistedFiles::new_from_persisted_snapshots(
-            Arc::clone(&time_provider),
             persisted_snapshots,
         ));
         let queryable_buffer = Arc::new(QueryableBuffer::new(QueryableBufferArgs {
@@ -210,7 +213,6 @@ impl WriteBufferImpl {
             last_cache_provider: Arc::clone(&last_cache),
             distinct_cache_provider: Arc::clone(&distinct_cache),
             persisted_files: Arc::clone(&persisted_files),
-            time_provider: Arc::clone(&time_provider),
             parquet_cache: parquet_cache.clone(),
         }));
 
@@ -240,6 +242,7 @@ impl WriteBufferImpl {
             persisted_files,
             buffer: queryable_buffer,
             metrics: WriteMetrics::new(&metric_registry),
+            query_file_limit: query_file_limit.unwrap_or(432),
         });
         Ok(result)
     }
@@ -343,6 +346,21 @@ impl WriteBufferImpl {
             table_def.table_id,
             &buffer_filter,
         );
+
+        if parquet_files.len() > self.query_file_limit {
+            return Err(DataFusionError::External(
+                format!(
+                    "Query would exceed file limit of {} parquet files. \
+                     Please specify a smaller time range for your \
+                     query. You can increase the file limit with the \
+                     `--query-file-limit` option in the serve command, however, \
+                     query performance will be slower and the server may get \
+                     OOM killed or become unstable as a result",
+                    self.query_file_limit
+                )
+                .into(),
+            ));
+        }
 
         let mut chunk_order = chunks.len() as i64;
 
@@ -758,7 +776,7 @@ impl DatabaseManager for WriteBufferImpl {
                         "int64" => FieldDataType::Integer,
                         "bool" => FieldDataType::Boolean,
                         "utf8" => FieldDataType::String,
-                        _ => todo!(),
+                        _ => unreachable!(),
                     },
                 });
             }
@@ -987,6 +1005,7 @@ mod tests {
             parquet_cache: Some(Arc::clone(&parquet_cache)),
             metric_registry: Default::default(),
             snapshotted_wal_files_to_keep: 10,
+            query_file_limit: None,
         })
         .await
         .unwrap();
@@ -1074,6 +1093,7 @@ mod tests {
             parquet_cache: Some(Arc::clone(&parquet_cache)),
             metric_registry: Default::default(),
             snapshotted_wal_files_to_keep: 10,
+            query_file_limit: None,
         })
         .await
         .unwrap();
@@ -1143,6 +1163,7 @@ mod tests {
                 parquet_cache: wbuf.parquet_cache.clone(),
                 metric_registry: Default::default(),
                 snapshotted_wal_files_to_keep: 10,
+                query_file_limit: None,
             })
             .await
             .unwrap()
@@ -1373,6 +1394,7 @@ mod tests {
             parquet_cache: write_buffer.parquet_cache.clone(),
             metric_registry: Default::default(),
             snapshotted_wal_files_to_keep: 10,
+            query_file_limit: None,
         })
         .await
         .unwrap();
@@ -3039,6 +3061,7 @@ mod tests {
             parquet_cache,
             metric_registry: Arc::clone(&metric_registry),
             snapshotted_wal_files_to_keep: 10,
+            query_file_limit: None,
         })
         .await
         .unwrap();

--- a/influxdb3_write/src/write_buffer/queryable_buffer.rs
+++ b/influxdb3_write/src/write_buffer/queryable_buffer.rs
@@ -25,7 +25,6 @@ use iox_query::chunk_statistics::{create_chunk_statistics, NoColumnRanges};
 use iox_query::exec::Executor;
 use iox_query::frontend::reorg::ReorgPlanner;
 use iox_query::QueryChunk;
-use iox_time::TimeProvider;
 use object_store::path::Path;
 use observability_deps::tracing::{error, info};
 use parking_lot::RwLock;
@@ -47,7 +46,6 @@ pub struct QueryableBuffer {
     persisted_files: Arc<PersistedFiles>,
     buffer: Arc<RwLock<BufferState>>,
     parquet_cache: Option<Arc<dyn ParquetCacheOracle>>,
-    time_provider: Arc<dyn TimeProvider>,
     /// Sends a notification to this watch channel whenever a snapshot info is persisted
     persisted_snapshot_notify_rx: tokio::sync::watch::Receiver<Option<PersistedSnapshot>>,
     persisted_snapshot_notify_tx: tokio::sync::watch::Sender<Option<PersistedSnapshot>>,
@@ -61,7 +59,6 @@ pub struct QueryableBufferArgs {
     pub distinct_cache_provider: Arc<DistinctCacheProvider>,
     pub persisted_files: Arc<PersistedFiles>,
     pub parquet_cache: Option<Arc<dyn ParquetCacheOracle>>,
-    pub time_provider: Arc<dyn TimeProvider>,
 }
 
 impl QueryableBuffer {
@@ -74,7 +71,6 @@ impl QueryableBuffer {
             distinct_cache_provider,
             persisted_files,
             parquet_cache,
-            time_provider,
         }: QueryableBufferArgs,
     ) -> Self {
         let buffer = Arc::new(RwLock::new(BufferState::new(Arc::clone(&catalog))));
@@ -89,7 +85,6 @@ impl QueryableBuffer {
             persisted_files,
             buffer,
             parquet_cache,
-            time_provider,
             persisted_snapshot_notify_rx,
             persisted_snapshot_notify_tx,
         }
@@ -122,9 +117,6 @@ impl QueryableBuffer {
             .partitioned_record_batches(Arc::clone(&table_def), buffer_filter)
             .map_err(|e| DataFusionError::Execution(format!("error getting batches {}", e)))?
             .into_iter()
-            .filter(|(_, (ts_min_max, _))| {
-                ts_min_max.min > (self.time_provider.now() - crate::THREE_DAYS).timestamp_nanos()
-            })
             .map(|(gen_time, (ts_min_max, batches))| {
                 let row_count = batches.iter().map(|b| b.num_rows()).sum::<usize>();
                 let chunk_stats = create_chunk_statistics(
@@ -805,8 +797,7 @@ mod tests {
                 Arc::clone(&catalog),
             )
             .unwrap(),
-            time_provider: Arc::clone(&time_provider),
-            persisted_files: Arc::new(PersistedFiles::new(Arc::clone(&time_provider))),
+            persisted_files: Arc::new(PersistedFiles::new()),
             parquet_cache: None,
         };
         let queryable_buffer = QueryableBuffer::new(queryable_buffer_args);

--- a/influxdb3_write/src/write_buffer/validator.rs
+++ b/influxdb3_write/src/write_buffer/validator.rs
@@ -242,14 +242,6 @@ fn validate_and_qualify_v1_line(
             .map(|ts| apply_precision_to_timestamp(precision, ts))
             .unwrap_or(ingest_time.timestamp_nanos());
 
-        if timestamp_ns < (ingest_time - crate::THREE_DAYS).timestamp_nanos() {
-            return Err(WriteLineError {
-                original_line: line.to_string(),
-                line_number: line_number + 1,
-                error_message: "line contained a date that was more than 3 days ago".into(),
-            });
-        }
-
         fields.push(Field::new(time_col_id, FieldData::Timestamp(timestamp_ns)));
 
         // if we have new columns defined, add them to the db_schema table so that subsequent lines


### PR DESCRIPTION
This commit does a few key things:

- Removes the 72 hour query and write restrictions in Core
- Limits the queries to a default number of parquet files. We chose 432 as this is about 72 hours using default settings for the gen1 timeblock
- The file limit can be increased, but the help text and error message when exceeded note that query performance will likely be degraded as a result.
- We warn users to use smaller time ranges if possible if they hit this query error

With this we eliminate the hard restriction we have in place, but instead create a soft one that users can choose to take the performance hit with. If they can't take that hit then it's recommended that they upgrade to Enterprise which has the compactor built in to make performant historical queries.