### PR TITLE
chore: ignore humantime RUSTSEC-2025-0014

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -12,6 +12,11 @@ ignore = [
     # Keep this here until our transisent dependencies no longer
     # need it
     "RUSTSEC-2024-0436",
+    # humantime is no longer maintained, we plan to replace it with
+    # something that is, e.g., jiff, but are ignoring this advisory
+    # until such a replacement has been adopted. See
+    # https://github.com/influxdata/influxdb/issues/26120
+    "RUSTSEC-2025-0014",
 ]
 git-fetch-with-cli = true
 


### PR DESCRIPTION
Ignoring the `humantime` RUSTSEC advisory to unblock CI.

See https://github.com/influxdata/influxdb/issues/26120