### PR TITLE
feat(processing_engine): integration with virtual environments.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2775,6 +2775,7 @@ dependencies = [
  "influxdb3_clap_blocks",
  "influxdb3_client",
  "influxdb3_process",
+ "influxdb3_processing_engine",
  "influxdb3_server",
  "influxdb3_sys_events",
  "influxdb3_telemetry",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2801,6 +2801,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "sha2",
+ "tempfile",
  "test-log",
  "test_helpers",
  "thiserror 1.0.69",

--- a/influxdb3/Cargo.toml
+++ b/influxdb3/Cargo.toml
@@ -59,6 +59,7 @@ uuid.workspace = true
 
 # Optional Dependencies
 console-subscriber = { version = "0.1.10", optional = true, features = ["parking_lot"] }
+tempfile = "3.15.0"
 
 [features]
 default = ["jemalloc_replacing_malloc", "azure", "gcp", "aws"]

--- a/influxdb3/Cargo.toml
+++ b/influxdb3/Cargo.toml
@@ -28,6 +28,7 @@ influxdb3_catalog = { path = "../influxdb3_catalog" }
 influxdb3_client = { path = "../influxdb3_client" }
 influxdb3_clap_blocks = { path = "../influxdb3_clap_blocks" }
 influxdb3_process = { path = "../influxdb3_process", default-features = false }
+influxdb3_processing_engine = {path = "../influxdb3_processing_engine"}
 influxdb3_server = { path = "../influxdb3_server" }
 influxdb3_wal = { path = "../influxdb3_wal" }
 influxdb3_write = { path = "../influxdb3_write" }

--- a/influxdb3/src/commands/install.rs
+++ b/influxdb3/src/commands/install.rs
@@ -1,0 +1,122 @@
+use crate::commands::serve::setup_processing_engine_env_manager;
+use anyhow::bail;
+use influxdb3_clap_blocks::plugins::{PackageManager, ProcessingEngineConfig};
+use influxdb3_client::Client;
+#[cfg(feature = "system-py")]
+use influxdb3_processing_engine::virtualenv;
+use secrecy::{ExposeSecret, Secret};
+use url::Url;
+
+#[derive(Debug, clap::Parser)]
+pub struct Config {
+    #[clap(subcommand)]
+    cmd: SubCommand,
+}
+
+#[derive(Debug, clap::Subcommand)]
+pub enum SubCommand {
+    Package(PackageConfig),
+}
+
+pub async fn command(config: Config) -> Result<(), anyhow::Error> {
+    match config.cmd {
+        SubCommand::Package(package_config) => {
+            package_config.run_command().await?;
+        }
+    }
+    Ok(())
+}
+
+#[derive(Debug, clap::Args)]
+pub struct PackageConfig {
+    /// Which package manager to use. Currently support pip, pipx and uv.
+    #[clap(long = "manager", default_value = "pip")]
+    manager: PackageManager,
+
+    /// Install packages from local directory
+    #[arg(long, conflicts_with = "remote")]
+    local: bool,
+
+    #[arg(long)]
+    remote: bool,
+    /// The host URL of the running InfluxDB 3 Core server
+    #[clap(
+        short = 'H',
+        long = "host",
+        env = "INFLUXDB3_HOST_URL",
+        default_value = "http://127.0.0.1:8181"
+    )]
+    host_url: Url,
+    /// The token for authentication with the InfluxDB 3 Core server
+    #[clap(long = "token", env = "INFLUXDB3_AUTH_TOKEN")]
+    auth_token: Option<Secret<String>>,
+
+    /// The processing engine config.
+    #[clap(flatten)]
+    pub processing_engine_config: ProcessingEngineConfig,
+
+    /// Path to requirements.txt file
+    #[arg(short = 'r', long = "requirements")]
+    requirements: Option<String>,
+
+    /// Package names to install
+    #[arg(required_unless_present = "requirements")]
+    packages: Vec<String>,
+}
+
+impl PackageConfig {
+    async fn run_command(&self) -> Result<(), anyhow::Error> {
+        if self.local {
+            self.run_command_local()
+        } else if self.remote {
+            self.run_command_remote().await
+        } else {
+            bail!("Please specify either --local or --remote")
+        }
+    }
+
+    #[cfg(feature = "system-py")]
+    fn run_command_local(&self) -> Result<(), anyhow::Error> {
+        // we're running locally, so need to make sure we're in the environment before running commands.
+        let environment_manager =
+            setup_processing_engine_env_manager(&self.processing_engine_config);
+        if environment_manager.plugin_dir.is_none() {
+            bail!("need plugin dir to install local packages")
+        };
+        // Initialize Python, so that we're operating against the virtual env if required.
+        virtualenv::init_pyo3(&environment_manager.virtual_env_location);
+
+        if let Some(requirements_path) = &self.requirements {
+            environment_manager
+                .package_manager
+                .install_requirements(requirements_path.to_string())?;
+        } else {
+            environment_manager
+                .package_manager
+                .install_packages(self.packages.clone())?;
+        }
+        Ok(())
+    }
+
+    #[cfg(not(feature = "system-py"))]
+    fn run_command_local(&self) -> Result<(), anyhow::Error> {
+        bail!("can't run local commands without system-py enabled")
+    }
+
+    async fn run_command_remote(&self) -> Result<(), anyhow::Error> {
+        let mut client = Client::new(self.host_url.clone())?;
+        if let Some(token) = &self.auth_token {
+            client = client.with_auth_token(token.expose_secret());
+        }
+        if let Some(requirements_path) = &self.requirements {
+            client
+                .api_v3_configure_processing_engine_trigger_install_requirements(requirements_path)
+                .await?;
+        } else {
+            client
+                .api_v3_configure_plugin_environment_install_packages(self.packages.clone())
+                .await?;
+        }
+        Ok(())
+    }
+}

--- a/influxdb3/src/commands/install.rs
+++ b/influxdb3/src/commands/install.rs
@@ -1,6 +1,6 @@
 use crate::commands::serve::setup_processing_engine_env_manager;
 use anyhow::bail;
-use influxdb3_clap_blocks::plugins::{PackageManager, ProcessingEngineConfig};
+use influxdb3_clap_blocks::plugins::ProcessingEngineConfig;
 use influxdb3_client::Client;
 #[cfg(feature = "system-py")]
 use influxdb3_processing_engine::virtualenv;
