### PR TITLE
feat: Add versions for InfluxDB Files

### DIFF
--- a/influxdb3_write/src/lib.rs
+++ b/influxdb3_write/src/lib.rs
@@ -92,7 +92,9 @@ pub trait Bufferer: Debug + Send + Sync + 'static {
     ) -> Vec<ParquetFile>;
 
     /// A channel to watch for when new persisted snapshots are created
-    fn watch_persisted_snapshots(&self) -> tokio::sync::watch::Receiver<Option<PersistedSnapshot>>;
+    fn watch_persisted_snapshots(
+        &self,
+    ) -> tokio::sync::watch::Receiver<Option<PersistedSnapshotVersion>>;
 }
 
 /// ChunkContainer is used by the query engine to get chunks for a given table. Chunks will generally be in the
@@ -140,6 +142,22 @@ pub struct BufferedWriteRequest {
     pub line_count: usize,
     pub field_count: usize,
     pub index_count: usize,
+}
+
+#[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Clone)]
+#[serde(tag = "version")]
+pub enum PersistedSnapshotVersion {
+    #[serde(rename = "1")]
+    V1(PersistedSnapshot),
+}
+
+impl PersistedSnapshotVersion {
+    #[cfg(test)]
+    fn v1_ref(&self) -> &PersistedSnapshot {
+        match self {
+            Self::V1(ps) => ps,
+        }
+    }
 }
 
 /// The collection of Parquet files that were persisted in a snapshot

--- a/influxdb3_write/src/snapshots/influxdb3_write__persister__tests__persisted_snapshot_structure.snap
+++ b/influxdb3_write/src/snapshots/influxdb3_write__persister__tests__persisted_snapshot_structure.snap
@@ -3,6 +3,7 @@ source: influxdb3_write/src/persister.rs
 expression: snapshot
 ---
 {
+  "version": "1",
   "node_id": "host",
   "next_file_id": 8,
   "snapshot_sequence_number": 0,


### PR DESCRIPTION
~~Below are two commits that add versioning for PersistedSnapshot and Catalog based files.~~ The work for Enterprise versions of these files can be found [over in the Enterprise repo](https://github.com/influxdata/influxdb_pro/pull/565). The approach is much the same: a wrapper versioned enum used for serialization and deserialization that we then can use to handle different versions when we read them from object store. We need to do this now so that we can keep our formats stable during the beta.

UPDATE: With the changes to the catalog they now include a version number in the header of the file and so that commit was dropped