### PR TITLE
feat: update crossbuilder to tagged version and update go linker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ orbs:
 parameters:
   cross-container-tag:
     type: string
-    default: go1.23.5-latest
+    default: go1.23.5-ba67b11de54aa0bf8f1f92a81f786205de8024b6
 
   workflow:
     type: string

--- a/scripts/ci/build-tests.sh
+++ b/scripts/ci/build-tests.sh
@@ -29,6 +29,7 @@ function build_mac () {
 }
 
 function build_windows () {
+    CGO_LDFLAGS="-lntdll -ladvapi32 -lkernel32 -luserenv -lws2_32" \
     CGO_ENABLED=1 PKG_CONFIG=$(which pkg-config) CC="$(xcc windows)" go-test-compile \
         -tags sqlite_foreign_keys,sqlite_json,timetzdata -o "${1}/" -x ./...
 }
@@ -69,7 +70,6 @@ function main () {
             build_mac "$out_dir"
             ;;
         windows)
-            export CGO_LDFLAGS="-lntdll -ladvapi32 -lkernel32 -luserenv -lws2_32 ${CGO_LDFLAGS}"
             build_windows "$out_dir"
             ;;
         *)

--- a/scripts/ci/build-tests.sh
+++ b/scripts/ci/build-tests.sh
@@ -69,6 +69,7 @@ function main () {
             build_mac "$out_dir"
             ;;
         windows)
+            export CGO_LDFLAGS="-lntdll -ladvapi32 -lkernel32 -luserenv -lws2_32 ${CGO_LDFLAGS}"
             build_windows "$out_dir"
             ;;
         *)

--- a/scripts/ci/build.sh
+++ b/scripts/ci/build.sh
@@ -47,6 +47,7 @@ function main () {
                 "$pkg"
             ;;
         windows_amd64)
+            export CGO_LDFLAGS="-lntdll -ladvapi32 -lkernel32 -luserenv -lws2_32 ${CGO_LDFLAGS}"
             export CC="$(xcc windows)"
             CGO_ENABLED=1 PKG_CONFIG=$(which pkg-config) go build \
                 -tags assets,sqlite_foreign_keys,sqlite_json,timetzdata \


### PR DESCRIPTION
This PR should fix the build step failures for influxdb on windows amd64. Updates the cross builder to
go1.23.5-ba67b11de54aa0bf8f1f92a81f786205de8024b6

Adds `export CGO_LDFLAGS="-lntdll -ladvapi32 -lkernel32 -luserenv -lws2_32 ${CGO_LDFLAGS}"` to cgo linker to link NT specific syscalls. 


Closes #26051 