@@ -15,6 +15,7 @@ pub struct Config {
 
 #[derive(Debug, clap::Subcommand)]
 pub enum SubCommand {
+    /// Install packages within the plugin environment
     Package(PackageConfig),
 }
 
@@ -29,14 +30,11 @@ pub async fn command(config: Config) -> Result<(), anyhow::Error> {
 
 #[derive(Debug, clap::Args)]
 pub struct PackageConfig {
-    /// Which package manager to use. Currently support pip, pipx and uv.
-    #[clap(long = "manager", default_value = "pip")]
-    manager: PackageManager,
-
     /// Install packages from local directory
     #[arg(long, conflicts_with = "remote")]
     local: bool,
 
+    /// Have the remote influxdb install packages
     #[arg(long)]
     remote: bool,
     /// The host URL of the running InfluxDB 3 Core server

--- a/influxdb3/src/commands/serve.rs
+++ b/influxdb3/src/commands/serve.rs
@@ -18,9 +18,7 @@ use influxdb3_clap_blocks::{
 use influxdb3_process::{
     build_malloc_conf, setup_metric_registry, INFLUXDB3_GIT_HASH, INFLUXDB3_VERSION, PROCESS_UUID,
 };
-use influxdb3_processing_engine::environment::{
-    PipManager, PipxManager, PythonEnvironmentManager, UVManager,
-};
+use influxdb3_processing_engine::environment::{PipManager, PythonEnvironmentManager, UVManager};
 use influxdb3_processing_engine::plugins::ProcessingEngineEnvironmentManager;
 use influxdb3_server::{
     auth::AllOrNothingAuthorizer,
@@ -622,12 +620,11 @@ pub async fn command(config: Config) -> Result<()> {
     Ok(())
 }
 
-fn setup_processing_engine_env_manager(
+pub(crate) fn setup_processing_engine_env_manager(
     config: &ProcessingEngineConfig,
 ) -> ProcessingEngineEnvironmentManager {
     let package_manager: Arc<dyn PythonEnvironmentManager> = match config.package_manager {
         PackageManager::Pip => Arc::new(PipManager),
-        PackageManager::Pipx => Arc::new(PipxManager),
         PackageManager::UV => Arc::new(UVManager),
     };
     ProcessingEngineEnvironmentManager {

--- a/influxdb3/src/commands/serve.rs
+++ b/influxdb3/src/commands/serve.rs
@@ -627,6 +627,10 @@ pub(crate) fn setup_processing_engine_env_manager(
         PackageManager::Pip => Arc::new(PipManager),
         PackageManager::UV => Arc::new(UVManager),
     };
+    println!(
+        "setting up package manager {:?} as {:?}",
+        config.package_manager, config.package_manager
+    );
     ProcessingEngineEnvironmentManager {
         plugin_dir: config.plugin_dir.clone(),
         virtual_env_location: config.virtual_env_location.clone(),

--- a/influxdb3/src/main.rs
+++ b/influxdb3/src/main.rs
@@ -26,6 +26,7 @@ mod commands {
     pub mod delete;
     pub mod disable;
     pub mod enable;
+    pub mod install;
     pub mod query;
     pub mod serve;
     pub mod show;
@@ -102,6 +103,9 @@ enum Command {
     /// Run the InfluxDB 3 Core server
     Serve(commands::serve::Config),
 
+    /// Install packages for the processing engine
+    Install(commands::install::Config),
+
     /// List resources on the InfluxDB 3 Core server
     Show(commands::show::Config),
 
@@ -165,6 +169,12 @@ fn main() -> Result<(), std::io::Error> {
                     handle_init_logs(init_logs_and_tracing(&config.logging_config));
                 if let Err(e) = commands::serve::command(config).await {
                     eprintln!("Serve command failed: {e}");
+                    std::process::exit(ReturnCode::Failure as _)
+                }
+            }
+            Some(Command::Install(config)) => {
+                if let Err(e) = commands::install::command(config).await {
+                    eprintln!("Install command failed: {e}");
                     std::process::exit(ReturnCode::Failure as _)
                 }
             }

--- a/influxdb3/tests/server/main.rs
+++ b/influxdb3/tests/server/main.rs
@@ -19,6 +19,7 @@ mod client;
 mod configure;
 mod flight;
 mod limits;
+mod packages;
 mod ping;
 mod query;
 mod system_tables;
@@ -49,6 +50,8 @@ pub struct TestConfig {
     auth_token: Option<(String, String)>,
     node_id: Option<String>,
     plugin_dir: Option<String>,
+    virtual_env_dir: Option<String>,
+    package_manager: Option<String>,
     // If None, use memory object store.
     object_store_dir: Option<String>,
 }
@@ -76,6 +79,17 @@ impl TestConfig {
         self
     }
 
+    /// Set the virtual env dir for this [`TestServer`]
+    pub fn with_virtual_env<S: Into<String>>(mut self, virtual_env_dir: S) -> Self {
+        self.virtual_env_dir = Some(virtual_env_dir.into());
+        self
+    }
+
+    pub fn with_package_manager<S: Into<String>>(mut self, package_manager: S) -> Self {
+        self.package_manager = Some(package_manager.into());
+        self
+    }
+
     // Set the object store dir for this [`TestServer`]
     pub fn with_object_store_dir<S: Into<String>>(mut self, object_store_dir: S) -> Self {
         self.object_store_dir = Some(object_store_dir.into());
@@ -91,6 +105,18 @@ impl ConfigProvider for TestConfig {
         }
         if let Some(plugin_dir) = &self.plugin_dir {
             args.append(&mut vec!["--plugin-dir".to_string(), plugin_dir.to_owned()]);
+        }
+        if let Some(virtual_env_dir) = &self.virtual_env_dir {
+            args.append(&mut vec![
+                "--virtual-env-location".to_string(),
+                virtual_env_dir.to_owned(),
+            ]);
+        }
+        if let Some(package_manager) = &self.package_manager {
+            args.append(&mut vec![
+                "--package-manager".to_string(),
+                package_manager.to_owned(),
+            ]);
         }
         args.push("--node-id".to_string());
         if let Some(host) = &self.node_id {

--- a/influxdb3/tests/server/packages.rs
+++ b/influxdb3/tests/server/packages.rs
@@ -1,0 +1,282 @@
+use crate::cli::run_with_confirmation;
+use crate::{ConfigProvider, TestServer};
+use anyhow::{bail, Result};
+use serde_json::Value;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use tempfile::{NamedTempFile, TempDir};
+
+const TEST_PACKAGE: &str = "tablib";
+const TEST_VERSION: &str = "3.8.0";
+
+struct VenvTest {
+    venv_dir: TempDir,
+    plugin_file: NamedTempFile,
+}
+
+impl VenvTest {
+    fn new() -> Result<Self> {
+        let venv_dir = TempDir::new()?;
+        let plugin_file = create_version_check_plugin()?;
+        Ok(Self {
+            venv_dir,
+            plugin_file,
+        })
+    }
+
+    fn venv_path(&self) -> PathBuf {
+        self.venv_dir.path().to_path_buf()
+    }
+
+    fn plugin_dir(&self) -> String {
+        self.plugin_file
+            .path()
+            .parent()
+            .unwrap()
+            .to_string_lossy()
+            .to_string()
+    }
+}
+
+fn create_version_check_plugin() -> Result<NamedTempFile> {
+    let plugin_code = r#"
+import pkg_resources
+
+def process_scheduled_call(influxdb3_local, schedule_time, args=None):
+    try:
+        version = pkg_resources.get_distribution('tablib').version
+        influxdb3_local.info(version)
+    except pkg_resources.DistributionNotFound:
+        influxdb3_local.info("tablib is not installed")
+"#;
+    let mut plugin_file = NamedTempFile::new()?;
+    plugin_file.write_all(plugin_code.as_bytes())?;
+    Ok(plugin_file)
+}
+
+async fn run_version_check(server_addr: &str, plugin_path: &str) -> Result<Vec<String>> {
+    let output = run_with_confirmation(&[
+        "test",
+        "schedule_plugin",
+        "-H",
+        server_addr,
+        "-d",
+        "version_check",
+        plugin_path,
+    ])?;
+
+    let json: Value = serde_json::from_str(&output)?;
+    Ok(json["log_lines"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|line| {
+            line.as_str()
+                .unwrap()
+                .trim_start_matches("INFO: ")
+                .to_string()
+        })
+        .collect())
+}
+
+fn setup_python_venv(venv_path: &Path) -> Result<()> {
+    Command::new("python3")
+        .args(["-m", "venv", venv_path.to_str().unwrap()])
+        .status()?;
+    Ok(())
+}
+
+fn setup_uv_venv(venv_path: &Path) -> Result<()> {
+    let status = Command::new("uv")
+        .args(["venv", venv_path.to_str().unwrap()])
+        .status()?;
+    if !status.success() {
+        bail!("failed to execute venv");
+    }
+    Ok(())
+}
+
+#[cfg(feature = "system-py")]
+#[test_log::test(tokio::test)]
+async fn test_python_venv_pip_install() -> Result<()> {
+    let test = VenvTest::new()?;
+    setup_python_venv(&test.venv_path())?;
+
+    let server = TestServer::configure()
+        .with_plugin_dir(test.plugin_dir())
+        .with_virtual_env(test.venv_path().to_string_lossy())
+        .spawn()
+        .await;
+    let server_addr = server.client_addr();
+
+    run_with_confirmation(&[
+        "create",
+        "database",
+        "--host",
+        &server_addr,
+        "version_check",
+    ])?;
+
+    // Check package is not installed
+    let logs = run_version_check(&server_addr, test.plugin_file.path().to_str().unwrap()).await?;
+    assert_eq!(logs, vec!["tablib is not installed"]);
+
+    // Install specific version
+    run_with_confirmation(&[
+        "install",
+        "package",
+        "--local",
+        "--package-manager",
+        "pip",
+        &format!("{}=={}", TEST_PACKAGE, TEST_VERSION),
+        "--virtual-env-location",
+        test.venv_path().to_str().unwrap(),
+        "--plugin-dir",
+        test.plugin_dir().as_str(),
+    ])?;
+
+    // Verify correct version installed
+    let logs = run_version_check(&server_addr, test.plugin_file.path().to_str().unwrap()).await?;
+    assert_eq!(logs, vec![TEST_VERSION]);
+
+    Ok(())
+}
+
+#[cfg(feature = "system-py")]
+#[test_log::test(tokio::test)]
+async fn test_uv_venv_uv_install() -> Result<()> {
+    let test = VenvTest::new()?;
+    setup_uv_venv(&test.venv_path())?;
+
+    let server = TestServer::configure()
+        .with_plugin_dir(test.plugin_dir())
+        .with_virtual_env(test.venv_path().to_string_lossy())
+        .with_package_manager("uv")
+        .spawn()
+        .await;
+    let server_addr = server.client_addr();
+
+    run_with_confirmation(&[
+        "create",
+        "database",
+        "--host",
+        &server_addr,
+        "version_check",
+    ])?;
+
+    // Check package is not installed
+    let logs = run_version_check(&server_addr, test.plugin_file.path().to_str().unwrap()).await?;
+    assert_eq!(vec!["tablib is not installed"], logs);
+
+    // Install with UV
+    run_with_confirmation(&[
+        "install",
+        "package",
+        "--local",
+        "--package-manager",
+        "uv",
+        "--plugin-dir",
+        test.plugin_dir().as_str(),
+        "--virtual-env-location",
+        test.venv_path().to_str().unwrap(),
+        TEST_PACKAGE,
+    ])?;
+
+    // Verify package is installed
+    let logs = run_version_check(&server_addr, test.plugin_file.path().to_str().unwrap()).await?;
+    assert!(!logs[0].contains("not installed"));
+
+    Ok(())
+}
+
+#[cfg(feature = "system-py")]
+#[test_log::test(tokio::test)]
+async fn test_venv_requirements_install() -> Result<()> {
+    let test = VenvTest::new()?;
+    setup_python_venv(&test.venv_path())?;
+
+    let server = TestServer::configure()
+        .with_plugin_dir(test.plugin_dir())
+        .with_virtual_env(test.venv_path().to_string_lossy())
+        .spawn()
+        .await;
+    let server_addr = server.client_addr();
+
+    run_with_confirmation(&[
+        "create",
+        "database",
+        "--host",
+        &server_addr,
+        "version_check",
+    ])?;
+
+    // Check package is not installed
+    let logs = run_version_check(&server_addr, test.plugin_file.path().to_str().unwrap()).await?;
+    assert_eq!(logs, vec!["tablib is not installed"]);
+
+    // Create requirements.txt
+    let mut requirements_file = NamedTempFile::new()?;
+    writeln!(requirements_file, "{}=={}", TEST_PACKAGE, TEST_VERSION)?;
+
+    // Install from requirements
+    run_with_confirmation(&[
+        "install",
+        "package",
+        "--local",
+        "--requirements",
+        requirements_file.path().to_str().unwrap(),
+        "--plugin-dir",
+        test.plugin_dir().as_str(),
+        "--virtual-env-location",
+        test.venv_path().to_str().unwrap(),
+    ])?;
+
+    // Verify installation
+    let logs = run_version_check(&server_addr, test.plugin_file.path().to_str().unwrap()).await?;
+    assert_eq!(logs, vec![TEST_VERSION]);
+    Ok(())
+}
+
+#[cfg(feature = "system-py")]
+#[test_log::test(tokio::test)]
+async fn test_venv_remote_install() -> Result<()> {
+    let test = VenvTest::new()?;
+    setup_python_venv(&test.venv_path())?;
+
+    let server = TestServer::configure()
+        .with_plugin_dir(test.plugin_dir())
+        .with_virtual_env(test.venv_path().to_string_lossy())
+        .spawn()
+        .await;
+    let server_addr = server.client_addr();
+
+    run_with_confirmation(&[
+        "create",
+        "database",
+        "--host",
+        &server_addr,
+        "version_check",
+    ])?;
+
+    // Check package is not installed
+    let logs = run_version_check(&server_addr, test.plugin_file.path().to_str().unwrap()).await?;
+    assert_eq!(logs, vec!["tablib is not installed"]);
+
+    // Test remote installation
+    run_with_confirmation(&[
+        "install",
+        "package",
+        "--remote",
+        "--host",
+        &server_addr,
+        "--virtual-env-location",
+        test.venv_path().to_str().unwrap(),
+        TEST_PACKAGE,
+    ])?;
+
+    // Verify installation
+    let logs = run_version_check(&server_addr, test.plugin_file.path().to_str().unwrap()).await?;
+    assert!(!logs[0].contains("not installed"));
+    Ok(())
+}

--- a/influxdb3/tests/server/packages.rs
+++ b/influxdb3/tests/server/packages.rs
@@ -64,7 +64,7 @@ async fn run_version_check(server_addr: &str, plugin_path: &str) -> Result<Vec<S
         "-d",
         "version_check",
         plugin_path,
-    ])?;
+    ]);
 
     let json: Value = serde_json::from_str(&output)?;
     Ok(json["log_lines"]
@@ -116,7 +116,7 @@ async fn test_python_venv_pip_install() -> Result<()> {
         "--host",
         &server_addr,
         "version_check",
-    ])?;
+    ]);
 
     // Check package is not installed
     let logs = run_version_check(&server_addr, test.plugin_file.path().to_str().unwrap()).await?;
@@ -126,15 +126,12 @@ async fn test_python_venv_pip_install() -> Result<()> {
     run_with_confirmation(&[
         "install",
         "package",
-        "--local",
+        "--host",
+        &server_addr,
         "--package-manager",
         "pip",
         &format!("{}=={}", TEST_PACKAGE, TEST_VERSION),
-        "--virtual-env-location",
-        test.venv_path().to_str().unwrap(),
-        "--plugin-dir",
-        test.plugin_dir().as_str(),
-    ])?;
+    ]);
 
     // Verify correct version installed
     let logs = run_version_check(&server_addr, test.plugin_file.path().to_str().unwrap()).await?;
@@ -163,7 +160,7 @@ async fn test_uv_venv_uv_install() -> Result<()> {
         "--host",
         &server_addr,
         "version_check",
-    ])?;
+    ]);
 
     // Check package is not installed
     let logs = run_version_check(&server_addr, test.plugin_file.path().to_str().unwrap()).await?;
@@ -173,15 +170,12 @@ async fn test_uv_venv_uv_install() -> Result<()> {
     run_with_confirmation(&[
         "install",
         "package",
-        "--local",
+        "--host",
+        &server_addr,
         "--package-manager",
         "uv",
-        "--plugin-dir",
-        test.plugin_dir().as_str(),
-        "--virtual-env-location",
-        test.venv_path().to_str().unwrap(),
         TEST_PACKAGE,
-    ])?;
+    ]);
 
     // Verify package is installed
     let logs = run_version_check(&server_addr, test.plugin_file.path().to_str().unwrap()).await?;
@@ -209,7 +203,7 @@ async fn test_venv_requirements_install() -> Result<()> {
         "--host",
         &server_addr,
         "version_check",
-    ])?;
+    ]);
 
     // Check package is not installed
     let logs = run_version_check(&server_addr, test.plugin_file.path().to_str().unwrap()).await?;
