### PR TITLE
feat(processing_engine): Have automatic plugin dir at /plugins for docker.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,12 +67,16 @@ RUN mkdir -p /usr/lib/influxdb3
 COPY --from=build /root/python /usr/lib/influxdb3/python
 RUN chown -R root:root /usr/lib/influxdb3
 
+RUN mkdir /plugins && \
+    chown influxdb3:influxdb3 /plugins
+
 USER influxdb3
 
 RUN mkdir ~/.influxdb3
 
 ARG PACKAGE=influxdb3
 ENV PACKAGE=$PACKAGE
+ENV INFLUXDB3_PLUGIN_DIR=/plugins
 
 COPY --from=build "/root/$PACKAGE" "/usr/bin/$PACKAGE"
 COPY docker/entrypoint.sh /usr/bin/entrypoint.sh

--- a/influxdb3/src/commands/serve.rs
+++ b/influxdb3/src/commands/serve.rs
@@ -47,9 +47,8 @@ use object_store::ObjectStore;
 use observability_deps::tracing::*;
 use panic_logging::SendPanicsToTracing;
 use parquet_file::storage::{ParquetStorage, StorageId};
-use std::env;
 use std::process::Command;
-use std::{num::NonZeroUsize, sync::Arc, time::Duration};
+use std::{env, num::NonZeroUsize, sync::Arc, time::Duration};
 use std::{
     path::{Path, PathBuf},
     str::FromStr,

--- a/influxdb3_clap_blocks/src/plugins.rs
+++ b/influxdb3_clap_blocks/src/plugins.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 #[derive(Debug, clap::Parser, Clone)]
 pub struct ProcessingEngineConfig {
     /// Location of the plugins
-    #[clap(long = "plugin-dir")]
+    #[clap(long = "plugin-dir", env = "INFLUXDB3_PLUGIN_DIR")]
     pub plugin_dir: Option<PathBuf>,
     #[clap(long = "virtual-env-location", env = "VIRTUAL_ENV")]
     pub virtual_env_location: Option<PathBuf>,

--- a/influxdb3_processing_engine/src/environment.rs
+++ b/influxdb3_processing_engine/src/environment.rs
@@ -141,6 +141,7 @@ impl PythonEnvironmentManager for PipManager {
         initialize_venv(venv_path)?;
         Ok(())
     }
+
     fn install_packages(&self, packages: Vec<String>) -> Result<(), PluginEnvironmentError> {
         let python_exe = find_python();
         Command::new(python_exe)

--- a/influxdb3_processing_engine/src/manager.rs
+++ b/influxdb3_processing_engine/src/manager.rs
@@ -27,9 +27,6 @@ pub enum ProcessingEngineError {
     #[error("wal error: {0}")]
     WalError(#[from] influxdb3_wal::Error),
 
-    #[error("server not started with --plugin-dir")]
-    PluginDirNotSet,
-
     #[error("plugin not found: {0}")]
     PluginNotFound(String),
 


### PR DESCRIPTION
Since @jdstrand got the venv stuff working in a different way than #26027, I thought I'd just pull this out. The main thing it does is ensure that /plugins is created in the docker images with the right permissions, which had been a pain point for users.