### PR TITLE
chore: update to python 3.11.11+20250212 for libssl

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -223,7 +223,7 @@ jobs:
     # scripts/fetch-python-standalone.bash for details. This should match the
     # 'build-docker' job, below.
     environment:
-      PBS_DATE: "20250106"
+      PBS_DATE: "20250212"
       PBS_VERSION: "3.11.11"
     steps:
       - checkout
@@ -542,7 +542,7 @@ jobs:
     # scripts/fetch-python-standalone.bash for details. This should match
     # the 'fetch-python' job, above.
     environment:
-      PBS_DATE: "20250106"
+      PBS_DATE: "20250212"
       PBS_VERSION: "3.11.11"
     machine:
       image: default


### PR DESCRIPTION
References:
- https://github.com/astral-sh/python-build-standalone/releases/tag/20250212
- https://github.com/astral-sh/python-build-standalone/commits/20250212/