@@ -223,14 +217,11 @@ async fn test_venv_requirements_install() -> Result<()> {
     run_with_confirmation(&[
         "install",
         "package",
-        "--local",
+        "--host",
+        &server_addr,
         "--requirements",
         requirements_file.path().to_str().unwrap(),
-        "--plugin-dir",
-        test.plugin_dir().as_str(),
-        "--virtual-env-location",
-        test.venv_path().to_str().unwrap(),
-    ])?;
+    ]);
 
     // Verify installation
     let logs = run_version_check(&server_addr, test.plugin_file.path().to_str().unwrap()).await?;
@@ -257,23 +248,14 @@ async fn test_venv_remote_install() -> Result<()> {
         "--host",
         &server_addr,
         "version_check",
-    ])?;
+    ]);
 
     // Check package is not installed
     let logs = run_version_check(&server_addr, test.plugin_file.path().to_str().unwrap()).await?;
     assert_eq!(logs, vec!["tablib is not installed"]);
 
     // Test remote installation
-    run_with_confirmation(&[
-        "install",
-        "package",
-        "--remote",
-        "--host",
-        &server_addr,
-        "--virtual-env-location",
-        test.venv_path().to_str().unwrap(),
-        TEST_PACKAGE,
-    ])?;
+    run_with_confirmation(&["install", "package", "--host", &server_addr, TEST_PACKAGE]);
 
     // Verify installation
     let logs = run_version_check(&server_addr, test.plugin_file.path().to_str().unwrap()).await?;

