### PR TITLE
feat: improve CLI list arg consistency (always use commas)

### DIFF
--- a/influxdb3/src/commands/common.rs
+++ b/influxdb3/src/commands/common.rs
@@ -80,34 +80,6 @@ where
     }
 }
 
-/// A clap argument provided as a list of items separated by `SEPARATOR`, which by default is a ','
-#[derive(Debug, Clone)]
-pub struct SeparatedList<T, const SEPARATOR: char = ','>(pub Vec<T>);
-
-impl<T, const SEPARATOR: char> FromStr for SeparatedList<T, SEPARATOR>
-where
-    T: FromStr<Err: Into<anyhow::Error>>,
-{
-    type Err = anyhow::Error;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Ok(Self(
-            s.split(SEPARATOR)
-                .map(|s| s.parse::<T>().map_err(Into::into))
-                .collect::<Result<Vec<T>, Self::Err>>()?,
-        ))
-    }
-}
-
-impl<T, const SEPARATOR: char> IntoIterator for SeparatedList<T, SEPARATOR> {
-    type Item = T;
-
-    type IntoIter = std::vec::IntoIter<Self::Item>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.0.into_iter()
-    }
-}
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum DataType {
     Int64,

--- a/influxdb3/src/commands/create.rs
+++ b/influxdb3/src/commands/create.rs
@@ -117,6 +117,7 @@ pub struct DatabaseConfig {
     #[clap(env = "INFLUXDB3_DATABASE_NAME", required = true)]
     pub database_name: String,
 }
+
 #[derive(Debug, clap::Args)]
 pub struct LastCacheConfig {
     #[clap(flatten)]
@@ -190,11 +191,11 @@ pub struct DistinctCacheConfig {
 
 #[derive(Debug, clap::Args)]
 pub struct TableConfig {
-    #[clap(long = "tags", required = true, num_args=0.., value_delimiter = ',')]
+    #[clap(long = "tags", required = true, value_delimiter = ',')]
     /// The list of tag names to be created for the table. Tags are alphanumeric, can contain - and _, and start with a letter or number
     tags: Vec<String>,
 
-    #[clap(short = 'f', long = "fields", value_parser = parse_key_val::<String, DataType>, num_args=0.., value_delimiter = ',')]
+    #[clap(short = 'f', long = "fields", value_parser = parse_key_val::<String, DataType>, value_delimiter = ',')]
     /// The list of field names and their data type to be created for the table. Fields are alphanumeric, can contain - and _, and start with a letter or number
     /// The expected format is a list like so: 'field_name:data_type'. Valid data types are: int64, uint64, float64, utf8, and bool
     fields: Vec<(String, DataType)>,

--- a/influxdb3/src/commands/create.rs
+++ b/influxdb3/src/commands/create.rs
@@ -1,6 +1,4 @@
-use crate::commands::common::{
-    DataType, InfluxDb3Config, SeparatedKeyValue, SeparatedList, parse_key_val,
-};
+use crate::commands::common::{DataType, InfluxDb3Config, SeparatedKeyValue, parse_key_val};
 use base64::Engine as _;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD as B64;
 use hashbrown::HashMap;
@@ -131,14 +129,14 @@ pub struct LastCacheConfig {
     /// Which columns in the table to use as keys in the cache. This is a comma separated list.
     ///
     /// Example: --key-columns "foo,bar,baz"
-    #[clap(long = "key-columns")]
-    key_columns: Option<SeparatedList<String>>,
+    #[clap(long = "key-columns", value_delimiter = ',')]
+    key_columns: Option<Vec<String>>,
 
     /// Which columns in the table to store as values in the cache. This is a comma separated list
     ///
     /// Example: --value-columns "foo,bar,baz"
-    #[clap(long = "value-columns")]
-    value_columns: Option<SeparatedList<String>>,
+    #[clap(long = "value-columns", value_delimiter = ',')]
+    value_columns: Option<Vec<String>>,
 
     /// The number of entries per unique key column combination the cache will store
     #[clap(long = "count")]
@@ -172,8 +170,8 @@ pub struct DistinctCacheConfig {
     /// The cache is a hieararchical structure, with a level for each column specified; the order
     /// specified here will determine the order of the levels from top-to-bottom of the cache
     /// hierarchy.
-    #[clap(long = "columns")]
-    columns: SeparatedList<String>,
+    #[clap(long = "columns", value_delimiter = ',')]
+    columns: Vec<String>,
 
     /// The maximum number of distinct value combinations to hold in the cache
     #[clap(long = "max-cardinality")]
@@ -192,11 +190,11 @@ pub struct DistinctCacheConfig {
 
 #[derive(Debug, clap::Args)]
 pub struct TableConfig {
-    #[clap(long = "tags", required = true, num_args=0..)]
+    #[clap(long = "tags", required = true, num_args=0.., value_delimiter = ',')]
     /// The list of tag names to be created for the table. Tags are alphanumeric, can contain - and _, and start with a letter or number
     tags: Vec<String>,
 
-    #[clap(short = 'f', long = "fields", value_parser = parse_key_val::<String, DataType>, num_args=0..)]
+    #[clap(short = 'f', long = "fields", value_parser = parse_key_val::<String, DataType>, num_args=0.., value_delimiter = ',')]
     /// The list of field names and their data type to be created for the table. Fields are alphanumeric, can contain - and _, and start with a letter or number
     /// The expected format is a list like so: 'field_name:data_type'. Valid data types are: int64, uint64, float64, utf8, and bool
     fields: Vec<(String, DataType)>,
@@ -224,8 +222,8 @@ pub struct TriggerConfig {
           help = "The plugin file must be for the given trigger type of wal, schedule, or request. Trigger specification format:\nFor wal_rows use: 'table:<TABLE_NAME>' or 'all_tables'\nFor scheduled use: 'cron:<CRON_EXPRESSION>' or 'every:<duration e.g. 10m>'\nFor request use: 'path:<PATH>' e.g. path:foo will be at /api/v3/engine/foo")]
     trigger_specification: TriggerSpecificationDefinition,
     /// Comma separated list of key/value pairs to use as trigger arguments. Example: key1=val1,key2=val2
-    #[clap(long = "trigger-arguments")]
-    trigger_arguments: Option<SeparatedList<SeparatedKeyValue<String, String>>>,
+    #[clap(long = "trigger-arguments", value_delimiter = ',')]
+    trigger_arguments: Option<Vec<SeparatedKeyValue<String, String>>>,
     /// Create trigger in disabled state
     #[clap(long)]
     disabled: bool,
@@ -422,8 +420,8 @@ mod tests {
         assert_eq!("bar", database_name);
         assert_eq!("foo", table);
         assert!(cache_name.is_some_and(|n| n == "bar"));
-        assert!(key_columns.is_some_and(|keys| keys.0 == ["tag1", "tag2", "tag3"]));
-        assert!(value_columns.is_some_and(|vals| vals.0 == ["field1", "field2", "field3"]));
+        assert!(key_columns.is_some_and(|keys| keys == ["tag1", "tag2", "tag3"]));
+        assert!(value_columns.is_some_and(|vals| vals == ["field1", "field2", "field3"]));
         assert!(count.is_some_and(|c| c == 5));
         assert!(ttl.is_some_and(|t| t.as_secs() == 3600));
     }

--- a/influxdb3/src/commands/plugin_test/wal.rs
+++ b/influxdb3/src/commands/plugin_test/wal.rs
@@ -1,4 +1,4 @@
-use crate::commands::common::{InfluxDb3Config, SeparatedKeyValue, SeparatedList};
+use crate::commands::common::{InfluxDb3Config, SeparatedKeyValue};
 use influxdb3_client::plugin_development::WalPluginTestRequest;
 use secrecy::ExposeSecret;
 use std::collections::HashMap;
@@ -25,8 +25,8 @@ pub struct WalPluginTest {
     #[clap(long = "file")]
     pub input_file: Option<String>,
     /// If given pass this map of string key/value pairs as input arguments
-    #[clap(long = "input-arguments")]
-    pub input_arguments: Option<SeparatedList<SeparatedKeyValue<String, String>>>,
+    #[clap(long = "input-arguments", value_delimiter = ',')]
+    pub input_arguments: Option<Vec<SeparatedKeyValue<String, String>>>,
 }
 
 impl From<WalPluginTest> for WalPluginTestRequest {

--- a/influxdb3/src/commands/test.rs
+++ b/influxdb3/src/commands/test.rs
@@ -1,4 +1,4 @@
-use crate::commands::common::{InfluxDb3Config, SeparatedKeyValue, SeparatedList};
+use crate::commands::common::{InfluxDb3Config, SeparatedKeyValue};
 use anyhow::Context;
 use hashbrown::HashMap;
 use influxdb3_client::Client;
@@ -64,8 +64,8 @@ pub struct WalPluginConfig {
     #[clap(long = "file")]
     pub input_file: Option<String>,
     /// If given pass this map of string key/value pairs as input arguments
-    #[clap(long = "input-arguments")]
-    pub input_arguments: Option<SeparatedList<SeparatedKeyValue<String, String>>>,
+    #[clap(long = "input-arguments", value_delimiter = ',')]
+    pub input_arguments: Option<Vec<SeparatedKeyValue<String, String>>>,
     /// The file name of the plugin, which should exist on the server in `<plugin-dir>/<filename>`.
     /// The plugin-dir is provided on server startup.
     #[clap(required = true)]
@@ -77,8 +77,8 @@ pub struct SchedulePluginConfig {
     #[clap(flatten)]
     influxdb3_config: InfluxDb3Config,
     /// If given pass this map of string key/value pairs as input arguments
-    #[clap(long = "input-arguments")]
-    pub input_arguments: Option<SeparatedList<SeparatedKeyValue<String, String>>>,
+    #[clap(long = "input-arguments", value_delimiter = ',')]
+    pub input_arguments: Option<Vec<SeparatedKeyValue<String, String>>>,
     /// The file name of the plugin, which should exist on the server in `<plugin-dir>/<filename>`.
     /// The plugin-dir is provided on server startup.
     #[clap(required = true)]

--- a/influxdb3/tests/cli/mod.rs
+++ b/influxdb3/tests/cli/mod.rs
@@ -413,15 +413,9 @@ async fn test_create_table() {
         "--host",
         &server_addr,
         "--tags",
-        "one",
-        "two",
-        "three",
+        "one,two,three",
         "--fields",
-        "four:utf8",
-        "five:uint64",
-        "six:float64",
-        "seven:int64",
-        "eight:bool",
+        "four:utf8,five:uint64,six:float64,seven:int64,eight:bool",
     ]);
     debug!(result = ?result, "create table");
     assert_contains!(&result, "Table \"foo\".\"bar\" created successfully");
@@ -456,6 +450,7 @@ async fn test_create_table() {
         .json::<Value>()
         .await
         .unwrap();
+    debug!(result = ?result, "data written");
     assert_eq!(
         result,
         json!([{


### PR DESCRIPTION
This fixes #25854 as discussed in the issue.

This removes the `SeparatedList` abstraction in favor of `clap`'s `value_delimiter` using `,` as the delimiter. This aligns us with the approach used in https://github.com/influxdata/influxdb3_core/tree/main/clap_blocks.
