### PR TITLE
refactor: use macro to define id types

### DIFF
--- a/influxdb3_catalog/src/catalog.rs
+++ b/influxdb3_catalog/src/catalog.rs
@@ -2080,19 +2080,21 @@ mod tests {
             ))
             .unwrap();
         let mut tables: Vec<(TableId, Arc<str>)> = vec![];
-        for i in 0..Catalog::NUM_TABLES_LIMIT {
-            let table_id = TableId::new();
-            let table_name = Arc::<str>::from(format!("test-table-{i}").as_str());
-            catalog
-                .apply_catalog_batch(&influxdb3_wal::create::catalog_batch(
-                    db_id,
-                    db_name,
-                    0,
-                    [influxdb3_wal::create::create_table_op(
+
+        catalog
+            .apply_catalog_batch(&influxdb3_wal::create::catalog_batch(
+                db_id,
+                db_name,
+                0,
+                (0..Catalog::NUM_TABLES_LIMIT).map(|i| {
+                    let table_id = TableId::new();
+                    let table_name = Arc::<str>::from(format!("test-table-{i}").as_str());
+                    tables.push((table_id, Arc::clone(&table_name)));
+                    influxdb3_wal::create::create_table_op(
                         db_id,
                         db_name,
                         table_id,
-                        Arc::clone(&table_name),
+                        table_name,
                         [
                             influxdb3_wal::create::field_def(
                                 ColumnId::new(),
@@ -2106,11 +2108,11 @@ mod tests {
                             ),
                         ],
                         [],
-                    )],
-                ))
-                .unwrap();
-            tables.push((table_id, table_name));
-        }
+                    )
+                }),
+            ))
+            .unwrap();
+
         assert_eq!(2_000, catalog.inner.read().table_count());
         // should not be able to create another table:
         let table_id = TableId::new();

--- a/influxdb3_id/src/lib.rs
+++ b/influxdb3_id/src/lib.rs
@@ -8,138 +8,59 @@ use std::sync::atomic::Ordering;
 mod serialize;
 pub use serialize::SerdeVecMap;
 
-#[derive(Debug, Copy, Clone, Eq, PartialOrd, Ord, PartialEq, Serialize, Deserialize, Hash)]
-pub struct DbId(u32);
+macro_rules! catalog_identifier_type {
+    ($name:ident, $atomic:ident) => {
+        #[derive(
+            Debug, Copy, Clone, Eq, PartialOrd, Ord, PartialEq, Serialize, Deserialize, Hash,
+        )]
+        pub struct $name(u32);
 
-static NEXT_DB_ID: AtomicU32 = AtomicU32::new(0);
+        static $atomic: AtomicU32 = AtomicU32::new(0);
 
-impl DbId {
-    pub fn new() -> Self {
-        Self(
-            NEXT_DB_ID
-                .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |n| n.checked_add(1))
-                .expect("Overflowed with DB IDs"),
-        )
-    }
+        impl $name {
+            pub fn new() -> Self {
+                Self(
+                    $atomic
+                        .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |n| n.checked_add(1))
+                        .expect("overflowed u32 when generating new identifier"),
+                )
+            }
 
-    pub fn next_id() -> DbId {
-        Self(NEXT_DB_ID.load(Ordering::SeqCst))
-    }
+            pub fn next_id() -> $name {
+                Self($atomic.load(Ordering::SeqCst))
+            }
 
-    pub fn set_next_id(&self) {
-        NEXT_DB_ID.store(self.0, Ordering::SeqCst)
-    }
+            pub fn set_next_id(&self) {
+                $atomic.store(self.0, Ordering::SeqCst)
+            }
 
-    pub fn as_u32(&self) -> u32 {
-        self.0
-    }
+            pub fn as_u32(&self) -> u32 {
+                self.0
+            }
+        }
+
+        impl Default for $name {
+            fn default() -> Self {
+                Self::new()
+            }
+        }
+
+        impl From<u32> for $name {
+            fn from(value: u32) -> Self {
+                Self(value)
+            }
+        }
+        impl Display for $name {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                write!(f, "{}", self.0)
+            }
+        }
+    };
 }
 
-impl Default for DbId {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl From<u32> for DbId {
-    fn from(value: u32) -> Self {
-        Self(value)
-    }
-}
-impl Display for DbId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-#[derive(Debug, Copy, Clone, Eq, PartialOrd, Ord, PartialEq, Serialize, Deserialize, Hash)]
-pub struct TableId(u32);
-
-static NEXT_TABLE_ID: AtomicU32 = AtomicU32::new(0);
-
-impl TableId {
-    pub fn new() -> Self {
-        Self(
-            NEXT_TABLE_ID
-                .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |n| n.checked_add(1))
-                .expect("Overflowed with Table IDs"),
-        )
-    }
-
-    pub fn next_id() -> Self {
-        Self(NEXT_TABLE_ID.load(Ordering::SeqCst))
-    }
-
-    pub fn set_next_id(&self) {
-        NEXT_TABLE_ID.store(self.0, Ordering::SeqCst)
-    }
-
-    pub fn as_u32(&self) -> u32 {
-        self.0
-    }
-}
-
-impl Default for TableId {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl From<u32> for TableId {
-    fn from(value: u32) -> Self {
-        Self(value)
-    }
-}
-
-impl Display for TableId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-#[derive(Debug, Copy, Clone, Eq, PartialOrd, Ord, PartialEq, Serialize, Deserialize, Hash)]
-pub struct ColumnId(u32);
-
-static NEXT_COLUMN_ID: AtomicU32 = AtomicU32::new(0);
-
-impl ColumnId {
-    pub fn new() -> Self {
-        Self(
-            NEXT_COLUMN_ID
-                .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |n| n.checked_add(1))
-                .expect("Overflowed with Column IDs"),
-        )
-    }
-
-    pub fn next_id() -> Self {
-        Self(NEXT_COLUMN_ID.load(Ordering::SeqCst))
-    }
-
-    pub fn set_next_id(&self) {
-        NEXT_COLUMN_ID.store(self.0, Ordering::SeqCst)
-    }
-
-    pub fn as_u32(&self) -> u32 {
-        self.0
-    }
-}
-impl From<u32> for ColumnId {
-    fn from(value: u32) -> Self {
-        Self(value)
-    }
-}
-
-impl Display for ColumnId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", self.0)
-    }
-}
-
-impl Default for ColumnId {
-    fn default() -> Self {
-        Self::new()
-    }
-}
+catalog_identifier_type!(DbId, NEXT_DB_ID);
+catalog_identifier_type!(TableId, NEXT_TABLE_ID);
+catalog_identifier_type!(ColumnId, NEXT_COLUMN_ID);
 
 /// The next file id to be used when persisting `ParquetFile`s
 pub static NEXT_FILE_ID: AtomicU64 = AtomicU64::new(0);
@@ -179,5 +100,17 @@ impl From<u64> for ParquetFileId {
 impl Default for ParquetFileId {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::DbId;
+
+    #[test]
+    #[should_panic]
+    fn test_overflow_error() {
+        DbId::from(u32::MAX).set_next_id();
+        DbId::new();
     }
 }


### PR DESCRIPTION
There is no issue for this. I added a macro to generate code for the catalog ID types to keep from copy/pasting.

I also refactored the test that checks deleted tables do not count against the limits. In Enterprise this test is quite slow where the limits are higher.