### PR TITLE
feat: upgrade go to 1.23.5 (#25925)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ orbs:
 parameters:
   cross-container-tag:
     type: string
-    default: go1.22.11-latest
+    default: go1.23.5-latest
 
   workflow:
     type: string
@@ -346,7 +346,7 @@ jobs:
       - run:
           name: staticcheck
           command: |
-            go install honnef.co/go/tools/cmd/staticcheck
+            go install honnef.co/go/tools/cmd/staticcheck@2024.1.1
             staticcheck ./...
           when: always
 

--- a/dbrp/http_server_dbrp_test.go
+++ b/dbrp/http_server_dbrp_test.go
@@ -307,7 +307,7 @@ func Test_handleGetDBRPs(t *testing.T) {
 			}
 
 			if !cmp.Equal(tt.ExpectedDBRPs, dbrps.Content) {
-				t.Fatalf(cmp.Diff(tt.ExpectedDBRPs, dbrps.Content))
+				t.Fatal(cmp.Diff(tt.ExpectedDBRPs, dbrps.Content))
 			}
 
 		})
@@ -432,7 +432,7 @@ func Test_handlePatchDBRP(t *testing.T) {
 			}
 
 			if !cmp.Equal(tt.ExpectedDBRP, dbrpResponse.Content) {
-				t.Fatalf(cmp.Diff(tt.ExpectedDBRP, dbrpResponse.Content))
+				t.Fatal(cmp.Diff(tt.ExpectedDBRP, dbrpResponse.Content))
 			}
 		})
 	}

