### PR TITLE
refactor: reduce catalog locks when getting chunks

### DIFF
--- a/influxdb3_catalog/src/catalog.rs
+++ b/influxdb3_catalog/src/catalog.rs
@@ -744,7 +744,7 @@ impl UpdateDatabaseSchema for CatalogOp {
     }
 }
 
-impl UpdateDatabaseSchema for influxdb3_wal::TableDefinition {
+impl UpdateDatabaseSchema for influxdb3_wal::WalTableDefinition {
     fn update_schema<'a>(
         &self,
         mut database_schema: Cow<'a, DatabaseSchema>,
@@ -1039,7 +1039,7 @@ impl TableDefinition {
     }
 
     /// Create a new table definition from a catalog op
-    pub fn new_from_op(table_definition: &influxdb3_wal::TableDefinition) -> Self {
+    pub fn new_from_op(table_definition: &influxdb3_wal::WalTableDefinition) -> Self {
         let mut columns = Vec::with_capacity(table_definition.field_definitions.len());
         for field_def in &table_definition.field_definitions {
             columns.push((
@@ -1059,7 +1059,7 @@ impl TableDefinition {
 
     pub(crate) fn check_and_add_new_fields(
         &self,
-        table_definition: &influxdb3_wal::TableDefinition,
+        table_definition: &influxdb3_wal::WalTableDefinition,
     ) -> Result<Cow<'_, Self>> {
         // validate the series key is the same
         if table_definition.key != self.series_key {
@@ -1942,7 +1942,7 @@ mod tests {
         let db_name = Arc::from("foo");
         let table_id = TableId::new();
         let table_name = Arc::from("bar");
-        let table_definition = influxdb3_wal::TableDefinition {
+        let table_definition = influxdb3_wal::WalTableDefinition {
             database_id: db_id,
             database_name: Arc::clone(&db_name),
             table_name: Arc::clone(&table_name),

--- a/influxdb3_wal/src/create.rs
+++ b/influxdb3_wal/src/create.rs
@@ -94,7 +94,7 @@ pub fn create_table_op(
     fields: impl IntoIterator<Item = FieldDefinition>,
     key: impl IntoIterator<Item = ColumnId>,
 ) -> CatalogOp {
-    CatalogOp::CreateTable(TableDefinition {
+    CatalogOp::CreateTable(WalTableDefinition {
         database_id: db_id,
         database_name: db_name.into(),
         table_name: table_name.into(),

--- a/influxdb3_wal/src/lib.rs
+++ b/influxdb3_wal/src/lib.rs
@@ -329,7 +329,7 @@ impl OrderedCatalogBatch {
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub enum CatalogOp {
     CreateDatabase(DatabaseDefinition),
-    CreateTable(TableDefinition),
+    CreateTable(WalTableDefinition),
     AddFields(FieldAdditions),
     CreateDistinctCache(DistinctCacheDefinition),
     DeleteDistinctCache(DistinctCacheDelete),
@@ -368,7 +368,7 @@ pub struct DeleteTableDefinition {
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
-pub struct TableDefinition {
+pub struct WalTableDefinition {
     pub database_id: DbId,
     pub database_name: Arc<str>,
     pub table_name: Arc<str>,

--- a/influxdb3_write/src/lib.rs
+++ b/influxdb3_write/src/lib.rs
@@ -615,7 +615,7 @@ impl<'a> ChunkFilter<'a> {
     }
 
     pub fn original_filters(&self) -> &[Expr] {
-        &self.filters
+        self.filters
     }
 }
 

--- a/influxdb3_write/src/persister.rs
+++ b/influxdb3_write/src/persister.rs
@@ -443,7 +443,7 @@ mod tests {
     use influxdb3_id::{ColumnId, DbId, SerdeVecMap, TableId};
     use influxdb3_wal::{
         CatalogBatch, CatalogOp, FieldDataType, FieldDefinition, SnapshotSequenceNumber,
-        TableDefinition, WalFileSequenceNumber,
+        WalFileSequenceNumber, WalTableDefinition,
     };
     use object_store::memory::InMemory;
     use observability_deps::tracing::info;
@@ -495,7 +495,7 @@ mod tests {
                 database_id: db_schema.id,
                 database_name: Arc::clone(&db_schema.name),
                 time_ns: 5000,
-                ops: vec![CatalogOp::CreateTable(TableDefinition {
+                ops: vec![CatalogOp::CreateTable(WalTableDefinition {
                     database_id: db_schema.id,
                     database_name: Arc::clone(&db_schema.name),
                     table_name: name.into(),

--- a/influxdb3_write/src/write_buffer/mod.rs
+++ b/influxdb3_write/src/write_buffer/mod.rs
@@ -13,7 +13,7 @@ use crate::write_buffer::queryable_buffer::QueryableBuffer;
 use crate::write_buffer::validator::WriteValidator;
 use crate::{chunk::ParquetChunk, DatabaseManager};
 use crate::{
-    BufferFilter, BufferedWriteRequest, Bufferer, ChunkContainer, DistinctCacheManager,
+    BufferedWriteRequest, Bufferer, ChunkContainer, ChunkFilter, DistinctCacheManager,
     LastCacheManager, ParquetFile, PersistedSnapshot, Precision, WriteBuffer, WriteLineError,
 };
 use async_trait::async_trait;
@@ -24,14 +24,13 @@ use data_types::{
 use datafusion::catalog::Session;
 use datafusion::common::DataFusionError;
 use datafusion::datasource::object_store::ObjectStoreUrl;
-use datafusion::logical_expr::Expr;
 use influxdb3_cache::distinct_cache::{self, CreateDistinctCacheArgs, DistinctCacheProvider};
 use influxdb3_cache::last_cache::{self, LastCacheProvider};
 use influxdb3_cache::parquet_cache::ParquetCacheOracle;
-use influxdb3_catalog::catalog::{Catalog, DatabaseSchema};
+use influxdb3_catalog::catalog::{Catalog, DatabaseSchema, TableDefinition};
 use influxdb3_id::{ColumnId, DbId, TableId};
 use influxdb3_wal::FieldDataType;
-use influxdb3_wal::TableDefinition;
+use influxdb3_wal::WalTableDefinition;
 use influxdb3_wal::{object_store::WalObjectStore, DeleteDatabaseDefinition};
 use influxdb3_wal::{
     CatalogBatch, CatalogOp, DistinctCacheDefinition, DistinctCacheDelete, LastCacheDefinition,
@@ -310,39 +309,23 @@ impl WriteBufferImpl {
 
     fn get_table_chunks(
         &self,
-        database_name: &str,
-        table_name: &str,
-        filters: &[Expr],
+        db_schema: Arc<DatabaseSchema>,
+        table_def: Arc<TableDefinition>,
+        filter: &ChunkFilter,
         projection: Option<&Vec<usize>>,
         ctx: &dyn Session,
     ) -> Result<Vec<Arc<dyn QueryChunk>>, DataFusionError> {
-        let db_schema = self.catalog.db_schema(database_name).ok_or_else(|| {
-            DataFusionError::Execution(format!("database {} not found", database_name))
-        })?;
-
-        let table_def = db_schema.table_definition(table_name).ok_or_else(|| {
-            DataFusionError::Execution(format!(
-                "table {} not found in db {}",
-                table_name, database_name
-            ))
-        })?;
-
-        let buffer_filter = BufferFilter::new(&table_def, filters)
-            .map_err(|error| DataFusionError::External(Box::new(error)))?;
-
         let mut chunks = self.buffer.get_table_chunks(
             Arc::clone(&db_schema),
-            table_name,
-            &buffer_filter,
+            Arc::clone(&table_def),
+            filter,
             projection,
             ctx,
         )?;
 
-        let parquet_files = self.persisted_files.get_files_filtered(
-            db_schema.id,
-            table_def.table_id,
-            &buffer_filter,
-        );
+        let parquet_files =
+            self.persisted_files
+                .get_files_filtered(db_schema.id, table_def.table_id, filter);
 
         let mut chunk_order = chunks.len() as i64;
 
@@ -368,33 +351,15 @@ impl WriteBufferImpl {
         &self,
         database_name: &str,
         table_name: &str,
-        filters: &[Expr],
+        filter: &ChunkFilter,
         projection: Option<&Vec<usize>>,
         ctx: &dyn Session,
-    ) -> Result<Vec<Arc<dyn QueryChunk>>, DataFusionError> {
-        let db_schema = self.catalog.db_schema(database_name).ok_or_else(|| {
-            DataFusionError::Execution(format!("database {} not found", database_name))
-        })?;
-
-        let table_def = db_schema.table_definition(table_name).ok_or_else(|| {
-            DataFusionError::Execution(format!(
-                "table {} not found in db {}",
-                table_name, database_name
-            ))
-        })?;
-
-        let filter = BufferFilter::new(&table_def, filters)
-            .map_err(|e| DataFusionError::External(Box::new(e)))?;
-
-        let chunks = self.buffer.get_table_chunks(
-            Arc::clone(&db_schema),
-            table_name,
-            &filter,
-            projection,
-            ctx,
-        )?;
-
-        Ok(chunks)
+    ) -> Vec<Arc<dyn QueryChunk>> {
+        let db_schema = self.catalog.db_schema(database_name).unwrap();
+        let table_def = db_schema.table_definition(table_name).unwrap();
+        self.buffer
+            .get_table_chunks(db_schema, table_def, filter, projection, ctx)
+            .unwrap()
     }
 }
 
@@ -472,7 +437,7 @@ impl Bufferer for WriteBufferImpl {
         &self,
         db_id: DbId,
         table_id: TableId,
-        filter: &BufferFilter,
+        filter: &ChunkFilter,
     ) -> Vec<ParquetFile> {
         self.buffer.persisted_parquet_files(db_id, table_id, filter)
     }
@@ -485,13 +450,13 @@ impl Bufferer for WriteBufferImpl {
 impl ChunkContainer for WriteBufferImpl {
     fn get_table_chunks(
         &self,
-        database_name: &str,
-        table_name: &str,
-        filters: &[Expr],
+        db_schema: Arc<DatabaseSchema>,
+        table_def: Arc<TableDefinition>,
+        filter: &ChunkFilter,
         projection: Option<&Vec<usize>>,
         ctx: &dyn Session,
     ) -> crate::Result<Vec<Arc<dyn QueryChunk>>, DataFusionError> {
-        self.get_table_chunks(database_name, table_name, filters, projection, ctx)
+        self.get_table_chunks(db_schema, table_def, filter, projection, ctx)
     }
 }
 
@@ -772,7 +737,7 @@ impl DatabaseManager for WriteBufferImpl {
             field_definitions
         };
 
-        let catalog_table_def = TableDefinition {
+        let catalog_table_def = WalTableDefinition {
             database_id: db_schema.id,
             database_name: Arc::clone(&db_schema.name),
             table_name: Arc::clone(&table_name),
@@ -908,6 +873,7 @@ mod tests {
     use super::*;
     use crate::paths::{CatalogFilePath, SnapshotInfoFilePath};
     use crate::persister::Persister;
+    use crate::test_helpers::WriteBufferTester;
     use crate::PersistedSnapshot;
     use arrow::record_batch::RecordBatch;
     use arrow_util::{assert_batches_eq, assert_batches_sorted_eq};
@@ -1012,7 +978,9 @@ mod tests {
             "| 1.0 | 1970-01-01T00:00:00.000000010Z |",
             "+-----+--------------------------------+",
         ];
-        let actual = get_table_batches(&write_buffer, "foo", "cpu", &session_context).await;
+        let actual = write_buffer
+            .get_record_batches_unchecked("foo", "cpu", &session_context)
+            .await;
         assert_batches_eq!(&expected, &actual);
 
         // do two more writes to trigger a snapshot
@@ -1047,7 +1015,9 @@ mod tests {
             "| 3.0 | 1970-01-01T00:00:00.000000030Z |",
             "+-----+--------------------------------+",
         ];
-        let actual = get_table_batches(&write_buffer, "foo", "cpu", &session_context).await;
+        let actual = write_buffer
+            .get_record_batches_unchecked("foo", "cpu", &session_context)
+            .await;
         assert_batches_eq!(&expected, &actual);
 
         // now load a new buffer from object storage
@@ -1078,7 +1048,9 @@ mod tests {
         .await
         .unwrap();
 
-        let actual = get_table_batches(&write_buffer, "foo", "cpu", &session_context).await;
+        let actual = write_buffer
+            .get_record_batches_unchecked("foo", "cpu", &session_context)
+            .await;
         assert_batches_eq!(&expected, &actual);
     }
 
@@ -1251,7 +1223,9 @@ mod tests {
             "| 1.0 | 1970-01-01T00:00:10Z |",
             "+-----+----------------------+",
         ];
-        let actual = get_table_batches(&write_buffer, "foo", "cpu", &session_context).await;
+        let actual = write_buffer
+            .get_record_batches_unchecked("foo", "cpu", &session_context)
+            .await;
         assert_batches_sorted_eq!(&expected, &actual);
 
         let _ = write_buffer
@@ -1273,7 +1247,9 @@ mod tests {
             "| 2.0 | 1970-01-01T00:01:05Z |",
             "+-----+----------------------+",
         ];
-        let actual = get_table_batches(&write_buffer, "foo", "cpu", &session_context).await;
+        let actual = write_buffer
+            .get_record_batches_unchecked("foo", "cpu", &session_context)
+            .await;
         assert_batches_sorted_eq!(&expected, &actual);
 
         // trigger snapshot with a third write, creating parquet files
@@ -1313,7 +1289,9 @@ mod tests {
             "| 1.0 | 1970-01-01T00:00:10Z |",
             "+-----+----------------------+",
         ];
-        let actual = get_table_batches(&write_buffer, "foo", "cpu", &session_context).await;
+        let actual = write_buffer
+            .get_record_batches_unchecked("foo", "cpu", &session_context)
+            .await;
         assert_batches_sorted_eq!(&expected, &actual);
 
         // now validate that buffered data and parquet data are all returned
@@ -1338,10 +1316,14 @@ mod tests {
             "| 1.0 | 1970-01-01T00:00:10Z |",
             "+-----+----------------------+",
         ];
-        let actual = get_table_batches(&write_buffer, "foo", "cpu", &session_context).await;
+        let actual = write_buffer
+            .get_record_batches_unchecked("foo", "cpu", &session_context)
+            .await;
         assert_batches_sorted_eq!(&expected, &actual);
 
-        let actual = get_table_batches(&write_buffer, "foo", "cpu", &session_context).await;
+        let actual = write_buffer
+            .get_record_batches_unchecked("foo", "cpu", &session_context)
+            .await;
         assert_batches_sorted_eq!(&expected, &actual);
         // and now replay in a new write buffer and attempt to write
         let catalog = Arc::new(
@@ -1385,7 +1367,9 @@ mod tests {
         );
 
         // verify the data is still there
-        let actual = get_table_batches(&write_buffer, "foo", "cpu", &ctx).await;
+        let actual = write_buffer
+            .get_record_batches_unchecked("foo", "cpu", &ctx)
+            .await;
         assert_batches_sorted_eq!(&expected, &actual);
 
         // now write some new data
@@ -1424,7 +1408,9 @@ mod tests {
             "| 6.0 | 1970-01-01T00:05:30Z |",
             "+-----+----------------------+",
         ];
-        let actual = get_table_batches(&write_buffer, "foo", "cpu", &ctx).await;
+        let actual = write_buffer
+            .get_record_batches_unchecked("foo", "cpu", &ctx)
+            .await;
         assert_batches_sorted_eq!(&expected, &actual);
     }
 
@@ -1753,7 +1739,9 @@ mod tests {
         // wait for snapshot to be created:
         verify_snapshot_count(1, &wbuf.persister).await;
         // Get the record batches from before shutting down buffer:
-        let batches = get_table_batches(&wbuf, db_name, tbl_name, &ctx).await;
+        let batches = wbuf
+            .get_record_batches_unchecked(db_name, tbl_name, &ctx)
+            .await;
         assert_batches_sorted_eq!(
             [
                 "+-----------+-------+----------------------+",
@@ -1777,7 +1765,9 @@ mod tests {
         }
 
         // Get the record batches from replayed buffer:
-        let batches = get_table_batches(&wbuf, db_name, tbl_name, &ctx).await;
+        let batches = wbuf
+            .get_record_batches_unchecked(db_name, tbl_name, &ctx)
+            .await;
         assert_batches_sorted_eq!(
             [
                 "+-----------+-------+----------------------+",
@@ -1860,7 +1850,9 @@ mod tests {
         .await;
 
         // Get the record batches from replyed buffer:
-        let batches = get_table_batches(&wbuf, db_name, tbl_name, &ctx).await;
+        let batches = wbuf
+            .get_record_batches_unchecked(db_name, tbl_name, &ctx)
+            .await;
         assert_batches_sorted_eq!(
             [
                 "+-----------+-------+----------------------+-------+",
@@ -1938,7 +1930,9 @@ mod tests {
         .await;
 
         // Get the record batches from replayed buffer:
-        let batches = get_table_batches(&wbuf, db_name, tbl_name, &ctx).await;
+        let batches = wbuf
+            .get_record_batches_unchecked(db_name, tbl_name, &ctx)
+            .await;
         assert_batches_sorted_eq!(
             [
                 "+-----------+-------+----------------------+",
@@ -2150,7 +2144,9 @@ mod tests {
         assert_eq!(0, test_store.get_range_request_count(&path));
         assert_eq!(0, test_store.head_request_count(&path));
 
-        let batches = get_table_batches(&wbuf, db_name, tbl_name, &ctx).await;
+        let batches = wbuf
+            .get_record_batches_unchecked(db_name, tbl_name, &ctx)
+            .await;
         assert_batches_sorted_eq!(
             [
                 "+--------+---------+------+----------------------+-----------+",
@@ -2256,7 +2252,9 @@ mod tests {
         assert_eq!(0, test_store.get_range_request_count(&path));
         assert_eq!(0, test_store.head_request_count(&path));
 
-        let batches = get_table_batches(&wbuf, db_name, tbl_name, &ctx).await;
+        let batches = wbuf
+            .get_record_batches_unchecked(db_name, tbl_name, &ctx)
+            .await;
         assert_batches_sorted_eq!(
             [
                 "+--------+---------+------+----------------------+-----------+",
@@ -2674,7 +2672,9 @@ mod tests {
         // at this point all of the data in query buffer will be
         // for timestamps 20 - 50 and none of recent data will be
         // in buffer.
-        let actual = get_table_batches(&write_buffer, "sample", "cpu", &session_context).await;
+        let actual = write_buffer
+            .get_record_batches_unchecked("sample", "cpu", &session_context)
+            .await;
         // not sorting, intentionally
         assert_batches_eq!(
             [
@@ -3048,41 +3048,22 @@ mod tests {
         (wbuf, ctx, time_provider, metric_registry)
     }
 
-    async fn get_table_batches(
-        write_buffer: &WriteBufferImpl,
-        database_name: &str,
-        table_name: &str,
-        ctx: &IOxSessionContext,
-    ) -> Vec<RecordBatch> {
-        let chunks = write_buffer
-            .get_table_chunks(database_name, table_name, &[], None, &ctx.inner().state())
-            .unwrap();
-        let mut batches = vec![];
-        for chunk in chunks {
-            let chunk = chunk
-                .data()
-                .read_to_batches(chunk.schema(), ctx.inner())
-                .await;
-            batches.extend(chunk);
-        }
-        batches
-    }
-
+    /// Get table batches from the buffer only
+    ///
+    /// This is meant to be used in tests.
     async fn get_table_batches_from_query_buffer(
         write_buffer: &WriteBufferImpl,
         database_name: &str,
         table_name: &str,
         ctx: &IOxSessionContext,
     ) -> Vec<RecordBatch> {
-        let chunks = write_buffer
-            .get_table_chunks_from_buffer_only(
-                database_name,
-                table_name,
-                &[],
-                None,
-                &ctx.inner().state(),
-            )
-            .unwrap();
+        let chunks = write_buffer.get_table_chunks_from_buffer_only(
+            database_name,
+            table_name,
+            &ChunkFilter::default(),
+            None,
+            &ctx.inner().state(),
+        );
         let mut batches = vec![];
         for chunk in chunks {
             let chunk = chunk

--- a/influxdb3_write/src/write_buffer/persisted_files.rs
+++ b/influxdb3_write/src/write_buffer/persisted_files.rs
@@ -2,7 +2,7 @@
 //! When queries come in they will combine whatever chunks exist from `QueryableBuffer` with
 //! the persisted files to get the full set of data to query.
 
-use crate::BufferFilter;
+use crate::ChunkFilter;
 use crate::{ParquetFile, PersistedSnapshot};
 use hashbrown::HashMap;
 use influxdb3_id::DbId;
@@ -49,7 +49,7 @@ impl PersistedFiles {
 
     /// Get the list of files for a given database and table, always return in descending order of min_time
     pub fn get_files(&self, db_id: DbId, table_id: TableId) -> Vec<ParquetFile> {
-        self.get_files_filtered(db_id, table_id, &BufferFilter::default())
+        self.get_files_filtered(db_id, table_id, &ChunkFilter::default())
     }
 
     /// Get the list of files for a given database and table, using the provided filter to filter results.
@@ -59,7 +59,7 @@ impl PersistedFiles {
         &self,
         db_id: DbId,
         table_id: TableId,
-        filter: &BufferFilter,
+        filter: &ChunkFilter,
     ) -> Vec<ParquetFile> {
         let three_days_ago = (self.time_provider.now() - crate::THREE_DAYS).timestamp_nanos();
         let mut files = {
@@ -388,7 +388,7 @@ mod tests {
         );
 
         for t in test_cases {
-            let filter = BufferFilter::new(&table_def, t.filter).unwrap();
+            let filter = ChunkFilter::new(&table_def, t.filter).unwrap();
             let filtered_files =
                 persisted_files.get_files_filtered(DbId::from(0), TableId::from(0), &filter);
             assert_eq!(

--- a/influxdb3_write/src/write_buffer/queryable_buffer.rs
+++ b/influxdb3_write/src/write_buffer/queryable_buffer.rs
@@ -3,7 +3,7 @@ use crate::paths::ParquetFilePath;
 use crate::persister::Persister;
 use crate::write_buffer::persisted_files::PersistedFiles;
 use crate::write_buffer::table_buffer::TableBuffer;
-use crate::{BufferFilter, ParquetFile, ParquetFileId, PersistedSnapshot};
+use crate::{ChunkFilter, ParquetFile, ParquetFileId, PersistedSnapshot};
 use anyhow::Context;
 use arrow::record_batch::RecordBatch;
 use async_trait::async_trait;
@@ -18,7 +18,7 @@ use hashbrown::HashMap;
 use influxdb3_cache::distinct_cache::DistinctCacheProvider;
 use influxdb3_cache::last_cache::LastCacheProvider;
 use influxdb3_cache::parquet_cache::{CacheRequest, ParquetCacheOracle};
-use influxdb3_catalog::catalog::{Catalog, DatabaseSchema};
+use influxdb3_catalog::catalog::{Catalog, DatabaseSchema, TableDefinition};
 use influxdb3_id::{DbId, TableId};
 use influxdb3_wal::{CatalogOp, SnapshotDetails, WalContents, WalFileNotifier, WalOp, WriteBatch};
 use iox_query::chunk_statistics::{create_chunk_statistics, NoColumnRanges};
@@ -98,15 +98,11 @@ impl QueryableBuffer {
     pub fn get_table_chunks(
         &self,
         db_schema: Arc<DatabaseSchema>,
-        table_name: &str,
-        buffer_filter: &BufferFilter,
+        table_def: Arc<TableDefinition>,
+        buffer_filter: &ChunkFilter,
         _projection: Option<&Vec<usize>>,
         _ctx: &dyn Session,
     ) -> Result<Vec<Arc<dyn QueryChunk>>, DataFusionError> {
-        let (table_id, table_def) = db_schema
-            .table_id_and_definition(table_name)
-            .ok_or_else(|| DataFusionError::Execution(format!("table {} not found", table_name)))?;
-
         let influx_schema = table_def.influx_schema();
 
         let buffer = self.buffer.read();
@@ -114,7 +110,7 @@ impl QueryableBuffer {
         let Some(db_buffer) = buffer.db_to_table.get(&db_schema.id) else {
             return Ok(vec![]);
         };
-        let Some(table_buffer) = db_buffer.get(&table_id) else {
+        let Some(table_buffer) = db_buffer.get(&table_def.table_id) else {
             return Ok(vec![]);
         };
 
@@ -419,7 +415,7 @@ impl QueryableBuffer {
         &self,
         db_id: DbId,
         table_id: TableId,
-        filter: &BufferFilter,
+        filter: &ChunkFilter,
     ) -> Vec<ParquetFile> {
         self.persisted_files
             .get_files_filtered(db_id, table_id, filter)

--- a/influxdb3_write/src/write_buffer/validator.rs
+++ b/influxdb3_write/src/write_buffer/validator.rs
@@ -351,7 +351,7 @@ fn validate_and_qualify_v1_line(
         for (id, name, influx_type) in &columns {
             field_definitions.push(FieldDefinition::new(*id, Arc::clone(name), influx_type));
         }
-        catalog_op = Some(CatalogOp::CreateTable(influxdb3_wal::TableDefinition {
+        catalog_op = Some(CatalogOp::CreateTable(influxdb3_wal::WalTableDefinition {
             table_id,
             database_id: db_schema.id,
             database_name: Arc::clone(&db_schema.name),


### PR DESCRIPTION
The main refactor was to change the `ChunkContainer` trait to use the `DatabaseSchema` and `TableDefinition` types directly in the signature, vs. their names; using their names led to an additional catalog lock and lookups for both entities, because there was already a catalog lock/lookup upstream in the `QueryTable`.

However, using the names in the `ChunkContainer::get_table_chunks` was convenient, specifically for tests, so I included a test helper trait in `influxdb3_write::test_helpers` called `WriteBufferTester` that provides convenience methods for getting record batches from a `WriteBuffer` implementation. Alongside the definition of `WriteBufferTester` is a blanket `impl` on that any `T` that implements `WriteBuffer`.

We have been implementing similar methods manually in several places when testing in Enterprise, so this should give us a unified implementation for that.

Some other house cleaning was included 🧹 

* Changed `influxdb3_wal::TableDefinition` to `WalTableDefinition` to reduce naming conflicts.
* Renamed `BufferFilter` to `ChunkFilter`, and within that, `BufferGuarantee` was changed to `HashedLiteralGuarantee`
* Reduced some lookups in the `table_buffer` code
