### PR TITLE
fix: Parquet format output not working in CLI for show commands

### DIFF
--- a/influxdb3/src/commands/show.rs
+++ b/influxdb3/src/commands/show.rs
@@ -1,9 +1,33 @@
 use clap::Parser;
 use secrecy::{ExposeSecret, Secret};
-use std::error::Error;
+use std::io;
+use std::str::Utf8Error;
+use tokio::fs::OpenOptions;
+use tokio::io::AsyncWriteExt;
 use url::Url;
 
 use crate::commands::common::Format;
+use system::Error as SystemCommandError;
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum Error {
+    #[error(transparent)]
+    Client(#[from] influxdb3_client::Error),
+
+    #[error(
+        "must specify an output file path with `--output` parameter when formatting \
+        the output as `parquet`"
+    )]
+    NoOutputFileForParquet,
+
+    #[error("invalid UTF8 received from server: {0}")]
+    Utf8(#[from] Utf8Error),
+
+    #[error("io error: {0}")]
+    Io(#[from] io::Error),
+
+    #[error(transparent)]
+    SystemCommand(#[from] SystemCommandError),
+}
 
 mod system;
 use system::SystemConfig;
@@ -45,15 +69,20 @@ pub struct DatabaseConfig {
     /// The format in which to output the list of databases
     #[clap(value_enum, long = "format", default_value = "pretty")]
     output_format: Format,
+
+    /// Put the list of databases into `output`
+    #[clap(short = 'o', long = "output")]
+    output_file_path: Option<String>,
 }
 
-pub(crate) async fn command(config: Config) -> Result<(), Box<dyn Error>> {
+pub(crate) async fn command(config: Config) -> Result<(), Error> {
     match config.cmd {
         SubCommand::Databases(DatabaseConfig {
             host_url,
             auth_token,
             show_deleted,
             output_format,
+            output_file_path,
         }) => {
             let mut client = influxdb3_client::Client::new(host_url)?;
 
@@ -61,14 +90,27 @@ pub(crate) async fn command(config: Config) -> Result<(), Box<dyn Error>> {
                 client = client.with_auth_token(t.expose_secret());
             }
 
-            let resp_bytes = client
+            let mut resp_bytes = client
                 .api_v3_configure_db_show()
-                .with_format(output_format.into())
+                .with_format(output_format.clone().into())
                 .with_show_deleted(show_deleted)
                 .send()
                 .await?;
 
-            println!("{}", std::str::from_utf8(&resp_bytes)?);
+            if let Some(path) = output_file_path {
+                let mut f = OpenOptions::new()
+                    .write(true)
+                    .create(true)
+                    .truncate(true)
+                    .open(path)
+                    .await?;
+                f.write_all_buf(&mut resp_bytes).await?;
+            } else {
+                if output_format.is_parquet() {
+                    Err(Error::NoOutputFileForParquet)?
+                }
+                println!("{}", std::str::from_utf8(&resp_bytes)?);
+            }
         }
         SubCommand::System(cfg) => system::command(cfg).await?,
     }

--- a/influxdb3/tests/cli/mod.rs
+++ b/influxdb3/tests/cli/mod.rs
@@ -1161,11 +1161,24 @@ async fn test_show_system() {
             name: "iox schema table name exists, but should error because we're concerned here with system tables",
             args: vec!["show", "system", "--host", server_addr.as_str(), "--database", db_name, "table", "cpu"],
         },
+        FailTestCase {
+            name: "fail without output-file when format is parquet for table",
+            args: vec!["show", "system", "--host", server_addr.as_str(), "--database", db_name, "table", "--format", "parquet","distinct_caches"]
+        },
+        FailTestCase {
+            name: "fail without output-file when format is parquet for table-list",
+            args: vec!["show", "system", "--host", server_addr.as_str(), "--database", db_name, "table-list", "--format", "parquet"]
+        },
+        FailTestCase {
+            name: "fail without output-file when format is parquet for summary",
+            args: vec!["show", "system", "--host", server_addr.as_str(), "--database", db_name, "summary", "--format", "parquet"]
+        },
     ];
 
     for case in cases {
         let output = run_and_err(&case.args);
         let snap_name = case.name.replace(' ', "_");
+        println!("Actual output {}", output);
         insta::assert_snapshot!(snap_name, output);
     }
 }

--- a/influxdb3/tests/cli/snapshots/lib__cli__fail_without_output-file_when_format_is_parquet_for_summary.snap
+++ b/influxdb3/tests/cli/snapshots/lib__cli__fail_without_output-file_when_format_is_parquet_for_summary.snap
@@ -1,0 +1,5 @@
+---
+source: influxdb3/tests/cli/mod.rs
+expression: output
+---
+Show command failed: must specify an output file path with `--output` parameter when formatting the output as `parquet`

--- a/influxdb3/tests/cli/snapshots/lib__cli__fail_without_output-file_when_format_is_parquet_for_table-list.snap
+++ b/influxdb3/tests/cli/snapshots/lib__cli__fail_without_output-file_when_format_is_parquet_for_table-list.snap
@@ -1,0 +1,5 @@
+---
+source: influxdb3/tests/cli/mod.rs
+expression: output
+---
+Show command failed: must specify an output file path with `--output` parameter when formatting the output as `parquet`

--- a/influxdb3/tests/cli/snapshots/lib__cli__fail_without_output-file_when_format_is_parquet_for_table.snap
+++ b/influxdb3/tests/cli/snapshots/lib__cli__fail_without_output-file_when_format_is_parquet_for_table.snap
@@ -1,0 +1,5 @@
+---
+source: influxdb3/tests/cli/mod.rs
+expression: output
+---
+Show command failed: must specify an output file path with `--output` parameter when formatting the output as `parquet`


### PR DESCRIPTION
BREAKING CHANGE:
The short option -o, previously used for order-by in the table-list command, has been replaced and is now used for the output option.

Closes #25941

Describe your proposed changes here.
1. Mandated the -o or --output option when -format specified as Parquet
2. Updated the following commands with the same fix
    - show databases
    - show system table
    - show system table-list
    - show system summary

- [X] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb/blob/main/README.md).
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
