### PR TITLE
refactor: `writer-id` to `node-id`

### DIFF
--- a/influxdb3/src/commands/create.rs
+++ b/influxdb3/src/commands/create.rs
@@ -377,7 +377,7 @@ pub async fn command(config: Config) -> Result<(), Box<dyn Error>> {
                 "\
                 Token: {token}\n\
                 Hashed Token: {hashed}\n\n\
-                Start the server with `influxdb3 serve --bearer-token {hashed} --object-store file --data-dir ~/.influxdb3 --writer-id YOUR_HOST_NAME`\n\n\
+                Start the server with `influxdb3 serve --bearer-token {hashed} --object-store file --data-dir ~/.influxdb3 --node-id YOUR_HOST_NAME`\n\n\
                 HTTP requests require the following header: \"Authorization: Bearer {token}\"\n\
                 This will grant you access to every HTTP endpoint or deny it otherwise
             ",

--- a/influxdb3/src/commands/serve.rs
+++ b/influxdb3/src/commands/serve.rs
@@ -240,17 +240,17 @@ pub struct Config {
     )]
     pub buffer_mem_limit_mb: usize,
 
-    /// The writer idendifier used as a prefix in all object store file paths. This should be unique
+    /// The node idendifier used as a prefix in all object store file paths. This should be unique
     /// for any InfluxDB 3 Core servers that share the same object store configuration, i.e., the
     /// same bucket.
     #[clap(
-        long = "writer-id",
+        long = "node-id",
         // TODO: deprecate this alias in future version
         alias = "host-id",
-        env = "INFLUXDB3_WRITER_IDENTIFIER_PREFIX",
+        env = "INFLUXDB3_NODE_IDENTIFIER_PREFIX",
         action
     )]
-    pub writer_identifier_prefix: String,
+    pub node_identifier_prefix: String,
 
     /// The size of the in-memory Parquet cache in megabytes (MB).
     #[clap(
