### PR TITLE
fix: typo in influxdb3 client docs

### DIFF
--- a/influxdb3_client/src/lib.rs
+++ b/influxdb3_client/src/lib.rs
@@ -911,7 +911,7 @@ impl QueryRequestBuilder<'_> {
     ///
     /// let client = Client::new("http://localhost:8181")?;
     /// let response_bytes = client
-    ///     .api_v3_query_sql("db_name", "SELECT * FROM foo WHERE bar = $bar AND foo > $fooz")
+    ///     .api_v3_query_sql("db_name", "SELECT * FROM foo WHERE bar = $bar AND foo > $foo")
     ///     .with_params_from([
     ///         ("bar", json!(false)),
     ///         ("foo", json!(10)),


### PR DESCRIPTION
Closes #

Fix a typo in influxdb3 client documents.

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
