### PR TITLE
fix: updates for package validation with portable glibc builds

### DIFF
--- a/.circleci/scripts/package-validation/validate
+++ b/.circleci/scripts/package-validation/validate
@@ -85,7 +85,7 @@ if [[ "${NEEDED:-}" ]]
 then
   if echo "$NEEDED" | grep -Eq "Shared library: \[libpython" ; then
     # if have libpython, ensure we are only linking things we expect
-    if echo "$NEEDED" | grep -Ev "Shared library: \[(ld-linux.*|libc|libdl|libgcc_s|libm|libpthread|libpython3.[0-9]{2})\.so" ; then
+    if echo "$NEEDED" | grep -Ev "Shared library: \[(ld-linux.*|libc|libdl|libgcc_s|libm|libpthread|libpython3.[0-9]{2}|librt)\.so" ; then
       cat <<'EOF'
 ERROR: found unexpected dynamically linked libraries! This may
        prevent all platforms from running influxdb3 without

--- a/.circleci/scripts/package-validation/validate
+++ b/.circleci/scripts/package-validation/validate
@@ -93,6 +93,24 @@ ERROR: found unexpected dynamically linked libraries! This may
 EOF
       exit 2
     fi
+
+    CUR_LATEST="$(readelf -s "$(which influxdb3)" | grep @GLIBC_ | sed 's/@@/@/' | cut -d @ -f 2 | cut -d ' ' -f 1 | cut -d _ -f 2 | grep -E '^[0-9]+\.[0-9][0-9.]*[0-9]$' | sort -uV | tail -1)" || true
+    if [ -z "$CUR_LATEST" ]; then
+        cat <<EOF
+ERROR: could not find any GLIBC symbols! The GLIBC compatibility
+       cannot be determined.
+EOF
+        exit 2
+    fi
+
+    MAX_VERSION="2.23"  # the portability we desire
+    if [[ $(printf '%s\n%s\n' "$CUR_LATEST" "$MAX_VERSION" | sort -V | tail -n 1) != "$MAX_VERSION" ]]; then
+        cat <<EOF
+ERROR: found GLIBC symbol version $CUR_LATEST > $MAX_VERSION. This will
+       prevent platforms with GLIBC < $CUR_LATEST from working.
+EOF
+        exit 2
+    fi
   else
     # if no libpython, then complain if any are NEEDED
     cat <<'EOF'

--- a/.circleci/scripts/package-validation/validate
+++ b/.circleci/scripts/package-validation/validate
@@ -45,11 +45,9 @@ install_rpm() {
   # see "install_deb" for "update"
   yum update -y
   yum install -y binutils
-  # temporary install with rpm --nodeps until we compile with older glibc
-  #yum localinstall -y "$(realpath "${PACKAGE_PATH}")"
   yum install -y shadow-utils       # for useradd
   yum install -y libxcrypt-compat   # for libcrypt.so.1
-  rpm -ivh --nodeps "$(realpath "${PACKAGE_PATH}")"
+  yum localinstall -y "$(realpath "${PACKAGE_PATH}")"
 }
 
 case ${PACKAGE_TYPE}

--- a/README_processing_engine.md
+++ b/README_processing_engine.md
@@ -68,9 +68,7 @@ well as a few OS-specific libraries. Specifically:
    * `python-build-standalone` is linked against `glibc` and is compatible with
      `glibc` [2.17+](https://github.com/astral-sh/python-build-standalone/blob/main/docs/running.rst#linux)
    * `influxdb3` is linked against `libpython` from `python-build-standalone` as
-     well as `glibc` (currently compatible with `glibc` 2.36+ (though 2.35 is
-     known to work; future releases will be built against an earlier `glibc`
-     release to improve compatibility))
+     well as `glibc` (official builds target `glibc` 2.23+)
  * Darwin (seen with `otool -L`; cross-compiled with [osxcross](https://github.com/tpoechtrager/osxcross)):
    * `python-build-standalone` is linked against:
      * `CoreFoundation.framework/Versions/A/CoreFoundation` compatibility
@@ -404,9 +402,6 @@ to be compiled on an older system with a `glibc` with the desired version.
 `python-build-standalone` and `rust` both support systems with `glibc` 2.17+,
 which is covers distributions going back to 2014 (CentOS/RHEL 7 (EOL), Debian 8
 (Jessie; EOL), Ubuntu 14.04 LTS (EOL), Fedora 21, etc.
-
-Certain InfluxDB alpha releases are compiled against a too new `glibc` (2.36).
-This will be addressed before release.
 
 
 ### How does InfluxDB find the correct libpython and the python runtime?


### PR DESCRIPTION
Closes #26011

Here is the followup I promised in https://github.com/influxdata/influxdb/pull/26124 (but there I was thinking the validation checks were in `ci-support`; they're not).

* fix(circleci): add librt.so to list of acceptable libraries
* feat(circleci): check for glibc portability
* fix(circleci): remove rpm --nodeps workaround in rpm validate
* chore: update README_processing_engine.md for glibc portability

Note, it's the `check_package_*` CircleCI jobs that run these scripts and they are only run on release builds, which are currently disabled. I did run snippets of the scripts locally.