### PR TITLE
fix: do not panic on invalid multiple subqueries

### DIFF
--- a/query/select.go
+++ b/query/select.go
@@ -588,11 +588,8 @@ func (b *exprIteratorBuilder) callIterator(ctx context.Context, expr *influxql.C
 				}
 				inputs = append(inputs, input)
 			case *influxql.SubQuery:
-				// Identify the name of the field we are using.
-				arg0 := expr.Args[0].(*influxql.VarRef)
-
 				opt.Ordered = false
-				input, err := buildExprIterator(ctx, arg0, b.ic, []influxql.Source{source}, opt, b.selector, false)
+				input, err := buildExprIterator(ctx, expr.Args[0], b.ic, []influxql.Source{source}, opt, b.selector, false)
 				if err != nil {
 					return err
 				}

--- a/query/select_test.go
+++ b/query/select_test.go
@@ -2879,6 +2879,14 @@ func TestSelect(t *testing.T) {
 			},
 			now: mustParseTime("1970-01-01T00:02:30Z"),
 		},
+		{
+			// This caused a panic in 1.11.7 and earlier versions
+			name: "Multiple_Subqueries_Fail",
+			q: `SELECT ABS(a_count - b_count) FROM
+                                  (SELECT COUNT(DISTINCT a_id) AS a_count FROM (SELECT last(v0), tag0 AS a_id FROM m0 GROUP BY tag0) FILL(0)),
+                                  (SELECT COUNT(DISTINCT b_id) as b_count FROM (SELECT last(v0), tag0 AS a_id FROM m0 GROUP BY tag0) FILL(0))`,
+			err: `invalid expression type: *influxql.Distinct`,
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			shardMapper := ShardMapper{


### PR DESCRIPTION
Multiple subqueries in a FROM clause caused a
panic, insead of returning an error because
they are syntactically invalid. This corrects
that problem

closes https://github.com/influxdata/influxdb/issues/26139