### PR TITLE
chore: fix cargo audit failures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -816,9 +816,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.7"
+version = "1.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a012a0df96dd6d06ba9a1b29d6402d1a5d77c6befd2566afdc26e10603dc93d7"
+checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
 dependencies = [
  "jobserver",
  "libc",
@@ -5206,15 +5206,14 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.8"
+version = "0.17.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+checksum = "70ac5d832aa16abd7d1def883a8545280c20a60f523a370aa3a9617c2b8550ee"
 dependencies = [
  "cc",
  "cfg-if",
  "getrandom",
  "libc",
- "spin",
  "untrusted",
  "windows-sys 0.52.0",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -8,6 +8,10 @@ ignore = [
     # dependent on datafusion-common moving away from instant
     # https://github.com/apache/datafusion/pull/13355
     "RUSTSEC-2024-0384",
+    # paste crate is no longer maintained, but it is past 1.0
+    # Keep this here until our transisent dependencies no longer
+    # need it
+    "RUSTSEC-2024-0436",
 ]
 git-fetch-with-cli = true
 
@@ -18,7 +22,6 @@ allow = [
     "Apache-2.0",
     "BSD-2-Clause",
     "BSD-3-Clause",
-    "BSD-4-Clause",
     "CC0-1.0",
     "ISC",
     "MIT",
@@ -28,7 +31,6 @@ allow = [
 exceptions = [
     # We should probably NOT bundle CA certs but use the OS ones.
     { name = "webpki-roots", allow = ["MPL-2.0"] },
-    { allow = ["OpenSSL"], name = "ring" },
 ]
 
 [[licenses.clarify]]


### PR DESCRIPTION
- update ring (ring v0.17.8 -> v0.17.13)
- added paste crate (unmaintained) to ignore list
