### PR TITLE
feat: Update trigger creation to validate plugin file present

### DIFF
--- a/influxdb3/src/commands/create.rs
+++ b/influxdb3/src/commands/create.rs
@@ -358,7 +358,8 @@ pub async fn command(config: Config) -> Result<(), Box<dyn Error>> {
                     .collect::<HashMap<String, String>>()
             });
 
-            client
+            //println!("does this work?");
+            match client
                 .api_v3_configure_processing_engine_trigger_create(
                     database_name,
                     &trigger_name,
@@ -367,8 +368,14 @@ pub async fn command(config: Config) -> Result<(), Box<dyn Error>> {
                     trigger_arguments,
                     disabled,
                 )
-                .await?;
-            println!("Trigger {} created successfully", trigger_name);
+                .await
+            {
+                Err(e) => {
+                    eprintln!("Failed to create trigger: {}", e);
+                    return Err(e.into());
+                }
+                Ok(_) => println!("Trigger {} created successfully", trigger_name),
+            }
         }
     }
     Ok(())

--- a/influxdb3_processing_engine/src/manager.rs
+++ b/influxdb3_processing_engine/src/manager.rs
@@ -33,7 +33,7 @@ pub enum ProcessingEngineError {
     PluginNotFound(String),
 
     #[error("plugin error: {0}")]
-    PluginError(#[from] crate::plugins::Error),
+    PluginError(#[from] crate::plugins::PluginError),
 
     #[error("failed to shutdown trigger {trigger_name} in database {database}")]
     TriggerShutdownError {
@@ -99,13 +99,13 @@ pub trait ProcessingEngineManager: Debug + Send + Sync + 'static {
         &self,
         request: WalPluginTestRequest,
         query_executor: Arc<dyn QueryExecutor>,
-    ) -> Result<WalPluginTestResponse, crate::plugins::Error>;
+    ) -> Result<WalPluginTestResponse, crate::plugins::PluginError>;
 
     async fn test_schedule_plugin(
         &self,
         request: SchedulePluginTestRequest,
         query_executor: Arc<dyn QueryExecutor>,
-    ) -> Result<SchedulePluginTestResponse, crate::plugins::Error>;
+    ) -> Result<SchedulePluginTestResponse, crate::plugins::PluginError>;
 
     async fn request_trigger(
         &self,

--- a/influxdb3_processing_engine/src/plugins.rs
+++ b/influxdb3_processing_engine/src/plugins.rs
@@ -31,7 +31,7 @@ use thiserror::Error;
 use tokio::sync::mpsc;
 
 #[derive(Debug, Error)]
-pub enum Error {
+pub enum PluginError {
     #[error("invalid database {0}")]
     InvalidDatabase(String),
 
@@ -68,6 +68,9 @@ pub enum Error {
 
     #[error("non-schedule plugin with schedule trigger: {0}")]
     NonSchedulePluginWithScheduleTrigger(String),
+
+    #[error("error reading file from Github: {0} {1}")]
+    FetchingFromGithub(reqwest::StatusCode, String),
 }
 
 #[cfg(feature = "system-py")]
@@ -101,11 +104,11 @@ pub(crate) fn run_schedule_plugin(
     time_provider: Arc<dyn TimeProvider>,
     context: PluginContext,
     plugin_receiver: mpsc::Receiver<ScheduleEvent>,
-) -> Result<(), Error> {
+) -> Result<(), PluginError> {
     // Ensure that the plugin is a schedule plugin
     let plugin_type = trigger_definition.trigger.plugin_type();
     if !matches!(plugin_type, influxdb3_wal::PluginType::Schedule) {
-        return Err(Error::NonSchedulePluginWithScheduleTrigger(format!(
+        return Err(PluginError::NonSchedulePluginWithScheduleTrigger(format!(
             "{:?}",
             trigger_definition
         )));
@@ -201,7 +204,7 @@ mod python_plugin {
         pub(crate) async fn run_wal_contents_plugin(
             &self,
             mut receiver: Receiver<WalEvent>,
-        ) -> Result<(), Error> {
+        ) -> Result<(), PluginError> {
             info!(?self.trigger_definition.trigger_name, ?self.trigger_definition.database_name, ?self.trigger_definition.plugin_filename, "starting wal contents plugin");
 
             loop {
@@ -220,7 +223,7 @@ mod python_plugin {
                         }
                     }
                     WalEvent::Shutdown(sender) => {
-                        sender.send(()).map_err(|_| Error::FailedToShutdown)?;
+                        sender.send(()).map_err(|_| PluginError::FailedToShutdown)?;
                         break;
                     }
                 }
@@ -234,7 +237,7 @@ mod python_plugin {
             mut receiver: Receiver<ScheduleEvent>,
             mut runner: ScheduleTriggerRunner,
             time_provider: Arc<dyn TimeProvider>,
-        ) -> Result<(), Error> {
+        ) -> Result<(), PluginError> {
             loop {
                 let Some(next_run_instant) = runner.next_run_time() else {
                     break;
@@ -243,7 +246,7 @@ mod python_plugin {
                 tokio::select! {
                     _ = time_provider.sleep_until(next_run_instant) => {
                         let Some(schema) = self.write_buffer.catalog().db_schema(self.db_name.as_str()) else {
-                            return Err(Error::MissingDb);
+                            return Err(PluginError::MissingDb);
                         };
                         runner.run_at_time(self, schema).await?;
                     }
@@ -254,7 +257,7 @@ mod python_plugin {
                                 break;
                             }
                             Some(ScheduleEvent::Shutdown(sender)) => {
-                                sender.send(()).map_err(|_| Error::FailedToShutdown)?;
+                                sender.send(()).map_err(|_| PluginError::FailedToShutdown)?;
                                 break;
                             }
                         }
@@ -268,7 +271,7 @@ mod python_plugin {
         pub(crate) async fn run_request_plugin(
             &self,
             mut receiver: Receiver<RequestEvent>,
-        ) -> Result<(), Error> {
+        ) -> Result<(), PluginError> {
             info!(?self.trigger_definition.trigger_name, ?self.trigger_definition.database_name, ?self.trigger_definition.plugin_filename, "starting request plugin");
 
             loop {
@@ -282,7 +285,7 @@ mod python_plugin {
                             self.write_buffer.catalog().db_schema(self.db_name.as_str())
                         else {
                             error!(?self.trigger_definition, "missing db schema");
-                            return Err(Error::MissingDb);
+                            return Err(PluginError::MissingDb);
                         };
                         let result = execute_request_trigger(
                             self.plugin_code.code().as_ref(),
@@ -340,7 +343,7 @@ mod python_plugin {
                         }
                     }
                     Some(RequestEvent::Shutdown(sender)) => {
-                        sender.send(()).map_err(|_| Error::FailedToShutdown)?;
+                        sender.send(()).map_err(|_| PluginError::FailedToShutdown)?;
                         break;
                     }
                 }
@@ -349,9 +352,12 @@ mod python_plugin {
             Ok(())
         }
 
-        async fn process_wal_contents(&self, wal_contents: Arc<WalContents>) -> Result<(), Error> {
+        async fn process_wal_contents(
+            &self,
+            wal_contents: Arc<WalContents>,
+        ) -> Result<(), PluginError> {
             let Some(schema) = self.write_buffer.catalog().db_schema(self.db_name.as_str()) else {
-                return Err(Error::MissingDb);
+                return Err(PluginError::MissingDb);
             };
 
             for wal_op in &wal_contents.ops {
@@ -481,7 +487,7 @@ mod python_plugin {
         pub(crate) fn try_new(
             trigger_spec: &TriggerSpecificationDefinition,
             time_provider: Arc<dyn TimeProvider>,
-        ) -> Result<Self, Error> {
+        ) -> Result<Self, PluginError> {
             match trigger_spec {
                 TriggerSpecificationDefinition::AllTablesWalWrite
                 | TriggerSpecificationDefinition::SingleTableWalWrite { .. } => {
@@ -538,7 +544,7 @@ mod python_plugin {
             &mut self,
             plugin: &TriggerPlugin,
             db_schema: Arc<DatabaseSchema>,
-        ) -> Result<(), Error> {
+        ) -> Result<(), PluginError> {
             let Some(trigger_time) = self.next_trigger_time else {
                 return Err(anyhow!("running a cron trigger that is finished.").into());
             };
@@ -584,7 +590,7 @@ pub(crate) fn run_test_wal_plugin(
     query_executor: Arc<dyn QueryExecutor>,
     code: String,
     request: WalPluginTestRequest,
-) -> Result<WalPluginTestResponse, Error> {
+) -> Result<WalPluginTestResponse, PluginError> {
     use data_types::NamespaceName;
     use influxdb3_wal::Gen1Duration;
     use influxdb3_write::write_buffer::validator::WriteValidator;
@@ -592,7 +598,7 @@ pub(crate) fn run_test_wal_plugin(
 
     let database = request.database;
     let namespace = NamespaceName::new(database.clone())
-        .map_err(|_e| Error::InvalidDatabase(database.clone()))?;
+        .map_err(|_e| PluginError::InvalidDatabase(database.clone()))?;
     // parse the lp into a write batch
     let validator = WriteValidator::initialize(
         namespace.clone(),
@@ -606,7 +612,7 @@ pub(crate) fn run_test_wal_plugin(
         Precision::Nanosecond,
     )?;
     let data = data.convert_lines_to_buffer(Gen1Duration::new_1m());
-    let db = catalog.db_schema(&database).ok_or(Error::MissingDb)?;
+    let db = catalog.db_schema(&database).ok_or(PluginError::MissingDb)?;
 
     let plugin_return_state = influxdb3_py_api::system_py::execute_python_with_batch(
         &code,
@@ -722,15 +728,17 @@ pub(crate) fn run_test_schedule_plugin(
     query_executor: Arc<dyn QueryExecutor>,
     code: String,
     request: influxdb3_client::plugin_development::SchedulePluginTestRequest,
-) -> Result<influxdb3_client::plugin_development::SchedulePluginTestResponse, Error> {
+) -> Result<influxdb3_client::plugin_development::SchedulePluginTestResponse, PluginError> {
     let database = request.database;
-    let db = catalog.db_schema(&database).ok_or(Error::MissingDb)?;
+    let db = catalog.db_schema(&database).ok_or(PluginError::MissingDb)?;
 
     let cron_schedule = request.schedule.as_deref().unwrap_or("* * * * * *");
 
     let schedule = cron::Schedule::from_str(cron_schedule)?;
     let Some(schedule_time) = schedule.after(&now_time.date_time()).next() else {
-        return Err(Error::CronScheduleNeverTriggers(cron_schedule.to_string()));
+        return Err(PluginError::CronScheduleNeverTriggers(
+            cron_schedule.to_string(),
+        ));
     };
 
     let plugin_return_state = influxdb3_py_api::system_py::execute_schedule_trigger(

--- a/influxdb3_server/src/http.rs
+++ b/influxdb3_server/src/http.rs
@@ -220,7 +220,7 @@ pub enum Error {
     PythonPluginsNotEnabled,
 
     #[error("Plugin error: {0}")]
-    Plugin(#[from] influxdb3_processing_engine::plugins::Error),
+    Plugin(#[from] influxdb3_processing_engine::plugins::PluginError),
 
     #[error("Processing engine error: {0}")]
     ProcessingEngine(#[from] influxdb3_processing_engine::manager::ProcessingEngineError),


### PR DESCRIPTION
This updates trigger creation to load the plugin file before creating the trigger.

Another small change is to make Github references use filenames and paths identical to what they would be in the plugin-dir. This makes it a little easier to have the plugins repo local and develop against it and then be able to reference the same file later with gh: once it's up on the repo.

In draft until #25914  gets merged in