### PR TITLE
fix: ensure "local" ObjectStore.list returns ordered elements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2885,6 +2885,7 @@ name = "influxdb3_clap_blocks"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "bytes",
  "clap",
  "datafusion",
  "futures",

--- a/influxdb3_clap_blocks/Cargo.toml
+++ b/influxdb3_clap_blocks/Cargo.toml
@@ -32,6 +32,8 @@ tokio.workspace = true
 trace_exporters.workspace = true
 trogging.workspace = true
 url.workspace = true
+bytes.workspace = true
+futures.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true


### PR DESCRIPTION

While initially attempting to reproduce a data corruption issue in enterprise, I encountered unexpected behavior during compactor restarts -- namely, that the compactor would always load the wrong compaction summary. It should just load the latest compaction summary which would show up as the first item in an object store listing if the object store listed items in UTF-8 binary order (ascending). 

This [is the case when using the S3-backed object store](https://docs.aws.amazon.com/AmazonS3/latest/userguide/ListingKeysUsingAPIs.html), but not when using the [`LocalFileSystem`](https://docs.rs/object_store/latest/object_store/local/struct.LocalFileSystem.html).

Indeed, the `ObjectStore` trait [explicitly doesn't guarantee](https://docs.rs/object_store/latest/object_store/trait.ObjectStore.html#tymethod.list) the order of list results.

This PR attempts to address this issue by wrapping the returned `LocalFileSystem` instances with one that collects the inner implementation's `list` operation results into a vec and sorts them before streamin them back to the caller.

One downside of this approach is that it will cause a tokio thread to block due to the use of `futures::executor::block_on`, but I don't know of any better way to collect results from the inner `LocalFileSystem.list`'s returned `BoxStream<...>` value.

The reason that's necessary is that `ObjectStore.list` isn't an async function so we can't await it without invoking some kind of async executor.

I went with this approach in spite of this downside because...

* The problem seems to be specific to the `LocalFileSystem` object object_store.
* Implementing the collection and sorting outside of the `ObjectStore` API would make it easy to miss a case where ordering of the object store list results is important and leave a bug for future developers to come across.
* The `--object-store=file` implementation is meant for local dev testing, not production -- I think it's fine to be more relaxed about blocking a tokio thread in this restricted scope.
