### PR TITLE
fix: ensure active toolchain installation in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,13 @@ RUN \
   --mount=type=cache,id=influxdb3_rustup,sharing=locked,target=/usr/local/rustup \
   --mount=type=cache,id=influxdb3_registry,sharing=locked,target=/usr/local/cargo/registry \
   --mount=type=cache,id=influxdb3_git,sharing=locked,target=/usr/local/cargo/git \
+    du -cshx /usr/local/rustup /usr/local/cargo/registry /usr/local/cargo/git && \
+    rustup toolchain install
+
+RUN \
+  --mount=type=cache,id=influxdb3_rustup,sharing=locked,target=/usr/local/rustup \
+  --mount=type=cache,id=influxdb3_registry,sharing=locked,target=/usr/local/cargo/registry \
+  --mount=type=cache,id=influxdb3_git,sharing=locked,target=/usr/local/cargo/git \
   --mount=type=cache,id=influxdb3_target,sharing=locked,target=/influxdb3/target \
     du -cshx /usr/local/rustup /usr/local/cargo/registry /usr/local/cargo/git /influxdb3/target && \
     PYO3_CONFIG_FILE="/influxdb3/python-artifacts/$PBS_TARGET/pyo3_config_file.txt" cargo build --target-dir /influxdb3/target --package="$PACKAGE" --profile="$PROFILE" --no-default-features --features="$FEATURES" && \


### PR DESCRIPTION
This fixes an issue that showed up in the enterprise repo's CI jobs but hasn't shown up in the OSS repo yet. 

The issue is that the container image our CI pipeline depends on [recently updated to rustup 1.28](https://github.com/rust-lang/docker-rust/pull/230) which according to its [changelog](https://blog.rust-lang.org/2025/03/02/Rustup-1.28.0.html#whats-new-in-rustup-1280) no longer automatically installs the active toolchain:

> rustup will no longer automatically install the active toolchain if it is not installed.

This leads to error messages that look like the following:

```
 > [build 7/7] RUN   --mount=type=ssh   --mount=type=cache,id=influxdb3_rustup,sharing=locked,target=/usr/local/rustup   --mount=type=cache,id=influxdb3_registry,sharing=locked,target=/usr/local/cargo/registry   --mount=type=cache,id=influxdb3_git,sharing=locked,target=/usr/local/cargo/git   --mount=type=cache,id=influxdb3_target,sharing=locked,target=/influxdb3/target     du -cshx /usr/local/rustup /usr/local/cargo/registry /usr/local/cargo/git /influxdb3/target &&     PYO3_CONFIG_FILE="/influxdb3/python-artifacts/aarch64-unknown-linux-gnu/pyo3_config_file.txt" cargo build --target-dir /influxdb3/target --package="influxdb3" --profile="release" --no-default-features --features="aws,gcp,azure,jemalloc_replacing_malloc,tokio_console,system-py" &&     objcopy --compress-debug-sections "target/release/influxdb3" &&     cp "/influxdb3/target/release/influxdb3" "/root/influxdb3" &&     patchelf --set-rpath '$ORIGIN/python/lib:$ORIGIN/../lib/influxdb3/python/lib' "/root/influxdb3" &&     cp -a "/influxdb3/python-artifacts/aarch64-unknown-linux-gnu/python" /root/python &&     du -cshx /usr/local/rustup /usr/local/cargo/registry /usr/local/cargo/git /influxdb3/target:
0.296 4.0K      /usr/local/rustup
0.296 4.0K      /usr/local/cargo/registry
0.296 4.0K      /usr/local/cargo/git
0.296 4.0K      /influxdb3/target
0.296 16K       total
0.305 error: toolchain '1.85.0-aarch64-unknown-linux-gnu' is not installed
0.305 help: run `rustup toolchain install 1.85.0-aarch64-unknown-linux-gnu` to install it
------
```

The first version of the rust iamge I noticed this happening for was `docker.io/library/rust:1.85.0-slim-bookworm@sha256:215987920101ed15967e9ab4bab3a20e1b71ab3c0551b5088b380e0d4e1758b1`. The last good image I see used in enterprise and OSS CI was `docker.io/library/rust:1.85.0-slim-bookworm@sha256:4702f80ef4c797815652b9e7ce830af888133754a844cf661c21315905a351c9`.
