### PR TITLE
test: query distinct cache via flight sql

### DIFF
--- a/influxdb3/tests/server/flight.rs
+++ b/influxdb3/tests/server/flight.rs
@@ -1,7 +1,9 @@
 use arrow_flight::sql::SqlInfo;
 use arrow_flight::Ticket;
+use arrow_util::assert_batches_eq;
 use arrow_util::assert_batches_sorted_eq;
 use influxdb3_client::Precision;
+use serde_json::json;
 use test_helpers::assert_contains;
 
 use crate::server::collect_stream;
@@ -219,6 +221,147 @@ async fn flight_influxql() {
         assert_contains!(
             response.to_string(),
             "This feature is not implemented: SHOW DATABASES"
+        );
+    }
+}
+
+#[test_log::test(tokio::test)]
+async fn test_flight_distinct_cache() {
+    let server = TestServer::spawn().await;
+
+    assert!(server
+        .api_v3_configure_table_create(&json!({
+            "db": "foo",
+                "table": "bar",
+                "tags": ["t1", "t2"],
+                "fields": []
+        }))
+        .await
+        .status()
+        .is_success());
+
+    assert!(server
+        .api_v3_configure_distinct_cache_create(&json!({
+            "db": "foo",
+            "table": "bar",
+            "name": "cache1",
+            "columns": ["t1", "t2"]
+        }))
+        .await
+        .status()
+        .is_success());
+
+    assert!(server
+        .write_lp_to_db(
+            "foo",
+            "\
+            bar,t1=a,t2=aa val=1\n\
+            bar,t1=a,t2=bb val=2\n\
+            bar,t1=b,t2=aa val=3\n\
+            bar,t1=b,t2=bb val=4\n\
+            ",
+            Precision::Auto
+        )
+        .await
+        .is_ok());
+
+    let mut client = server.flight_sql_client("foo").await;
+
+    {
+        let response = client
+            .query("SELECT * FROM distinct_cache('bar')")
+            .await
+            .unwrap();
+        let batches = collect_stream(response).await;
+        assert_batches_eq!(
+            [
+                "+----+----+",
+                "| t1 | t2 |",
+                "+----+----+",
+                "| a  | aa |",
+                "| a  | bb |",
+                "| b  | aa |",
+                "| b  | bb |",
+                "+----+----+",
+            ],
+            &batches
+        );
+    }
+
+    // create another cache on the same table:
+    assert!(server
+        .api_v3_configure_distinct_cache_create(&json!({
+            "db": "foo",
+            "table": "bar",
+            "name": "cache2",
+            "columns": ["t1"]
+        }))
+        .await
+        .status()
+        .is_success());
+
+    {
+        // this will error because the cache name needs to be specified:
+        let error = client
+            .query("SELECT * FROM distinct_cache('bar')")
+            .await
+            .unwrap_err()
+            .to_string();
+        assert_contains!(
+            error,
+            "could not find distinct value cache for the given arguments"
+        );
+    }
+
+    assert!(server
+        .write_lp_to_db(
+            "foo",
+            "\
+            bar,t1=c,t2=aa val=1\n\
+            bar,t1=c,t2=bb val=2\n\
+            ",
+            Precision::Auto
+        )
+        .await
+        .is_ok());
+
+    {
+        let response = client
+            .query("SELECT * FROM distinct_cache('bar', 'cache1')")
+            .await
+            .unwrap();
+        let batches = collect_stream(response).await;
+        assert_batches_eq!(
+            [
+                "+----+----+",
+                "| t1 | t2 |",
+                "+----+----+",
+                "| a  | aa |",
+                "| a  | bb |",
+                "| b  | aa |",
+                "| b  | bb |",
+                "| c  | aa |",
+                "| c  | bb |",
+                "+----+----+",
+            ],
+            &batches
+        );
+    }
+    {
+        let response = client
+            .query("SELECT * FROM distinct_cache('bar', 'cache2')")
+            .await
+            .unwrap();
+        let batches = collect_stream(response).await;
+        assert_batches_eq!(
+            [
+                "+----+", // prevent fmt from inlining
+                "| t1 |", // prevent fmt from inlining
+                "+----+", // prevent fmt from inlining
+                "| c  |", // prevent fmt from inlining
+                "+----+", // prevent fmt from inlining
+            ],
+            &batches
         );
     }
 }

