### PR TITLE
fix: remove request uri from error log

### DIFF
--- a/influxdb3_server/src/http.rs
+++ b/influxdb3_server/src/http.rs
@@ -1815,7 +1815,7 @@ pub(crate) async fn route_request<T: TimeProvider>(
             Ok(response)
         }
         Err(error) => {
-            error!(%error, %method, %uri, ?content_length, "Error while handling request");
+            error!(%error, %method, path = uri.path(), ?content_length, "Error while handling request");
             Ok(error.into_response())
         }
     }


### PR DESCRIPTION
Changes an `error!` from logging the full request URI to just log the path. This is to prevent emitting passwords for legacy APIs that accept the auth token in the `p` parameter (`/query` and `/write`).
