### PR TITLE
fix: ensure fields in memory match on disk

### DIFF
--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -1290,7 +1290,7 @@ func (e *Engine) addToIndexFromKey(keys [][]byte, fieldTypes []influxql.DataType
 		keys[i], field = SeriesAndFieldFromCompositeKey(keys[i])
 		name := models.ParseName(keys[i])
 		mf := e.fieldset.CreateFieldsIfNotExists(name)
-		if _, err := mf.CreateFieldIfNotExists(string(field), fieldTypes[i]); err != nil {
+		if _, _, err := mf.CreateFieldIfNotExists(string(field), fieldTypes[i]); err != nil {
 			return err
 		}
 

--- a/tsdb/field_validator.go
+++ b/tsdb/field_validator.go
@@ -59,6 +59,13 @@ func ValidateAndCreateFields(mf *MeasurementFields, point models.Point, skipSize
 					err, fieldName, point.Name(), dataType, f.Type),
 				Dropped: 1,
 			}
+		} else if err != nil {
+			return fieldsToCreate, &PartialWriteError{
+				Reason: fmt.Sprintf(
+					"error adding field %q to measurement %q: %s",
+					fieldName, point.Name(), err),
+				Dropped: 1,
+			}
 		} else if created {
 			fieldsToCreate = append(fieldsToCreate, &FieldCreate{point.Name(), f})
 		}

--- a/tsdb/field_validator.go
+++ b/tsdb/field_validator.go
@@ -50,7 +50,6 @@ func ValidateAndCreateFields(mf *MeasurementFields, point models.Point, skipSize
 			continue
 		}
 
