### PR TITLE
chore: back-port catalog debug log cleanup from enterprise

### DIFF
--- a/influxdb3/src/commands/serve.rs
+++ b/influxdb3/src/commands/serve.rs
@@ -550,7 +550,7 @@ pub async fn command(config: Config) -> Result<()> {
         .register_node(
             &config.node_identifier_prefix,
             num_cpus as u64,
-            influxdb3_catalog::log::NodeMode::Core,
+            vec![influxdb3_catalog::log::NodeMode::Core],
         )
         .await?;
     let node_def = catalog

--- a/influxdb3_catalog/src/log.rs
+++ b/influxdb3_catalog/src/log.rs
@@ -45,6 +45,13 @@ impl CatalogBatch {
         })
     }
 
+    pub fn n_ops(&self) -> usize {
+        match self {
+            CatalogBatch::Node(node_batch) => node_batch.ops.len(),
+            CatalogBatch::Database(database_batch) => database_batch.ops.len(),
+        }
+    }
+
     pub fn as_database(&self) -> Option<&DatabaseBatch> {
         match self {
             CatalogBatch::Node(_) => None,
@@ -158,7 +165,7 @@ pub struct RegisterNodeLog {
     pub instance_id: Arc<str>,
     pub registered_time_ns: i64,
     pub core_count: u64,
-    pub mode: NodeMode,
+    pub mode: Vec<NodeMode>,
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]

--- a/influxdb3_catalog/src/snapshot.rs
+++ b/influxdb3_catalog/src/snapshot.rs
@@ -116,7 +116,7 @@ impl From<CatalogSnapshot> for InnerCatalog {
 struct NodeSnapshot {
     node_id: Arc<str>,
     instance_id: Arc<str>,
-    mode: NodeMode,
+    mode: Vec<NodeMode>,
     state: NodeState,
     core_count: u64,
 }
@@ -126,7 +126,7 @@ impl From<&NodeDefinition> for NodeSnapshot {
         Self {
             node_id: Arc::clone(&node.node_id),
             instance_id: Arc::clone(&node.instance_id),
-            mode: node.mode,
+            mode: node.mode.clone(),
             state: node.state,
             core_count: node.core_count,
         }

--- a/influxdb3_wal/src/object_store.rs
+++ b/influxdb3_wal/src/object_store.rs
@@ -123,7 +123,7 @@ impl WalObjectStore {
         last_wal_sequence_number: Option<WalFileSequenceNumber>,
         all_wal_file_paths: &[Path],
     ) -> crate::Result<()> {
-        debug!(">>> replaying");
+        debug!("replaying");
         let paths = self.load_existing_wal_file_paths(last_wal_sequence_number, all_wal_file_paths);
 
         let last_snapshot_sequence_number = {
@@ -378,7 +378,7 @@ impl WalObjectStore {
                     debug!(
                         ?path,
                         ?last_wal_path,
-                        ">>> path and last_wal_path check when replaying"
+                        "path and last_wal_path check when replaying"
                     );
                     // last_wal_sequence_number that comes from persisted snapshot is
                     // holds the last wal number (inclusive) that has been snapshotted
@@ -409,7 +409,7 @@ impl WalObjectStore {
             ?last,
             ?curr_num_files,
             ?self.snapshotted_wal_files_to_keep,
-            ">>> checking num wal files to delete"
+            "checking num wal files to delete"
         );
 
         if curr_num_files > self.snapshotted_wal_files_to_keep {
@@ -421,7 +421,7 @@ impl WalObjectStore {
                 ?curr_num_files,
                 ?num_files_to_delete,
                 ?last_to_delete,
-                ">>> more wal files than num files to keep around"
+                "more wal files than num files to keep around"
             );
 
             for idx in oldest..last_to_delete {
@@ -429,7 +429,7 @@ impl WalObjectStore {
                     &self.node_identifier_prefix,
                     WalFileSequenceNumber::new(idx),
                 );
-                debug!(?path, ">>> deleting wal file");
+                debug!(?path, "deleting wal file");
 
                 loop {
                     // if there are errors in between we are changing oldest to
@@ -475,7 +475,7 @@ fn oldest_wal_file_num(all_wal_file_paths: &[Path]) -> Option<WalFileSequenceNum
     debug!(
         ?file_name_with_path,
         ?wal_file_name,
-        ">>> file name path and wal file name"
+        "file name path and wal file name"
     );
     WalFileSequenceNumber::from_str(wal_file_name).ok()
 }
@@ -1535,7 +1535,7 @@ mod tests {
             .await
             .unwrap();
 
-        debug!(?all_paths, ">>> test: all paths in object store");
+        debug!(?all_paths, "test: all paths in object store");
 
         let wal = WalObjectStore::new_without_replay(
             Arc::clone(&time_provider),
@@ -1593,10 +1593,7 @@ mod tests {
             .await
             .unwrap();
 
-        debug!(
-            ?all_paths,
-            ">>> test: all paths in object store after removal"
-        );
+        debug!(?all_paths, "test: all paths in object store after removal");
 
         assert!(object_store.get(&path1).await.ok().is_some());
         assert!(object_store.get(&path2).await.ok().is_some());
@@ -1625,10 +1622,7 @@ mod tests {
             .await
             .unwrap();
 
-        debug!(
-            ?all_paths,
-            ">>> test: all paths in object store after removal"
-        );
+        debug!(?all_paths, "test: all paths in object store after removal");
 
         let err = object_store.get(&path1).await.err().unwrap();
 
@@ -1683,7 +1677,7 @@ mod tests {
             .await
             .unwrap();
 
-        debug!(?all_paths, ">>> test: all paths in object store");
+        debug!(?all_paths, "test: all paths in object store");
 
         let wal = WalObjectStore::new_without_replay(
             Arc::clone(&time_provider),

--- a/influxdb3_wal/src/snapshot_tracker.rs
+++ b/influxdb3_wal/src/snapshot_tracker.rs
@@ -61,7 +61,7 @@ impl SnapshotTracker {
         debug!(
             wal_periods_len = ?self.wal_periods.len(),
             num_snapshots_after = ?self.number_of_periods_to_snapshot_after(),
-            ">>> wal periods and snapshots"
+            "wal periods and snapshots"
         );
 
         if !self.should_run_snapshot(force_snapshot) {
@@ -113,7 +113,7 @@ impl SnapshotTracker {
         let t = self.wal_periods.last()?.max_time;
         // round the last timestamp down to the gen1_duration
         let t = t - (t.get() % self.gen1_duration.as_nanos());
-        debug!(timestamp_ns = ?t, gen1_duration_ns = ?self.gen1_duration.as_nanos(), ">>> last timestamp");
+        debug!(timestamp_ns = ?t, gen1_duration_ns = ?self.gen1_duration.as_nanos(), "last timestamp");
 
         // any wal period that has data before this time can be snapshot
         let periods_to_snapshot = self
@@ -122,7 +122,7 @@ impl SnapshotTracker {
             .take_while(|period| period.max_time < t)
             .cloned()
             .collect::<Vec<_>>();
-        debug!(?periods_to_snapshot, ">>> periods to snapshot");
+        debug!(?periods_to_snapshot, "periods to snapshot");
         let first_wal_file_number = periods_to_snapshot
             .iter()
             .peekable()

--- a/influxdb3_write/src/lib.rs
+++ b/influxdb3_write/src/lib.rs
@@ -336,7 +336,7 @@ impl<'a> ChunkFilter<'a> {
     /// This method analyzes the incoming `exprs` to determine if there are any filters on the
     /// `time` column and attempt to derive the boundaries on `time` from the query.
     pub fn new(table_def: &Arc<TableDefinition>, exprs: &'a [Expr]) -> Result<Self> {
-        debug!(input = ?exprs, ">>> creating chunk filter");
+        debug!(input = ?exprs, "creating chunk filter");
         let mut time_interval: Option<Interval> = None;
         let arrow_schema = table_def.schema.as_arrow();
         let time_col_index = arrow_schema

--- a/influxdb3_write/src/write_buffer/validator.rs
+++ b/influxdb3_write/src/write_buffer/validator.rs
@@ -12,7 +12,7 @@ use influxdb3_id::{DbId, TableId};
 use influxdb3_types::http::FieldDataType;
 use influxdb3_wal::{Field, FieldData, Gen1Duration, Row, TableChunks, WriteBatch};
 use iox_time::Time;
-use observability_deps::tracing::debug;
+use observability_deps::tracing::trace;
 use schema::TIME_COLUMN_NAME;
 
 use super::Error;
@@ -97,7 +97,7 @@ impl WriteValidator<Initialized> {
     /// with name `db_name`. This initializes the database if it does not already exist.
     pub fn initialize(db_name: NamespaceName<'static>, catalog: Arc<Catalog>) -> Result<Self> {
         let txn = catalog.begin(db_name.as_str())?;
-        debug!(transaction = ?txn, ">>> initialize write validator");
+        trace!(transaction = ?txn, "initialize write validator");
         Ok(WriteValidator {
             state: Initialized { catalog, txn },
         })


### PR DESCRIPTION
No issue.

There were a lot of excess `DEBUG` logs littered around the catalog code from the catalog refactor that were causing a lot of noise in the log output.

This reduces that noise by:
* removing log statements that were redundant
* simplifying what is included in log statements to make them less verbose
* changing some `DEBUG` to `TRACE` in case that verbosity is needed in some cases
* several `>>>` were removed from the beginning of `DEBUG` logs throughout the code

In addition, the severity of the message emitted when there are no subscribers on catalog broadcast was changed from `WARN` to `INFO` to not raise any alarms.
