### PR TITLE
feat: Add error joins/returns (#25996)

### DIFF
--- a/tsdb/engine/tsm1/compact.go
+++ b/tsdb/engine/tsm1/compact.go
@@ -1101,16 +1101,25 @@ func (c *Compactor) writeNewFiles(generation, sequence int, src []string, iter K
 			}
 			return nil, err
 		} else if err != nil {
+			var errs []error
+			errs = append(errs, err)
 			// We hit an error and didn't finish the compaction.  Abort.
 			// Remove any tmp files we already completed
 			// discard later errors to return the first one from the write() call
 			for _, f := range files {
-				_ = os.RemoveAll(f)
+				err = os.RemoveAll(f)
+				if err != nil {
+					errs = append(errs, err)
+				}
 			}
 			// Remove the temp file
 			// discard later errors to return the first one from the write() call
-			_ = os.RemoveAll(fileName)
-			return nil, err
+			err = os.RemoveAll(fileName)
+			if err != nil {
+				errs = append(errs, err)
+			}
+
+			return nil, errors.Join(errs...)
 		}
 
 		files = append(files, fileName)


### PR DESCRIPTION
This pr adds err handling for branch that did not specify os file removal errors previously. This is part of EAR #5819.

(cherry picked from commit 306a184a8dfc76a27a0214186895ede25b5a5f0e)

