### PR TITLE
fix: add alias for node_id to writer_id for backward compatibility

### DIFF
--- a/influxdb3_catalog/src/catalog.rs
+++ b/influxdb3_catalog/src/catalog.rs
@@ -374,6 +374,8 @@ pub struct InnerCatalog {
     sequence: CatalogSequenceNumber,
     /// The `node_id` is the prefix that is passed in when starting up
     /// (`node_identifier_prefix`)
+    // TODO: deprecate this alias
+    #[serde(alias = "writer_id")]
     node_id: Arc<str>,
     /// The instance_id uniquely identifies the instance that generated the catalog
     instance_id: Arc<str>,

--- a/influxdb3_write/src/lib.rs
+++ b/influxdb3_write/src/lib.rs
@@ -219,6 +219,8 @@ pub struct BufferedWriteRequest {
 #[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Clone)]
 pub struct PersistedSnapshot {
     /// The node identifier that persisted this snapshot
+    // TODO: deprecate this alias
+    #[serde(alias = "writer_id")]
     pub node_id: String,
     /// The next file id to be used with `ParquetFile`s when the snapshot is loaded
     pub next_file_id: ParquetFileId,


### PR DESCRIPTION
This change is to reduce friction from the recent change from `writer-id` to `node-id` in https://github.com/influxdata/influxdb/pull/25905 by adding deserialization aliases to the catalog and snapshot types so that existing catalog and snapshot JSON files will still successfully deserialize without users needing to start completely from scratch.

Any users that have been running since the alpha release will have catalog and snapshot files written with `writer_id`. This will still support those files, but write new ones with the `node_id` field name going forward.