### PR TITLE
chore: re-enable release on merge to main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -651,9 +651,9 @@ workflows:
   snapshot:
     jobs:
       - fetch-python:
-          <<: *release_filter
+          <<: *main_filter
       - build-release:
-          <<: *release_filter
+          <<: *main_filter
           name: build-snapshot-<< matrix.target >>
           matrix:
             parameters:
@@ -667,15 +667,15 @@ workflows:
           requires:
             - fetch-python
       - build-packages:
-          <<: *release_filter
+          <<: *main_filter
           requires:
             - build-release
       - sign-packages:
-          <<: *release_filter
+          <<: *main_filter
           requires:
             - build-packages
       - publish-packages:
-          <<: *release_filter
+          <<: *main_filter
           matrix:
             parameters:
               destination: [ snapshots ]
@@ -781,7 +781,7 @@ workflows:
           platform: arm64
           resource_class: arm.2xlarge
       - publish-docker:
-          <<: *release_filter
+          <<: *docker_filter
           requires:
             - build-docker-amd64
             - build-docker-arm64


### PR DESCRIPTION
Re-enable the snapshot process in CI to do build on merge to `main`.