--- a/influxdb3_clap_blocks/src/lib.rs
+++ b/influxdb3_clap_blocks/src/lib.rs
@@ -3,5 +3,6 @@
 pub mod datafusion;
 pub mod memory_size;
 pub mod object_store;
+pub mod plugins;
 pub mod socket_addr;
 pub mod tokio;

--- a/influxdb3_clap_blocks/src/plugins.rs
+++ b/influxdb3_clap_blocks/src/plugins.rs
@@ -10,7 +10,7 @@ pub struct ProcessingEngineConfig {
     pub plugin_dir: Option<PathBuf>,
     #[clap(long = "virtual-env-location", env = "VIRTUAL_ENV")]
     pub virtual_env_location: Option<PathBuf>,
-    #[clap(long = "package-manager", default_value = "pip")]
+    #[clap(long = "package-manager", default_value = "discover")]
     pub package_manager: PackageManager,
 }
 

--- a/influxdb3_clap_blocks/src/plugins.rs
+++ b/influxdb3_clap_blocks/src/plugins.rs
@@ -1,15 +1,15 @@
 use std::path::PathBuf;
 
-/// Specifies the behavior of the Processing Engine.
-/// Currently used to determine the plugin directory and which tooling to use to initialize python,
-/// but will expand for other settings, such as error behavior.
+// Specifies the behavior of the Processing Engine.
+// Currently used to determine the plugin directory and which tooling to use to initialize python,
+// but will expand for other settings, such as error behavior.
 #[derive(Debug, clap::Parser, Clone)]
 pub struct ProcessingEngineConfig {
+    /// Location of the plugins
     #[clap(long = "plugin-dir")]
     pub plugin_dir: Option<PathBuf>,
     #[clap(long = "virtual-env-location", env = "VIRTUAL_ENV")]
     pub virtual_env_location: Option<PathBuf>,
-
     #[clap(long = "package-manager", default_value = "pip")]
     pub package_manager: PackageManager,
 }

