### PR TITLE
feat: port changes back to core from enterprise

### DIFF
--- a/influxdb3_write/src/lib.rs
+++ b/influxdb3_write/src/lib.rs
@@ -346,6 +346,12 @@ impl ParquetFile {
     }
 }
 
+impl AsRef<ParquetFile> for ParquetFile {
+    fn as_ref(&self) -> &ParquetFile {
+        self
+    }
+}
+
 #[cfg(test)]
 impl ParquetFile {
     pub(crate) fn create_for_test(path: impl Into<String>) -> Self {


### PR DESCRIPTION
Includes 2 main changes

- update the function signature for `cache_parquet_files`
- bring in `Evict` variant for parquet `CacheRequest`