### PR TITLE
fix: detect python runtime for PipManager and venv setup

### DIFF
--- a/influxdb3_processing_engine/src/environment.rs
+++ b/influxdb3_processing_engine/src/environment.rs
@@ -1,6 +1,7 @@
 use crate::environment::PluginEnvironmentError::PluginEnvironmentDisabled;
 #[cfg(feature = "system-py")]
 use crate::virtualenv::{initialize_venv, VenvError};
+use std::env;
 use std::fmt::Debug;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -86,6 +87,36 @@ impl PythonEnvironmentManager for UVManager {
     }
 }
 
+// XXX: put this somewhere common
+fn find_python() -> PathBuf {
+    let python_exe_bn = if cfg!(windows) {
+        "python.exe"
+    } else {
+        "python3"
+    };
+    if let Ok(v) = env::var("VIRTUAL_ENV") {
+        let mut path = PathBuf::from(v);
+        if cfg!(windows) {
+            path.push("Scripts");
+        } else {
+            path.push("bin");
+        }
+        path.push(python_exe_bn);
+        path
+    } else if let Ok(v) = env::var("PYTHONHOME") {
+        // honor PYTHONHOME (set earlier for python standalone). python build
+        // standalone has bin/python3 on OSX/Linx and python.exe on Windows
+        let mut path = PathBuf::from(v);
+        if !cfg!(windows) {
+            path.push("bin");
+        }
+        path.push(python_exe_bn);
+        path
+    } else {
+        PathBuf::from(python_exe_bn)
+    }
+}
+
 impl PythonEnvironmentManager for PipManager {
     fn init_pyenv(
         &self,
@@ -98,7 +129,8 @@ impl PythonEnvironmentManager for PipManager {
         };
 
         if !is_valid_venv(venv_path) {
-            Command::new("python3")
+            let python_exe = find_python();
+            Command::new(python_exe)
                 .arg("-m")
                 .arg("venv")
                 .arg(venv_path)
@@ -110,7 +142,10 @@ impl PythonEnvironmentManager for PipManager {
         Ok(())
     }
     fn install_packages(&self, packages: Vec<String>) -> Result<(), PluginEnvironmentError> {
-        Command::new("pip")
+        let python_exe = find_python();
+        Command::new(python_exe)
+            .arg("-m")
+            .arg("pip")
             .arg("install")
             .args(&packages)
             .output()?;
@@ -120,7 +155,10 @@ impl PythonEnvironmentManager for PipManager {
         &self,
         requirements_path: String,
     ) -> Result<(), PluginEnvironmentError> {
-        Command::new("pip")
+        let python_exe = find_python();
+        Command::new(python_exe)
+            .arg("-m")
+            .arg("pip")
             .args(["install", "-r", &requirements_path])
             .output()?;
         Ok(())


### PR DESCRIPTION
Helps with #26012

https://github.com/influxdata/influxdb/pull/25969 left open a number of issues surrounding initial default venv setup and entering a venv when python build standalone is used which were captured in #26012. @jacksonrnewhouse noted that things worked when PATH was set to point to where the unpacked python build standalone was. This PR builds on the techniques from https://github.com/influxdata/influxdb/pull/25969 to resolve these issues by:
* adjusting `influxdb3/src/commands/serve.rs` to consider PYTHONHOME when looking for a valid `pip`
* adjusting `influxdb3_processing_engine/src/environment.rs` to have PipManager look for VIRTUAL_ENV and PYTHONHOME when creating the initial venv and installing packages (in practice, PYTHONHOME will be used when creating the venv and VIRTUAL_ENV will be used when installing packages)
* adjusting influxdb3_processing_engine/src/virtualenv.rs to consider VIRTUAL_ENV when determining the python version in the venv

IMPORTANT: like with https://github.com/influxdata/influxdb/pull/25969, the rust changes are expected to be changed since it is expected that these should be put in a library somewhere, replaced by some sort of build time variable that hardcodes the path to python, or something else. This PR is meant to resolve the open issues I left so that proper fixes can be developed in the fullness of time.

This was tested on Linux amd64 where the default `.venv` directory is now correctly setup up with python build standalone builds and `install packages foo` correctly installs `foo` into the `.venv` and makes it usable by scripts. Assuming @jacksonrnewhouse is ok with the approach, I can test the others.