--- a/influxdb3_clap_blocks/src/plugins.rs
+++ b/influxdb3_clap_blocks/src/plugins.rs
@@ -18,6 +18,5 @@ pub struct ProcessingEngineConfig {
 pub enum PackageManager {
     #[default]
     Pip,
-    Pipx,
     UV,
 }

--- a/influxdb3_clap_blocks/src/plugins.rs
+++ b/influxdb3_clap_blocks/src/plugins.rs
@@ -17,6 +17,7 @@ pub struct ProcessingEngineConfig {
 #[derive(Debug, Clone, Copy, Default, clap::ValueEnum)]
 pub enum PackageManager {
     #[default]
+    Discover,
     Pip,
     UV,
 }

--- a/influxdb3_clap_blocks/src/plugins.rs
+++ b/influxdb3_clap_blocks/src/plugins.rs
@@ -1,0 +1,23 @@
+use std::path::PathBuf;
+
+/// Specifies the behavior of the Processing Engine.
+/// Currently used to determine the plugin directory and which tooling to use to initialize python,
+/// but will expand for other settings, such as error behavior.
+#[derive(Debug, clap::Parser, Clone)]
+pub struct ProcessingEngineConfig {
+    #[clap(long = "plugin-dir")]
+    pub plugin_dir: Option<PathBuf>,
+    #[clap(long = "virtual-env-location", env = "VIRTUAL_ENV")]
+    pub virtual_env_location: Option<PathBuf>,
+
+    #[clap(long = "package-manager", default_value = "pip")]
+    pub package_manager: PackageManager,
+}
+
+#[derive(Debug, Clone, Copy, Default, clap::ValueEnum)]
+pub enum PackageManager {
+    #[default]
+    Pip,
+    Pipx,
+    UV,
+}

--- a/influxdb3_client/src/lib.rs
+++ b/influxdb3_client/src/lib.rs
@@ -679,6 +679,66 @@ impl Client {
         }
     }
 
+    /// Make a request to api/v3/configure/plugin_environment/install_packages
+    pub async fn api_v3_configure_plugin_environment_install_packages(
+        &self,
+        packages: Vec<String>,
+    ) -> Result<()> {
+        let api_path = "/api/v3/configure/plugin_environment/install_packages";
+        let url = self.base_url.join(api_path)?;
+        #[derive(Serialize)]
+        struct Req {
+            packages: Vec<String>,
+        }
+        let mut req = self.http_client.post(url).json(&Req { packages });
+        if let Some(token) = &self.auth_token {
+            req = req.bearer_auth(token.expose_secret());
+        }
+        let resp = req
+            .send()
+            .await
+            .map_err(|src| Error::request_send(Method::DELETE, api_path, src))?;
+        let status = resp.status();
+        match status {
+            StatusCode::OK => Ok(()),
+            code => Err(Error::ApiError {
+                code,
+                message: resp.text().await.map_err(Error::Text)?,
+            }),
+        }
+    }
+
+    /// Make a request to api/v3/configure/plugin_environment/install_requirements
+    pub async fn api_v3_configure_processing_engine_trigger_install_requirements(
+        &self,
+        requirements_location: impl Into<String> + Send,
+    ) -> Result<()> {
+        let api_path = "/api/v3/configure/plugin_environment/install_requirements";
+        let url = self.base_url.join(api_path)?;
+        #[derive(Serialize)]
+        struct Req {
+            requirements_location: String,
+        }
+        let mut req = self.http_client.post(url).json(&Req {
+            requirements_location: requirements_location.into(),
+        });
+        if let Some(token) = &self.auth_token {
+            req = req.bearer_auth(token.expose_secret());
+        }
+        let resp = req
+            .send()
+            .await
+            .map_err(|src| Error::request_send(Method::DELETE, api_path, src))?;
+        let status = resp.status();
+        match status {
+            StatusCode::OK => Ok(()),
+            code => Err(Error::ApiError {
+                code,
+                message: resp.text().await.map_err(Error::Text)?,
+            }),
+        }
+    }
+
     /// Make a request to `POST /api/v3/configure/processing_engine_trigger/disable`
     pub async fn api_v3_configure_processing_engine_trigger_disable(
         &self,

--- a/influxdb3_processing_engine/Cargo.toml
+++ b/influxdb3_processing_engine/Cargo.toml
@@ -33,8 +33,6 @@ tokio.workspace = true
 
 [dependencies.pyo3]
 version = "0.23.3"
-# this is necessary to automatically initialize the Python interpreter
-features = ["auto-initialize"]
 optional = true
 
 [dev-dependencies]

--- a/influxdb3_processing_engine/src/environment.rs
+++ b/influxdb3_processing_engine/src/environment.rs
@@ -14,7 +14,7 @@ pub enum PluginEnvironmentError {
 }
 
 pub trait PythonEnvironmentManager: Debug + Send + Sync + 'static {
-    fn install_package(&self, package_name: String) -> Result<(), PluginEnvironmentError>;
+    fn install_packages(&self, packages: Vec<String>) -> Result<(), PluginEnvironmentError>;
 
     fn install_requirements(&self, requirements_path: String)
         -> Result<(), PluginEnvironmentError>;
@@ -24,16 +24,15 @@ pub trait PythonEnvironmentManager: Debug + Send + Sync + 'static {
 pub struct UVManager;
 #[derive(Debug, Copy, Clone)]
 pub struct PipManager;
-#[derive(Debug, Copy, Clone)]
-pub struct PipxManager;
 
 #[derive(Debug, Copy, Clone)]
 pub struct DisabledManager;
 
 impl PythonEnvironmentManager for UVManager {
-    fn install_package(&self, package: String) -> Result<(), PluginEnvironmentError> {
+    fn install_packages(&self, packages: Vec<String>) -> Result<(), PluginEnvironmentError> {
         Command::new("uv")
-            .args(["pip", "install", &package])
+            .args(["pip", "install"])
+            .args(&packages)
             .output()?;
         Ok(())
     }
@@ -50,8 +49,11 @@ impl PythonEnvironmentManager for UVManager {
 }
 
 impl PythonEnvironmentManager for PipManager {
-    fn install_package(&self, package: String) -> Result<(), PluginEnvironmentError> {
-        Command::new("pip").args(["install", &package]).output()?;
+    fn install_packages(&self, packages: Vec<String>) -> Result<(), PluginEnvironmentError> {
+        Command::new("pip")
+            .arg("install")
+            .args(&packages)
+            .output()?;
         Ok(())
     }
     fn install_requirements(
@@ -65,24 +67,8 @@ impl PythonEnvironmentManager for PipManager {
     }
 }
 
-impl PythonEnvironmentManager for PipxManager {
-    fn install_package(&self, package: String) -> Result<(), PluginEnvironmentError> {
-        Command::new("pipx").args(["install", &package]).output()?;
-        Ok(())
-    }
-    fn install_requirements(
-        &self,
-        requirements_path: String,
-    ) -> Result<(), PluginEnvironmentError> {
-        Command::new("pipx")
-            .args(["install", "-r", &requirements_path])
-            .output()?;
-        Ok(())
-    }
-}
-
 impl PythonEnvironmentManager for DisabledManager {
-    fn install_package(&self, _package: String) -> Result<(), PluginEnvironmentError> {
+    fn install_packages(&self, _packages: Vec<String>) -> Result<(), PluginEnvironmentError> {
         Err(PluginEnvironmentDisabled)
     }
 

--- a/influxdb3_processing_engine/src/environment.rs
+++ b/influxdb3_processing_engine/src/environment.rs
@@ -1,0 +1,95 @@
+use crate::environment::PluginEnvironmentError::PluginEnvironmentDisabled;
+use std::fmt::Debug;
+use std::process::Command;
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum PluginEnvironmentError {
+    #[error("Package manager not available: {0}")]
+    PackageManagerNotFound(String),
+    #[error("External call failed: {0}")]
+    InstallationFailed(#[from] std::io::Error),
+    #[error("Plugin environment management is disabled")]
+    PluginEnvironmentDisabled,
+}
+
+pub trait PythonEnvironmentManager: Debug + Send + Sync + 'static {
+    fn install_package(&self, package_name: String) -> Result<(), PluginEnvironmentError>;
+
+    fn install_requirements(&self, requirements_path: String)
+        -> Result<(), PluginEnvironmentError>;
+}
+
+#[derive(Debug, Copy, Clone)]
+pub struct UVManager;
+#[derive(Debug, Copy, Clone)]
+pub struct PipManager;
+#[derive(Debug, Copy, Clone)]
+pub struct PipxManager;
+
+#[derive(Debug, Copy, Clone)]
+pub struct DisabledManager;
+
+impl PythonEnvironmentManager for UVManager {
+    fn install_package(&self, package: String) -> Result<(), PluginEnvironmentError> {
+        Command::new("uv")
+            .args(["pip", "install", &package])
+            .output()?;
+        Ok(())
+    }
+
+    fn install_requirements(
+        &self,
+        requirements_path: String,
+    ) -> Result<(), PluginEnvironmentError> {
+        Command::new("uv")
+            .args(["pip", "install", "-r", &requirements_path])
+            .output()?;
+        Ok(())
+    }
+}
+
+impl PythonEnvironmentManager for PipManager {
+    fn install_package(&self, package: String) -> Result<(), PluginEnvironmentError> {
+        Command::new("pip").args(["install", &package]).output()?;
+        Ok(())
+    }
+    fn install_requirements(
+        &self,
+        requirements_path: String,
+    ) -> Result<(), PluginEnvironmentError> {
+        Command::new("pip")
+            .args(["install", "-r", &requirements_path])
+            .output()?;
+        Ok(())
+    }
+}
+
+impl PythonEnvironmentManager for PipxManager {
+    fn install_package(&self, package: String) -> Result<(), PluginEnvironmentError> {
+        Command::new("pipx").args(["install", &package]).output()?;
+        Ok(())
+    }
+    fn install_requirements(
+        &self,
+        requirements_path: String,
+    ) -> Result<(), PluginEnvironmentError> {
+        Command::new("pipx")
+            .args(["install", "-r", &requirements_path])
+            .output()?;
+        Ok(())
+    }
+}
+
+impl PythonEnvironmentManager for DisabledManager {
+    fn install_package(&self, _package: String) -> Result<(), PluginEnvironmentError> {
+        Err(PluginEnvironmentDisabled)
+    }
+
+    fn install_requirements(
+        &self,
+        _requirements_path: String,
+    ) -> Result<(), PluginEnvironmentError> {
+        Err(PluginEnvironmentDisabled)
+    }
+}

--- a/influxdb3_processing_engine/src/lib.rs
+++ b/influxdb3_processing_engine/src/lib.rs
@@ -31,6 +31,7 @@ use tokio::sync::{mpsc, oneshot, RwLock};
 
 pub mod manager;
 pub mod plugins;
+pub(crate) mod virtualenv;
 
 #[derive(Debug)]
 pub struct ProcessingEngineManagerImpl {
@@ -208,6 +209,11 @@ impl ProcessingEngineManagerImpl {
         time_provider: Arc<dyn TimeProvider>,
         wal: Arc<dyn Wal>,
     ) -> Self {
+        // if given a plugin dir, try to initialize the virtualenv.
+        if let Some(ref plugin_dir) = plugin_dir {
+            let venv_path = plugin_dir.join(".venv");
+            virtualenv::try_init_venv(&venv_path)
+        }
         Self {
             plugin_dir,
             catalog,

--- a/influxdb3_processing_engine/src/lib.rs
+++ b/influxdb3_processing_engine/src/lib.rs
@@ -214,9 +214,15 @@ impl ProcessingEngineManagerImpl {
         wal: Arc<dyn Wal>,
     ) -> Self {
         // if given a plugin dir, try to initialize the virtualenv.
-        if environment.plugin_dir.is_some() {
-            #[cfg(feature = "system-py")]
-            virtualenv::init_pyo3(&environment.virtual_env_location);
+        #[cfg(feature = "system-py")]
+        if let Some(plugin_dir) = &environment.plugin_dir {
+            {
+                environment
+                    .package_manager
+                    .init_pyenv(plugin_dir, environment.virtual_env_location.as_ref())
+                    .expect("unable to initialize python environment");
+                virtualenv::init_pyo3();
+            }
         }
         Self {
             environment_manager: environment,

--- a/influxdb3_processing_engine/src/lib.rs
+++ b/influxdb3_processing_engine/src/lib.rs
@@ -1,3 +1,4 @@
+use crate::environment::PythonEnvironmentManager;
 use crate::manager::{ProcessingEngineError, ProcessingEngineManager};
 #[cfg(feature = "system-py")]
 use crate::plugins::PluginContext;
@@ -34,11 +35,11 @@ pub mod manager;
 pub mod plugins;
 
 #[cfg(feature = "system-py")]
-pub(crate) mod virtualenv;
+pub mod virtualenv;
 
 #[derive(Debug)]
 pub struct ProcessingEngineManagerImpl {
-    plugin_dir: Option<std::path::PathBuf>,
+    environment_manager: ProcessingEngineEnvironmentManager,
     catalog: Arc<Catalog>,
     write_buffer: Arc<dyn WriteBuffer>,
     query_executor: Arc<dyn QueryExecutor>,
@@ -218,7 +219,7 @@ impl ProcessingEngineManagerImpl {
             virtualenv::init_pyo3(&environment.virtual_env_location);
         }
         Self {
-            plugin_dir: environment.plugin_dir,
+            environment_manager: environment,
             catalog,
             write_buffer,
             query_executor,
@@ -253,7 +254,11 @@ impl ProcessingEngineManagerImpl {
         }
 
         // otherwise we assume it is a local file
-        let plugin_dir = self.plugin_dir.clone().context("plugin dir not set")?;
+        let plugin_dir = self
+            .environment_manager
+            .plugin_dir
+            .clone()
+            .context("plugin dir not set")?;
         let plugin_path = plugin_dir.join(name);
 
         // read it at least once to make sure it's there
@@ -702,6 +707,10 @@ impl ProcessingEngineManager for ProcessingEngineManagerImpl {
             error!(%e, "error receiving response from plugin");
             ProcessingEngineError::RequestHandlerDown
         })?)
+    }
+
+    fn get_environment_manager(&self) -> Arc<dyn PythonEnvironmentManager> {
+        Arc::clone(&self.environment_manager.package_manager)
     }
 }
 

--- a/influxdb3_processing_engine/src/manager.rs
+++ b/influxdb3_processing_engine/src/manager.rs
@@ -1,3 +1,4 @@
+use crate::environment::{PluginEnvironmentError, PythonEnvironmentManager};
 use bytes::Bytes;
 use hashbrown::HashMap;
 use hyper::{Body, Response};
@@ -46,6 +47,9 @@ pub enum ProcessingEngineError {
 
     #[error("request handler for trigger down")]
     RequestHandlerDown,
+
+    #[error("error installing python packages: {0}")]
+    PythonPackageError(#[from] PluginEnvironmentError),
 }
 
 /// `[ProcessingEngineManager]` is used to interact with the processing engine,
@@ -114,4 +118,6 @@ pub trait ProcessingEngineManager: Debug + Send + Sync + 'static {
         request_headers: HashMap<String, String>,
         request_body: Bytes,
     ) -> Result<Response<Body>, ProcessingEngineError>;
+
+    fn get_environment_manager(&self) -> Arc<dyn PythonEnvironmentManager>;
 }

--- a/influxdb3_processing_engine/src/plugins.rs
+++ b/influxdb3_processing_engine/src/plugins.rs
@@ -790,8 +790,13 @@ mod tests {
     use influxdb3_write::Precision;
     use iox_time::Time;
 
+    fn ensure_pyo3() {
+        pyo3::prepare_freethreaded_python();
+    }
+
     #[test]
     fn test_wal_plugin() {
+        ensure_pyo3();
         let now = Time::from_timestamp_nanos(1);
         let catalog = Catalog::new("foo".into(), "bar".into());
         let code = r#"
@@ -874,6 +879,7 @@ def process_writes(influxdb3_local, table_batches, args=None):
 
     #[test]
     fn test_wal_plugin_invalid_lines() {
+        ensure_pyo3();
         // set up a catalog and write some data into it to create a schema
         let now = Time::from_timestamp_nanos(1);
         let catalog = Arc::new(Catalog::new("foo".into(), "bar".into()));

--- a/influxdb3_processing_engine/src/plugins.rs
+++ b/influxdb3_processing_engine/src/plugins.rs
@@ -1,3 +1,4 @@
+use crate::environment::PythonEnvironmentManager;
 #[cfg(feature = "system-py")]
 use crate::PluginCode;
 #[cfg(feature = "system-py")]
@@ -23,6 +24,7 @@ use influxdb3_write::WriteBuffer;
 use iox_time::TimeProvider;
 use observability_deps::tracing::error;
 use std::fmt::Debug;
+use std::path::PathBuf;
 #[cfg(feature = "system-py")]
 use std::str::FromStr;
 use std::sync::Arc;
@@ -94,6 +96,13 @@ pub(crate) fn run_wal_contents_plugin(
             .await
             .expect("trigger plugin failed");
     });
+}
+
+#[derive(Debug, Clone)]
+pub struct ProcessingEngineEnvironmentManager {
+    pub plugin_dir: Option<PathBuf>,
+    pub virtual_env_location: Option<PathBuf>,
+    pub package_manager: Arc<dyn PythonEnvironmentManager>,
 }
 
 #[cfg(feature = "system-py")]

--- a/influxdb3_processing_engine/src/virtualenv.rs
+++ b/influxdb3_processing_engine/src/virtualenv.rs
@@ -1,5 +1,5 @@
-use observability_deps::tracing::{debug, warn};
-use std::path::{Path, PathBuf};
+use observability_deps::tracing::debug;
+use std::path::Path;
 use std::process::Command;
 use std::sync::Once;
 use thiserror::Error;
@@ -7,11 +7,11 @@ use thiserror::Error;
 static PYTHON_INIT: Once = Once::new();
 
 #[derive(Error, Debug)]
-pub(crate) enum VenvError {
+pub enum VenvError {
     #[error("Failed to initialize virtualenv: {0}")]
     InitError(String),
-    #[error("IO error: {0}")]
-    IoError(#[from] std::io::Error),
+    #[error("Error shelling out: {0}")]
+    CommandError(#[from] std::io::Error),
 }
 
 fn get_python_version() -> Result<(u8, u8), std::io::Error> {
@@ -43,17 +43,8 @@ fn set_pythonpath(venv_dir: &Path) -> Result<(), std::io::Error> {
     Ok(())
 }
 
-pub fn init_pyo3(venv_path: &Option<PathBuf>) {
+pub fn init_pyo3() {
     PYTHON_INIT.call_once(|| {
-        if let Some(venv_path) = venv_path {
-            if let Err(err) = initialize_venv(venv_path) {
-                warn!(
-                    "Failed to initialize virtualenv at {}: {}",
-                    venv_path.to_string_lossy(),
-                    err
-                );
-            }
-        }
         pyo3::prepare_freethreaded_python();
     })
 }

--- a/influxdb3_processing_engine/src/virtualenv.rs
+++ b/influxdb3_processing_engine/src/virtualenv.rs
@@ -1,0 +1,97 @@
+use observability_deps::tracing::{info, warn};
+use std::path::Path;
+use std::process::Command;
+use std::sync::Once;
+use thiserror::Error;
+
+static PYTHON_INIT: Once = Once::new();
+
+#[derive(Error, Debug)]
+pub(crate) enum VenvError {
+    #[error("Failed to initialize virtualenv: {0}")]
+    InitError(String),
+    #[error("IO error: {0}")]
+    IoError(#[from] std::io::Error),
+}
+
+fn get_python_version() -> Result<(u8, u8), std::io::Error> {
+    let output = Command::new("python3")
+        .args(["-c", "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')"])
+        .output()?;
+
+    let version = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let mut parts = version.split('.');
+    let major: u8 = parts.next().unwrap().parse().unwrap();
+    let minor: u8 = parts.next().unwrap().parse().unwrap();
+
+    Ok((major, minor))
+}
+
+#[cfg(unix)]
+fn set_pythonpath(venv_dir: &Path) -> Result<(), std::io::Error> {
+    let (major, minor) = get_python_version()?;
+    let site_packages = venv_dir
+        .join("lib")
+        .join(format!("python{}.{}", major, minor))
+        .join("site-packages");
+
+    info!("site packages is {}", site_packages.to_string_lossy());
+
+    if site_packages.exists() {
+        std::env::set_var("PYTHONPATH", site_packages);
+    }
+
+    Ok(())
+}
+
+pub(crate) fn try_init_venv(venv_path: &Path) {
+    PYTHON_INIT.call_once(|| {
+        if let Err(err) = initialize_venv(venv_path) {
+            warn!(
+                "Failed to initialize virtualenv at {}: {}",
+                venv_path.to_string_lossy(),
+                err
+            );
+        }
+        pyo3::prepare_freethreaded_python();
+    })
+}
+
+#[cfg(unix)]
+pub(crate) fn initialize_venv(venv_path: &Path) -> Result<(), VenvError> {
+    use std::process::Command;
+
+    let activate_script = venv_path.join("bin").join("activate");
+    if !activate_script.exists() {
+        return Err(VenvError::InitError(format!(
+            "Activation script not found at {:?}",
+            activate_script
+        )));
+    }
+
+    let output = Command::new("bash")
+        .arg("-c")
+        .arg(format!(
+            "source {} && env",
+            activate_script.to_str().unwrap()
+        ))
+        .output()?;
+
+    if !output.status.success() {
+        return Err(VenvError::InitError(
+            String::from_utf8_lossy(&output.stderr).to_string(),
+        ));
+    }
+    set_pythonpath(venv_path)?;
+
+    // Apply environment changes
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .filter_map(|line| line.split_once('='))
+        .for_each(|(key, value)| {
+            println!("{}={}", key, value);
+            std::env::set_var(key, value)});
+
+
+    Ok(())
+}

--- a/influxdb3_processing_engine/src/virtualenv.rs
+++ b/influxdb3_processing_engine/src/virtualenv.rs
@@ -43,7 +43,7 @@ fn set_pythonpath(venv_dir: &Path) -> Result<(), std::io::Error> {
     Ok(())
 }
 
-pub(crate) fn init_pyo3(venv_path: &Option<PathBuf>) {
+pub fn init_pyo3(venv_path: &Option<PathBuf>) {
     PYTHON_INIT.call_once(|| {
         if let Some(venv_path) = venv_path {
             if let Err(err) = initialize_venv(venv_path) {
@@ -88,10 +88,7 @@ pub(crate) fn initialize_venv(venv_path: &Path) -> Result<(), VenvError> {
     String::from_utf8_lossy(&output.stdout)
         .lines()
         .filter_map(|line| line.split_once('='))
-        .for_each(|(key, value)| {
-            println!("{}={}", key, value);
-            std::env::set_var(key, value)
-        });
+        .for_each(|(key, value)| std::env::set_var(key, value));
 
     Ok(())
 }

--- a/influxdb3_py_api/Cargo.toml
+++ b/influxdb3_py_api/Cargo.toml
@@ -28,8 +28,7 @@ tokio.workspace = true
 
 [dependencies.pyo3]
 version = "0.23.3"
-# this is necessary to automatically initialize the Python interpreter
-features = ["auto-initialize", "experimental-async"]
+features = ["experimental-async"]
 optional = true
 
 

--- a/influxdb3_server/Cargo.toml
+++ b/influxdb3_server/Cargo.toml
@@ -84,8 +84,6 @@ url.workspace = true
 
 [dependencies.pyo3]
 version = "0.23.3"
-# this is necessary to automatically initialize the Python interpreter
-features = ["auto-initialize"]
 optional = true
 
 [features]

--- a/influxdb3_server/src/builder.rs
+++ b/influxdb3_server/src/builder.rs
@@ -154,7 +154,7 @@ impl<T: TimeProvider>
         let persister = Arc::clone(&self.persister.0);
         let authorizer = Arc::clone(&self.authorizer);
         let processing_engine = Arc::new(ProcessingEngineManagerImpl::new(
-            self.common_state.plugin_dir.clone(),
+            self.common_state.processing_engine_environment.clone(),
             self.write_buffer.0.catalog(),
             Arc::clone(&self.write_buffer.0),
             Arc::clone(&self.query_executor.0),

--- a/influxdb3_server/src/http.rs
+++ b/influxdb3_server/src/http.rs
@@ -25,7 +25,7 @@ use influxdb3_cache::last_cache;
 use influxdb3_catalog::catalog::Error as CatalogError;
 use influxdb3_internal_api::query_executor::{QueryExecutor, QueryExecutorError};
 use influxdb3_process::{INFLUXDB3_GIT_HASH_SHORT, INFLUXDB3_VERSION};
-use influxdb3_processing_engine::manager::ProcessingEngineManager;
+use influxdb3_processing_engine::manager::{ProcessingEngineError, ProcessingEngineManager};
 use influxdb3_wal::TriggerSpecificationDefinition;
 use influxdb3_write::persister::TrackedMemoryArrowWriter;
 use influxdb3_write::write_buffer::Error as WriteBufferError;
@@ -1058,6 +1058,51 @@ where
             .body(Body::empty())?)
     }
 
+    async fn install_plugin_environment_packages(
+        &self,
+        req: Request<Body>,
+    ) -> Result<Response<Body>> {
+        let ProcessingEngineInstallPackagesRequest { packages } =
+            if let Some(query) = req.uri().query() {
+                serde_urlencoded::from_str(query)?
+            } else {
+                self.read_body_json(req).await?
+            };
+        let manager = self.processing_engine.get_environment_manager();
+        manager
+            .install_packages(packages)
+            .map_err(ProcessingEngineError::from)?;
+
+        Ok(Response::builder()
+            .status(StatusCode::OK)
+            .body(Body::empty())?)
+    }
+
+    async fn install_plugin_environment_requirements(
+        &self,
+        req: Request<Body>,
+    ) -> Result<Response<Body>> {
+        let ProcessingEngineInstallRequirementsRequest {
+            requirements_location,
+        } = if let Some(query) = req.uri().query() {
+            serde_urlencoded::from_str(query)?
+        } else {
+            self.read_body_json(req).await?
+        };
+        info!(
+            "installing plugin environment requirements from {}",
+            requirements_location
+        );
+        let manager = self.processing_engine.get_environment_manager();
+        manager
+            .install_requirements(requirements_location)
+            .map_err(ProcessingEngineError::from)?;
+
+        Ok(Response::builder()
+            .status(StatusCode::OK)
+            .body(Body::empty())?)
+    }
+
     async fn disable_processing_engine_trigger(
         &self,
         req: Request<Body>,
@@ -1663,6 +1708,16 @@ struct ProcessEngineTriggerDeleteRequest {
 }
 
 #[derive(Debug, Deserialize)]
+struct ProcessingEngineInstallPackagesRequest {
+    packages: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ProcessingEngineInstallRequirementsRequest {
+    requirements_location: String,
+}
+
+#[derive(Debug, Deserialize)]
 struct ProcessingEngineTriggerIdentifier {
     db: String,
     trigger_name: String,
@@ -1802,6 +1857,14 @@ pub(crate) async fn route_request<T: TimeProvider>(
         }
         (Method::DELETE, "/api/v3/configure/processing_engine_trigger") => {
             http_server.delete_processing_engine_trigger(req).await
+        }
+        (Method::POST, "/api/v3/configure/plugin_environment/install_packages") => {
+            http_server.install_plugin_environment_packages(req).await
+        }
+        (Method::POST, "/api/v3/configure/plugin_environment/install_requirements") => {
+            http_server
+                .install_plugin_environment_requirements(req)
+                .await
         }
         (Method::GET, "/api/v3/configure/database") => http_server.show_databases(req).await,
         (Method::POST, "/api/v3/configure/database") => http_server.create_database(req).await,

--- a/influxdb3_write/Cargo.toml
+++ b/influxdb3_write/Cargo.toml
@@ -68,8 +68,6 @@ uuid.workspace = true
 
 [dependencies.pyo3]
 version = "0.23.3"
-# this is necessary to automatically initialize the Python interpreter
-features = ["auto-initialize"]
 optional = true
 
 [dev-dependencies]


### PR DESCRIPTION
This integrates the processing engine with a specified virtual environment, either from a CLI flag or through the VIRTUAL_ENV environment variable. In order for this to work we switch from auto-initializing pyo3 to an initialize call that first sources the bin environment. I've only tested this on OS X, let me know how much time I should spend getting this to work on windows.

I've also added an `install` verb to the CLI. It currently is used to install packages, namely either a list of python packages or a requirement.txt. It supports either `pip` or `uv pip` instillation. Note that the operator will have to be careful lining up the virtual environment and the package manager. In particular, a virtualenv created by `uv` will not see packages installed directly via pip.

The tests create a virtualenv in a temp directory. I updated run_with_confirmation() so it'd surface errors from the CLI.