### PR TITLE
fix: Make sure JSON fully closes on empty records

### DIFF
--- a/influxdb3/tests/cli/mod.rs
+++ b/influxdb3/tests/cli/mod.rs
@@ -335,6 +335,39 @@ async fn test_show_databases() {
 }
 
 #[test_log::test(tokio::test)]
+async fn test_show_empty_database() {
+    let server = TestServer::spawn().await;
+    let server_addr = server.client_addr();
+    let output = run(&["show", "databases", "--host", &server_addr]);
+    assert_eq!(
+        "\
+        +---------------+\n\
+        | iox::database |\n\
+        +---------------+\n\
+        +---------------+",
+        output
+    );
+    let output = run(&[
+        "show",
+        "databases",
+        "--host",
+        &server_addr,
+        "--format",
+        "json",
+    ]);
+    assert_eq!(output, "[]");
+    let output = run(&[
+        "show",
+        "databases",
+        "--host",
+        &server_addr,
+        "--format",
+        "jsonl",
+    ]);
+    assert_eq!(output, "");
+}
+
+#[test_log::test(tokio::test)]
 async fn test_create_database() {
     let server = TestServer::spawn().await;
     let server_addr = server.client_addr();


### PR DESCRIPTION
This fixes an issue when querying for data with no values would create incomplete JSON. This first showed up in #26057 due to `influxdb3 show database` having no data on a fresh run of the server.

While the code we had, handled the fact that if there was no data written then we should have written `[]`, however, there was a subtle edge case we did not handle. If we got a record batch and wrote it into the writer we would expect it to then write the opening `[` even if there was no data. However, this was not the case. It would only do so once it was actually writing data or we called `finish` which doesn't work for us here since we're hacking around the API in order to stream data back.

This took quite a while to track down, but the end result is a simple fix to a hard problem: if we're polling data for the first time and the first record batch is empty just write a `[` into the Body of the request. Our later code will handle closing the bracket and we're all good. If there is data then the JSON writer can handle it as normal.

Closes #26057