### PR TITLE
chore: rust ci job fix to address rustup 1.28.0 changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,6 +79,13 @@ commands:
     description: Verify installed components
     steps:
       - run:
+          name: Activate toolchain
+          command: |
+            rustup toolchain install
+            rustup component add clippy
+            rustup component add rustfmt
+
+      - run:
           name: Verify installed components
           command: |
             rustup --version


### PR DESCRIPTION
- activate toolchain explicitly
- add clippy and rustfmt components

You can see the failures in main branch [here](https://app.circleci.com/pipelines/github/influxdata/influxdb/44497/workflows/6c87a561-cabf-41fb-8d77-29ec59e2c3b8). Not sure if these can be moved to the rust image itself that we're pulling from quay.io, but for now this fixes the failing jobs. 