### PR TITLE
feat: query path instrumentation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3303,6 +3303,7 @@ dependencies = [
  "test_helpers",
  "thiserror 1.0.69",
  "tokio",
+ "trace",
  "url",
  "uuid",
 ]

--- a/influxdb3_cache/src/parquet_cache/mod.rs
+++ b/influxdb3_cache/src/parquet_cache/mod.rs
@@ -158,6 +158,9 @@ pub trait ParquetCacheOracle: Send + Sync + Debug {
 
     // Get a receiver that is notified when a prune takes place and how much memory was freed
     fn prune_notifier(&self) -> watch::Receiver<usize>;
+
+    // check in cache already
+    fn in_cache(&self, path: &Path) -> bool;
 }
 
 /// Concrete implementation of the [`ParquetCacheOracle`]
@@ -245,6 +248,10 @@ impl ParquetCacheOracle for MemCacheOracle {
 
     fn prune_notifier(&self) -> watch::Receiver<usize> {
         self.prune_notifier_tx.subscribe()
+    }
+
+    fn in_cache(&self, path: &Path) -> bool {
+        self.mem_store.cache.path_already_fetched(path)
     }
 }
 

--- a/influxdb3_write/Cargo.toml
+++ b/influxdb3_write/Cargo.toml
@@ -25,6 +25,7 @@ metric.workspace = true
 parquet_file.workspace = true
 observability_deps.workspace = true
 schema.workspace = true
+trace.workspace = true
 
 # Local deps
 influxdb3_cache = { path = "../influxdb3_cache" }


### PR DESCRIPTION
- spans added for buffer, parquet chunks along with number of files that are already in parquet cache along with the sql

**NOTE: The parquet cache check for files is done at the point of call to `TableProvider::scan`, the data may get evicted by the time datafusion actually tries to access it but for a lot of the queries which are running in perf test env, this is a good enough approximation for now**

The workflow here is, 

- spin up `influxdb3` with extra switches `--traces-exporter-jaeger-agent-port 6831 --traces-exporter-jaeger-service-name influxdb3-core --traces-exporter jaeger` and 
- `jaeger` - following [docs](https://www.jaegertracing.io/docs/2.3/getting-started/)

Once it's running, issue queries and then in jaeger ui (running on `http://localhost:16686`), search for 

- service name: `influxdb3-core`
- operation: `query_database_sql`
- tags: `query="select count(*) from cpu_4 where time > now() - interval '15 minutes' limit 1"`


![image (13)](https://github.com/user-attachments/assets/1d285471-08e3-4eca-87f4-6baaa341618c)

That should return bunch of traces and drilling into one of those `get_db_namespace` should show `table_chunks` span that shows the buffer chunks, parquet chunks and how many parquet chunks are already in the cache

![image (12)](https://github.com/user-attachments/assets/23a94204-cee4-45a5-93c3-2356dc3b24d6)

![image (11)](https://github.com/user-attachments/assets/84ff4f75-31a6-4826-8b23-c548d01fc0d0)
