### PR TITLE
feat(processing_engine): Support Flask semantics for responses from request plugins.

### DIFF
--- a/influxdb3/src/commands/create.rs
+++ b/influxdb3/src/commands/create.rs
@@ -472,7 +472,7 @@ mod tests {
 
         let trigger_arguments = trigger_arguments.expect("args must include trigger arguments");
 
-        assert_eq!(2, trigger_arguments.0.len());
+        assert_eq!(2, trigger_arguments.len());
 
         let query_path = trigger_arguments
             .into_iter()


### PR DESCRIPTION
Closes #25894. Also patches a minor regression introduced in #26094.

