### PR TITLE
fix: ensure temp files removed on failed compaction

### DIFF
--- a/tsdb/engine/tsm1/compact.go
+++ b/tsdb/engine/tsm1/compact.go
@@ -1031,7 +1031,7 @@ func (c *Compactor) CompactFull(tsmFiles []string, logger *zap.Logger) ([]string
 	c.mu.RUnlock()
 
 	if !enabled {
-		if err := c.removeTmpFiles(files); err != nil {
+		if err := c.RemoveTmpFiles(files); err != nil {
 			return nil, err
 		}
 		return nil, errCompactionsDisabled
@@ -1063,7 +1063,7 @@ func (c *Compactor) CompactFast(tsmFiles []string, logger *zap.Logger) ([]string
 	c.mu.RUnlock()
 
 	if !enabled {
-		if err := c.removeTmpFiles(files); err != nil {
+		if err := c.RemoveTmpFiles(files); err != nil {
 			return nil, err
 		}
 		return nil, errCompactionsDisabled
@@ -1073,15 +1073,16 @@ func (c *Compactor) CompactFast(tsmFiles []string, logger *zap.Logger) ([]string
 
 }
 
-// removeTmpFiles is responsible for cleaning up a compaction that
+// RemoveTmpFiles is responsible for cleaning up a compaction that
 // was started, but then abandoned before the temporary files were dealt with.
-func (c *Compactor) removeTmpFiles(files []string) error {
+func (c *Compactor) RemoveTmpFiles(files []string) error {
+	var errs []error
 	for _, f := range files {
 		if err := os.Remove(f); err != nil {
-			return fmt.Errorf("error removing temp compaction file: %v", err)
+			errs = append(errs, fmt.Errorf("error removing temp compaction file %s: %w", f, err))
 		}
 	}
-	return nil
+	return errors.Join(errs...)
 }
 
 // writeNewFiles writes from the iterator into new TSM files, rotating

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -2320,6 +2320,11 @@ func (s *compactionStrategy) compactGroup() {
 	}
 
 	if err != nil {
+		defer func(fs []string) {
+			if removeErr := s.compactor.RemoveTmpFiles(fs); removeErr != nil {
+				log.Warn("Unable to remove temporary file(s)", zap.Error(removeErr))
+			}
+		}(files)
 		_, inProgress := err.(errCompactionInProgress)
 		if err == errCompactionsDisabled || inProgress {
 			log.Info("Aborted compaction", zap.Error(err))


### PR DESCRIPTION
Add more robust temporary file removal
on a failed compaction. Don't halt on
a failed removal, and don't assume a
failed compaction won't generate
temporary files.

closes https://github.com/influxdata/influxdb/issues/26068