### PR TITLE
fix: last cache with specific value columns can be queried

### DIFF
--- a/influxdb3_cache/src/last_cache/mod.rs
+++ b/influxdb3_cache/src/last_cache/mod.rs
@@ -1631,4 +1631,66 @@ mod tests {
             );
         }
     }
+
+    #[test_log::test(tokio::test)]
+    async fn test_non_specified_key_val_cols() {
+        let writer = TestWriter::new();
+        let _ = writer.write_lp_to_write_batch("cpu,region=us-east,host=a usage=99,temp=88", 0);
+
+        // create a last cache provider so we can use it to create our UDTF provider:
+        let db_schema = writer.db_schema();
+        let table_def = db_schema.table_definition("cpu").unwrap();
+        let provider = LastCacheProvider::new_from_catalog(writer.catalog()).unwrap();
+        let usage_col_id = table_def.column_name_to_id("usage").unwrap();
+        provider
+            .create_cache(
+                db_schema.id,
+                None,
+                CreateLastCacheArgs {
+                    table_def,
+                    count: LastCacheSize::default(),
+                    ttl: LastCacheTtl::default(),
+                    key_columns: LastCacheKeyColumnsArg::SeriesKey,
+                    value_columns: LastCacheValueColumnsArg::Explicit(vec![usage_col_id]),
+                },
+            )
+            .unwrap();
+
+        let write_batch = writer.write_lp_to_write_batch(
+            "\
+            cpu,region=us-east,host=a usage=77,temp=66\n\
+            cpu,region=us-east,host=b usage=77,temp=66\n\
+            cpu,region=us-west,host=c usage=77,temp=66\n\
+            cpu,region=us-west,host=d usage=77,temp=66\n\
+            cpu,region=ca-east,host=e usage=77,temp=66\n\
+            cpu,region=ca-cent,host=f usage=77,temp=66\n\
+            cpu,region=ca-west,host=g usage=77,temp=66\n\
+            cpu,region=ca-west,host=h usage=77,temp=66\n\
+            cpu,region=eu-cent,host=i usage=77,temp=66\n\
+            cpu,region=eu-cent,host=j usage=77,temp=66\n\
+            cpu,region=eu-west,host=k usage=77,temp=66\n\
+            cpu,region=eu-west,host=l usage=77,temp=66\n\
+            ",
+            1_000,
+        );
+
+        let wal_contents = influxdb3_wal::create::wal_contents(
+            (0, 1, 0),
+            [influxdb3_wal::create::write_batch_op(write_batch)],
+        );
+        provider.write_wal_contents_to_cache(&wal_contents);
+
+        let ctx = SessionContext::new();
+        let last_cache_fn = LastCacheFunction::new(db_schema.id, Arc::clone(&provider));
+        ctx.register_udtf(LAST_CACHE_UDTF_NAME, Arc::new(last_cache_fn));
+
+        let results = ctx
+            .sql("select * from last_cache('cpu')")
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .unwrap();
+        assert_batches_sorted_eq!([""], &results);
+    }
 }


### PR DESCRIPTION
Closes #25923
Closes #25922

This fixes last cache construction when an explicit set of value columns is provided. As a result, such caches will be queryable.

A test to verify, i.e., from the reproducer, was added.