### PR TITLE
fix: serialize distinct cache in catalog

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3747,6 +3747,7 @@ checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
 dependencies = [
  "autocfg",
  "scopeguard",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,7 @@ mockall = { version = "0.13.0" }
 non-empty-string = "0.2.5"
 num_cpus = "1.16.0"
 object_store = "0.11.1"
-parking_lot = "0.12.1"
+parking_lot = { version = "0.12.1", features = ["serde"] }
 paste = "1.0.15"
 parquet = { version = "53.0.0", features = ["object_store"] }
 pbjson = "0.6.0"

--- a/influxdb3_catalog/src/snapshots/influxdb3_catalog__catalog__tests__catalog_serialization.snap
+++ b/influxdb3_catalog/src/snapshots/influxdb3_catalog__catalog__tests__catalog_serialization.snap
@@ -267,8 +267,7 @@ expression: catalog
       }
     ]
   ],
-  "sequence": 0,
-  "node_id": "sample-host-id",
   "instance_id": "instance-id",
-  "db_map": []
+  "node_id": "sample-host-id",
+  "sequence": 0
 }

--- a/influxdb3_catalog/src/snapshots/influxdb3_catalog__catalog__tests__serialize_distinct_cache.snap
+++ b/influxdb3_catalog/src/snapshots/influxdb3_catalog__catalog__tests__serialize_distinct_cache.snap
@@ -15,7 +15,7 @@ expression: catalog
             0,
             {
               "table_id": 0,
-              "table_name": "test",
+              "table_name": "test_table",
               "key": [
                 0,
                 1,
@@ -93,20 +93,17 @@ expression: catalog
                   }
                 ]
               ],
-              "last_caches": [
+              "distinct_caches": [
                 {
                   "table_id": 0,
-                  "table": "test",
-                  "name": "test_table_last_cache",
-                  "keys": [
-                    1,
-                    2
+                  "table": "test_table",
+                  "name": "test_cache",
+                  "cols": [
+                    0,
+                    1
                   ],
-                  "vals": [
-                    4
-                  ],
-                  "n": 1,
-                  "ttl": 600
+                  "max_cardinality": 100,
+                  "max_age_seconds": 10
                 }
               ],
               "deleted": false
@@ -120,5 +117,5 @@ expression: catalog
   ],
   "instance_id": "instance-id",
   "node_id": "sample-host-id",
-  "sequence": 0
+  "sequence": 2
 }

--- a/influxdb3_catalog/src/snapshots/influxdb3_catalog__catalog__tests__serialize_series_keys.snap
+++ b/influxdb3_catalog/src/snapshots/influxdb3_catalog__catalog__tests__serialize_series_keys.snap
@@ -102,8 +102,7 @@ expression: catalog
       }
     ]
   ],
-  "sequence": 0,
-  "node_id": "sample-host-id",
   "instance_id": "instance-id",
-  "db_map": []
+  "node_id": "sample-host-id",
+  "sequence": 0
 }

--- a/influxdb3_write/src/write_buffer/snapshots/influxdb3_write__write_buffer__tests__catalog-after-last-cache-create-and-new-field.snap
+++ b/influxdb3_write/src/write_buffer/snapshots/influxdb3_write__write_buffer__tests__catalog-after-last-cache-create-and-new-field.snap
@@ -92,12 +92,6 @@ expression: catalog_json
       }
     ]
   ],
-  "db_map": [
-    {
-      "db_id": 0,
-      "name": "db"
-    }
-  ],
   "instance_id": "[uuid]",
   "node_id": "test_host",
   "sequence": 3

--- a/influxdb3_write/src/write_buffer/snapshots/influxdb3_write__write_buffer__tests__catalog-immediately-after-last-cache-create.snap
+++ b/influxdb3_write/src/write_buffer/snapshots/influxdb3_write__write_buffer__tests__catalog-immediately-after-last-cache-create.snap
@@ -82,12 +82,6 @@ expression: catalog_json
       }
     ]
   ],
-  "db_map": [
-    {
-      "db_id": 0,
-      "name": "db"
-    }
-  ],
   "instance_id": "[uuid]",
   "node_id": "test_host",
   "sequence": 2

--- a/influxdb3_write/src/write_buffer/snapshots/influxdb3_write__write_buffer__tests__catalog-immediately-after-last-cache-delete.snap
+++ b/influxdb3_write/src/write_buffer/snapshots/influxdb3_write__write_buffer__tests__catalog-immediately-after-last-cache-delete.snap
@@ -79,12 +79,6 @@ expression: catalog_json
       }
     ]
   ],
-  "db_map": [
-    {
-      "db_id": 0,
-      "name": "db"
-    }
-  ],
   "instance_id": "[uuid]",
   "node_id": "test_host",
   "sequence": 4


### PR DESCRIPTION
The distinct cache info for tables was not serialized in the catalog. This fixes that, but also updates the catalog serialization to use the same snapshot pattern for serialization from the Catalog type all the way down. This removes the need to serialize the `db_map` from the catalog.

The Eq and PartialEq derives were removed from Catalog and InnerCatalog as they were only used in tests, where assertions using them were replaced by insta snapshot tests.

A test was added to check serialization/deserialization of distinct caches in the catalog.

There is no issue for this.