### PR TITLE
fix: don't use modified .cargo/config.toml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -287,7 +287,7 @@ jobs:
   # Build a dev binary with the default cargo profile
   build-dev:
     docker:
-      - image: us-east1-docker.pkg.dev/influxdata-team-edge/ci-support/ci-cross-influxdb3@sha256:d0c9ed7385866ceeb9c143bda0e2ea607bed0000eb73577d02f9e52e1bddc2d6
+      - image: us-east1-docker.pkg.dev/influxdata-team-edge/ci-support/ci-cross-influxdb3@sha256:1f41029cb68a723c3b559a44bcf91e04b6a71b631b0886185562f4a90e1460ba
         auth:
           username: _json_key
           password: $CISUPPORT_GCS_AUTHORIZATION
@@ -350,7 +350,7 @@ jobs:
   # Compile cargo "release" profile binaries for influxdb3 edge releases
   build-release:
     docker:
-      - image: us-east1-docker.pkg.dev/influxdata-team-edge/ci-support/ci-cross-influxdb3@sha256:d0c9ed7385866ceeb9c143bda0e2ea607bed0000eb73577d02f9e52e1bddc2d6
+      - image: us-east1-docker.pkg.dev/influxdata-team-edge/ci-support/ci-cross-influxdb3@sha256:1f41029cb68a723c3b559a44bcf91e04b6a71b631b0886185562f4a90e1460ba
         auth:
           username: _json_key
           password: $CISUPPORT_GCS_AUTHORIZATION

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ valgrind-out.txt
 *.pending-snap
 # Helix editor configuration directory:
 **/.helix
+# .cargo/config.toml is checked in, but glibc builds create .cargo/config to
+# override it, which we can ignore
+.cargo/config


### PR DESCRIPTION
Closes #26147

    fix: don't use modified .cargo/config.toml
    
    We need to both add and remove keys from rustflags, but modifying
    .cargo/config.toml in place causes the version string to have -dirty
    appended to it. Use ci-support that instead creates ./.cargo/config (a
    historic filename that is preferred over ./.cargo/config.toml if it
    exists) and then git ignore ./.cargo/config.
    
    References:
    - https://github.com/influxdata/influxdb/issues/26147
    - https://doc.rust-lang.org/cargo/reference/config.html?highlight=rustflags#hierarchical-structure


Tested by:
  * after putting this PR up, triggered a CircleCI pipeline for the PR to use `persist_debug = true` (which causes the `build-dev` to persist debug builds that we can examine)
  * download a Linux debug tarball for this CI run, eg, https://output.circle-artifacts.com/output/job/717e419f-9109-473a-be4b-8debb567ddcf/artifacts/0/artifacts/influxdb3-core_x86_64-unknown-linux-gnu.tar.gz
  * run:
```
$ tar -zxf /path/to/tarball
# LD_LIBRARY_PATH needed because persisted debug builds don't have `patchelf` run on them like release builds do
$ LD_LIBRARY_PATH=./python/lib ./influxdb3 -V  # should not say `-dirty` any more
influxdb3 0.1.0, revision v2.5.0-14386-g1e0d237553e15da0defc6aa2102764aec1488ff5

# verify have a portable glibc still (should have nothing higher than GLIBC_2.23)
$ readelf -s ./influxdb3 | grep @GLIBC_ | sed 's/@@/@/' | cut -d @ -f 2 | cut -d ' ' -f 1 | sort -uV
GLIBC_2.2.5
GLIBC_2.3
GLIBC_2.3.2
GLIBC_2.3.4
GLIBC_2.4
GLIBC_2.6
GLIBC_2.7
GLIBC_2.9
GLIBC_2.10
GLIBC_2.12
GLIBC_2.14
GLIBC_2.15
GLIBC_2.16
GLIBC_2.17
GLIBC_2.18
```