### PR TITLE
fix: ensure temp files removed on failed compaction (#26070)

### DIFF
--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -2224,6 +2224,11 @@ func (s *compactionStrategy) compactGroup() {
 	}
 
 	if err != nil {
+		defer func(fs []string) {
+			if removeErr := s.compactor.RemoveTmpFiles(fs); removeErr != nil {
+				log.Warn("Unable to remove temporary file(s)", zap.Error(removeErr))
+			}
+		}(files)
 		_, inProgress := err.(errCompactionInProgress)
 		if err == errCompactionsDisabled || inProgress {
 			log.Info("Aborted compaction", zap.Error(err))


### PR DESCRIPTION
Add more robust temporary file removal
on a failed compaction. Don't halt on
a failed removal, and don't assume a
failed compaction won't generate
temporary files.

closes https://github.com/influxdata/influxdb/issues/26068

(cherry picked from commit ba95c9b0f061d9730739a2997d18efd7ed11dc8e)

closes https://github.com/influxdata/influxdb/issues/26069