@@ -419,7 +419,7 @@ pub async fn command(config: Config) -> Result<()> {
     let num_cpus = num_cpus::get();
     let build_malloc_conf = build_malloc_conf();
     info!(
-        writer_id = %config.writer_identifier_prefix,
+        node_id = %config.node_identifier_prefix,
         git_hash = %INFLUXDB3_GIT_HASH as &str,
         version = %INFLUXDB3_VERSION.as_ref() as &str,
         uuid = %PROCESS_UUID.as_ref() as &str,
@@ -509,7 +509,7 @@ pub async fn command(config: Config) -> Result<()> {
 
     let persister = Arc::new(Persister::new(
         Arc::clone(&object_store),
-        config.writer_identifier_prefix,
+        config.node_identifier_prefix,
     ));
     let wal_config = WalConfig {
         gen1_duration: config.gen1_duration,

--- a/influxdb3/src/main.rs
+++ b/influxdb3/src/main.rs
@@ -55,7 +55,7 @@ long_about = r#"InfluxDB 3 Core server and command line tools
 
 Examples:
     # Run the InfluxDB 3 Core server
-    influxdb3 serve --object-store file --data-dir ~/.influxdb3 --writer_id my_writer_name
+    influxdb3 serve --object-store file --data-dir ~/.influxdb3 --node_id my_node_name
 
     # Display all commands short form
     influxdb3 -h
@@ -64,10 +64,10 @@ Examples:
     influxdb3 --help
 
     # Run the InfluxDB 3 Core server with extra verbose logging
-    influxdb3 serve -v --object-store file --data-dir ~/.influxdb3 --writer_id my_writer_name
+    influxdb3 serve -v --object-store file --data-dir ~/.influxdb3 --node_id my_node_name
 
     # Run InfluxDB 3 Core with full debug logging specified with LOG_FILTER
-    LOG_FILTER=debug influxdb3 serve --object-store file --data-dir ~/.influxdb3 --writer_id my_writer_name
+    LOG_FILTER=debug influxdb3 serve --object-store file --data-dir ~/.influxdb3 --node_id my_node_name
 "#
 )]
 struct Config {

--- a/influxdb3/tests/server/cli.rs
+++ b/influxdb3/tests/server/cli.rs
@@ -113,8 +113,8 @@ fn create_plugin_file(code: &str) -> NamedTempFile {
 async fn test_telemetry_disabled_with_debug_msg() {
     let serve_args = &[
         "serve",
-        "--writer-id",
-        "the-best-writer",
+        "--node-id",
+        "the-best-node",
         "--object-store",
         "memory",
     ];
@@ -141,8 +141,8 @@ async fn test_telemetry_disabled_with_debug_msg() {
 async fn test_telemetry_disabled() {
     let serve_args = &[
         "serve",
-        "--writer-id",
-        "the-best-writer",
+        "--node-id",
+        "the-best-node",
         "--object-store",
         "memory",
     ];
@@ -168,8 +168,8 @@ async fn test_telemetry_disabled() {
 async fn test_telemetry_enabled_with_debug_msg() {
     let serve_args = &[
         "serve",
-        "--writer-id",
-        "the-best-writer",
+        "--node-id",
+        "the-best-node",
         "--object-store",
         "memory",
     ];
@@ -198,8 +198,8 @@ async fn test_telemetry_enabled_with_debug_msg() {
 async fn test_telementry_enabled() {
     let serve_args = &[
         "serve",
-        "--writer-id",
-        "the-best-writer",
+        "--node-id",
+        "the-best-node",
         "--object-store",
         "memory",
     ];

--- a/influxdb3/tests/server/main.rs
+++ b/influxdb3/tests/server/main.rs
@@ -47,7 +47,7 @@ trait ConfigProvider {
 #[derive(Debug, Default)]
 pub struct TestConfig {
     auth_token: Option<(String, String)>,
-    writer_id: Option<String>,
+    node_id: Option<String>,
     plugin_dir: Option<String>,
     // If None, use memory object store.
     object_store_dir: Option<String>,
@@ -65,8 +65,8 @@ impl TestConfig {
     }
 
     /// Set a host identifier prefix on the spawned [`TestServer`]
-    pub fn with_writer_id<S: Into<String>>(mut self, writer_id: S) -> Self {
-        self.writer_id = Some(writer_id.into());
+    pub fn with_node_id<S: Into<String>>(mut self, node_id: S) -> Self {
+        self.node_id = Some(node_id.into());
         self
     }
 
@@ -92,8 +92,8 @@ impl ConfigProvider for TestConfig {
         if let Some(plugin_dir) = &self.plugin_dir {
             args.append(&mut vec!["--plugin-dir".to_string(), plugin_dir.to_owned()]);
         }
-        args.push("--writer-id".to_string());
-        if let Some(host) = &self.writer_id {
+        args.push("--node-id".to_string());
+        if let Some(host) = &self.node_id {
             args.push(host.to_owned());
         } else {
             args.push("test-server".to_string());

--- a/influxdb3_cache/src/last_cache/mod.rs
+++ b/influxdb3_cache/src/last_cache/mod.rs
@@ -1349,9 +1349,9 @@ mod tests {
             .insert(table_def.table_id, Arc::new(table_def));
         // Create the catalog and clone its InnerCatalog (which is what the LastCacheProvider is
         // initialized from):
-        let writer_id = Arc::from("sample-host-id");
+        let node_id = Arc::from("sample-host-id");
         let instance_id = Arc::from("sample-instance-id");
-        let catalog = Catalog::new(writer_id, instance_id);
+        let catalog = Catalog::new(node_id, instance_id);
         let db_id = database.id;
         catalog.insert_database(database);
         let catalog = Arc::new(catalog);

--- a/influxdb3_catalog/src/catalog.rs
+++ b/influxdb3_catalog/src/catalog.rs
@@ -195,9 +195,9 @@ impl Catalog {
     /// Limit for the number of tables across all DBs that InfluxDB 3 Core OSS can have
     pub(crate) const NUM_TABLES_LIMIT: usize = 2000;
 
-    pub fn new(writer_id: Arc<str>, instance_id: Arc<str>) -> Self {
+    pub fn new(node_id: Arc<str>, instance_id: Arc<str>) -> Self {
         Self {
-            inner: RwLock::new(InnerCatalog::new(writer_id, instance_id)),
+            inner: RwLock::new(InnerCatalog::new(node_id, instance_id)),
         }
     }
 
@@ -304,8 +304,8 @@ impl Catalog {
         Arc::clone(&self.inner.read().instance_id)
     }
 
-    pub fn writer_id(&self) -> Arc<str> {
-        Arc::clone(&self.inner.read().writer_id)
+    pub fn node_id(&self) -> Arc<str> {
+        Arc::clone(&self.inner.read().node_id)
     }
 
     #[cfg(test)]
@@ -372,9 +372,9 @@ pub struct InnerCatalog {
     /// The catalog is a map of databases with their table schemas
     databases: SerdeVecMap<DbId, Arc<DatabaseSchema>>,
     sequence: CatalogSequenceNumber,
-    /// The `writer_id` is the prefix that is passed in when starting up
-    /// (`writer_identifier_prefix`)
-    writer_id: Arc<str>,
+    /// The `node_id` is the prefix that is passed in when starting up
+    /// (`node_identifier_prefix`)
+    node_id: Arc<str>,
     /// The instance_id uniquely identifies the instance that generated the catalog
     instance_id: Arc<str>,
     /// If true, the catalog has been updated since the last time it was serialized
@@ -438,11 +438,11 @@ serde_with::serde_conv!(
 );
 
 impl InnerCatalog {
-    pub(crate) fn new(writer_id: Arc<str>, instance_id: Arc<str>) -> Self {
+    pub(crate) fn new(node_id: Arc<str>, instance_id: Arc<str>) -> Self {
         Self {
             databases: SerdeVecMap::new(),
             sequence: CatalogSequenceNumber::new(0),
-            writer_id,
+            node_id,
             instance_id,
             updated: false,
             db_map: BiHashMap::new(),
@@ -1428,10 +1428,10 @@ mod tests {
 
     #[test]
     fn catalog_serialization() {
-        let writer_id = Arc::from("sample-host-id");
+        let node_id = Arc::from("sample-host-id");
         let instance_id = Arc::from("instance-id");
         let cloned_instance_id = Arc::clone(&instance_id);
-        let catalog = Catalog::new(writer_id, cloned_instance_id);
+        let catalog = Catalog::new(node_id, cloned_instance_id);
         let mut database = DatabaseSchema {
             id: DbId::from(0),
             name: "test_db".into(),
@@ -1541,7 +1541,7 @@ mod tests {
                     ]
                 ],
                 "sequence": 0,
-                "writer_id": "test",
+                "node_id": "test",
                 "instance_id": "test",
                 "db_map": []
             }"#;
@@ -1587,7 +1587,7 @@ mod tests {
                     ]
                 ],
                 "sequence": 0,
-                "writer_id": "test",
+                "node_id": "test",
                 "instance_id": "test",
                 "db_map": []
             }"#;
@@ -1700,9 +1700,9 @@ mod tests {
 
     #[test]
     fn serialize_series_keys() {
-        let writer_id = Arc::from("sample-host-id");
+        let node_id = Arc::from("sample-host-id");
         let instance_id = Arc::from("instance-id");
-        let catalog = Catalog::new(writer_id, instance_id);
+        let catalog = Catalog::new(node_id, instance_id);
         let mut database = DatabaseSchema {
             id: DbId::from(0),
             name: "test_db".into(),
@@ -1757,9 +1757,9 @@ mod tests {
 
     #[test]
     fn serialize_last_cache() {
-        let writer_id = Arc::from("sample-host-id");
+        let node_id = Arc::from("sample-host-id");
         let instance_id = Arc::from("instance-id");
-        let catalog = Catalog::new(writer_id, instance_id);
+        let catalog = Catalog::new(node_id, instance_id);
         let mut database = DatabaseSchema {
             id: DbId::from(0),
             name: "test_db".into(),
@@ -1823,14 +1823,14 @@ mod tests {
     }
 
     #[test]
-    fn catalog_instance_and_writer_ids() {
-        let writer_id = Arc::from("sample-host-id");
+    fn catalog_instance_and_node_ids() {
+        let node_id = Arc::from("sample-host-id");
         let instance_id = Arc::from("sample-instance-id");
-        let cloned_writer_id = Arc::clone(&writer_id);
+        let cloned_node_id = Arc::clone(&node_id);
         let cloned_instance_id = Arc::clone(&instance_id);
-        let catalog = Catalog::new(cloned_writer_id, cloned_instance_id);
+        let catalog = Catalog::new(cloned_node_id, cloned_instance_id);
         assert_eq!(instance_id, catalog.instance_id());
-        assert_eq!(writer_id, catalog.writer_id());
+        assert_eq!(node_id, catalog.node_id());
     }
 
     /// See: https://github.com/influxdata/influxdb/issues/25524

--- a/influxdb3_catalog/src/snapshots/influxdb3_catalog__catalog__tests__catalog_serialization.snap
+++ b/influxdb3_catalog/src/snapshots/influxdb3_catalog__catalog__tests__catalog_serialization.snap
@@ -269,7 +269,7 @@ expression: catalog
     ]
   ],
   "sequence": 0,
-  "writer_id": "sample-host-id",
+  "node_id": "sample-host-id",
   "instance_id": "instance-id",
   "db_map": []
 }

--- a/influxdb3_catalog/src/snapshots/influxdb3_catalog__catalog__tests__serialize_last_cache.snap
+++ b/influxdb3_catalog/src/snapshots/influxdb3_catalog__catalog__tests__serialize_last_cache.snap
@@ -120,7 +120,7 @@ expression: catalog
     ]
   ],
   "sequence": 0,
-  "writer_id": "sample-host-id",
+  "node_id": "sample-host-id",
   "instance_id": "instance-id",
   "db_map": []
 }

--- a/influxdb3_catalog/src/snapshots/influxdb3_catalog__catalog__tests__serialize_series_keys.snap
+++ b/influxdb3_catalog/src/snapshots/influxdb3_catalog__catalog__tests__serialize_series_keys.snap
@@ -104,7 +104,7 @@ expression: catalog
     ]
   ],
   "sequence": 0,
-  "writer_id": "sample-host-id",
+  "node_id": "sample-host-id",
   "instance_id": "instance-id",
   "db_map": []
 }

--- a/influxdb3_server/src/lib.rs
+++ b/influxdb3_server/src/lib.rs
@@ -760,9 +760,9 @@ mod tests {
             DedicatedExecutor::new_testing(),
         ));
         let persister = Arc::new(Persister::new(Arc::clone(&object_store), "test_host"));
-        let sample_writer_id = Arc::from("sample-host-id");
+        let sample_node_id = Arc::from("sample-host-id");
         let instance_id = Arc::from("sample-instance-id");
-        let catalog = Arc::new(Catalog::new(sample_writer_id, instance_id));
+        let catalog = Arc::new(Catalog::new(sample_node_id, instance_id));
         let write_buffer_impl = influxdb3_write::write_buffer::WriteBufferImpl::new(
             influxdb3_write::write_buffer::WriteBufferImplArgs {
                 persister: Arc::clone(&persister),

--- a/influxdb3_server/src/query_executor/mod.rs
+++ b/influxdb3_server/src/query_executor/mod.rs
@@ -821,9 +821,9 @@ mod tests {
         );
         let persister = Arc::new(Persister::new(Arc::clone(&object_store), "test_host"));
         let exec = make_exec(Arc::clone(&object_store));
-        let writer_id = Arc::from("sample-host-id");
+        let node_id = Arc::from("sample-host-id");
         let instance_id = Arc::from("instance-id");
-        let catalog = Arc::new(Catalog::new(writer_id, instance_id));
+        let catalog = Arc::new(Catalog::new(node_id, instance_id));
         let write_buffer_impl = WriteBufferImpl::new(WriteBufferImplArgs {
             persister,
             catalog: Arc::clone(&catalog),

--- a/influxdb3_wal/src/object_store.rs
+++ b/influxdb3_wal/src/object_store.rs
@@ -20,7 +20,7 @@ use tokio::sync::{oneshot, OwnedSemaphorePermit, Semaphore};
 #[derive(Debug)]
 pub struct WalObjectStore {
     object_store: Arc<dyn ObjectStore>,
-    writer_identifier_prefix: String,
+    node_identifier_prefix: String,
     file_notifier: Arc<dyn WalFileNotifier>,
     added_file_notifiers: parking_lot::Mutex<Vec<Arc<dyn WalFileNotifier>>>,
     /// Buffered wal ops go in here along with the state to track when to snapshot
@@ -37,21 +37,21 @@ impl WalObjectStore {
     pub async fn new(
         time_provider: Arc<dyn TimeProvider>,
         object_store: Arc<dyn ObjectStore>,
-        writer_identifier_prefix: impl Into<String> + Send,
+        node_identifier_prefix: impl Into<String> + Send,
         file_notifier: Arc<dyn WalFileNotifier>,
         config: WalConfig,
         last_wal_sequence_number: Option<WalFileSequenceNumber>,
         last_snapshot_sequence_number: Option<SnapshotSequenceNumber>,
         snapshotted_wal_files_to_keep: u64,
     ) -> Result<Arc<Self>, crate::Error> {
-        let writer_identifier = writer_identifier_prefix.into();
+        let node_identifier = node_identifier_prefix.into();
         let all_wal_file_paths =
-            load_all_wal_file_paths(Arc::clone(&object_store), writer_identifier.clone()).await?;
+            load_all_wal_file_paths(Arc::clone(&object_store), node_identifier.clone()).await?;
         let flush_interval = config.flush_interval;
         let wal = Self::new_without_replay(
             time_provider,
             object_store,
-            writer_identifier,
+            node_identifier,
             file_notifier,
             config,
             last_wal_sequence_number,
@@ -72,7 +72,7 @@ impl WalObjectStore {
     fn new_without_replay(
         time_provider: Arc<dyn TimeProvider>,
         object_store: Arc<dyn ObjectStore>,
-        writer_identifier_prefix: impl Into<String>,
+        node_identifier_prefix: impl Into<String>,
         file_notifier: Arc<dyn WalFileNotifier>,
         config: WalConfig,
         last_wal_sequence_number: Option<WalFileSequenceNumber>,
@@ -85,7 +85,7 @@ impl WalObjectStore {
 
         Self {
             object_store,
-            writer_identifier_prefix: writer_identifier_prefix.into(),
+            node_identifier_prefix: node_identifier_prefix.into(),
             file_notifier,
             added_file_notifiers: Default::default(),
             flush_buffer: Mutex::new(FlushBuffer::new(
@@ -274,7 +274,7 @@ impl WalObjectStore {
                 .await
         };
         info!(
-            host = self.writer_identifier_prefix,
+            host = self.node_identifier_prefix,
             n_ops = %wal_contents.ops.len(),
             min_timestamp_ns = %wal_contents.min_timestamp_ns,
             max_timestamp_ns = %wal_contents.max_timestamp_ns,
@@ -282,7 +282,7 @@ impl WalObjectStore {
             "flushing WAL buffer to object store"
         );
 
-        let wal_path = wal_path(&self.writer_identifier_prefix, wal_contents.wal_file_number);
+        let wal_path = wal_path(&self.node_identifier_prefix, wal_contents.wal_file_number);
         let data = crate::serialize::serialize_to_file_bytes(&wal_contents)
             .expect("unable to serialize wal contents into bytes for file");
         let data = Bytes::from(data);
@@ -375,7 +375,7 @@ impl WalObjectStore {
                 // that came before it:
                 if let Some(last_wal_sequence_number) = last_wal_sequence_number {
                     let last_wal_path =
-                        wal_path(&self.writer_identifier_prefix, last_wal_sequence_number);
+                        wal_path(&self.node_identifier_prefix, last_wal_sequence_number);
                     debug!(
                         ?path,
                         ?last_wal_path,
@@ -427,7 +427,7 @@ impl WalObjectStore {
 
             for idx in oldest..last_to_delete {
                 let path = wal_path(
-                    &self.writer_identifier_prefix,
+                    &self.node_identifier_prefix,
                     WalFileSequenceNumber::new(idx),
                 );
                 debug!(?path, ">>> deleting wal file");
@@ -483,11 +483,11 @@ fn oldest_wal_file_num(all_wal_file_paths: &[Path]) -> Option<WalFileSequenceNum
 
 async fn load_all_wal_file_paths(
     object_store: Arc<dyn ObjectStore>,
-    writer_identifier_prefix: String,
+    node_identifier_prefix: String,
 ) -> Result<Vec<Path>, crate::Error> {
     let mut paths = Vec::new();
     let mut offset: Option<Path> = None;
-    let path = Path::from(format!("{writer}/wal", writer = writer_identifier_prefix));
+    let path = Path::from(format!("{writer}/wal", writer = node_identifier_prefix));
     loop {
         let mut listing = if let Some(offset) = offset {
             object_store.list_with_offset(Some(&path), &offset)
@@ -819,9 +819,9 @@ impl WalBuffer {
     }
 }
 
-pub fn wal_path(writer_identifier_prefix: &str, wal_file_number: WalFileSequenceNumber) -> Path {
+pub fn wal_path(node_identifier_prefix: &str, wal_file_number: WalFileSequenceNumber) -> Path {
     Path::from(format!(
-        "{writer_identifier_prefix}/wal/{:011}.wal",
+        "{node_identifier_prefix}/wal/{:011}.wal",
         wal_file_number.0
     ))
 }

--- a/influxdb3_write/src/lib.rs
+++ b/influxdb3_write/src/lib.rs
@@ -218,8 +218,8 @@ pub struct BufferedWriteRequest {
 /// The collection of Parquet files that were persisted in a snapshot
 #[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Clone)]
 pub struct PersistedSnapshot {
-    /// The writer identifier that persisted this snapshot
-    pub writer_id: String,
+    /// The node identifier that persisted this snapshot
+    pub node_id: String,
     /// The next file id to be used with `ParquetFile`s when the snapshot is loaded
     pub next_file_id: ParquetFileId,
     /// The next db id to be used for databases when the snapshot is loaded
@@ -249,13 +249,13 @@ pub struct PersistedSnapshot {
 
 impl PersistedSnapshot {
     pub fn new(
-        writer_id: String,
+        node_id: String,
         snapshot_sequence_number: SnapshotSequenceNumber,
         wal_file_sequence_number: WalFileSequenceNumber,
         catalog_sequence_number: CatalogSequenceNumber,
     ) -> Self {
         Self {
-            writer_id,
+            node_id,
             next_file_id: ParquetFileId::next_id(),
             next_db_id: DbId::next_id(),
             next_table_id: TableId::next_id(),
@@ -733,7 +733,7 @@ mod tests {
 
         // add dbs_1 to snapshot
         let persisted_snapshot_1 = PersistedSnapshot {
-            writer_id: host.to_string(),
+            node_id: host.to_string(),
             next_file_id: ParquetFileId::from(0),
             next_db_id: DbId::from(1),
             next_table_id: TableId::from(1),
@@ -778,7 +778,7 @@ mod tests {
 
         // add dbs_2 to snapshot
         let persisted_snapshot_2 = PersistedSnapshot {
-            writer_id: host.to_string(),
+            node_id: host.to_string(),
             next_file_id: ParquetFileId::from(5),
             next_db_id: DbId::from(2),
             next_table_id: TableId::from(22),

--- a/influxdb3_write/src/persister.rs
+++ b/influxdb3_write/src/persister.rs
@@ -84,19 +84,19 @@ pub struct Persister {
     /// The interface to the object store being used
     object_store: Arc<dyn ObjectStore>,
     /// Prefix used for all paths in the object store for this persister
-    writer_identifier_prefix: String,
+    node_identifier_prefix: String,
     pub(crate) mem_pool: Arc<dyn MemoryPool>,
 }
 
 impl Persister {
     pub fn new(
         object_store: Arc<dyn ObjectStore>,
-        writer_identifier_prefix: impl Into<String>,
+        node_identifier_prefix: impl Into<String>,
     ) -> Self {
         Self {
             object_store_url: ObjectStoreUrl::parse(DEFAULT_OBJECT_STORE_URL).unwrap(),
             object_store,
-            writer_identifier_prefix: writer_identifier_prefix.into(),
+            node_identifier_prefix: node_identifier_prefix.into(),
             mem_pool: Arc::new(UnboundedMemoryPool::default()),
         }
     }
@@ -114,8 +114,8 @@ impl Persister {
     }
 
     /// Get the host identifier prefix
-    pub fn writer_identifier_prefix(&self) -> &str {
-        &self.writer_identifier_prefix
+    pub fn node_identifier_prefix(&self) -> &str {
+        &self.node_identifier_prefix
     }
 
     /// Try loading the catalog, if there is no catalog generate new
@@ -127,10 +127,8 @@ impl Persister {
                 let uuid = Uuid::new_v4().to_string();
                 let instance_id = Arc::from(uuid.as_str());
                 info!(instance_id = ?instance_id, "Catalog not found, creating new instance id");
-                let new_catalog = Catalog::new(
-                    Arc::from(self.writer_identifier_prefix.as_str()),
-                    instance_id,
-                );
+                let new_catalog =
+                    Catalog::new(Arc::from(self.node_identifier_prefix.as_str()), instance_id);
                 self.persist_catalog(&new_catalog).await?;
                 new_catalog
             }
@@ -144,7 +142,7 @@ impl Persister {
     pub async fn load_catalog(&self) -> Result<Option<InnerCatalog>> {
         let mut list = self
             .object_store
-            .list(Some(&CatalogFilePath::dir(&self.writer_identifier_prefix)));
+            .list(Some(&CatalogFilePath::dir(&self.node_identifier_prefix)));
         let mut catalog_path: Option<ObjPath> = None;
         while let Some(item) = list.next().await {
             let item = item?;
@@ -204,12 +202,12 @@ impl Persister {
 
             let mut snapshot_list = if let Some(offset) = offset {
                 self.object_store.list_with_offset(
-                    Some(&SnapshotInfoFilePath::dir(&self.writer_identifier_prefix)),
+                    Some(&SnapshotInfoFilePath::dir(&self.node_identifier_prefix)),
                     &offset,
                 )
             } else {
                 self.object_store.list(Some(&SnapshotInfoFilePath::dir(
-                    &self.writer_identifier_prefix,
+                    &self.node_identifier_prefix,
                 )))
             };
 
@@ -273,7 +271,7 @@ impl Persister {
     /// be the catalog that is returned the next time `load_catalog` is called.
     pub async fn persist_catalog(&self, catalog: &Catalog) -> Result<()> {
         let catalog_path = CatalogFilePath::new(
-            self.writer_identifier_prefix.as_str(),
+            self.node_identifier_prefix.as_str(),
             catalog.sequence_number(),
         );
         let json = serde_json::to_vec_pretty(&catalog)?;
@@ -282,7 +280,7 @@ impl Persister {
             .await?;
         // It's okay if this fails as it's just cleanup of the old catalog
         // a new persist will come in and clean the old one up.
-        let prefix = self.writer_identifier_prefix.clone();
+        let prefix = self.node_identifier_prefix.clone();
         let obj_store = Arc::clone(&self.object_store);
         tokio::spawn(async move {
             let mut items = Vec::new();
@@ -311,7 +309,7 @@ impl Persister {
     /// Persists the snapshot file
     pub async fn persist_snapshot(&self, persisted_snapshot: &PersistedSnapshot) -> Result<()> {
         let snapshot_file_path = SnapshotInfoFilePath::new(
-            self.writer_identifier_prefix.as_str(),
+            self.node_identifier_prefix.as_str(),
             persisted_snapshot.snapshot_sequence_number,
         );
         let json = serde_json::to_vec_pretty(persisted_snapshot)?;
@@ -458,12 +456,12 @@ mod tests {
 
     #[tokio::test]
     async fn persist_catalog() {
-        let writer_id = Arc::from("sample-host-id");
+        let node_id = Arc::from("sample-host-id");
         let instance_id = Arc::from("sample-instance-id");
         let local_disk =
             LocalFileSystem::new_with_prefix(test_helpers::tmp_dir().unwrap()).unwrap();
         let persister = Persister::new(Arc::new(local_disk), "test_host");
-        let catalog = Catalog::new(writer_id, instance_id);
+        let catalog = Catalog::new(node_id, instance_id);
         let _ = catalog.db_or_create("my_db");
 
         persister.persist_catalog(&catalog).await.unwrap();
@@ -471,13 +469,13 @@ mod tests {
 
     #[tokio::test]
     async fn persist_catalog_with_cleanup() {
-        let writer_id = Arc::from("sample-host-id");
+        let node_id = Arc::from("sample-host-id");
         let instance_id = Arc::from("sample-instance-id");
         let prefix = test_helpers::tmp_dir().unwrap();
         let local_disk = LocalFileSystem::new_with_prefix(prefix).unwrap();
         let obj_store: Arc<dyn ObjectStore> = Arc::new(local_disk);
         let persister = Persister::new(Arc::clone(&obj_store), "test_host");
-        let catalog = Catalog::new(Arc::clone(&writer_id), instance_id);
+        let catalog = Catalog::new(Arc::clone(&node_id), instance_id);
         persister.persist_catalog(&catalog).await.unwrap();
         let db_schema = catalog.db_or_create("my_db_1").unwrap();
         persister.persist_catalog(&catalog).await.unwrap();
@@ -589,17 +587,17 @@ mod tests {
 
     #[tokio::test]
     async fn persist_and_load_newest_catalog() {
-        let writer_id: Arc<str> = Arc::from("sample-host-id");
+        let node_id: Arc<str> = Arc::from("sample-host-id");
         let instance_id: Arc<str> = Arc::from("sample-instance-id");
         let local_disk =
             LocalFileSystem::new_with_prefix(test_helpers::tmp_dir().unwrap()).unwrap();
         let persister = Persister::new(Arc::new(local_disk), "test_host");
-        let catalog = Catalog::new(writer_id.clone(), instance_id.clone());
+        let catalog = Catalog::new(node_id.clone(), instance_id.clone());
         let _ = catalog.db_or_create("my_db");
 
         persister.persist_catalog(&catalog).await.unwrap();
 
-        let catalog = Catalog::new(writer_id.clone(), instance_id.clone());
+        let catalog = Catalog::new(node_id.clone(), instance_id.clone());
         let _ = catalog.db_or_create("my_second_db");
 
         persister.persist_catalog(&catalog).await.unwrap();
@@ -622,7 +620,7 @@ mod tests {
             LocalFileSystem::new_with_prefix(test_helpers::tmp_dir().unwrap()).unwrap();
         let persister = Persister::new(Arc::new(local_disk), "test_host");
         let info_file = PersistedSnapshot {
-            writer_id: "test_host".to_string(),
+            node_id: "test_host".to_string(),
             next_file_id: ParquetFileId::from(0),
             next_db_id: DbId::from(1),
             next_table_id: TableId::from(1),
@@ -646,7 +644,7 @@ mod tests {
             LocalFileSystem::new_with_prefix(test_helpers::tmp_dir().unwrap()).unwrap();
         let persister = Persister::new(Arc::new(local_disk), "test_host");
         let info_file = PersistedSnapshot {
-            writer_id: "test_host".to_string(),
+            node_id: "test_host".to_string(),
             next_file_id: ParquetFileId::from(0),
             next_db_id: DbId::from(1),
             next_table_id: TableId::from(1),
@@ -661,7 +659,7 @@ mod tests {
             parquet_size_bytes: 0,
         };
         let info_file_2 = PersistedSnapshot {
-            writer_id: "test_host".to_string(),
+            node_id: "test_host".to_string(),
             next_file_id: ParquetFileId::from(1),
             next_db_id: DbId::from(1),
             next_table_id: TableId::from(1),
@@ -676,7 +674,7 @@ mod tests {
             parquet_size_bytes: 0,
         };
         let info_file_3 = PersistedSnapshot {
-            writer_id: "test_host".to_string(),
+            node_id: "test_host".to_string(),
             next_file_id: ParquetFileId::from(2),
             next_db_id: DbId::from(1),
             next_table_id: TableId::from(1),
@@ -712,7 +710,7 @@ mod tests {
             LocalFileSystem::new_with_prefix(test_helpers::tmp_dir().unwrap()).unwrap();
         let persister = Persister::new(Arc::new(local_disk), "test_host");
         let info_file = PersistedSnapshot {
-            writer_id: "test_host".to_string(),
+            node_id: "test_host".to_string(),
             next_file_id: ParquetFileId::from(0),
             next_db_id: DbId::from(1),
             next_table_id: TableId::from(1),
@@ -741,7 +739,7 @@ mod tests {
         let persister = Persister::new(Arc::new(local_disk), "test_host");
         for id in 0..1001 {
             let info_file = PersistedSnapshot {
-                writer_id: "test_host".to_string(),
+                node_id: "test_host".to_string(),
                 next_file_id: ParquetFileId::from(id),
                 next_db_id: DbId::from(1),
                 next_table_id: TableId::from(1),
@@ -868,7 +866,7 @@ mod tests {
         ]
         .into();
         let snapshot = PersistedSnapshot {
-            writer_id: "host".to_string(),
+            node_id: "host".to_string(),
             next_file_id: ParquetFileId::new(),
             next_db_id: DbId::new(),
             next_table_id: TableId::new(),
@@ -973,7 +971,7 @@ mod tests {
             {
               "databases": [],
               "sequence": 0,
-              "writer_id": "test_host",
+              "node_id": "test_host",
               "instance_id": "24b1e1bf-b301-4101-affa-e3d668fe7d20",
               "db_map": [],
               "table_map": []

--- a/influxdb3_write/src/snapshots/influxdb3_write__persister__tests__persisted_snapshot_structure.snap
+++ b/influxdb3_write/src/snapshots/influxdb3_write__persister__tests__persisted_snapshot_structure.snap
@@ -3,7 +3,7 @@ source: influxdb3_write/src/persister.rs
 expression: snapshot
 ---
 {
-  "writer_id": "host",
+  "node_id": "host",
   "next_file_id": 8,
   "next_db_id": 2,
   "next_table_id": 4,

--- a/influxdb3_write/src/write_buffer/mod.rs
+++ b/influxdb3_write/src/write_buffer/mod.rs
@@ -220,7 +220,7 @@ impl WriteBufferImpl {
         let wal = WalObjectStore::new(
             Arc::clone(&time_provider),
             persister.object_store(),
-            persister.writer_identifier_prefix(),
+            persister.node_identifier_prefix(),
             Arc::clone(&queryable_buffer) as Arc<dyn WalFileNotifier>,
             wal_config,
             last_wal_sequence_number,
@@ -921,9 +921,9 @@ mod tests {
 
     #[test]
     fn parse_lp_into_buffer() {
-        let writer_id = Arc::from("sample-host-id");
+        let node_id = Arc::from("sample-host-id");
         let instance_id = Arc::from("sample-instance-id");
-        let catalog = Arc::new(Catalog::new(writer_id, instance_id));
+        let catalog = Arc::new(Catalog::new(node_id, instance_id));
         let db_name = NamespaceName::new("foo").unwrap();
         let lp = "cpu,region=west user=23.2 100\nfoo f1=1i";
         WriteValidator::initialize(db_name, Arc::clone(&catalog), 0)
@@ -2573,7 +2573,7 @@ mod tests {
         let total_buffer_size_bytes_before = total_buffer_size_bytes_after;
         debug!(">>> 2nd snapshot..");
         //   PersistedSnapshot{
-        //     writer_id: "test_host",
+        //     node_id: "test_host",
         //     next_file_id: ParquetFileId(1),
         //     next_db_id: DbId(1),
         //     next_table_id: TableId(1),

--- a/influxdb3_write/src/write_buffer/queryable_buffer.rs
+++ b/influxdb3_write/src/write_buffer/queryable_buffer.rs
@@ -201,7 +201,7 @@ impl QueryableBuffer {
                             table_name: Arc::clone(&table_name),
                             chunk_time: chunk.chunk_time,
                             path: ParquetFilePath::new(
-                                self.persister.writer_identifier_prefix(),
+                                self.persister.node_identifier_prefix(),
                                 db_schema.name.as_ref(),
                                 database_id.as_u32(),
                                 table_name.as_ref(),
@@ -269,7 +269,7 @@ impl QueryableBuffer {
             );
             // persist the individual files, building the snapshot as we go
             let mut persisted_snapshot = PersistedSnapshot::new(
-                persister.writer_identifier_prefix().to_string(),
+                persister.node_identifier_prefix().to_string(),
                 snapshot_details.snapshot_sequence_number,
                 snapshot_details.last_wal_sequence_number,
                 catalog.sequence_number(),

--- a/influxdb3_write/src/write_buffer/snapshots/influxdb3_write__write_buffer__tests__catalog-after-last-cache-create-and-new-field.snap
+++ b/influxdb3_write/src/write_buffer/snapshots/influxdb3_write__write_buffer__tests__catalog-after-last-cache-create-and-new-field.snap
@@ -100,6 +100,6 @@ expression: catalog_json
     }
   ],
   "instance_id": "[uuid]",
-  "sequence": 3,
-  "writer_id": "test_host"
+  "node_id": "test_host",
+  "sequence": 3
 }

--- a/influxdb3_write/src/write_buffer/snapshots/influxdb3_write__write_buffer__tests__catalog-immediately-after-last-cache-create.snap
+++ b/influxdb3_write/src/write_buffer/snapshots/influxdb3_write__write_buffer__tests__catalog-immediately-after-last-cache-create.snap
@@ -90,6 +90,6 @@ expression: catalog_json
     }
   ],
   "instance_id": "[uuid]",
-  "sequence": 2,
-  "writer_id": "test_host"
+  "node_id": "test_host",
+  "sequence": 2
 }

--- a/influxdb3_write/src/write_buffer/snapshots/influxdb3_write__write_buffer__tests__catalog-immediately-after-last-cache-delete.snap
+++ b/influxdb3_write/src/write_buffer/snapshots/influxdb3_write__write_buffer__tests__catalog-immediately-after-last-cache-delete.snap
@@ -87,6 +87,6 @@ expression: catalog_json
     }
   ],
   "instance_id": "[uuid]",
-  "sequence": 4,
-  "writer_id": "test_host"
+  "node_id": "test_host",
+  "sequence": 4
 }

--- a/influxdb3_write/src/write_buffer/validator.rs
+++ b/influxdb3_write/src/write_buffer/validator.rs
@@ -509,10 +509,10 @@ mod tests {
 
     #[test]
     fn write_validator_v1() -> Result<(), Error> {
-        let writer_id = Arc::from("sample-host-id");
+        let node_id = Arc::from("sample-host-id");
         let instance_id = Arc::from("sample-instance-id");
         let namespace = NamespaceName::new("test").unwrap();
-        let catalog = Arc::new(Catalog::new(writer_id, instance_id));
+        let catalog = Arc::new(Catalog::new(node_id, instance_id));
         let result = WriteValidator::initialize(namespace.clone(), Arc::clone(&catalog), 0)
             .unwrap()
             .v1_parse_lines_and_update_schema(

--- a/install_influxdb.sh
+++ b/install_influxdb.sh
@@ -111,7 +111,7 @@ case "$INSTALL_TYPE" in
         printf "${BOLD}NEXT STEPS${NC}\n"
         printf "1) Run the Docker image:\n"
         printf "   ├─ ${BOLD}mkdir plugins${NC} ${DIM}(To store and access plugins)${NC}\n"
-        printf "   └─ ${BOLD}docker run -it -p ${PORT}:${PORT} -v ./plugins:/plugins influxdb3-${EDITION_TAG} serve --object-store memory --writer-id writer0 --plugin-dir /plugins${NC} ${DIM}(To start)${NC}\n"
+        printf "   └─ ${BOLD}docker run -it -p ${PORT}:${PORT} -v ./plugins:/plugins influxdb3-${EDITION_TAG} serve --object-store memory --node-id nodeNodeNodeNodeNodenodeNODENODENODEnodeNodeNODEnodeNODEnodeNODE/plugins${NC} ${DIM}(To start)${NC}\n"
         printf "2) View documentation at \033[4;94mhttps://docs.influxdata.com/influxdb3/${EDITION_TAG}/${NC}\n\n"
 
         END_TIME=$(date +%s)
@@ -193,13 +193,13 @@ if [ "${EDITION}" = "Core" ]; then
     printf "└─ Start InfluxDB Now? (y/n): "
     read -r START_SERVICE
     if echo "$START_SERVICE" | grep -q "^[Yy]$" ; then
-        # Prompt for Writer ID
+        # Prompt for Node ID
         echo
-        printf "${BOLD}Enter Your Writer ID${NC}\n"
-        printf "├─ A Writer ID is a unique, uneditable identifier for a service.\n"
-        printf "└─ Enter a Writer ID (default: writer0): "
-        read -r WRITER_ID
-        WRITER_ID=${WRITER_ID:-writer0}
+        printf "${BOLD}Enter Your Node ID${NC}\n"
+        printf "├─ A Node ID is a unique, uneditable identifier for a service.\n"
+        printf "└─ Enter a Node ID (default: node0): "
+        read -r NODE_ID
+        NODE_ID=${NODE_ID:-node0}
 
         # Prompt for storage solution
         echo
@@ -328,10 +328,10 @@ if [ "${EDITION}" = "Core" ]; then
         # Start and give up to 30 seconds to respond
         echo
         printf "${BOLD}Starting InfluxDB${NC}\n"
-        printf "├─${DIM} Writer ID: %s${NC}\n" "$WRITER_ID"
+        printf "├─${DIM} Node ID: %s${NC}\n" "$NODE_ID"
         printf "├─${DIM} Storage: %s${NC}\n" "$STORAGE_TYPE"
-        printf "├─${DIM} '%s' serve --writer-id='%s' --http-bind='0.0.0.0:%s' %s${NC}\n" "$INSTALL_LOC/$BINARY_NAME" "$WRITER_ID" "$PORT" "$STORAGE_FLAGS_ECHO"
-        "$INSTALL_LOC/$BINARY_NAME" serve --writer-id="$WRITER_ID" --http-bind="0.0.0.0:$PORT" $STORAGE_FLAGS > /dev/null &
+        printf "├─${DIM} '%s' serve --node-id='%s' --http-bind='0.0.0.0:%s' %s${NC}\n" "$INSTALL_LOC/$BINARY_NAME" "$NODE_ID" "$PORT" "$STORAGE_FLAGS_ECHO"
+        "$INSTALL_LOC/$BINARY_NAME" serve --node-id="$NODE_ID" --http-bind="0.0.0.0:$PORT" $STORAGE_FLAGS > /dev/null &
         PID="$!"
 
         SUCCESS=0

--- a/install_influxdb3.sh
+++ b/install_influxdb3.sh
@@ -111,7 +111,7 @@ case "$INSTALL_TYPE" in
         printf "${BOLD}NEXT STEPS${NC}\n"
         printf "1) Run the Docker image:\n"
         printf "   ├─ ${BOLD}mkdir plugins${NC} ${DIM}(To store and access plugins)${NC}\n"
-        printf "   └─ ${BOLD}docker run -it -p ${PORT}:${PORT} -v ./plugins:/plugins influxdb3-${EDITION_TAG} serve --object-store memory --writer-id writer0 --plugin-dir /plugins${NC} ${DIM}(To start)${NC}\n"
+        printf "   └─ ${BOLD}docker run -it -p ${PORT}:${PORT} -v ./plugins:/plugins influxdb3-${EDITION_TAG} serve --object-store memory --node-id node --plugin-dir /plugins${NC} ${DIM}(To start)${NC}\n"
         printf "2) View documentation at \033[4;94mhttps://docs.influxdata.com/influxdb3/${EDITION_TAG}/${NC}\n\n"
 
         END_TIME=$(date +%s)
@@ -193,13 +193,13 @@ if [ "${EDITION}" = "Core" ]; then
     printf "└─ Start InfluxDB Now? (y/n): "
     read -r START_SERVICE
     if echo "$START_SERVICE" | grep -q "^[Yy]$" ; then
-        # Prompt for Writer ID
+        # Prompt for Node ID
         echo
-        printf "${BOLD}Enter Your Writer ID${NC}\n"
-        printf "├─ A Writer ID is a unique, uneditable identifier for a service.\n"
-        printf "└─ Enter a Writer ID (default: writer0): "
-        read -r WRITER_ID
-        WRITER_ID=${WRITER_ID:-writer0}
+        printf "${BOLD}Enter Your Node ID${NC}\n"
+        printf "├─ A Node ID is a unique, uneditable identifier for a service.\n"
+        printf "└─ Enter a Node ID (default: node0): "
+        read -r NODE_ID
+        NODE_ID=${NODE_ID:-node0}
 
         # Prompt for storage solution
         echo
@@ -328,10 +328,10 @@ if [ "${EDITION}" = "Core" ]; then
         # Start and give up to 30 seconds to respond
         echo
         printf "${BOLD}Starting InfluxDB${NC}\n"
-        printf "├─${DIM} Writer ID: %s${NC}\n" "$WRITER_ID"
+        printf "├─${DIM} Node ID: %s${NC}\n" "$NODE_ID"
         printf "├─${DIM} Storage: %s${NC}\n" "$STORAGE_TYPE"
-        printf "├─${DIM} '%s' serve --writer-id='%s' --http-bind='0.0.0.0:%s' %s${NC}\n" "$INSTALL_LOC/$BINARY_NAME" "$WRITER_ID" "$PORT" "$STORAGE_FLAGS_ECHO"
-        "$INSTALL_LOC/$BINARY_NAME" serve --writer-id="$WRITER_ID" --http-bind="0.0.0.0:$PORT" $STORAGE_FLAGS > /dev/null &
+        printf "├─${DIM} '%s' serve --node-id='%s' --http-bind='0.0.0.0:%s' %s${NC}\n" "$INSTALL_LOC/$BINARY_NAME" "$NODE_ID" "$PORT" "$STORAGE_FLAGS_ECHO"
+        "$INSTALL_LOC/$BINARY_NAME" serve --node-id="$NODE_ID" --http-bind="0.0.0.0:$PORT" $STORAGE_FLAGS > /dev/null &
         PID="$!"
 
         SUCCESS=0


### PR DESCRIPTION
Related: https://github.com/influxdata/influxdb_pro/issues/429

This changes the naming of the identifier used to uniquely identify an InfluxDB 3 server from `writer-id` to `node-id`.

Therefore, the argument that is passed on server start will now be `--node-id` (not `--writer-id`, or previously `--host-id`).

This PR makes changes of naming throughout the codebase so that struct fields, variable names, function arguments, etc. all follow the new naming convention.
