### PR TITLE
fix: remove accidentally-commited dbg! macro

### DIFF
--- a/influxdb3_server/src/http.rs
+++ b/influxdb3_server/src/http.rs
@@ -1598,7 +1598,7 @@ async fn record_batch_stream_to_body(
                     mut self: Pin<&mut Self>,
                     ctx: &mut std::task::Context<'_>,
                 ) -> Poll<Self::Output> {
-                    match dbg!(self.stream.poll_next_unpin(ctx)) {
+                    match self.stream.poll_next_unpin(ctx) {
                         Poll::Ready(Some(batch)) => {
                             let batch = match batch {
                                 Ok(batch) => batch,


### PR DESCRIPTION
I noticed this while running tests on a WIP branch I've been working on.

To be clear, this is a problem because it results in spurious debug logs to stderr every time the JsonFuture is polled.