--- a/influxdb3/tests/server/mod.rs
+++ b/influxdb3/tests/server/mod.rs
@@ -383,6 +383,18 @@ impl TestServer {
             .expect("send /query request to server")
     }
 
+    pub async fn api_v3_configure_table_create(&self, request: &serde_json::Value) -> Response {
+        self.http_client
+            .post(format!(
+                "{base}/api/v3/configure/table",
+                base = self.client_addr()
+            ))
+            .json(request)
+            .send()
+            .await
+            .expect("failed to send request to create table")
+    }
+
     pub async fn api_v3_configure_last_cache_create(
         &self,
         request: &serde_json::Value,


### PR DESCRIPTION
Related to #26002 

This was an attempt at re-producing the issue described in #26002. An integration test is added that queries the distinct cache using the FlightSQL client, in the same manor as in the issue.

Here is an example of the log output during a query that succeeded:
```
2025-02-13T16:00:36.172967Z  INFO service_grpc_flight: GetFlightInfo request namespace_name=foo cmd=CommandStatementQuerySELECT * FROM distinct_cache('bar') trace=
2025-02-13T16:00:36.196305Z  INFO iox_query::query_log: query when="received" id=ad150cad-51f0-4086-827b-cb3a8b460f2b namespace_id=0 namespace_name="influxdb3 oss" query_type="flightsql" query_text=CommandStatementQuerySELECT * FROM distinct_cache('bar') query_params=Params { } issue_time=2025-02-13T16:00:36.195870+00:00 success=false running=true cancelled=false
2025-02-13T16:00:36.196382Z  INFO service_grpc_flight: DoGet request namespace_name=foo query=CommandStatementQuerySELECT * FROM distinct_cache('bar') trace="" variant="flightsql"
2025-02-13T16:00:36.219698Z  INFO iox_query::query_log: query when="planned" id=ad150cad-51f0-4086-827b-cb3a8b460f2b namespace_id=0 namespace_name="influxdb3 oss" query_type="flightsql" query_text=CommandStatementQuerySELECT * FROM distinct_cache('bar') query_params=Params { } issue_time=2025-02-13T16:00:36.195870+00:00 partitions=0 parquet_files=0 deduplicated_partitions=0 deduplicated_parquet_files=0 plan_duration_secs=0.023818 success=false running=true cancelled=false
2025-02-13T16:00:36.220361Z  INFO iox_query::query_log: query when="permit" id=ad150cad-51f0-4086-827b-cb3a8b460f2b namespace_id=0 namespace_name="influxdb3 oss" query_type="flightsql" query_text=CommandStatementQuerySELECT * FROM distinct_cache('bar') query_params=Params { } issue_time=2025-02-13T16:00:36.195870+00:00 partitions=0 parquet_files=0 deduplicated_partitions=0 deduplicated_parquet_files=0 plan_duration_secs=0.023818 permit_duration_secs=0.000669 success=false running=true cancelled=false
2025-02-13T16:00:36.221514Z  INFO iox_query::query_log: query when="success" id=ad150cad-51f0-4086-827b-cb3a8b460f2b namespace_id=0 namespace_name="influxdb3 oss" query_type="flightsql" query_text=CommandStatementQuerySELECT * FROM distinct_cache('bar') query_params=Params { } issue_time=2025-02-13T16:00:36.195870+00:00 partitions=0 parquet_files=0 deduplicated_partitions=0 deduplicated_parquet_files=0 plan_duration_secs=0.023818 permit_duration_secs=0.000669 execute_duration_secs=0.001151 end2end_duration_secs=0.025641 compute_duration_secs=0.0 max_memory=0 ingester_metrics=IngesterMetrics { latency_to_plan = 0ns, latency_to_full_data = 0ns, response_rows = 0, partition_count = 0, response_size = 0 } success=true running=false cancelled=false
```

The test does not reproduce the reported issue, but I am adding it in this PR for more test coverage.