### PR TITLE
chore: update Dockerfile to RUST_VERSION=1.85, install libz-dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 #syntax=docker/dockerfile:1.2
-ARG RUST_VERSION=1.84
+ARG RUST_VERSION=1.85
 FROM rust:${RUST_VERSION}-slim-bookworm as build
 
 # cache mounts below may already exist and owned by root
 USER root
 
 RUN apt update \
-    && apt install --yes binutils build-essential curl pkg-config libssl-dev clang lld git patchelf protobuf-compiler zstd \
+    && apt install --yes binutils build-essential curl pkg-config libssl-dev clang lld git patchelf protobuf-compiler zstd libz-dev \
     && rm -rf /var/lib/{apt,dpkg,cache,log}
 
 # Build influxdb3


### PR DESCRIPTION
The perf team reported build issues with the following error message:

```
0.454 error: process didn't exit successfully: `/usr/local/rustup/toolchains/1.85.0-x86_64-unknown-linux-gnu/bin/rustc -vV` (exit status: 127)
0.454 --- stderr
0.454 /usr/local/rustup/toolchains/1.85.0-x86_64-unknown-linux-gnu/bin/rustc: error while loading shared libraries: libz.so.1: cannot open shared object file: No such file or directory
```

Looking into their CI job, I noticed that they override the RUST_VERSION in our dockerfile to automatically change the upstream container image: https://github.com/influxdata/perf-tools/blob/c9073f681429ac093206c0a8f86e89cf62421467/.circleci/template.yml#L532

This PR updates our default RUST_VERSION to 1.85 and attempts a fix that can be verified by our own CI.
