### PR TITLE
fix: lock MeasurementFields while validating

### DIFF
--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -1290,7 +1290,7 @@ func (e *Engine) addToIndexFromKey(keys [][]byte, fieldTypes []influxql.DataType
 		keys[i], field = SeriesAndFieldFromCompositeKey(keys[i])
 		name := models.ParseName(keys[i])
 		mf := e.fieldset.CreateFieldsIfNotExists(name)
-		if err := mf.CreateFieldIfNotExists(field, fieldTypes[i]); err != nil {
+		if _, err := mf.CreateFieldIfNotExists(field, fieldTypes[i]); err != nil {
 			return err
 		}
 

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -705,8 +705,8 @@ func (s *Shard) validateSeriesAndFields(points []models.Point, tracker StatsTrac
 		err := func(p models.Point, iter models.FieldIterator) error {
 			name := p.Name()
 			mf := engine.MeasurementFields(name)
-			mf.mu.Lock()
-			defer mf.mu.Unlock()
+			mf.mu.RLock()
+			defer mf.mu.RUnlock()
 			// Check with the field validator.
 			if err := ValidateFields(mf, p, s.options.Config.SkipFieldSizeValidation); err != nil {
 				switch err := err.(type) {
@@ -1586,7 +1586,7 @@ func (a Shards) ExpandSources(sources influxql.Sources) (influxql.Sources, error
 
 // MeasurementFields holds the fields of a measurement and their codec.
 type MeasurementFields struct {
-	mu sync.Mutex
+	mu sync.RWMutex
 
 	fields atomic.Value // map[string]*Field
 }

--- a/tsdb/shard_test.go
+++ b/tsdb/shard_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math"
 	"os"
+	"path"
 	"path/filepath"
 	"reflect"
 	"regexp"
@@ -14,11 +15,9 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
-
-	assert2 "github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/google/go-cmp/cmp"
@@ -30,9 +29,12 @@ import (
 	"github.com/influxdata/influxdb/query"
 	"github.com/influxdata/influxdb/tsdb"
 	_ "github.com/influxdata/influxdb/tsdb/engine"
+	"github.com/influxdata/influxdb/tsdb/engine/tsm1"
 	_ "github.com/influxdata/influxdb/tsdb/index"
 	"github.com/influxdata/influxdb/tsdb/index/inmem"
 	"github.com/influxdata/influxql"
+	assert2 "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestShardWriteAndIndex(t *testing.T) {
@@ -52,7 +54,8 @@ func TestShardWriteAndIndex(t *testing.T) {
 
 	// Calling WritePoints when the engine is not open will return
 	// ErrEngineClosed.
-	if got, exp := sh.WritePoints(nil, tsdb.NoopStatsTracker()), tsdb.ErrEngineClosed; got != exp {
+	got := sh.WritePoints(nil, tsdb.NoopStatsTracker())
+	if exp := tsdb.ErrEngineClosed; got != exp {
 		t.Fatalf("got %v, expected %v", got, exp)
 	}
 
@@ -122,7 +125,8 @@ func TestShard_Open_CorruptFieldsIndex(t *testing.T) {
 
 	// Calling WritePoints when the engine is not open will return
 	// ErrEngineClosed.
-	if got, exp := sh.WritePoints(nil, tsdb.NoopStatsTracker()), tsdb.ErrEngineClosed; got != exp {
+	got := sh.WritePoints(nil, tsdb.NoopStatsTracker())
+	if exp := tsdb.ErrEngineClosed; got != exp {
 		t.Fatalf("got %v, expected %v", got, exp)
 	}
 
@@ -1687,7 +1691,7 @@ func TestMeasurementFieldSet_SaveLoad(t *testing.T) {
 	}
 	defer checkMeasurementFieldSetClose(t, mf)
 	fields := mf.CreateFieldsIfNotExists([]byte(measurement))
-	if err := fields.CreateFieldIfNotExists([]byte(fieldName), influxql.Float); err != nil {
+	if _, err := fields.CreateFieldIfNotExists([]byte(fieldName), influxql.Float); err != nil {
 		t.Fatalf("create field error: %v", err)
 	}
 	change := tsdb.FieldChange{
@@ -1739,7 +1743,7 @@ func TestMeasurementFieldSet_Corrupt(t *testing.T) {
 		measurement := []byte("cpu")
 		fields := mf.CreateFieldsIfNotExists(measurement)
 		fieldName := "value"
-		if err := fields.CreateFieldIfNotExists([]byte(fieldName), influxql.Float); err != nil {
+		if _, err := fields.CreateFieldIfNotExists([]byte(fieldName), influxql.Float); err != nil {
 			t.Fatalf("create field error: %v", err)
 		}
 		change := tsdb.FieldChange{
@@ -1810,7 +1814,7 @@ func TestMeasurementFieldSet_CorruptChangeFile(t *testing.T) {
 	defer checkMeasurementFieldSetClose(t, mf)
 	for _, f := range testFields {
 		fields := mf.CreateFieldsIfNotExists([]byte(f.Measurement))
-		if err := fields.CreateFieldIfNotExists([]byte(f.Field), f.FieldType); err != nil {
+		if _, err := fields.CreateFieldIfNotExists([]byte(f.Field), f.FieldType); err != nil {
 			t.Fatalf("create field error: %v", err)
 		}
 		change := tsdb.FieldChange{
@@ -1872,7 +1876,7 @@ func TestMeasurementFieldSet_DeleteEmpty(t *testing.T) {
 	defer checkMeasurementFieldSetClose(t, mf)
 
 	fields := mf.CreateFieldsIfNotExists([]byte(measurement))
-	if err := fields.CreateFieldIfNotExists([]byte(fieldName), influxql.Float); err != nil {
+	if _, err := fields.CreateFieldIfNotExists([]byte(fieldName), influxql.Float); err != nil {
 		t.Fatalf("create field error: %v", err)
 	}
 
@@ -2005,7 +2009,7 @@ func testFieldMaker(t *testing.T, wg *sync.WaitGroup, mf *tsdb.MeasurementFieldS
 	fields := mf.CreateFieldsIfNotExists([]byte(measurement))
 
 	for _, fieldName := range fieldNames {
-		if err := fields.CreateFieldIfNotExists([]byte(fieldName), influxql.Float); err != nil {
+		if _, err := fields.CreateFieldIfNotExists([]byte(fieldName), influxql.Float); err != nil {
 			t.Logf("create field error: %v", err)
 			t.Fail()
 			return
@@ -2654,4 +2658,162 @@ func (a seriesIDSets) ForEach(f func(ids *tsdb.SeriesIDSet)) error {
 		f(v)
 	}
 	return nil
+}
+
+// Tests concurrently writing to the same shard with different field types which
+// can trigger a panic when the shard is snapshotted to TSM files.
+func TestShard_WritePoints_ForceFieldConflictConcurrent(t *testing.T) {
+	const Runs = 50
+	if testing.Short() || runtime.GOOS == "windows" {
+		t.Skip("Skipping on short or windows")
+	}
+	for i := 0; i < Runs; i++ {
+		conflictShard(t, i)
+	}
+}
+
+func conflictShard(t *testing.T, run int) {
+	const measurement = "cpu"
+	const field = "value"
+	const numTypes = 4 // float, int, bool, string
+	const pointCopies = 10
+	const trialsPerShard = 10
+
+	tmpDir, _ := os.MkdirTemp("", "shard_test")
+	defer func() {
+		require.NoError(t, os.RemoveAll(tmpDir), "removing %s", tmpDir)
+	}()
+	tmpShard := filepath.Join(tmpDir, "shard")
+	tmpWal := filepath.Join(tmpDir, "wal")
+
+	sfile := MustOpenSeriesFile()
+	defer func() {
+		require.NoError(t, sfile.Close(), "closing series file")
+		require.NoError(t, os.RemoveAll(sfile.Path()), "removing series file %s", sfile.Path())
+	}()
+
+	opts := tsdb.NewEngineOptions()
+	opts.Config.WALDir = tmpWal
+	opts.InmemIndex = inmem.NewIndex(filepath.Base(tmpDir), sfile.SeriesFile)
+	opts.SeriesIDSets = seriesIDSets([]*tsdb.SeriesIDSet{})
+	sh := tsdb.NewShard(1, tmpShard, tmpWal, sfile.SeriesFile, opts)
+	require.NoError(t, sh.Open(), "opening shard: %s", sh.Path())
+	defer func() {
+		require.NoError(t, sh.Close(), "closing shard %s", tmpShard)
+	}()
+	var wg sync.WaitGroup
+	mu := sync.RWMutex{}
+	maxConcurrency := atomic.Int64{}
+
+	currentTime := time.Now()
+
+	points := make([]models.Point, 0, pointCopies*numTypes)
+
+	for i := 0; i < pointCopies; i++ {
+		points = append(points, models.MustNewPoint(
+			measurement,
+			models.NewTags(map[string]string{"host": "server"}),
+			map[string]interface{}{field: 1.0},
+			currentTime.Add(time.Duration(i)*time.Second),
+		))
+		points = append(points, models.MustNewPoint(
+			measurement,
+			models.NewTags(map[string]string{"host": "server"}),
+			map[string]interface{}{field: int64(1)},
+			currentTime.Add(time.Duration(i)*time.Second),
+		))
+		points = append(points, models.MustNewPoint(
+			measurement,
+			models.NewTags(map[string]string{"host": "server"}),
+			map[string]interface{}{field: "one"},
+			currentTime.Add(time.Duration(i)*time.Second),
+		))
+		points = append(points, models.MustNewPoint(
+			measurement,
+			models.NewTags(map[string]string{"host": "server"}),
+			map[string]interface{}{field: true},
+			currentTime.Add(time.Duration(i)*time.Second),
+		))
+	}
+	concurrency := atomic.Int64{}
+
+	for i := 0; i < trialsPerShard; i++ {
+		mu.Lock()
+		wg.Add(len(points))
+		// Write points concurrently
+		for i := 0; i < pointCopies; i++ {
+			for j := 0; j < numTypes; j++ {
+				concurrency.Add(1)
+				go func(mp models.Point) {
+					mu.RLock()
+					defer concurrency.Add(-1)
+					defer mu.RUnlock()
+					defer wg.Done()
+					if err := sh.WritePoints([]models.Point{mp}, tsdb.NoopStatsTracker()); err == nil {
+						fs, err := mp.Fields()
+						require.NoError(t, err, "getting fields")
+						require.Equal(t,
+							sh.MeasurementFields([]byte(measurement)).Field(field).Type,
+							influxql.InspectDataType(fs[field]),
+							"field types mismatch on run %d: types exp: %s, got: %s", run+1, sh.MeasurementFields([]byte(measurement)).Field(field).Type.String(), influxql.InspectDataType(fs[field]).String())
+					} else {
+						require.ErrorContains(t, err, tsdb.ErrFieldTypeConflict.Error(), "unexpected error")
+					}
+					if c := concurrency.Load(); maxConcurrency.Load() < c {
+						maxConcurrency.Store(c)
+					}
+				}(points[i*numTypes+j])
+			}
+		}
+		mu.Unlock()
+		wg.Wait()
+		dir, err := sh.CreateSnapshot(false)
+		require.NoError(t, err, "creating snapshot: %s", sh.Path())
+		require.NoError(t, os.RemoveAll(dir), "removing snapshot directory %s", dir)
+	}
+	keyType := map[string]byte{}
+	files, err := os.ReadDir(tmpShard)
+	require.NoError(t, err, "reading shard directory %s", tmpShard)
+	for i, file := range files {
+		if !strings.HasSuffix(path.Ext(file.Name()), tsm1.TSMFileExtension) {
+			continue
+		}
+		ffile := path.Join(tmpShard, file.Name())
+		fh, err := os.Open(ffile)
+		require.NoError(t, err, "opening snapshot file %s", ffile)
+		tr, err := tsm1.NewTSMReader(fh)
+		require.NoError(t, err, "creating TSM reader for %s", ffile)
+		key, typ := tr.KeyAt(0)
+		if oldTyp, ok := keyType[string(key)]; ok {
+			require.Equal(t, oldTyp, typ,
+				"field type mismatch in run %d TSM file %d -- %q in %s\nfirst seen: %s, newest: %s, field type: %s",
+				run+1,
+				i+1,
+				string(key),
+				ffile,
+				blockTypeString(oldTyp),
+				blockTypeString(typ),
+				sh.MeasurementFields([]byte(measurement)).Field(field).Type.String())
+		} else {
+			keyType[string(key)] = typ
+		}
+		// Must close after all uses of key (mapped memory)
+		require.NoError(t, tr.Close(), "closing TSM reader")
+	}
+	// t.Logf("Type %s wins run %d with concurrency: %d", sh.MeasurementFields([]byte(measurement)).Field(field).Type.String(), run+1, maxConcurrency.Load())
+}
+
+func blockTypeString(typ byte) string {
+	switch typ {
+	case tsm1.BlockFloat64:
+		return "float64"
+	case tsm1.BlockInteger:
+		return "int64"
+	case tsm1.BlockBoolean:
+		return "bool"
+	case tsm1.BlockString:
+		return "string"
+	default:
+		return "unknown"
+	}
 }


### PR DESCRIPTION
There was a window where a race between writes with 
differing types for the same field were being validated. 
Lock the MeasurementFields struct during field
validation to avoid this.

closes https://github.com/influxdata/influxdb/issues/23756