### PR TITLE
fix: Parquet format output not working in CLI

### DIFF
--- a/influxdb3/src/commands/show.rs
+++ b/influxdb3/src/commands/show.rs
@@ -68,7 +68,7 @@ pub(crate) async fn command(config: Config) -> Result<(), Box<dyn Error>> {
                 .send()
                 .await?;
 
-            println!("{}", std::str::from_utf8(&resp_bytes)?);
+            println!("{}", String::from_utf8_lossy(&resp_bytes));
         }
         SubCommand::System(cfg) => system::command(cfg).await?,
     }


### PR DESCRIPTION
Closes #25941

Describe your proposed changes here.
Replacing std::str::from_utf8 with String::from_utf8_lossy to handle Non-UTF-8 Characters
 
- [X] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb/blob/main/README.md).
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
