### PR TITLE
test: small change to distinct cache cli test

### DIFF
--- a/influxdb3/tests/cli/mod.rs
+++ b/influxdb3/tests/cli/mod.rs
@@ -1246,7 +1246,7 @@ async fn distinct_cache_create_and_delete() {
         .await
         .expect("write to db");
 
-    let result = run_with_confirmation(&[
+    let create_args = &[
         "create",
         "distinct_cache",
         "-H",
@@ -1262,9 +1262,16 @@ async fn distinct_cache_create_and_delete() {
         "--max-age",
         "200s",
         "cache_money",
-    ]);
+    ];
+
+    let result = run_with_confirmation(create_args);
 
     assert_contains!(result, "new cache created");
+
+    // try to create again, should not work:
+    let result = run_with_confirmation_and_err(create_args);
+
+    assert_contains!(result, "attempted to create a resource that already exists");
 
     let result = run_with_confirmation(&[
         "delete",


### PR DESCRIPTION
Added one check to the distinct cache create test that checks duplicate creation behaviour while investigating [influxdb_pro#601](https://github.com/influxdata/influxdb_pro/issues/601)
