### PR TITLE
fix: off-by-one in catalog update logic

### DIFF
--- a/influxdb3_catalog/src/catalog/update.rs
+++ b/influxdb3_catalog/src/catalog/update.rs
@@ -694,7 +694,7 @@ impl Catalog {
             let batch = self.apply_ordered_catalog_batch(&ordered_catalog_batch, permit);
             self.broadcast_update(batch);
             sequence_number = sequence_number.next();
-            if update_until.is_some_and(|max_sequence| sequence_number >= max_sequence) {
+            if update_until.is_some_and(|max_sequence| sequence_number > max_sequence) {
                 break;
             }
         }


### PR DESCRIPTION
No issue.

The method for updating the catalog to a given sequence number was off-by-one, and was only updating to the sequence before the given `update_to` sequence. This fixes that by correcting the condition.

I checked this change in enterprise as well, but making it here so it can be sync'd up.

See related [slack thread](https://influxdata.slack.com/archives/C06BQA608J3/p1741779301185649).
