### PR TITLE
feat: introduce parquet caching in query path

### DIFF
--- a/influxdb3/src/commands/serve.rs
+++ b/influxdb3/src/commands/serve.rs
@@ -295,6 +295,16 @@ pub struct Config {
     )]
     pub disable_parquet_mem_cache: bool,
 
+    /// The duration from `now` to check if parquet files pulled in query path requires caching
+    /// Enter as a human-readable time, e.g., "5h", "3d"
+    #[clap(
+        long = "parquet-mem-cache-query-path-duration",
+        env = "INFLUXDB3_PARQUET_MEM_CACHE_PRUNE_INTERVAL",
+        default_value = "5h",
+        action
+    )]
+    pub parquet_mem_cache_query_path_duration: humantime::Duration,
+
     /// The interval on which to evict expired entries from the Last-N-Value cache, expressed as a
     /// human-readable time, e.g., "20s", "1m", "1h".
     #[clap(
@@ -458,6 +468,7 @@ pub async fn command(config: Config) -> Result<()> {
             Arc::clone(&time_provider) as _,
             Arc::clone(&metrics),
             config.parquet_mem_cache_size.as_num_bytes(),
+            config.parquet_mem_cache_query_path_duration.into(),
             config.parquet_mem_cache_prune_percentage.into(),
             config.parquet_mem_cache_prune_interval.into(),
         );

--- a/influxdb3/src/commands/serve.rs
+++ b/influxdb3/src/commands/serve.rs
@@ -299,7 +299,7 @@ pub struct Config {
     /// Enter as a human-readable time, e.g., "5h", "3d"
     #[clap(
         long = "parquet-mem-cache-query-path-duration",
-        env = "INFLUXDB3_PARQUET_MEM_CACHE_PRUNE_INTERVAL",
+        env = "INFLUXDB3_PARQUET_MEM_CACHE_QUERY_PATH_DURATION",
         default_value = "5h",
         action
     )]

--- a/influxdb3_cache/Cargo.toml
+++ b/influxdb3_cache/Cargo.toml
@@ -7,6 +7,7 @@ license.workspace = true
 
 [dependencies]
 # Core Crates
+data_types.workspace = true
 iox_time.workspace = true
 metric.workspace = true
 observability_deps.workspace = true


### PR DESCRIPTION
This commit scans the parquet files that will be used in query to check if they can be cached. There are three conditions to satisfy,
  - not cached already
  - cache has enough space
  - file times overlap with the cache policy times

closes: https://github.com/influxdata/influxdb/issues/25906

The approach taken in this commit allows background handler to decide whether parquet files in query path need caching. An alternate approach would be to filter them out based on the time ranges first and only submit request where parquet files time ranges overlap with cache policy. But these parquet files are only to be cached when there is space and that would've possibly meant adding some flag or creating another variation of cache request which is eventual but conditional (i.e space is there or not). Other eventual requests fill the cache immediately currently. I did consider this approach but I backtracked as the decision to cache something or not will be in 2 different places, and the tradeoff is background cache handler will need to process more messages.