### PR TITLE
fix: actually call the deferred function

### DIFF
--- a/cmd/influx_inspect/type_conflicts/schema.go
+++ b/cmd/influx_inspect/type_conflicts/schema.go
@@ -125,7 +125,7 @@ func (s Schema) WriteConflictsFile(filename string) error {
 
 func (s Schema) encodeSchema(filename string) (rErr error) {
 	schemaFile, err := os.Create(filename)
-	defer errors2.Capture(&rErr, schemaFile.Close)
+	defer errors2.Capture(&rErr, schemaFile.Close)()
 	if err != nil {
 		return fmt.Errorf("unable to create schema file: %w", err)
 	}


### PR DESCRIPTION
Add parentheses to ensure a deferred
function is called on method exit.