### PR TITLE
feat: first stab at locally updating parquet cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2826,6 +2826,7 @@ dependencies = [
  "async-trait",
  "bimap",
  "bytes",
+ "chrono",
  "dashmap",
  "data_types",
  "datafusion",

--- a/influxdb3/src/commands/serve.rs
+++ b/influxdb3/src/commands/serve.rs
@@ -510,6 +510,7 @@ pub async fn command(config: Config) -> Result<()> {
     let persister = Arc::new(Persister::new(
         Arc::clone(&object_store),
         config.node_identifier_prefix,
+        Arc::clone(&time_provider) as _,
     ));
     let wal_config = WalConfig {
         gen1_duration: config.gen1_duration,

--- a/influxdb3_cache/Cargo.toml
+++ b/influxdb3_cache/Cargo.toml
@@ -22,6 +22,7 @@ anyhow.workspace = true
 arrow.workspace = true
 async-trait.workspace = true
 bytes.workspace = true
+chrono.workspace = true
 dashmap.workspace = true
 datafusion.workspace = true
 futures.workspace = true

--- a/influxdb3_cache/src/parquet_cache/mod.rs
+++ b/influxdb3_cache/src/parquet_cache/mod.rs
@@ -27,7 +27,7 @@ use object_store::{
     path::Path, Error, GetOptions, GetResult, GetResultPayload, ListResult, MultipartUpload,
     ObjectMeta, ObjectStore, PutMultipartOpts, PutOptions, PutPayload, PutResult,
 };
-use observability_deps::tracing::{error, info, warn};
+use observability_deps::tracing::{debug, error, info, warn};
 use tokio::sync::{
     mpsc::{channel, Receiver, Sender},
     oneshot, watch,
@@ -66,38 +66,64 @@ impl ParquetFileDataToCache {
     }
 }
 
-/// A request to fetch an item at the given `path` from an object store
-///
-/// Contains a notifier to notify the caller that registers the cache request when the item
-/// has been cached successfully (or if the cache request failed in some way)
 #[derive(Debug)]
-pub struct CacheRequest {
+pub struct ImmediateCacheRequest {
+    path: Path,
+    parquet_data: ParquetFileDataToCache,
+}
+
+#[derive(Debug)]
+pub struct EventualCacheRequest {
     path: Path,
     notifier: oneshot::Sender<()>,
-    parquet_bytes: Option<ParquetFileDataToCache>,
+}
+
+impl EventualCacheRequest {
+    fn get_path_and_notifier(self) -> (Path, oneshot::Sender<()>) {
+        (self.path, self.notifier)
+    }
+}
+
+#[derive(Debug)]
+pub enum CacheRequest {
+    // When creating parquet files, the serialized bytes are already
+    // present so it can be directly loaded into the cache. This
+    // Immediate mode request caters for that use case.
+    Immediate(ImmediateCacheRequest),
+    // When there is only a path to a parquet file in object store then a
+    // GET request is needed to pull the actual data and store it in
+    // the cache. This Eventual mode request caters for that use case.
+    Eventual(EventualCacheRequest),
 }
 
 impl CacheRequest {
-    // Create a new [`CacheRequest`] along with a receiver to catch the notify message when
-    // the cache request has been fulfilled.
-    pub fn create(
-        path: Path,
-        bytes: Option<ParquetFileDataToCache>,
-    ) -> (Self, oneshot::Receiver<()>) {
+    // Create a new [`CacheRequest::Immediate`] for loading the bytes passed in immediately into the cache.
+    pub fn create_immediate_mode_cache_request(path: Path, bytes: ParquetFileDataToCache) -> Self {
+        Self::Immediate(ImmediateCacheRequest {
+            path,
+            parquet_data: bytes,
+        })
+    }
+
+    // Create a new [`CacheRequest::Eventual`] for eventually loading the path passed in, by doing
+    // a GET request from object store for the path. Since it is async operation, the receiver is
+    // passed back to notify once the data is loaded into the cache
+    pub fn create_eventual_mode_cache_request(path: Path) -> (Self, oneshot::Receiver<()>) {
         let (notifier, receiver) = oneshot::channel();
         (
-            Self {
-                path,
-                notifier,
-                parquet_bytes: bytes,
-            },
+            Self::Eventual(EventualCacheRequest { path, notifier }),
             receiver,
         )
     }
 
-    /// Helper to get path used to create this request
     pub fn get_path(&self) -> &Path {
-        &self.path
+        match self {
+            CacheRequest::Immediate(ImmediateCacheRequest {
+                path,
+                parquet_data: _,
+            }) => path,
+            CacheRequest::Eventual(EventualCacheRequest { path, notifier: _ }) => path,
+        }
     }
 }
 
@@ -112,11 +138,16 @@ pub trait ParquetCacheOracle: Send + Sync + Debug {
 
 /// Concrete implementation of the [`ParquetCacheOracle`]
 ///
-/// This implementation sends all requests registered to be cached.
+/// This implementation keeps a local reference to [`MemCachedObjectStore`] to immediately cache
+/// any requests. This also spins up the background job to cache any requests that require looking
+/// up parquet files from object store. In the latter case when the GET request to object store
+/// completes eventually a notification is sent to the caller to indicate that the request has been
+/// fulfilled.
 #[derive(Debug, Clone)]
 pub struct MemCacheOracle {
-    cache_request_tx: Sender<CacheRequest>,
+    cache_request_tx: Sender<EventualCacheRequest>,
     prune_notifier_tx: watch::Sender<usize>,
+    mem_store: Arc<MemCachedObjectStore>,
 }
 
 // TODO(trevor): make this configurable with reasonable default
@@ -132,22 +163,56 @@ impl MemCacheOracle {
         let (cache_request_tx, cache_request_rx) = channel(CACHE_REQUEST_BUFFER_SIZE);
         background_cache_request_handler(Arc::clone(&mem_cached_store), cache_request_rx);
         let (prune_notifier_tx, _prune_notifier_rx) = watch::channel(0);
-        background_cache_pruner(mem_cached_store, prune_notifier_tx.clone(), prune_interval);
+        background_cache_pruner(
+            Arc::clone(&mem_cached_store),
+            prune_notifier_tx.clone(),
+            prune_interval,
+        );
         Self {
             cache_request_tx,
             prune_notifier_tx,
+            mem_store: Arc::clone(&mem_cached_store),
         }
     }
 }
 
 impl ParquetCacheOracle for MemCacheOracle {
     fn register(&self, request: CacheRequest) {
-        let tx = self.cache_request_tx.clone();
-        tokio::spawn(async move {
-            if let Err(error) = tx.send(request).await {
-                error!(%error, "error registering cache request");
-            };
-        });
+        let path = request.get_path();
+        // We assume that objects on object store are immutable, so we can skip objects that
+        // we have already fetched, in eventual mode we send the notification immediately, so
+        // that it doesn't wait it's turn in the queue.
+        let already_in_cache = self.mem_store.cache.path_already_fetched(path);
+        debug!(
+            ?already_in_cache,
+            ?path,
+            ">>> is path already in parquet cache"
+        );
+        match request {
+            CacheRequest::Immediate(ImmediateCacheRequest { path, parquet_data }) => {
+                if !already_in_cache {
+                    let cache_value = CacheValue {
+                        data: parquet_data.bytes,
+                        meta: parquet_data.object_meta,
+                    };
+                    self.mem_store
+                        .cache
+                        .set_cache_value_directly(&path, Arc::new(cache_value));
+                }
+            }
+            CacheRequest::Eventual(eventual_cache_req) => {
+                if !already_in_cache {
+                    let tx = self.cache_request_tx.clone();
+                    tokio::spawn(async move {
+                        if let Err(error) = tx.send(eventual_cache_req).await {
+                            error!(%error, "error registering cache request");
+                        };
+                    });
+                } else {
+                    let _ = eventual_cache_req.notifier.send(());
+                }
+            }
+        }
     }
 
     fn prune_notifier(&self) -> watch::Receiver<usize> {
@@ -730,40 +795,18 @@ impl ObjectStore for MemCachedObjectStore {
 
 /// Handle [`CacheRequest`]s in a background task
 ///
-/// This waits on the given `Receiver` for new cache requests to be registered, i.e., via the oracle.
+/// This waits on the given `Receiver` for new eventual cache requests to be registered (via oracle).
 /// If a cache request is received for an entry that has not already been fetched successfully, or
 /// one that is in the process of being fetched, then this will spin a separate background task to
 /// fetch the object from object store and update the cache. This is so that cache requests can be
 /// handled in parallel.
 fn background_cache_request_handler(
     mem_store: Arc<MemCachedObjectStore>,
-    mut rx: Receiver<CacheRequest>,
+    mut rx: Receiver<EventualCacheRequest>,
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
-        while let Some(CacheRequest {
-            path,
-            notifier,
-            parquet_bytes,
-        }) = rx.recv().await
-        {
-            // We assume that objects on object store are immutable, so we can skip objects that
-            // we have already fetched:
-            if mem_store.cache.path_already_fetched(&path) {
-                continue;
-            }
-
-            // if we have parquet bytes already we can just use it to populate the cache
-            if let Some(parquet_bytes) = parquet_bytes {
-                let cache_value = CacheValue {
-                    data: parquet_bytes.bytes,
-                    meta: parquet_bytes.object_meta,
-                };
-                mem_store
-                    .cache
-                    .set_cache_value_directly(&path, Arc::new(cache_value));
-                continue;
-            }
-
+        while let Some(cache_request) = rx.recv().await {
+            let (path, notifier) = cache_request.get_path_and_notifier();
             // Create a future that will go and fetch the cache value from the store:
             let path_cloned = path.clone();
             let store_cloned = Arc::clone(&mem_store.inner);
@@ -825,12 +868,13 @@ pub(crate) mod tests {
     use std::{sync::Arc, time::Duration};
 
     use arrow::datatypes::ToByteSlice;
+    use bytes::Bytes;
     use influxdb3_test_helpers::object_store::{
         RequestCountedObjectStore, SynchronizedObjectStore,
     };
     use iox_time::{MockProvider, Time, TimeProvider};
     use metric::{Attributes, Metric, Registry, U64Counter, U64Gauge};
-    use object_store::{memory::InMemory, path::Path, ObjectStore, PutPayload};
+    use object_store::{memory::InMemory, path::Path, ObjectStore, PutPayload, PutResult};
 
     use pretty_assertions::assert_eq;
     use tokio::sync::Notify;
@@ -838,7 +882,7 @@ pub(crate) mod tests {
     use crate::parquet_cache::{
         create_cached_obj_store_and_oracle,
         metrics::{CACHE_ACCESS_NAME, CACHE_SIZE_BYTES_NAME, CACHE_SIZE_N_FILES_NAME},
-        test_cached_obj_store_and_oracle, CacheRequest,
+        test_cached_obj_store_and_oracle, CacheRequest, ParquetFileDataToCache,
     };
 
     macro_rules! assert_payload_at_equals {
@@ -858,7 +902,7 @@ pub(crate) mod tests {
     }
 
     #[tokio::test]
-    async fn hit_cache_instead_of_object_store() {
+    async fn hit_cache_instead_of_object_store_eventual() {
         // set up the inner test object store and then wrap it with the mem cached store:
         let inner_store = Arc::new(RequestCountedObjectStore::new(Arc::new(InMemory::new())));
         let time_provider: Arc<dyn TimeProvider> =
@@ -880,9 +924,9 @@ pub(crate) mod tests {
         assert_payload_at_equals!(cached_store, payload, path);
         assert_eq!(1, inner_store.total_read_request_count(&path));
 
-        // TODO:
         // cache the entry:
-        let (cache_request, notifier_rx) = CacheRequest::create(path.clone(), None);
+        let (cache_request, notifier_rx) =
+            CacheRequest::create_eventual_mode_cache_request(path.clone());
         oracle.register(cache_request);
 
         // wait for cache notify:
@@ -897,6 +941,163 @@ pub(crate) mod tests {
         // should hit the cache this time, so the inner store should not have been hit, and counts
         // should therefore be same as previous:
         assert_eq!(2, inner_store.total_read_request_count(&path));
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn hit_cache_instead_of_object_store_immediate() {
+        // set up the inner test object store and then wrap it with the mem cached store:
+        let inner_store = Arc::new(RequestCountedObjectStore::new(Arc::new(InMemory::new())));
+        let time_provider: Arc<dyn TimeProvider> =
+            Arc::new(MockProvider::new(Time::from_timestamp_nanos(0)));
+        let (cached_store, oracle) = test_cached_obj_store_and_oracle(
+            Arc::clone(&inner_store) as _,
+            Arc::clone(&time_provider),
+            Default::default(),
+        );
+        let path = Path::from("0.parquet");
+        let payload = b"hello world";
+
+        let put_result = PutResult {
+            e_tag: Some("some-etag".to_string()),
+            version: Some("version-abc".to_string()),
+        };
+
+        let to_cache = ParquetFileDataToCache::new(
+            &path,
+            time_provider.now().date_time(),
+            Bytes::from_static(payload),
+            put_result,
+        );
+
+        // cache the entry:
+        let cache_request =
+            CacheRequest::create_immediate_mode_cache_request(path.clone(), to_cache);
+        oracle.register(cache_request);
+
+        let _ = cached_store.get(&path).await;
+        // create request to inner store, this data is not in object store
+        assert_eq!(0, inner_store.total_read_request_count(&path));
+
+        // get the payload from the outer store and it should exist
+        assert_payload_at_equals!(cached_store, payload, path);
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn hit_cache_instead_of_object_store_immediate_and_eventual() {
+        // set up the inner test object store and then wrap it with the mem cached store:
+        let inner_store = Arc::new(RequestCountedObjectStore::new(Arc::new(InMemory::new())));
+        let time_provider: Arc<dyn TimeProvider> =
+            Arc::new(MockProvider::new(Time::from_timestamp_nanos(0)));
+        let (cached_store, oracle) = test_cached_obj_store_and_oracle(
+            Arc::clone(&inner_store) as _,
+            Arc::clone(&time_provider),
+            Default::default(),
+        );
+        let path_1_eventually_cached = Path::from("0.parquet");
+        let payload_1_eventually_cached = b"hello world";
+
+        let path_2_immediately_cached = Path::from("1.parquet");
+        let payload_2_immediately_cached = b"good-bye world";
+
+        // Add file to object store
+        cached_store
+            .put(
+                &path_1_eventually_cached,
+                PutPayload::from_static(payload_1_eventually_cached),
+            )
+            .await
+            .unwrap();
+
+        // GET the payload from the object store before caching:
+        assert_payload_at_equals!(
+            cached_store,
+            payload_1_eventually_cached,
+            path_1_eventually_cached
+        );
+        assert_eq!(
+            1,
+            inner_store.total_read_request_count(&path_1_eventually_cached)
+        );
+
+        // prepare for immediate request
+        let put_result = PutResult {
+            e_tag: Some("some-etag".to_string()),
+            version: Some("version-abc".to_string()),
+        };
+        let to_cache = ParquetFileDataToCache::new(
+            &path_2_immediately_cached,
+            time_provider.now().date_time(),
+            Bytes::from_static(payload_2_immediately_cached),
+            put_result,
+        );
+        // Do an immediate cache request to other file
+        let immediate_cache_request = CacheRequest::create_immediate_mode_cache_request(
+            path_2_immediately_cached.clone(),
+            to_cache,
+        );
+        oracle.register(immediate_cache_request);
+
+        // Now try to cache 1st path eventually
+        let (cache_request, notifier_rx) =
+            CacheRequest::create_eventual_mode_cache_request(path_1_eventually_cached.clone());
+        oracle.register(cache_request);
+
+        // Oracle should've fulfilled the immediate cache request
+        assert_payload_at_equals!(
+            cached_store,
+            payload_2_immediately_cached,
+            path_2_immediately_cached
+        );
+
+        // Now wait for eventual request to finish
+        let _ = notifier_rx.await;
+
+        // Because eventual mode request went through, there will be another GET request to inner
+        // store
+        assert_eq!(
+            2,
+            inner_store.total_read_request_count(&path_1_eventually_cached)
+        );
+
+        // get the payload from the outer store again:
+        assert_payload_at_equals!(
+            cached_store,
+            payload_1_eventually_cached,
+            path_1_eventually_cached
+        );
+
+        // should hit the cache this time, so the inner store should not have been hit, and counts
+        // should therefore be same as previous:
+        assert_eq!(
+            2,
+            inner_store.total_read_request_count(&path_1_eventually_cached)
+        );
+
+        // Now try to cache 1st path again eventually
+        let (cache_request, notifier_rx) =
+            CacheRequest::create_eventual_mode_cache_request(path_1_eventually_cached.clone());
+        oracle.register(cache_request);
+        // should resolve immediately as path is already in cache
+        let _ = notifier_rx.await;
+
+        // no changes to inner store
+        assert_eq!(
+            2,
+            inner_store.total_read_request_count(&path_1_eventually_cached)
+        );
+
+        // Try caching 2nd path (previously immediately cached)
+        let (cache_request, notifier_rx) =
+            CacheRequest::create_eventual_mode_cache_request(path_2_immediately_cached.clone());
+        oracle.register(cache_request);
+        // should resolve immediately as path is already in cache
+        let _ = notifier_rx.await;
+
+        // again - no changes to inner store
+        assert_eq!(
+            2,
+            inner_store.total_read_request_count(&path_1_eventually_cached)
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 1)]
@@ -925,7 +1126,8 @@ pub(crate) mod tests {
             .unwrap();
 
         // cache the entry and wait for it to complete:
-        let (cache_request, notifier_rx) = CacheRequest::create(path_1.clone(), None);
+        let (cache_request, notifier_rx) =
+            CacheRequest::create_eventual_mode_cache_request(path_1.clone());
         oracle.register(cache_request);
         let _ = notifier_rx.await;
         // there will have been one get request made by the cache oracle:
@@ -952,7 +1154,8 @@ pub(crate) mod tests {
 
         // cache the second entry and wait for it to complete, this will not evict the first entry
         // as both can fit in the cache:
-        let (cache_request, notifier_rx) = CacheRequest::create(path_2.clone(), None);
+        let (cache_request, notifier_rx) =
+            CacheRequest::create_eventual_mode_cache_request(path_2.clone());
         oracle.register(cache_request);
         let _ = notifier_rx.await;
         // will have another request for the second path to the inner store, by the oracle:
@@ -991,7 +1194,8 @@ pub(crate) mod tests {
 
         // cache the third entry and wait for it to complete, this will push the cache past its
         // capacity:
-        let (cache_request, notifier_rx) = CacheRequest::create(path_3.clone(), None);
+        let (cache_request, notifier_rx) =
+            CacheRequest::create_eventual_mode_cache_request(path_3.clone());
         oracle.register(cache_request);
         let _ = notifier_rx.await;
         // will now have another request for the third path to the inner store, by the oracle:
@@ -1046,7 +1250,8 @@ pub(crate) mod tests {
             .unwrap();
 
         // cache the entry, but don't wait on it until below in spawned task:
-        let (cache_request, notifier_rx) = CacheRequest::create(path.clone(), None);
+        let (cache_request, notifier_rx) =
+            CacheRequest::create_eventual_mode_cache_request(path.clone());
         oracle.register(cache_request);
 
         // we are in the middle of a get request, i.e., the cache entry is "fetching"
@@ -1207,7 +1412,8 @@ pub(crate) mod tests {
         assert_eq!(1, counted_store.total_read_request_count(&path));
 
         // have the cache oracle cache the object:
-        let (cache_request, notifier_rx) = CacheRequest::create(path.clone(), None);
+        let (cache_request, notifier_rx) =
+            CacheRequest::create_eventual_mode_cache_request(path.clone());
         oracle.register(cache_request);
 
         // we are in the middle of a get request, i.e., the cache entry is "fetching" once this

--- a/influxdb3_processing_engine/src/lib.rs
+++ b/influxdb3_processing_engine/src/lib.rs
@@ -1271,7 +1271,11 @@ mod tests {
     ) -> (ProcessingEngineManagerImpl, NamedTempFile) {
         let time_provider: Arc<dyn TimeProvider> = Arc::new(MockProvider::new(start));
         let metric_registry = Arc::new(Registry::new());
-        let persister = Arc::new(Persister::new(Arc::clone(&object_store), "test_host"));
+        let persister = Arc::new(Persister::new(
+            Arc::clone(&object_store),
+            "test_host",
+            Arc::clone(&time_provider) as _,
+        ));
         let catalog = Arc::new(persister.load_or_create_catalog().await.unwrap());
         let last_cache = LastCacheProvider::new_from_catalog(Arc::clone(&catalog) as _).unwrap();
         let distinct_cache = DistinctCacheProvider::new_from_catalog(

--- a/influxdb3_server/src/lib.rs
+++ b/influxdb3_server/src/lib.rs
@@ -759,7 +759,11 @@ mod tests {
             },
             DedicatedExecutor::new_testing(),
         ));
-        let persister = Arc::new(Persister::new(Arc::clone(&object_store), "test_host"));
+        let persister = Arc::new(Persister::new(
+            Arc::clone(&object_store),
+            "test_host",
+            Arc::clone(&time_provider) as _,
+        ));
         let sample_node_id = Arc::from("sample-host-id");
         let instance_id = Arc::from("sample-instance-id");
         let catalog = Arc::new(Catalog::new(sample_node_id, instance_id));

--- a/influxdb3_server/src/query_executor/mod.rs
+++ b/influxdb3_server/src/query_executor/mod.rs
@@ -819,7 +819,11 @@ mod tests {
             Arc::clone(&time_provider) as _,
             Default::default(),
         );
-        let persister = Arc::new(Persister::new(Arc::clone(&object_store), "test_host"));
+        let persister = Arc::new(Persister::new(
+            Arc::clone(&object_store),
+            "test_host",
+            Arc::clone(&time_provider) as _,
+        ));
         let exec = make_exec(Arc::clone(&object_store));
         let node_id = Arc::from("sample-host-id");
         let instance_id = Arc::from("instance-id");

--- a/influxdb3_write/src/write_buffer/mod.rs
+++ b/influxdb3_write/src/write_buffer/mod.rs
@@ -2091,7 +2091,7 @@ mod tests {
         assert_eq!(DbId::next_id().as_u32(), 1);
     }
 
-    #[tokio::test]
+    #[test_log::test(tokio::test)]
     async fn test_parquet_cache() {
         // set up a write buffer using a TestObjectStore so we can spy on requests that get
         // through to the object store for parquet files:
@@ -2163,8 +2163,8 @@ mod tests {
         let path = ObjPath::from(persisted_files[0].path.as_str());
 
         // check the number of requests to that path before making a query:
-        // there should be one get request, made by the cache oracle:
-        assert_eq!(1, test_store.get_request_count(&path));
+        // there should be no get request, made by the cache oracle:
+        assert_eq!(0, test_store.get_request_count(&path));
         assert_eq!(0, test_store.get_opts_request_count(&path));
         assert_eq!(0, test_store.get_ranges_request_count(&path));
         assert_eq!(0, test_store.get_range_request_count(&path));
@@ -2193,7 +2193,7 @@ mod tests {
         );
 
         // counts should not change, since requests for this parquet file hit the cache:
-        assert_eq!(1, test_store.get_request_count(&path));
+        assert_eq!(0, test_store.get_request_count(&path));
         assert_eq!(0, test_store.get_opts_request_count(&path));
         assert_eq!(0, test_store.get_ranges_request_count(&path));
         assert_eq!(0, test_store.get_range_request_count(&path));

--- a/influxdb3_write/src/write_buffer/mod.rs
+++ b/influxdb3_write/src/write_buffer/mod.rs
@@ -956,7 +956,11 @@ mod tests {
             Arc::clone(&time_provider),
             Default::default(),
         );
-        let persister = Arc::new(Persister::new(Arc::clone(&object_store), "test_host"));
+        let persister = Arc::new(Persister::new(
+            Arc::clone(&object_store),
+            "test_host",
+            Arc::clone(&time_provider),
+        ));
         let catalog = Arc::new(persister.load_or_create_catalog().await.unwrap());
         let last_cache = LastCacheProvider::new_from_catalog(Arc::clone(&catalog) as _).unwrap();
         let distinct_cache = DistinctCacheProvider::new_from_catalog(
@@ -3046,7 +3050,11 @@ mod tests {
         } else {
             (object_store, None)
         };
-        let persister = Arc::new(Persister::new(Arc::clone(&object_store), "test_host"));
+        let persister = Arc::new(Persister::new(
+            Arc::clone(&object_store),
+            "test_host",
+            Arc::clone(&time_provider) as _,
+        ));
         let catalog = Arc::new(persister.load_or_create_catalog().await.unwrap());
         let last_cache = LastCacheProvider::new_from_catalog(Arc::clone(&catalog) as _).unwrap();
         let distinct_cache = DistinctCacheProvider::new_from_catalog(

--- a/influxdb3_write/src/write_buffer/queryable_buffer.rs
+++ b/influxdb3_write/src/write_buffer/queryable_buffer.rs
@@ -15,8 +15,8 @@ use datafusion::catalog::Session;
 use datafusion::common::DataFusionError;
 use datafusion_util::stream_from_batches;
 use hashbrown::HashMap;
-use influxdb3_cache::{distinct_cache::DistinctCacheProvider, last_cache::LastCacheProvider};
 use influxdb3_cache::parquet_cache::{CacheRequest, ParquetCacheOracle};
+use influxdb3_cache::{distinct_cache::DistinctCacheProvider, last_cache::LastCacheProvider};
 use influxdb3_catalog::catalog::{Catalog, DatabaseSchema, TableDefinition};
 use influxdb3_id::{DbId, TableId};
 use influxdb3_wal::{CatalogOp, SnapshotDetails, WalContents, WalFileNotifier, WalOp, WriteBatch};
@@ -273,7 +273,6 @@ impl QueryableBuffer {
                 snapshot_details.last_wal_sequence_number,
                 catalog.sequence_number(),
             );
-            let mut cache_notifiers = vec![];
             let persist_jobs_empty = persist_jobs.is_empty();
             for persist_job in persist_jobs {
                 let path = persist_job.path.to_string();
@@ -286,7 +285,6 @@ impl QueryableBuffer {
                 let SortDedupePersistSummary {
                     file_size_bytes,
                     file_meta_data,
-                    parquet_cache_rx,
                 } = sort_dedupe_persist(
                     persist_job,
                     Arc::clone(&persister),
@@ -306,7 +304,6 @@ impl QueryableBuffer {
                 // https://github.com/influxdata/influxdb/issues/25677
                 .expect("sort, deduplicate, and persist buffer data as parquet");
 
-                cache_notifiers.push(parquet_cache_rx);
                 persisted_snapshot.add_parquet_file(
                     database_id,
                     table_id,
@@ -377,11 +374,6 @@ impl QueryableBuffer {
             // on a background task to ensure that the cache has been populated before we clear
             // the buffer
             tokio::spawn(async move {
-                // wait on the cache updates to complete if there is a cache:
-                for notifier in cache_notifiers.into_iter().flatten() {
-                    let _ = notifier.await;
-                }
-
                 // same reason as explained above, if persist jobs are empty, no snapshotting
                 // has happened so no need to clear the snapshots
                 if !persist_jobs_empty {
@@ -622,19 +614,13 @@ struct PersistJob {
 pub(crate) struct SortDedupePersistSummary {
     pub file_size_bytes: u64,
     pub file_meta_data: FileMetaData,
-    pub parquet_cache_rx: Option<oneshot::Receiver<()>>,
 }
 
 impl SortDedupePersistSummary {
-    fn new(
-        file_size_bytes: u64,
-        file_meta_data: FileMetaData,
-        parquet_cache_rx: Option<oneshot::Receiver<()>>,
-    ) -> Self {
+    fn new(file_size_bytes: u64, file_meta_data: FileMetaData) -> Self {
         Self {
             file_size_bytes,
             file_meta_data,
-            parquet_cache_rx,
         }
     }
 }
@@ -715,20 +701,14 @@ async fn sort_dedupe_persist(
         {
             Ok((size_bytes, parquet_meta, to_cache)) => {
                 info!("Persisted parquet file: {}", persist_job.path.to_string());
-                let parquet_cache_rx = parquet_cache.map(|parquet_cache_oracle| {
-                    let (cache_request, cache_notify_rx) = CacheRequest::create(
+                if let Some(parquet_cache_oracle) = parquet_cache {
+                    let cache_request = CacheRequest::create_immediate_mode_cache_request(
                         Path::from(persist_job.path.to_string()),
-                        // TODO follow this meta_data and see how to avoid cloning here
-                        Some(to_cache),
+                        to_cache,
                     );
                     parquet_cache_oracle.register(cache_request);
-                    cache_notify_rx
-                });
-                return Ok(SortDedupePersistSummary::new(
-                    size_bytes,
-                    parquet_meta,
-                    parquet_cache_rx,
-                ));
+                }
+                return Ok(SortDedupePersistSummary::new(size_bytes, parquet_meta));
             }
             Err(e) => {
                 error!(
@@ -781,7 +761,12 @@ mod tests {
         register_current_runtime_for_io();
 
         let catalog = Arc::new(Catalog::new("hosta".into(), "foo".into()));
-        let persister = Arc::new(Persister::new(Arc::clone(&object_store), "hosta"));
+        let time_provider = Arc::new(MockProvider::new(Time::from_timestamp_nanos(0)));
+        let persister = Arc::new(Persister::new(
+            Arc::clone(&object_store),
+            "hosta",
+            time_provider,
+        ));
         let time_provider: Arc<dyn TimeProvider> =
             Arc::new(MockProvider::new(Time::from_timestamp_nanos(0)));
 


### PR DESCRIPTION
closes: https://github.com/influxdata/influxdb/issues/25887

This PR allows local updates for parquet cache without going to object store. Following are the main changes,
- Introduces `Immediate` and `Eventual` modes for cache request
- The oracle now holds the reference to cache through object store that is used in the background runner
- Any requests with `Immediate` mode directly goes into the cache in a synchronous call, the machinery built to cache in the background now takes only `EventualCacheRequest` (where we know only the path and do not have access to serialized parquet bytes, this option will be used)
- All await to wait for all cache request being fulfilled in queryable buffer is removed, as when snapshotting we always have access to serialized bytes.