### PR TITLE
fix: defer calls that return a closure need to be called

### DIFF
--- a/cmd/influxd/inspect/type_conflicts/schema.go
+++ b/cmd/influxd/inspect/type_conflicts/schema.go
@@ -125,7 +125,7 @@ func (s Schema) WriteConflictsFile(filename string) error {
 
 func (s Schema) encodeSchema(filename string) (rErr error) {
 	schemaFile, err := os.Create(filename)
-	defer errors2.Capture(&rErr, schemaFile.Close)
+	defer errors2.Capture(&rErr, schemaFile.Close)()
 	if err != nil {
 		return fmt.Errorf("unable to create schema file: %w", err)
 	}

--- a/sqlite/sqlite.go
+++ b/sqlite/sqlite.go
@@ -229,7 +229,7 @@ func (s *SqlStore) RestoreSqlStore(ctx context.Context, r io.Reader) (rErr error
 		return err
 	}
 	copySyncClose := func(f *os.File, r io.Reader) (innerErr error) {
-		defer errors2.Capture(&innerErr, f.Close) // close the temp file
+		defer errors2.Capture(&innerErr, f.Close)() // close the temp file
 
 		// Copy the contents of r to the temporary file
 		if _, err := io.Copy(f, r); err != nil {
@@ -240,7 +240,7 @@ func (s *SqlStore) RestoreSqlStore(ctx context.Context, r io.Reader) (rErr error
 		}
 		return nil
 	}
-	if err = copySyncClose(f, r); err != nil {
+	if err := copySyncClose(f, r); err != nil {
 		return err
 	}
 

--- a/sqlite/sqlite.go
+++ b/sqlite/sqlite.go
@@ -138,7 +138,7 @@ func (s *SqlStore) BackupSqlStore(ctx context.Context, w io.Writer) (rErr error)
 	if err != nil {
 		return err
 	}
-	defer errors2.Capture(&rErr, dest.Close)
+	defer errors2.Capture(&rErr, dest.Close)()
 
 	if err := backup(ctx, dest, s); err != nil {
 		return err
@@ -227,7 +227,7 @@ func (s *SqlStore) RestoreSqlStore(ctx context.Context, r io.Reader) (rErr error
 	if err != nil {
 		return err
 	}
-	defer errors2.Capture(&rErr, f.Close)
+	defer errors2.Capture(&rErr, f.Close)()
 
 	// Copy the contents of r to the temporary file
 	if _, err := io.Copy(f, r); err != nil {


### PR DESCRIPTION
This fix will stop leaking file handles to temporary files.

* fixes #25950
* Closes #25950

Describe your proposed changes here.

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
