### PR TITLE
fix: test case introduced by #26094

### DIFF
--- a/influxdb3/src/commands/create.rs
+++ b/influxdb3/src/commands/create.rs
@@ -472,7 +472,7 @@ mod tests {
 
         let trigger_arguments = trigger_arguments.expect("args must include trigger arguments");
 
-        assert_eq!(2, trigger_arguments.0.len());
+        assert_eq!(2, trigger_arguments.len());
 
         let query_path = trigger_arguments
             .into_iter()


### PR DESCRIPTION
In https://github.com/influxdata/influxdb/pull/26094 I introduced a buggy test case, but it somehow passed CI: https://app.circleci.com/pipelines/github/influxdata/influxdb/44477/workflows/71d2b9c9-b2e3-4cca-8fb2-da68542861bd/jobs/420814?invite=true#step-103-50025_110

But main branch is demonstrating the problem: https://app.circleci.com/pipelines/github/influxdata/influxdb/44479/workflows/6fd5d9f9-1c31-4863-8e9c-a2935cf6194f/jobs/420844?invite=true#step-103-46166_55

This PR should fix it.