--- a/flux/client.go
+++ b/flux/client.go
@@ -3,6 +3,7 @@ package flux
 import (
 	"context"
 	"crypto/tls"
+	errors2 "errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -78,7 +79,7 @@ func (c *Client) ping(u *url.URL) error {
 	}
 
 	if resp.StatusCode != http.StatusNoContent {
-		var err = fmt.Errorf(string(body))
+		var err = errors2.New(string(body))
 		return err
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/influxdata/influxdb/v2
 
-go 1.22.0
+go 1.23.0
 
-toolchain go1.22.11
+toolchain go1.23.5
 
 require (
 	github.com/BurntSushi/toml v1.2.1

--- a/http/check_test.go
+++ b/http/check_test.go
@@ -635,7 +635,7 @@ func TestService_handleGetCheck(t *testing.T) {
 			res := w.Result()
 			content := res.Header.Get("Content-Type")
 			body, _ := io.ReadAll(res.Body)
-			t.Logf(res.Header.Get("X-Influx-Error"))
+			t.Log(res.Header.Get("X-Influx-Error"))
 
 			if res.StatusCode != tt.wants.statusCode {
 				t.Errorf("%q. handleGetCheck() = %v, want %v", tt.name, res.StatusCode, tt.wants.statusCode)

--- a/http/notification_endpoint_test.go
+++ b/http/notification_endpoint_test.go
@@ -385,7 +385,7 @@ func TestService_handleGetNotificationEndpoint(t *testing.T) {
 			res := w.Result()
 			content := res.Header.Get("Content-Type")
 			body, _ := io.ReadAll(res.Body)
-			t.Logf(res.Header.Get("X-Influx-Error"))
+			t.Log(res.Header.Get("X-Influx-Error"))
 
 			if res.StatusCode != tt.wants.statusCode {
 				t.Errorf("%q. handleGetNotificationEndpoint() = %v, want %v", tt.name, res.StatusCode, tt.wants.statusCode)

--- a/http/resources_test.go
+++ b/http/resources_test.go
@@ -51,7 +51,7 @@ func TestResourceListHandler(t *testing.T) {
 	resp := w.Result()
 	body, _ := io.ReadAll(resp.Body)
 	if resp.StatusCode != http.StatusOK {
-		t.Logf(string(body))
+		t.Log(string(body))
 		t.Errorf("unexpected status: %s", resp.Status)
 	}
 

--- a/kit/platform/id_test.go
+++ b/kit/platform/id_test.go
@@ -78,7 +78,7 @@ func TestDecodeFromString(t *testing.T) {
 	var id platform.ID
 	err := id.DecodeFromString("020f755c3c082000")
 	if err != nil {
-		t.Errorf(err.Error())
+		t.Error(err.Error())
 	}
 	want := []byte{48, 50, 48, 102, 55, 53, 53, 99, 51, 99, 48, 56, 50, 48, 48, 48}
 	got, _ := id.Encode()
@@ -164,12 +164,12 @@ func TestMarshalling(t *testing.T) {
 	init := "ca55e77eca55e77e"
 	id1, err := platform.IDFromString(init)
 	if err != nil {
-		t.Errorf(err.Error())
+		t.Error(err.Error())
 	}
 
 	serialized, err := json.Marshal(id1)
 	if err != nil {
-		t.Errorf(err.Error())
+		t.Error(err.Error())
 	}
 
 	var id2 platform.ID

--- a/notification/check/threshold.go
+++ b/notification/check/threshold.go
@@ -2,6 +2,7 @@ package check
 
 import (
 	"encoding/json"
+	errors2 "errors"
 	"fmt"
 	"strings"
 
@@ -101,7 +102,7 @@ func multiError(errs []error) error {
 		b.WriteString(err.Error() + "\n")
 	}
 
-	return fmt.Errorf(b.String())
+	return errors2.New(b.String())
 }
 
 // GenerateFlux returns a flux script for the threshold provided. If there

--- a/pkger/service_test.go
+++ b/pkger/service_test.go
@@ -5163,7 +5163,7 @@ func TestService(t *testing.T) {
 			}
 			dashSVC := mock.NewDashboardService()
 			dashSVC.FindDashboardsF = func(_ context.Context, f influxdb.DashboardFilter, _ influxdb.FindOptions) ([]*influxdb.Dashboard, int, error) {
-				if (f.IDs != nil && len(f.IDs) > 0 &&
+				if (len(f.IDs) > 0 &&
 					f.IDs[0] != nil && *f.IDs[0] != dash.ID) &&
 					(f.OrganizationID == nil || *f.OrganizationID != orgID) {
 					return nil, 0, errors.New("not suppose to get here")

--- a/task/taskmodel/task_test.go
+++ b/task/taskmodel/task_test.go
@@ -152,7 +152,7 @@ from(bucket: "x") |> range(start: -1h)
 			t.Fatalf("expected Cron to be \"\" but was %s", op.Cron)
 		}
 		if !cmp.Equal(*tu.Flux, expscript) {
-			t.Fatalf(cmp.Diff(*tu.Flux, expscript))
+			t.Fatal(cmp.Diff(*tu.Flux, expscript))
 		}
 	})
 

--- a/telegraf.go
+++ b/telegraf.go
@@ -131,7 +131,7 @@ func (tc *TelegrafConfig) UnmarshalJSON(b []byte) error {
 				"buckets": []string{},
 			}
 		}
-	} else if tcd.Metadata == nil || len(tcd.Metadata) == 0 {
+	} else if len(tcd.Metadata) == 0 {
 		// Get buckets from the config.
 		m, err := parseMetadata(tc.Config)
 		if err != nil {

--- a/tsdb/engine/tsm1/file_store_test.go
+++ b/tsdb/engine/tsm1/file_store_test.go
@@ -2,6 +2,7 @@ package tsm1_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -2430,12 +2431,12 @@ func TestFileStore_OpenFail(t *testing.T) {
 	const mmapErrMsg = "mmap failure in test"
 	const fullMmapErrMsg = "system limit for vm.max_map_count may be too low: " + mmapErrMsg
 	// With an mmap failure, the files should all be left where they are, because they are not corrupt
-	openFail(t, dir, fullMmapErrMsg, tsm1.NewMmapError(fmt.Errorf(mmapErrMsg)))
+	openFail(t, dir, fullMmapErrMsg, tsm1.NewMmapError(errors.New(mmapErrMsg)))
 	assert.FileExistsf(t, f, "file not found, but should not have been moved for mmap failure")
 
 	// With a non-mmap failure, the file failing to open should be moved aside
 	const otherErrMsg = "some Random Init Failure"
-	openFail(t, dir, otherErrMsg, fmt.Errorf(otherErrMsg))
+	openFail(t, dir, otherErrMsg, errors.New(otherErrMsg))
 	assert.NoFileExistsf(t, f, "file found, but should have been moved for open failure")
 	assert.FileExistsf(t, f+"."+tsm1.BadTSMFileExtension, "file not found, but should have been moved here for open failure")
 }

--- a/tsdb/shard_test.go
+++ b/tsdb/shard_test.go
@@ -66,13 +66,13 @@ func TestShardWriteAndIndex(t *testing.T) {
 
 	err := sh.WritePoints(context.Background(), []models.Point{pt})
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err.Error())
 	}
 
 	pt.SetTime(time.Unix(2, 3))
 	err = sh.WritePoints(context.Background(), []models.Point{pt})
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err.Error())
 	}
 
 	validateIndex := func() {
@@ -98,7 +98,7 @@ func TestShardWriteAndIndex(t *testing.T) {
 	pt.SetTime(time.Unix(2, 6))
 	err = sh.WritePoints(context.Background(), []models.Point{pt})
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err.Error())
 	}
 
 	sh.Close()
@@ -129,13 +129,13 @@ func TestShardRebuildIndex(t *testing.T) {
 
 	err := sh.WritePoints(context.Background(), []models.Point{pt})
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err.Error())
 	}
 
 	pt.SetTime(time.Unix(2, 3))
 	err = sh.WritePoints(context.Background(), []models.Point{pt})
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err.Error())
 	}
 
 	indexPath := filepath.Join(tmpShard, "index")
@@ -160,10 +160,10 @@ func TestShardRebuildIndex(t *testing.T) {
 	// ensure the index gets rebuilt after its directory is deleted and
 	// the shard is reopened.
 	if err := sh.Close(); err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err.Error())
 	}
 	if err := os.RemoveAll(indexPath); err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err.Error())
 	}
 
 	sh = tsdb.NewShard(1, tmpShard, tmpWal, sfile.SeriesFile, opts)
