### PR TITLE
feat: Use ldext in build-test.sh

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ orbs:
 parameters:
   cross-container-tag:
     type: string
-    default: go1.23.5-deb10f07f31767ee55b0b5f87edd34635673cf41
+    default: go1.23.5-latest
 
   workflow:
     type: string

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ orbs:
 parameters:
   cross-container-tag:
     type: string
-    default: go1.23.5-7f22c06468ede67bf302b259f1e93fa5083cc641
+    default: go1.23.5-deb10f07f31767ee55b0b5f87edd34635673cf41
 
   workflow:
     type: string

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ orbs:
 parameters:
   cross-container-tag:
     type: string
-    default: go1.23.5-ba67b11de54aa0bf8f1f92a81f786205de8024b6
+    default: go1.23.5-7f22c06468ede67bf302b259f1e93fa5083cc641
 
   workflow:
     type: string

--- a/scripts/ci/build-tests.sh
+++ b/scripts/ci/build-tests.sh
@@ -29,8 +29,10 @@ function build_mac () {
 }
 
 function build_windows () {
-    CGO_LDFLAGS="-lntdll -ladvapi32 -lkernel32 -luserenv -lws2_32" \
-    CGO_ENABLED=1 PKG_CONFIG=$(which pkg-config) CC="$(xcc windows)" go-test-compile \
+  export CC="$(xcc windows)"
+  export CGO_LDFLAGS="-lntdll -ladvapi32 -lkernel32 -luserenv -lws2_32"
+
+  CGO_ENABLED=1 PKG_CONFIG=$(which pkg-config)  go-test-compile \
         -tags sqlite_foreign_keys,sqlite_json,timetzdata \
         -ldext "${CC}" \
         -o "${1}/"

--- a/scripts/ci/build-tests.sh
+++ b/scripts/ci/build-tests.sh
@@ -31,7 +31,9 @@ function build_mac () {
 function build_windows () {
     CGO_LDFLAGS="-lntdll -ladvapi32 -lkernel32 -luserenv -lws2_32" \
     CGO_ENABLED=1 PKG_CONFIG=$(which pkg-config) CC="$(xcc windows)" go-test-compile \
-        -tags sqlite_foreign_keys,sqlite_json,timetzdata -o "${1}/" -x ./...
+        -tags sqlite_foreign_keys,sqlite_json,timetzdata \
+        -ldext "${CC}" \
+        -o "${1}/"
 }
 
 function build_test_tools () {

--- a/scripts/ci/build-tests.sh
+++ b/scripts/ci/build-tests.sh
@@ -36,6 +36,7 @@ function build_windows () {
         -tags sqlite_foreign_keys,sqlite_json,timetzdata \
         -ldext "${CC}" \
         -o "${1}/"
+        ./...
 }
 
 function build_test_tools () {

--- a/scripts/ci/build-tests.sh
+++ b/scripts/ci/build-tests.sh
@@ -34,9 +34,7 @@ function build_windows () {
 
   CGO_ENABLED=1 PKG_CONFIG=$(which pkg-config)  go-test-compile \
         -tags sqlite_foreign_keys,sqlite_json,timetzdata \
-        -ldext "${CC}" \
-        -o "${1}/"
-        ./...
+        -ldext "${CC}" -o "${1}/" ./...
 }
 
 function build_test_tools () {


### PR DESCRIPTION
This PR updates the build_windows function in build-tests.sh to use the -ldext flag to specify that we are using the windows compiler for cross compilation. It also removes -x as a flag which would output all file names as it was built. This fixes the build-tests script. 
