### PR TITLE
feat: add precision flag to write subcommand

### DIFF
--- a/influxdb3/src/commands/write.rs
+++ b/influxdb3/src/commands/write.rs
@@ -4,6 +4,7 @@ use std::{
 };
 
 use clap::Parser;
+use influxdb3_client::Precision;
 use secrecy::ExposeSecret;
 use tokio::io;
 
@@ -53,6 +54,10 @@ pub struct Config {
 
     /// Give a quoted line protocol line via the command line
     line_protocol: Option<Vec<String>>,
+
+    /// Specify a supported precision (eg: ns, us, ms, s).
+    #[clap(short = 'p', long = "precision")]
+    precision: Option<Precision>,
 }
 
 pub(crate) async fn command(config: Config) -> Result<()> {
@@ -83,6 +88,9 @@ pub(crate) async fn command(config: Config) -> Result<()> {
     };
 
     let mut req = client.api_v3_write_lp(database_name);
+    if let Some(precision) = config.precision {
+        req = req.precision(precision);
+    }
     if config.accept_partial_writes {
         req = req.accept_partial(true);
     }

--- a/influxdb3/tests/server/cli.rs
+++ b/influxdb3/tests/server/cli.rs
@@ -1767,3 +1767,98 @@ async fn write_and_query_via_string() {
         result
     );
 }
+
+#[test_log::test(tokio::test)]
+async fn write_with_precision_arg() {
+    let server = TestServer::spawn().await;
+    let server_addr = server.client_addr();
+    let db_name = "foo";
+    let table_name = "bar";
+
+    struct TestCase {
+        name: &'static str,
+        precision: Option<&'static str>,
+        expected: &'static str,
+    }
+
+    let tests = vec![
+        TestCase {
+            name: "default precision is seconds",
+            precision: None,
+            expected: "1970-01-01T00:00:01",
+        },
+        TestCase {
+            name: "set seconds precision",
+            precision: Some("s"),
+            expected: "1970-01-01T00:00:01",
+        },
+        TestCase {
+            name: "set milliseconds precision",
+            precision: Some("ms"),
+            expected: "1970-01-01T00:00:00.001",
+        },
+        TestCase {
+            name: "set microseconds precision",
+            precision: Some("us"),
+            expected: "1970-01-01T00:00:00.000001",
+        },
+        TestCase {
+            name: "set nanoseconds precision",
+            precision: Some("ns"),
+            expected: "1970-01-01T00:00:00.000000001",
+        },
+    ];
+
+    for test in tests {
+        let TestCase {
+            name,
+            precision,
+            expected,
+        } = test;
+        let name_tag = name.replace(' ', "_");
+        let lp = format!("{table_name},name={name_tag} theanswer=42 1");
+
+        let mut args = vec!["write", "--host", &server_addr, "--database", db_name];
+        if let Some(precision) = precision {
+            args.extend(vec!["--precision", precision]);
+        }
+        args.push(&lp);
+
+        run(args.as_slice());
+        let result = server
+            .api_v3_query_sql(&[
+                ("db", db_name),
+                (
+                    "q",
+                    format!("SELECT * FROM {table_name} WHERE name='{name_tag}'").as_str(),
+                ),
+                ("format", "json"),
+            ])
+            .await
+            .json::<Value>()
+            .await
+            .unwrap();
+        assert_eq!(
+            result,
+            json!([{
+                "name": name_tag,
+                "theanswer": 42.0,
+                "time": expected,
+            }]),
+            "test failed: {name}",
+        );
+    }
+
+    let lp = format!("{table_name},name=invalid_precision theanswer=42 1");
+    let output = run_and_err(&[
+        "write",
+        "--host",
+        &server_addr,
+        "--database",
+        db_name,
+        "--precision",
+        "fake",
+        &lp,
+    ]);
+    insta::assert_snapshot!("invalid_precision", output);
+}

--- a/influxdb3/tests/server/snapshots/server__cli__invalid_precision.snap
+++ b/influxdb3/tests/server/snapshots/server__cli__invalid_precision.snap
@@ -1,0 +1,8 @@
+---
+source: influxdb3/tests/server/cli.rs
+expression: output
+snapshot_kind: text
+---
+error: invalid value 'fake' for '--precision <PRECISION>': unrecognized precision unit: fake
+
+For more information, try '--help'.

--- a/influxdb3_client/src/lib.rs
+++ b/influxdb3_client/src/lib.rs
@@ -54,6 +54,9 @@ pub enum Error {
         #[source]
         source: reqwest::Error,
     },
+
+    #[error("unrecognized precision unit: {0}")]
+    UnrecognizedUnit(String),
 }
 
 impl Error {
@@ -901,6 +904,21 @@ pub enum Precision {
     Millisecond,
     Microsecond,
     Nanosecond,
+}
+
+impl std::str::FromStr for Precision {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self> {
+        let p = match s {
+            "s" => Self::Second,
+            "ms" => Self::Millisecond,
+            "us" => Self::Microsecond,
+            "ns" => Self::Nanosecond,
+            _ => return Err(Error::UnrecognizedUnit(s.into())),
+        };
+        Ok(p)
+    }
 }
 
 /// Builder type for composing a request to `/api/v3/write_lp`


### PR DESCRIPTION
Addresses https://github.com/influxdata/influxdb/issues/25930

This adds simple `--precision` flag to the `influxdb3 write` subcommand along with round trip write/query tests to validate the resulting timestamp precision in the query output.