@@ -177,7 +177,7 @@ func TestShardRebuildIndex(t *testing.T) {
 	pt.SetTime(time.Unix(2, 6))
 	err = sh.WritePoints(context.Background(), []models.Point{pt})
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err.Error())
 	}
 
 	sh.Close()
@@ -216,7 +216,7 @@ func TestShard_Open_CorruptFieldsIndex(t *testing.T) {
 
 	err := sh.WritePoints(context.Background(), []models.Point{pt})
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err.Error())
 	}
 
 	if err := sh.Close(); err != nil {
@@ -342,7 +342,7 @@ func TestShardWriteAddNewField(t *testing.T) {
 
 	err := sh.WritePoints(context.Background(), []models.Point{pt})
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err.Error())
 	}
 
 	pt = models.MustNewPoint(
@@ -354,7 +354,7 @@ func TestShardWriteAddNewField(t *testing.T) {
 
 	err = sh.WritePoints(context.Background(), []models.Point{pt})
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err.Error())
 	}
 
 	if got, exp := sh.SeriesN(), int64(1); got != exp {
@@ -629,7 +629,7 @@ func TestShard_Close_RemoveIndex(t *testing.T) {
 
 	err := sh.WritePoints(context.Background(), []models.Point{pt})
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err.Error())
 	}
 
 	if got, exp := sh.SeriesN(), int64(1); got != exp {


### PR DESCRIPTION
* feat: This PR updates the go toolchain from 1.22.11 to 1.23.5

(cherry picked from commit 73722a5b66c9c60c2954a1eb0f25da3c7be00278)

