### PR TITLE
chore: clean up runtime code for python setup

### DIFF
--- a/README_processing_engine.md
+++ b/README_processing_engine.md
@@ -310,6 +310,11 @@ minor release is straightforward, but processes for verifying builds of
 InfluxDB with the new `python-build-standalone` minor release are
 [TBD](https://github.com/influxdata/influxdb/issues/26045).
 
+References:
+ * https://www.python.org/dev/security/
+ * https://mail.python.org/mailman3/lists/security-announce.python.org/
+ * https://mail.python.org/archives/list/security-announce@python.org/latest
+ * https://github.com/astral-sh/python-build-standalone/releases
 
 ### How is python-build-standalone licensed?
 

--- a/README_processing_engine.md
+++ b/README_processing_engine.md
@@ -307,7 +307,8 @@ the `PBS_DATE` and `PBS_VERSION` environment variables in
 astral-sh creates new builds for CPython minor releases as they become
 available from upstream Python. Updating the official builds to pull in a new
 minor release is straightforward, but processes for verifying builds of
-InfluxDB with the new `python-build-standalone` minor release are TBD.
+InfluxDB with the new `python-build-standalone` minor release are
+[TBD](https://github.com/influxdata/influxdb/issues/26045).
 
 
 ### How is python-build-standalone licensed?

--- a/influxdb3/src/commands/serve.rs
+++ b/influxdb3/src/commands/serve.rs
@@ -23,6 +23,8 @@ use influxdb3_processing_engine::environment::{
     DisabledManager, PipManager, PythonEnvironmentManager, UVManager,
 };
 use influxdb3_processing_engine::plugins::ProcessingEngineEnvironmentManager;
+#[cfg(feature = "system-py")]
+use influxdb3_processing_engine::virtualenv::find_python;
 use influxdb3_server::{
     CommonServerState,
     auth::AllOrNothingAuthorizer,
@@ -49,10 +51,7 @@ use panic_logging::SendPanicsToTracing;
 use parquet_file::storage::{ParquetStorage, StorageId};
 use std::process::Command;
 use std::{env, num::NonZeroUsize, sync::Arc, time::Duration};
-use std::{
-    path::{Path, PathBuf},
-    str::FromStr,
-};
+use std::{path::Path, str::FromStr};
 use thiserror::Error;
 use tokio::net::TcpListener;
 use tokio::time::Instant;
@@ -665,31 +664,18 @@ pub(crate) fn setup_processing_engine_env_manager(
 
 fn determine_package_manager() -> Arc<dyn PythonEnvironmentManager> {
     // Check for pip (highest preference)
-    // XXX: put this somewhere common
-    let python_exe_bn = if cfg!(windows) {
-        "python.exe"
-    } else {
-        "python3"
-    };
-    let python_exe = if let Ok(v) = env::var("PYTHONHOME") {
-        // honor PYTHONHOME (set earlier for python standalone). python build
-        // standalone has bin/python3 on OSX/Linux and python.exe on Windows
-        let mut path = PathBuf::from(v);
-        if !cfg!(windows) {
-            path.push("bin");
-        }
-        path.push(python_exe_bn);
-        path
-    } else {
-        PathBuf::from(python_exe_bn)
-    };
-
-    if let Ok(output) = Command::new(python_exe)
-        .args(["-m", "pip", "--version"])
-        .output()
+    #[cfg(feature = "system-py")]
     {
-        if output.status.success() {
-            return Arc::new(PipManager);
+        let python_exe = find_python();
+        debug!("Running: {} -m pip --version", python_exe.display());
+
+        if let Ok(output) = Command::new(&python_exe)
+            .args(["-m", "pip", "--version"])
+            .output()
+        {
+            if output.status.success() {
+                return Arc::new(PipManager);
+            }
         }
     }
 

--- a/influxdb3/src/main.rs
+++ b/influxdb3/src/main.rs
@@ -14,11 +14,6 @@ use dotenvy::dotenv;
 use influxdb3_clap_blocks::tokio::TokioIoConfig;
 use influxdb3_process::VERSION_STRING;
 use observability_deps::tracing::warn;
-#[cfg(feature = "system-py")]
-use std::{
-    env,
-    path::{Path, PathBuf},
-};
 use trogging::{
     TroggingGuard,
     cli::LoggingConfigBuilderExt,
@@ -124,9 +119,6 @@ enum Command {
 fn main() -> Result<(), std::io::Error> {
     #[cfg(unix)]
     install_crash_handler(); // attempt to render a useful stacktrace to stderr
-
-    #[cfg(feature = "system-py")]
-    set_pythonhome();
 
     // load all environment variables from .env before doing anything
     load_dotenv();
@@ -310,39 +302,4 @@ fn init_logs_and_tracing(
 
     let subscriber = Registry::default().with(layers);
     trogging::install_global(subscriber)
-}
-
-// XXX: this should be somewhere more appropriate
-#[cfg(feature = "system-py")]
-fn set_pythonhome() {
-    // This would ideally be detected by pyo3, but it isn't
-    match env::var("PYTHONHOME") {
-        Ok(_) => {}
-        Err(env::VarError::NotPresent) => {
-            let exe_path = env::current_exe().unwrap();
-            let exe_dir = exe_path.parent().unwrap();
-
-            let pythonhome: PathBuf = if cfg!(target_os = "linux")
-                && (exe_dir == Path::new("/usr/bin") || exe_dir == Path::new("/usr/local/bin"))
-            {
-                // Official Linux builds may be in /usr or /usr/local
-                // XXX: handle this for local build and install (eg DESTDIR)
-                let parent_dir = exe_dir.parent().unwrap();
-                parent_dir.join("lib/influxdb3/python")
-            } else {
-                exe_dir.join("python")
-            };
-
-            if pythonhome.is_dir() {
-                unsafe { env::set_var("PYTHONHOME", pythonhome.to_str().unwrap()) };
-                //println!("Set PYTHONHOME to '{}'", env::var("PYTHONHOME").unwrap());
-            } else {
-                // TODO: use logger
-                eprintln!("Could not find python installation. May need to set PYTHONHOME");
-            }
-        }
-        Err(e) => {
-            eprintln!("Failed to retrieve PYTHONHOME: {e}");
-        }
-    };
 }

--- a/influxdb3_processing_engine/src/virtualenv.rs
+++ b/influxdb3_processing_engine/src/virtualenv.rs
@@ -105,28 +105,19 @@ fn get_python_version() -> Result<(u8, u8), std::io::Error> {
     Ok((major, minor))
 }
 
-fn set_pythonpath(venv_dir: &Path) -> Result<(), std::io::Error> {
-    let (major, minor) = get_python_version()?;
-    let site_packages = if cfg!(target_os = "windows") {
-        venv_dir.join("Lib").join("site-packages")
-    } else {
-        venv_dir
-            .join("lib")
-            .join(format!("python{}.{}", major, minor))
-            .join("site-packages")
-    };
-
-    debug!("Setting PYTHONPATH to: {}", site_packages.to_string_lossy());
-    unsafe {
-        std::env::set_var("PYTHONPATH", &site_packages);
-    }
-
-    Ok(())
-}
-
 pub fn init_pyo3() {
-    // PYO3 compiled against python-build-standalone needs PYTHONHOME set
-    // to the installation location for initialization to work correctly
+    // When activating a venv in the shell, sys.base_prefix and
+    // sys.base_exec_prefix should be set to the installation location
+    // while sys.prefix and sys.exec_prefix should be set to the venv dir.
+    // Unfortunately, at this point, we can't use Py_InitializeFromConfig()
+    // to set any of these and certain platforms are unable to find
+    // python-build-standalone. For now, we'll set PYTHONHOME to the
+    // installation location to make python work, but by setting it now
+    // (ie, after Py_InitializeFromConfig() can be called), sys.prefix and
+    // sys.exec_prefix also end up being set to the installation location.
+    //
+    // Note: init_pyo3() is called after initialize_venv() and initialize_venv()
+    // will set VIRTUAL_ENV as appropriate.
     let python_inst = find_python_install();
     let orig_pyhome_env = env::var("PYTHONHOME").ok();
     if let Some(path) = python_inst {
@@ -143,9 +134,9 @@ pub fn init_pyo3() {
     PYTHON_INIT.call_once(|| {
         pyo3::prepare_freethreaded_python();
 
-        // This sets the signal handler fo SIGINT to be the default, allowing CTRL+C to work.
-        // See https://github.com/PyO3/pyo3/issues/3218.
         Python::with_gil(|py| {
+            // This sets the signal handler fo SIGINT to be the default, allowing CTRL+C to work.
+            // See https://github.com/PyO3/pyo3/issues/3218.
             py.run(
                 &CString::new("import signal;signal.signal(signal.SIGINT, signal.SIG_DFL)")
                     .unwrap(),
@@ -153,18 +144,81 @@ pub fn init_pyo3() {
                 None,
             )
             .expect("should be able to set signal handler.");
+
+            if let Ok(v) = env::var("VIRTUAL_ENV") {
+                // XXX: ideally we would reorganize the code so that we can
+                // call Py_InitializeFromConfig() with base_prefix and
+                // base_exec_prefix set to the python-build-standalone location
+                // (/path/to/python-build-standalone) and prefix and
+                // exec_prefix to the value of VIRTUAL_ENV. For now, clean up
+                // the side-effect of having set PYTHONHOME, above, and set
+                // sys.prefix and sys.exec_prefix manually.
+                debug!(
+                    "Updating sys.prefix and sys.exec_prefix to VIRTUAL_ENV: {}",
+                    v
+                );
+                let prefix = Path::new(&v);
+                // Note: need to use python raw strings (r'') for Windows paths
+                py.run(
+                    &CString::new(format!(
+                        "import sys; sys.prefix = r'{}'; sys.exec_prefix = r'{}'",
+                        prefix.display(),
+                        prefix.display()
+                    ))
+                    .unwrap(),
+                    None,
+                    None,
+                )
+                .expect("should be able set sys.prefix and sys.exec_prefix");
+
+                // When using activate scripts, initializing python within a
+                // venv results in the venv's site-packages being appended to
+                // the end of sys.path, so do that here. We could instead set
+                // the PYTHONPATH env var, but that prepends to sys.path.
+                if let Ok((major, minor)) = get_python_version() {
+                    let venv_dir = Path::new(&v);
+                    let site_packages = if cfg!(target_os = "windows") {
+                        venv_dir.join("Lib").join("site-packages")
+                    } else {
+                        venv_dir
+                            .join("lib")
+                            .join(format!("python{}.{}", major, minor))
+                            .join("site-packages")
+                    };
+
+                    debug!("Updating sys.path to append: {}", site_packages.display());
+                    // Note: need to use python raw strings (r'') for Windows paths
+                    py.run(
+                        &CString::new(format!(
+                            "import sys; sys.path.append(r'{}') if r'{}' not in sys.path else None",
+                            site_packages.display(),
+                            site_packages.display(),
+                        ))
+                        .unwrap(),
+                        None,
+                        None,
+                    )
+                    .expect("should be able append to sys.path");
+                }
+            }
         });
     });
 
-    // now that we're initialized, restore/unset PYTHONHOME
-    match orig_pyhome_env {
-        Some(v) => {
-            debug!("Restoring previous PYTHONHOME to: {}", v);
-            unsafe { env::set_var("PYTHONHOME", v) }
-        }
-        None => {
-            debug!("Unsetting temporary PYTHONHOME");
-            unsafe { env::remove_var("PYTHONHOME") }
+    // Now that we're initialized, unset/restore PYTHONHOME
+    if env::var("VIRTUAL_ENV").is_ok() {
+        // venv activate scripts always unset PYTHONHOME, let's do the same
+        debug!("Unsetting temporary PYTHONHOME when VIRTUAL_ENV is set");
+        unsafe { env::remove_var("PYTHONHOME") }
+    } else {
+        match orig_pyhome_env {
+            Some(v) => {
+                debug!("Restoring previous PYTHONHOME to: {}", v);
+                unsafe { env::set_var("PYTHONHOME", v) }
+            }
+            None => {
+                debug!("Unsetting temporary PYTHONHOME");
+                unsafe { env::remove_var("PYTHONHOME") }
+            }
         }
     }
 }
@@ -222,8 +276,6 @@ pub(crate) fn initialize_venv(venv_path: &Path) -> Result<(), VenvError> {
     if let Ok(v) = env::var("VIRTUAL_ENV") {
         debug!("VIRTUAL_ENV set to: {}", v);
     }
-
-    set_pythonpath(venv_path)?;
 
     Ok(())
 }

--- a/influxdb3_processing_engine/src/virtualenv.rs
+++ b/influxdb3_processing_engine/src/virtualenv.rs
@@ -17,13 +17,47 @@ pub enum VenvError {
     CommandError(#[from] std::io::Error),
 }
 
-fn get_python_version() -> Result<(u8, u8), std::io::Error> {
+// Find the python installation location (not virtual env).
+// XXX: use build flag?
+fn find_python_install() -> PathBuf {
+    let influxdb3_exe = env::current_exe().unwrap();
+    let influxdb3_exe_dir = influxdb3_exe.parent().unwrap();
+    let influxdb3_rel_dir = influxdb3_exe_dir.join("python");
+    let influxdb3_linux_dir = influxdb3_exe_dir.join("../lib/influxdb3/python");
+
+    let python_inst = if cfg!(target_os = "linux")
+        && (influxdb3_exe_dir == Path::new("/usr/bin")
+            || influxdb3_exe_dir == Path::new("/usr/local/bin"))
+        && influxdb3_linux_dir.is_dir()
+    {
+        // Official Linux deb/rpm/docker builds are in /usr (but also allow for
+        // /usr/local) so use runtime in /usr/[local/]lib/influxdb3/python/
+        influxdb3_linux_dir
+    } else if influxdb3_rel_dir.is_dir() {
+        // Official tar/zip builds use runtime in python/ relative to executable
+        influxdb3_rel_dir
+    } else {
+        // Could not find python-build-standalone installation
+        PathBuf::new()
+    };
+    debug!(
+        "Found python standalone installation: {}",
+        python_inst.display()
+    );
+    python_inst
+}
+
+pub fn find_python() -> PathBuf {
     let python_exe_bn = if cfg!(windows) {
         "python.exe"
     } else {
         "python3"
     };
+
+    let python_home = find_python_install();
     let python_exe = if let Ok(v) = env::var("VIRTUAL_ENV") {
+        // After initialize_venv(), VIRTUAL_ENV is set, so honor it (thus
+        // allowing package installs to be installed in the venv)
         let mut path = PathBuf::from(v);
         if cfg!(windows) {
             path.push("Scripts");
@@ -32,10 +66,26 @@ fn get_python_version() -> Result<(u8, u8), std::io::Error> {
         }
         path.push(python_exe_bn);
         path
+    } else if !python_home.as_os_str().is_empty() {
+        // Prior to initialize_venv(), VIRTUAL_ENV is not set so we'll want to
+        // look for where the python installation is, which allows
+        // 'python -m venv' to work correctly
+        let mut path = python_home;
+        if !cfg!(windows) {
+            path.push("bin");
+        }
+        path.push(python_exe_bn);
+        path
     } else {
+        // Fallback to searching PATH
         PathBuf::from(python_exe_bn)
     };
+    debug!("Found python executable: {}", python_exe.display());
+    python_exe
+}
 
+fn get_python_version() -> Result<(u8, u8), std::io::Error> {
+    let python_exe = find_python();
     let output = Command::new(python_exe)
         .args([
             "-c",
@@ -71,6 +121,21 @@ fn set_pythonpath(venv_dir: &Path) -> Result<(), std::io::Error> {
 }
 
 pub fn init_pyo3() {
+    // PYO3 compiled against python-build-standalone needs PYTHONHOME set
+    // to the installation location for initialization to work correctly
+    let python_inst = find_python_install();
+    let orig_pyhome_env = env::var("PYTHONHOME").ok();
+    if !python_inst.as_os_str().is_empty() {
+        // Found python-build-standalone installation
+        debug!(
+            "Temporarily setting PYTHONHOME during initialization to: {}",
+            python_inst.to_string_lossy()
+        );
+        unsafe {
+            env::set_var("PYTHONHOME", &python_inst);
+        }
+    }
+
     PYTHON_INIT.call_once(|| {
         pyo3::prepare_freethreaded_python();
 
@@ -86,6 +151,18 @@ pub fn init_pyo3() {
             .expect("should be able to set signal handler.");
         });
     });
+
+    // now that we're initialized, restore/unset PYTHONHOME
+    match orig_pyhome_env {
+        Some(v) => {
+            debug!("Restoring previous PYTHONHOME to: {}", v);
+            unsafe { env::set_var("PYTHONHOME", v) }
+        }
+        None => {
+            debug!("Unsetting temporary PYTHONHOME");
+            unsafe { env::remove_var("PYTHONHOME") }
+        }
+    }
 }
 
 pub(crate) fn initialize_venv(venv_path: &Path) -> Result<(), VenvError> {
@@ -134,6 +211,10 @@ pub(crate) fn initialize_venv(venv_path: &Path) -> Result<(), VenvError> {
         .lines()
         .filter_map(|line| line.split_once('='))
         .for_each(|(key, value)| unsafe { std::env::set_var(key, value) });
+
+    if let Ok(v) = env::var("VIRTUAL_ENV") {
+        debug!("VIRTUAL_ENV set to: {}", v);
+    }
 
     set_pythonpath(venv_path)?;
 


### PR DESCRIPTION
ccd5d22aab introduced working but temporary code for setting up the python runtime environment. This cleans that up:


* chore: clean up runtime code for python setup
    
    ccd5d22aab introduced working but temporary code for setting up the
    python runtime environment. This cleans that up:
    
    * refactor various find_python() functionality into virtualenv.rs
    * refactor PYTHONHOME calculation to virtualenv.rs:find_python_install()
    * adjust init_pyo3() to temporarily set PYTHONHOME based on
      virtualenv.rs:find_python_install() as this is the only place it is
      needed (indeed, venv activation scripts try to remove it)
    
    Importantly, virtualenv.rs:find_python_install() tries to find the
    python build standalone runtime based on a few heuristics. This function
    could be improved in the fullness of time to, eg, be configured via a
    build parameter.
    
    Also, virtualenv.rs:find_python() can be used pre and post venv
    activation. Before entering the venv, it will use find_python_install()
    which is useful for things like setting up the initial venv. After
    entering the venv, it will honor VIRTUAL_ENV (as set by
    virtualenv.rs:initialize_venv()) to find python, which is important for
    install packages with pip and having them installed into the venv.

* chore: update README_processing_engine.md for default venv
* chore: add bug reference for venv migrations with python minor releases
* chore: update README_processing_engine.md for default venv
* chore: add bug reference for venv migrations with python minor releases
* chore: add security URLs to README_processing_engine.md
* chore: find_python_home() returns Option<PathBuf>. Thanks Jackson Newhouse
* fix: manually set sys.prefix, exec_prefix and sys.path
    
    When activating a venv in the shell, sys.base_prefix and
    sys.base_exec_prefix should be set to the installation location while
    sys.prefix and sys.exec_prefix should be set to the venv dir.
    Unfortunately, when initialize_venv() and init_pyo3() are called, we
    can't use Py_InitializeFromConfig() to set any of these and certain
    platforms are unable to find python-build-standalone. For now, we'll
    temporarily set PYTHONHOME in init_pyo3() to the installation location
    to make python work. By setting it at this point in the code, sys.prefix
    and sys.exec_prefix end up also being set to the installation location,
    which is fine when not under a venv, but is different from when entering
    an venv.
    
    To address this, in PYTHON_INIT.call_once() and when VIRTUAL_ENV is set
    (which initialize_venv() will have set at this point), manually set
    sys.prefix and sys.exec_prefix to what is in VIRTUAL_ENV.
    
    Similarly, when activating a venv in the shell, sys.path is appended to
    have the venv's site-packages dir. Previously we were setting PYTHONPATH
    in initialize_venv() which ensures that the venv's site-packages dir is
    in sys.path, but this ends up having the venv's site-packages dir first
    in sys.path. To correct this, don't set PYTHONPATH any more and instead
    adjust PYTHON_INIT.call_once() to append the venv's site-packages dir to
    sys.path when VIRTUAL_ENV is set.
    
    Finally, when exiting init_pyo3(), unconditionally unset PYTHONHOME when
    VIRTUAL_ENV is set (like activation scripts do) and restore/unset when
    it isn't.
    
    Prior to these changes, all target incorrectly had the venv's
    site-packages first in sys.path and OSX and Windows additionally had an
    incorrect sys.prefix and sys.exec_prefix. With these initialization
    changes in place, the runtime environment for the plugins is much closer
    to that of a shell activated venv.

Importantly, virtualenv.rs:find_python_install() tries to find the python build standalone runtime based on a few heuristics. This function could be improved in the fullness of time to, eg, be configured via a build parameter.

Also, virtualenv.rs:find_python() can be used pre and post venv activation. Before entering the venv, it will use find_python_install() which is useful for things like setting up the initial venv. After entering the venv, it will honor VIRTUAL_ENV (as set by virtualenv.rs:initialize_venv()) to find python, which is important for install packages with pip and having them installed into the venv.

## Testing
This has been tested to work correctly for all of:

* Darwin arm64
* Linux amd64
* Docker amd64
* Windows amd64

The paths are correctly setup when `.venv` doesn't exist, when it does and when `--virtual-env-location` is set (to an existing or non-existing dir).

Furthermore, I did testing before and after `fix: manually set sys.prefix, exec_prefix and sys.path` [1f8001d0](https://github.com/influxdata/influxdb/pull/26042/commits/1f8001d080d100ac2862b9c18601c44869b24ef2).

### Shell activated venv

It is useful to compare what a shell activated venv looks like to know how we compare:

<details>

```
#
# Create an alternative venv with python-build-standalone to demonstrate how things are set up
#

# linux
$ ./tmp/influxdb3-pe/install/python/bin/python3 -m venv ~/tmp/influxdb3-pe/venv-alt
$ source ~/tmp/influxdb3-pe/venv-alt/bin/activate
(venv-alt)$ python3 -c "import sys; [print('%s = %s' % (a, getattr(sys, a))) for a in ['base_exec_prefix', 'base_prefix', 'exec_prefix', 'executable', 'path', 'prefix'] if not a.startswith('_')]"
base_exec_prefix = /home/jamie/tmp/influxdb3-pe/install/python
base_prefix = /home/jamie/tmp/influxdb3-pe/install/python
exec_prefix = /home/jamie/tmp/influxdb3-pe/venv-alt
executable = /home/jamie/tmp/influxdb3-pe/venv-alt/bin/python3
path = ['', '/home/jamie/tmp/influxdb3-pe/install/python/lib/python311.zip', '/home/jamie/tmp/influxdb3-pe/install/python/lib/python3.11', '/home/jamie/tmp/influxdb3-pe/install/python/lib/python3.11/lib-dynload', '/home/jamie/tmp/influxdb3-pe/venv-alt/lib/python3.11/site-packages']
prefix = /home/jamie/tmp/influxdb3-pe/venv-alt

# osx
$ ./tmp/influxdb3-pe/install/python/bin/python3 -m venv ~/tmp/influxdb3-pe/venv-alt
$ source ~/tmp/influxdb3-pe/venv-alt/bin/activate
(venv-alt)$ python3 -c "import sys; [print('%s = %s' % (a, getattr(sys, a))) for a in ['base_exec_prefix', 'base_prefix', 'exec_prefix', 'executable', 'path', 'prefix'] if not a.startswith('_')]"
base_exec_prefix = /Users/jamie/tmp/influxdb3-pe/install/python
base_prefix = /Users/jamie/tmp/influxdb3-pe/install/python
exec_prefix = /Users/jamie/tmp/influxdb3-pe/venv-alt
executable = /Users/jamie/tmp/influxdb3-pe/venv-alt/bin/python3
path = ['', '/Users/jamie/tmp/influxdb3-pe/install/python/lib/python311.zip', '/Users/jamie/tmp/influxdb3-pe/install/python/lib/python3.11', '/Users/jamie/tmp/influxdb3-pe/install/python/lib/python3.11/lib-dynload', '/Users/jamie/tmp/influxdb3-pe/venv-alt/lib/python3.11/site-packages']
prefix = /Users/jamie/tmp/influxdb3-pe/venv-alt

# windows
$ influxdb3-pe\install\python\python.exe -m venv Z:\influxdb3-pe\venv-alt
$ Z:\influxdb3-pe\venv-alt\Scripts\activate
(venv-alt)$ python -c "import sys; [print('%s = %s' % (a, getattr(sys, a))) for a in ['base_exec_prefix', 'base_prefix', 'exec_prefix', 'executable', 'path', 'prefix'] if not a.startswith('_')]"
base_exec_prefix = Z:\influxdb3-pe\install\python
base_prefix = Z:\influxdb3-pe\install\python
exec_prefix = Z:\influxdb3-pe\venv-alt
executable = Z:\influxdb3-pe\venv-alt\Scripts\python.exe
path = ['', 'Z:\\influxdb3-pe\\install\\python\\python311.zip', 'Z:\\influxdb3-pe\\install\\python\\DLLs', 'Z:\\influxdb3-pe\\install\\python\\Lib', 'Z:\\influxdb3-pe\\install\\python', 'Z:\\influxdb3-pe\\venv-alt', 'Z:\\influxdb3-pe\\venv-alt\\Lib\\site-packages']
prefix = Z:\influxdb3-pe\venv-alt

```

</details>

On all OSes:
* `base_prefix` and `base_exec_prefix` point to the `python-build-standalone` runtime dir
* `prefix` and `exec_prefix` point to the venv dir
* `path` has the venv's site-packages at the end of the list

### Current main

All targets for current main incorrectly have the venv's site-packages first in sys.path and OSX and Windows additionally had an incorrect sys.prefix and sys.exec_prefix. This doesn't seem to affect the operations of plugins.

#### Linux

<details>

```
#
# linux
#
$ ~/tmp/influxdb3-pe/install/influxdb3 serve --node-id=local01 --object-store=file --data-dir ~/tmp/influxdb3-pe/data --plugin-dir ~/tmp/influxdb3-pe/data/plugins

# WRONG: client - show paths (prefix/exec_prefix are venv,
# base_prefix/base_exec_prefix are python install location BUT SYS.PATH HAS
# VENV's SITE-PACKAGES FIRST
$ ~/tmp/influxdb3-pe/install/influxdb3 test schedule_plugin -d mydb01 simple.py
{
  "trigger_time": "2025-02-25T20:49:17Z",
  "log_lines": [
    "INFO: sys.prefix = /home/jamie/tmp/influxdb3-pe/data/plugins/.venv",
    "INFO: sys.exec_prefix = /home/jamie/tmp/influxdb3-pe/data/plugins/.venv",
    "INFO: sys.base_prefix = /home/jamie/tmp/influxdb3-pe/install/python",
    "INFO: sys.base_exec_prefix = /home/jamie/tmp/influxdb3-pe/install/python",
    "INFO: sys.executable = /home/jamie/tmp/influxdb3-pe/data/plugins/.venv/bin/python3",
    "INFO: sys.path = ['/home/jamie/tmp/influxdb3-pe/data/plugins/.venv/lib/python3.11/site-packages', '/home/jamie/tmp/influxdb3-pe/install/python/lib/python311.zip', '/home/jamie/tmp/influxdb3-pe/install/python/lib/python3.11', '/home/jamie/tmp/influxdb3-pe/install/python/lib/python3.11/lib-dynload']",
    "INFO: 'requests' location = not found"
  ],
  "database_writes": {},                   
  "errors": []  
}
```

</details>

#### OSX

<details>

```
#
# osx
#
# serve
$ ~/tmp/influxdb3-pe/install/influxdb3 serve --node-id my_host --object-store file --data-dir ./tmp/influxdb3-pe/data --plugin-dir ./tmp/influxdb3-pe/data/plugins

# WRONG client - show paths (PREFIX/EXEC_PREFIX ARE PYTHON INSTALL LOCATION,
# base_prefix/base_exec_prefix are python install location BUT SYS.PATH HAS
# VENV's SITE-PACKAGES FIRST
$ ~/tmp/influxdb3-pe/install/influxdb3 test schedule_plugin -d mydb01 simple.py
{
  "trigger_time": "2025-02-25T20:54:38Z",
  "log_lines": [
    "INFO: sys.prefix = /Users/jamie/tmp/influxdb3-pe/install/python",
    "INFO: sys.exec_prefix = /Users/jamie/tmp/influxdb3-pe/install/python",
    "INFO: sys.base_prefix = /Users/jamie/tmp/influxdb3-pe/install/python",
    "INFO: sys.base_exec_prefix = /Users/jamie/tmp/influxdb3-pe/install/python",
    "INFO: sys.executable = /Users/jamie/tmp/influxdb3-pe/install/influxdb3",
    "INFO: sys.path = ['/Users/jamie/tmp/influxdb3-pe/data/plugins/.venv/lib/python3.11/site-packages', '/Users/jamie/tmp/influxdb3-pe/install/python/lib/python311.zip', '/Users/jamie/tmp/influxdb3-pe/install/python/lib/python3.11', '/Users/jamie/tmp/influxdb3-pe/install/python/lib/python3.11/lib-dynload', '/Users/jamie/tmp/influxdb3-pe/install/python/lib/python3.11/site-packages']",
    "INFO: 'requests' location = not found"
  ],
  "database_writes": {},
  "errors": []
}
```

</details>

#### Windows

<details>

```
#
# windows
#
# serve
> influxdb3-pe\install\influxdb3.exe serve --node-id=local01 --object-store=file --data-dir Z:\influxdb3-pe\data --plugin-dir Z:\influxdb3-pe\data\plugins

# WRONG - client - show paths (PREFIX/EXEC_PREFIX ARE PYTHON INSTALL LOCATION,
# base_prefix/base_exec_prefix are python install location BUT SYS.PATH HAS
# VENV's SITE-PACKAGES FIRST
> influxdb3-pe\install\influxdb3.exe test schedule_plugin -d mydb01 simple.py
{
  "trigger_time": "2025-02-25T20:57:53Z",
  "log_lines": [
    "INFO: sys.prefix = Z:\\influxdb3-pe\\install\\python",
    "INFO: sys.exec_prefix = Z:\\influxdb3-pe\\install\\python",
    "INFO: sys.base_prefix = Z:\\influxdb3-pe\\install\\python",
    "INFO: sys.base_exec_prefix = Z:\\influxdb3-pe\\install\\python",
    "INFO: sys.executable = Z:\\influxdb3-pe\\install\\influxdb3.exe",
    "INFO: sys.path = ['Z:\\\\influxdb3-pe\\\\data\\\\plugins\\\\.venv\\\\Lib\\\\site-packages', 'Z:\\\\influxdb3-pe\\\\install\\\\python311.zip', 'Z:\\\\influxdb3-pe\\\\install\\\\python\\\\DLLs', 'Z:\\\\influxdb3-pe\\\\install\\\\python\\\\Lib', 'Z:\\\\influxdb3-pe\\\\install', 'Z:\\\\influxdb3-pe\\\\install\\\\python', 'Z:\\\\influxdb3-pe\\\\install\\\\python\\\\Lib\\\\site-packages']",
    "INFO: 'requests' location = not found"
  ],
  "database_writes": {},
  "errors": []
}
```

</details>


### With this PR

While the current main behavior doesn't seem to be causing problems, it seems like there could be potential for them. With this PR, the runtime environment for the plugins is much closer to that of a shell activated venv.

#### Linux
<details>

```
#
# linux
#
# server
$ ~/tmp/influxdb3-pe/install/influxdb3 serve --node-id=local01 --object-store=file --data-dir ~/tmp/influxdb3-pe/data --plugin-dir ~/tmp/influxdb3-pe/data/plugins
...

# client - show paths (prefix/exec_prefix are venv,
# base_prefix/base_exec_prefix are python install location, sys.path has
# .venv's site-packages appended
$ ~/tmp/influxdb3-pe/install/influxdb3 test schedule_plugin -d mydb01 simple.py
{
  "trigger_time": "2025-02-25T20:25:11Z",
  "log_lines": [
    "INFO: sys.prefix = /home/jamie/tmp/influxdb3-pe/data/plugins/.venv",
    "INFO: sys.exec_prefix = /home/jamie/tmp/influxdb3-pe/data/plugins/.venv",
    "INFO: sys.base_prefix = /home/jamie/tmp/influxdb3-pe/install/python",
    "INFO: sys.base_exec_prefix = /home/jamie/tmp/influxdb3-pe/install/python",
    "INFO: sys.executable = /home/jamie/tmp/influxdb3-pe/data/plugins/.venv/bin/python3",
    "INFO: sys.path = ['/home/jamie/tmp/influxdb3-pe/install/python/lib/python311.zip', '/home/jamie/tmp/influxdb3-pe/install/python/lib/python3.11', '/home/jamie/tmp/influxdb3-pe/install/python/lib/python3.11/lib-dynload', '/home/jamie/tmp/influxdb3-pe/data/plugins/.venv/lib/python3.11/site-packages']",
    "INFO: 'requests' location = not found"
  ],
  "database_writes": {},
  "errors": []
}

# client - install requests
$ ~/tmp/influxdb3-pe/install/influxdb3 install package requests

# client - show paths (as above, but requests was found in venv)
$ ~/tmp/influxdb3-pe/install/influxdb3 test schedule_plugin -d mydb01 simple.py
{
  "trigger_time": "2025-02-25T20:27:57Z",
  "log_lines": [
    "INFO: sys.prefix = /home/jamie/tmp/influxdb3-pe/data/plugins/.venv",
    "INFO: sys.exec_prefix = /home/jamie/tmp/influxdb3-pe/data/plugins/.venv",
    "INFO: sys.base_prefix = /home/jamie/tmp/influxdb3-pe/install/python",
    "INFO: sys.base_exec_prefix = /home/jamie/tmp/influxdb3-pe/install/python",
    "INFO: sys.executable = /home/jamie/tmp/influxdb3-pe/data/plugins/.venv/bin/python3",
    "INFO: sys.path = ['/home/jamie/tmp/influxdb3-pe/install/python/lib/python311.zip', '/home/jamie/tmp/influxdb3-pe/install/python/lib/python3.11', '/home/jamie/tmp/influxdb3-pe/install/python/lib/python3.11/lib-dynload', '/home/jamie/tmp/influxdb3-pe/data/plugins/.venv/lib/python3.11/site-packages']",
    "INFO: 'requests' location = /home/jamie/tmp/influxdb3-pe/data/plugins/.venv/lib/python3.11/site-packages/requests/__init__.py"
  ],
  "database_writes": {},
  "errors": []
}
```

</details>

#### OSX

<details>

```
# osx
# server
$ ~/tmp/influxdb3-pe/install/influxdb3 serve --node-id my_host --object-store file --data-dir ./tmp/influxdb3-pe/data --plugin-dir ./tmp/influxdb3-pe/data/plugins

# client - show paths (prefix/exec_prefix are venv,
# base_prefix/base_exec_prefix are python install location, sys.path has
# .venv's site-packages appended
$ ~/tmp/influxdb3-pe/install/influxdb3 test schedule_plugin -d mydb01 simple.py
{
  "trigger_time": "2025-02-25T20:33:07Z",
  "log_lines": [
    "INFO: sys.prefix = /Users/jamie/tmp/influxdb3-pe/data/plugins/.venv",
    "INFO: sys.exec_prefix = /Users/jamie/tmp/influxdb3-pe/data/plugins/.venv",
    "INFO: sys.base_prefix = /Users/jamie/tmp/influxdb3-pe/install/python",
    "INFO: sys.base_exec_prefix = /Users/jamie/tmp/influxdb3-pe/install/python",
    "INFO: sys.executable = /Users/jamie/tmp/influxdb3-pe/install/influxdb3",
    "INFO: sys.path = ['/Users/jamie/tmp/influxdb3-pe/install/python/lib/python311.zip', '/Users/jamie/tmp/influxdb3-pe/install/python/lib/python3.11', '/Users/jamie/tmp/influxdb3-pe/install/python/lib/python3.11/lib-dynload', '/Users/jamie/tmp/influxdb3-pe/install/python/lib/python3.11/site-packages', '/Users/jamie/tmp/influxdb3-pe/data/plugins/.venv/lib/python3.11/site-packages']",
    "INFO: 'requests' location = not found"
  ],
  "database_writes": {},
  "errors": []
}

# client - install requests
$ ~/tmp/influxdb3-pe/install/influxdb3 install package requests

# client - show paths (as above, but requests was found in venv)
$ ~/tmp/influxdb3-pe/install/influxdb3 test schedule_plugin -d mydb01 simple.py
{
  "trigger_time": "2025-02-25T20:34:54Z",
  "log_lines": [
    "INFO: sys.prefix = /Users/jamie/tmp/influxdb3-pe/data/plugins/.venv",
    "INFO: sys.exec_prefix = /Users/jamie/tmp/influxdb3-pe/data/plugins/.venv",
    "INFO: sys.base_prefix = /Users/jamie/tmp/influxdb3-pe/install/python",
    "INFO: sys.base_exec_prefix = /Users/jamie/tmp/influxdb3-pe/install/python",
    "INFO: sys.executable = /Users/jamie/tmp/influxdb3-pe/install/influxdb3",
    "INFO: sys.path = ['/Users/jamie/tmp/influxdb3-pe/install/python/lib/python311.zip', '/Users/jamie/tmp/influxdb3-pe/install/python/lib/python3.11', '/Users/jamie/tmp/influxdb3-pe/install/python/lib/python3.11/lib-dynload', '/Users/jamie/tmp/influxdb3-pe/install/python/lib/python3.11/site-packages', '/Users/jamie/tmp/influxdb3-pe/data/plugins/.venv/lib/python3.11/site-packages']",
    "INFO: 'requests' location = /Users/jamie/tmp/influxdb3-pe/data/plugins/.venv/lib/python3.11/site-packages/requests/__init__.py"
  ],
  "database_writes": {},
  "errors": []
}
```

</details>

#### Windows

<details>

```
# windows
# server
> influxdb3-pe\install\influxdb3.exe serve --node-id=local01 --object-store=file --data-dir Z:\influxdb3-pe\data --plugin-dir Z:\influxdb3-pe\data\plugins
...

# client - show paths (prefix/exec_prefix are venv,
# base_prefix/base_exec_prefix are python install location, sys.path has
# .venv's site-packages appended
> influxdb3-pe\install\influxdb3.exe test schedule_plugin -d mydb01 simple.py
{
  "trigger_time": "2025-02-25T17:34:16Z",
  "log_lines": [
    "INFO: sys.prefix = Z:\\influxdb3-pe\\data\\plugins\\.venv",
    "INFO: sys.exec_prefix = Z:\\influxdb3-pe\\data\\plugins\\.venv",
    "INFO: sys.base_prefix = Z:\\influxdb3-pe\\install\\python",
    "INFO: sys.base_exec_prefix = Z:\\influxdb3-pe\\install\\python",
    "INFO: sys.executable = Z:\\influxdb3-pe\\install\\influxdb3.exe",
    "INFO: sys.path = ['Z:\\\\influxdb3-pe\\\\install\\\\python311.zip', 'Z:\\\\influxdb3-pe\\\\install\\\\python\\\\DLLs', 'Z:\\\\influxdb3-pe\\\\install\\\\python\\\\Lib', 'Z:\\\\influxdb3-pe\\\\install', 'Z:\\\\influxdb3-pe\\\\install\\\\python', 'Z:\\\\influxdb3-pe\\\\install\\\\python\\\\Lib\\\\site-packages', 'Z:\\\\influxdb3-pe\\\\data\\\\plugins\\\\.venv\\\\Lib\\\\site-packages']",
    "INFO: 'requests' location = not found"
  ],
  "database_writes": {},
  "errors": []
}

# client - install requests
> influxdb3-pe\install\influxdb3.exe install package requests

# client - show paths (as above, but requests was found in venv)
> influxdb3-pe\install\influxdb3.exe test schedule_plugin -d mydb01 simple.py
{
  "trigger_time": "2025-02-25T17:35:54Z",
  "log_lines": [
    "INFO: sys.prefix = Z:\\influxdb3-pe\\data\\plugins\\.venv",
    "INFO: sys.exec_prefix = Z:\\influxdb3-pe\\data\\plugins\\.venv",
    "INFO: sys.base_prefix = Z:\\influxdb3-pe\\install\\python",
    "INFO: sys.base_exec_prefix = Z:\\influxdb3-pe\\install\\python",
    "INFO: sys.executable = Z:\\influxdb3-pe\\install\\influxdb3.exe",
    "INFO: sys.path = ['Z:\\\\influxdb3-pe\\\\install\\\\python311.zip', 'Z:\\\\influxdb3-pe\\\\install\\\\python\\\\DLLs', 'Z:\\\\influxdb3-pe\\\\install\\\\python\\\\Lib', 'Z:\\\\influxdb3-pe\\\\install', 'Z:\\\\influxdb3-pe\\\\install\\\\python', 'Z:\\\\influxdb3-pe\\\\install\\\\python\\\\Lib\\\\site-packages', 'Z:\\\\influxdb3-pe\\\\data\\\\plugins\\\\.venv\\\\Lib\\\\site-packages']",
    "INFO: 'requests' location = Z:\\influxdb3-pe\\data\\plugins\\.venv\\Lib\\site-packages\\requests\\__init__.py"
  ],
  "database_writes": {},
  "errors": []
}
```

</details>

Closes #26012