### PR TITLE
feat(processing_engine): improve package management for standalone python.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,12 +67,17 @@ RUN mkdir -p /usr/lib/influxdb3
 COPY --from=build /root/python /usr/lib/influxdb3/python
 RUN chown -R root:root /usr/lib/influxdb3
 
+RUN mkdir /plugins && \
+    chown influxdb3:influxdb3 /plugins
+
 USER influxdb3
 
 RUN mkdir ~/.influxdb3
 
 ARG PACKAGE=influxdb3
 ENV PACKAGE=$PACKAGE
+ENV INFLUXDB3_PLUGIN_DIR=/plugins
+ENV STANDALONE_ROOT=/usr/lib/influxdb3/python
 
 COPY --from=build "/root/$PACKAGE" "/usr/bin/$PACKAGE"
 COPY docker/entrypoint.sh /usr/bin/entrypoint.sh

--- a/influxdb3/src/main.rs
+++ b/influxdb3/src/main.rs
@@ -14,7 +14,9 @@ use dotenvy::dotenv;
 use influxdb3_clap_blocks::tokio::TokioIoConfig;
 use influxdb3_process::VERSION_STRING;
 use observability_deps::tracing::warn;
+#[cfg(feature = "system-py")]
 use std::env;
+#[cfg(feature = "system-py")]
 use std::path::{Path, PathBuf};
 use trogging::{
     cli::LoggingConfigBuilderExt,

--- a/influxdb3_clap_blocks/src/plugins.rs
+++ b/influxdb3_clap_blocks/src/plugins.rs
@@ -6,18 +6,21 @@ use std::path::PathBuf;
 #[derive(Debug, clap::Parser, Clone)]
 pub struct ProcessingEngineConfig {
     /// Location of the plugins
-    #[clap(long = "plugin-dir")]
+    #[clap(long = "plugin-dir", env = "INFLUXDB3_PLUGIN_DIR")]
     pub plugin_dir: Option<PathBuf>,
     #[clap(long = "virtual-env-location", env = "VIRTUAL_ENV")]
     pub virtual_env_location: Option<PathBuf>,
     #[clap(long = "package-manager", default_value = "discover")]
     pub package_manager: PackageManager,
+    #[clap(long = "standalone-root", env = "STANDALONE_ROOT")]
+    pub standalone_root: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, Default, clap::ValueEnum)]
 pub enum PackageManager {
     #[default]
     Discover,
+    Standalone,
     Pip,
     UV,
 }

--- a/influxdb3_processing_engine/src/manager.rs
+++ b/influxdb3_processing_engine/src/manager.rs
@@ -27,9 +27,6 @@ pub enum ProcessingEngineError {
     #[error("wal error: {0}")]
     WalError(#[from] influxdb3_wal::Error),
 
-    #[error("server not started with --plugin-dir")]
-    PluginDirNotSet,
-
     #[error("plugin not found: {0}")]
     PluginNotFound(String),
 


### PR DESCRIPTION
This adds another package manager specifically for standalone python. I also added a default plugin dir in the docker image of /plugin, as folks had had permissions issues with our existing images, particularly on docker. 

You can now run the docker image without any additional arguments and it'll run a plugin manager using the standalone python.

@jdstrand, I've only tested the images on OS X, but I don't think this will cause any issues on other platforms.