-		// If the field is not present, remember to create it.
 		fieldName := string(fieldKey)
 		f, created, err := mf.CreateFieldIfNotExists(fieldName, dataType)
 		if errors.Is(err, ErrFieldTypeConflict) {

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -575,7 +575,7 @@ func (s *Shard) WritePoints(points []models.Point, tracker StatsTracker) error {
 	}
 
 	// add any new fields and keep track of what needs to be saved
-	if numFieldsCreated, err := s.createFieldsAndMeasurements(fieldsToCreate); err != nil {
+	if numFieldsCreated, err := s.saveFieldsAndMeasurements(fieldsToCreate); err != nil {
 		return err
 	} else {
 		atomic.AddInt64(&s.stats.FieldsCreated, int64(numFieldsCreated))
@@ -605,10 +605,10 @@ func (s *Shard) WritePoints(points []models.Point, tracker StatsTracker) error {
 // validateSeriesAndFields checks which series and fields are new and whose metadata should be saved and indexed.
 func (s *Shard) validateSeriesAndFields(points []models.Point, tracker StatsTracker) ([]models.Point, []*FieldCreate, error) {
 	var (
-		fieldsToCreate []*FieldCreate
-		err            error
-		dropped        int
-		reason         string // only first error reason is set unless returned from CreateSeriesListIfNotExists
+		createdFieldsToSave []*FieldCreate
+		err                 error
+		dropped             int
+		reason              string // only first error reason is set unless returned from CreateSeriesListIfNotExists
 	)
 
 	// Create all series against the index in bulk.
@@ -703,37 +703,28 @@ func (s *Shard) validateSeriesAndFields(points []models.Point, tracker StatsTrac
 			continue
 		}
 
-		var newFields []*FieldCreate
-		var validateErr error
 		name := p.Name()
 		mf := engine.MeasurementFields(name)
 		// Check with the field validator.
-		if newFields, validateErr = ValidateFields(mf, p, s.options.Config.SkipFieldSizeValidation); validateErr != nil {
-			var err PartialWriteError
-			switch {
-			case errors.As(validateErr, &err):
-				// This will turn into an error later, outside this lambda
-				if reason == "" {
-					reason = err.Reason
-				}
-				dropped += err.Dropped
-				atomic.AddInt64(&s.stats.WritePointsDropped, int64(err.Dropped))
-				continue
-			default:
-				// Return validateErr, because err will be nil here
-				return nil, nil, validateErr
-			}
-		}
+		newFields, partialWriteError := ValidateAndCreateFields(mf, p, s.options.Config.SkipFieldSizeValidation)
+		createdFieldsToSave = append(createdFieldsToSave, newFields...)
 
+		if partialWriteError != nil {
+			if reason == "" {
+				reason = partialWriteError.Reason
+			}
+			dropped += partialWriteError.Dropped
+			atomic.AddInt64(&s.stats.WritePointsDropped, int64(partialWriteError.Dropped))
+			continue
+		}
 		points[j] = points[i]
 		j++
-		fieldsToCreate = append(fieldsToCreate, newFields...)
 	}
 	if dropped > 0 {
 		err = PartialWriteError{Reason: reason, Dropped: dropped, Database: s.database, RetentionPolicy: s.retentionPolicy}
 	}
 
-	return points[:j], fieldsToCreate, err
+	return points[:j], createdFieldsToSave, err
 }
 
 const unPrintReplRune = '?'
@@ -758,7 +749,7 @@ func makePrintable(s string) string {
 	return b.String()
 }
 
-func (s *Shard) createFieldsAndMeasurements(fieldsToCreate []*FieldCreate) (int, error) {
+func (s *Shard) saveFieldsAndMeasurements(fieldsToCreate []*FieldCreate) (int, error) {
 	if len(fieldsToCreate) == 0 {
 		return 0, nil
 	}
@@ -771,17 +762,12 @@ func (s *Shard) createFieldsAndMeasurements(fieldsToCreate []*FieldCreate) (int,
 	// add fields
 	changes := make([]*FieldChange, 0, len(fieldsToCreate))
 	for _, f := range fieldsToCreate {
-		mf := engine.MeasurementFields(f.Measurement)
-		if created, err := mf.CreateFieldIfNotExists(f.Field.Name, f.Field.Type); err != nil {
-			return 0, err
-		} else if created {
-			numCreated++
-			s.index.SetFieldName(f.Measurement, f.Field.Name)
-			changes = append(changes, &FieldChange{
-				FieldCreate: *f,
-				ChangeType:  AddMeasurementField,
-			})
-		}
+		numCreated++
+		s.index.SetFieldName(f.Measurement, f.Field.Name)
+		changes = append(changes, &FieldChange{
+			FieldCreate: *f,
+			ChangeType:  AddMeasurementField,
+		})
 	}
 
 	return numCreated, engine.MeasurementFieldSet().Save(changes)
@@ -1589,18 +1575,19 @@ func (m *MeasurementFields) bytes() int {
 
 // CreateFieldIfNotExists creates a new field with the given name and type.
 // Returns an error if the field already exists with a different type.
-func (m *MeasurementFields) CreateFieldIfNotExists(name string, typ influxql.DataType) (bool, error) {
+func (m *MeasurementFields) CreateFieldIfNotExists(name string, typ influxql.DataType) (*Field, bool, error) {
 	newField := &Field{
 		Name: name,
 		Type: typ,
 	}
 	if f, loaded := m.fields.LoadOrStore(newField.Name, newField); loaded {
 		if f.Type != typ {
-			return false, ErrFieldTypeConflict
+			return f, false, ErrFieldTypeConflict
 		}
-		return false, nil
+		return f, false, nil
+	} else {
+		return f, true, nil
 	}
-	return true, nil
 }
 
 func (m *MeasurementFields) FieldN() int {
@@ -2258,7 +2245,7 @@ func (fs *MeasurementFieldSet) ApplyChanges() error {
 				fs.Delete(string(fc.Measurement))
 			} else {
 				mf := fs.CreateFieldsIfNotExists(fc.Measurement)
-				if _, err := mf.CreateFieldIfNotExists(fc.Field.Name, fc.Field.Type); err != nil {
+				if _, _, err := mf.CreateFieldIfNotExists(fc.Field.Name, fc.Field.Type); err != nil {
 					err = fmt.Errorf("failed creating %q.%q: %w", fc.Measurement, fc.Field.Name, err)
 					log.Error("field creation", zap.Error(err))
 					return err

--- a/tsdb/shard_test.go
+++ b/tsdb/shard_test.go
@@ -1691,7 +1691,7 @@ func TestMeasurementFieldSet_SaveLoad(t *testing.T) {
 	}
 	defer checkMeasurementFieldSetClose(t, mf)
 	fields := mf.CreateFieldsIfNotExists([]byte(measurement))
-	if _, err := fields.CreateFieldIfNotExists(fieldName, influxql.Float); err != nil {
+	if _, _, err := fields.CreateFieldIfNotExists(fieldName, influxql.Float); err != nil {
 		t.Fatalf("create field error: %v", err)
 	}
 	change := tsdb.FieldChange{
@@ -1743,7 +1743,7 @@ func TestMeasurementFieldSet_Corrupt(t *testing.T) {
 		measurement := []byte("cpu")
 		fields := mf.CreateFieldsIfNotExists(measurement)
 		fieldName := "value"
-		if _, err := fields.CreateFieldIfNotExists(fieldName, influxql.Float); err != nil {
+		if _, _, err := fields.CreateFieldIfNotExists(fieldName, influxql.Float); err != nil {
 			t.Fatalf("create field error: %v", err)
 		}
 		change := tsdb.FieldChange{
@@ -1814,7 +1814,7 @@ func TestMeasurementFieldSet_CorruptChangeFile(t *testing.T) {
 	defer checkMeasurementFieldSetClose(t, mf)
 	for _, f := range testFields {
 		fields := mf.CreateFieldsIfNotExists([]byte(f.Measurement))
-		if _, err := fields.CreateFieldIfNotExists(f.Field, f.FieldType); err != nil {
+		if _, _, err := fields.CreateFieldIfNotExists(f.Field, f.FieldType); err != nil {
 			t.Fatalf("create field error: %v", err)
 		}
 		change := tsdb.FieldChange{
@@ -1876,7 +1876,7 @@ func TestMeasurementFieldSet_DeleteEmpty(t *testing.T) {
 	defer checkMeasurementFieldSetClose(t, mf)
 
 	fields := mf.CreateFieldsIfNotExists([]byte(measurement))
-	if _, err := fields.CreateFieldIfNotExists(fieldName, influxql.Float); err != nil {
+	if _, _, err := fields.CreateFieldIfNotExists(fieldName, influxql.Float); err != nil {
 		t.Fatalf("create field error: %v", err)
 	}
 
@@ -2009,7 +2009,7 @@ func testFieldMaker(t *testing.T, wg *sync.WaitGroup, mf *tsdb.MeasurementFieldS
 	fields := mf.CreateFieldsIfNotExists([]byte(measurement))
 
 	for _, fieldName := range fieldNames {
-		if _, err := fields.CreateFieldIfNotExists(fieldName, influxql.Float); err != nil {
+		if _, _, err := fields.CreateFieldIfNotExists(fieldName, influxql.Float); err != nil {
 			t.Logf("create field error: %v", err)
 			t.Fail()
 			return


### PR DESCRIPTION
A field could be created in  memory but not
saved to disk if a later field in that
point was invalid (type conflict, too big)
Ensure that if a field is created, it is
saved