### PR TITLE
fix: retention period update buckets

### DIFF
--- a/tenant/http_server_bucket.go
+++ b/tenant/http_server_bucket.go
@@ -210,6 +210,10 @@ func (b *bucketUpdate) toInfluxDB() *influxdb.BucketUpdate {
 			sgd := time.Duration(*rule.ShardGroupDurationSeconds) * time.Second
 			upd.ShardGroupDuration = &sgd
 		}
+	} else if len(b.RetentionRules) == 0 {
+		rp := time.Duration(0)
+		upd.RetentionPeriod = &rp
+		upd.ShardGroupDuration = &rp
 	}
 
 	return &upd

--- a/tenant/http_server_bucket_test.go
+++ b/tenant/http_server_bucket_test.go
@@ -213,20 +213,19 @@ func TestHTTPBucketService_InvalidRetention(t *testing.T) {
 }
 
 func TestRententionNever(t *testing.T) {
-	s := itesting.NewTestInmemStore(t)
 	id := mock.NewStaticIDGenerator(idOne)
 	orgID := mock.NewStaticIDGenerator(idOne)
 	bucket := &influxdb.Bucket{
 		ID:                  id.ID(),
-		Type:                influxdb.BucketTypeUser,
 		OrgID:               orgID.ID(),
+		Type:                influxdb.BucketTypeUser,
 		Name:                "bucket",
 		Description:         "words",
 		RetentionPolicyName: "",
 		RetentionPeriod:     time.Duration(60) * time.Minute,
 		ShardGroupDuration:  time.Duration(24) * time.Hour,
 	}
-	store := tenant.NewStore(s)
+	store := tenant.NewStore(itesting.NewTestInmemStore(t))
 	ctx := context.Background()
 	err := store.Update(ctx, func(tx kv.Tx) error {
 		if err := store.CreateBucket(tx.Context(), tx, bucket); err != nil {

--- a/tenant/http_server_bucket_test.go
+++ b/tenant/http_server_bucket_test.go
@@ -212,7 +212,7 @@ func TestHTTPBucketService_InvalidRetention(t *testing.T) {
 	}
 }
 
-func Test(t *testing.T) {
+func TestRententionNever(t *testing.T) {
 	s := itesting.NewTestInmemStore(t)
 	id := mock.NewStaticIDGenerator(idOne)
 	orgID := mock.NewStaticIDGenerator(idOne)

--- a/tenant/http_server_bucket_test.go
+++ b/tenant/http_server_bucket_test.go
@@ -212,7 +212,7 @@ func TestHTTPBucketService_InvalidRetention(t *testing.T) {
 	}
 }
 
-func TestRententionNever(t *testing.T) {
+func TestRetentionNever(t *testing.T) {
 	id := mock.NewStaticIDGenerator(idOne)
 	orgID := mock.NewStaticIDGenerator(idOne)
 	bucket := &influxdb.Bucket{


### PR DESCRIPTION
Closes https://github.com/influxdata/ui/issues/1607

Fix the bug when updating the retention period of buckets:
-  Before fix: set a retention period, eg. 1 hour, then change to never -> the retention period is still 1 hour
-  After fix: set a retention period, eg. 1 hour, then change to never -> the retention period changes to never
- Test case added 
- [Issue Link](https://github.com/influxdata/ui/issues/1607)

https://github.com/user-attachments/assets/28787c36-016c-45fe-b5e7-ca3f4d8b41bc



- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
