### PR TITLE
fix: Remove nil dereference

### DIFF
--- a/coordinator/statement_executor.go
+++ b/coordinator/statement_executor.go
@@ -759,7 +759,7 @@ func (e *StatementExecutor) executeShowMeasurementsStatement(ctx *query.Executio
 		dbInfo := e.MetaClient.Database(q.Database)
 		if dbInfo == nil {
 			return ctx.Send(&query.Result{
-				Err: fmt.Errorf("unknown database %s", dbInfo.Name),
+				Err: fmt.Errorf("unknown database %s", q.Database),
 			})
 		}
 		for _, rpInfo := range dbInfo.RetentionPolicies {


### PR DESCRIPTION
As I was going through some of the `statement_executor` code I noticed that we were dereferencing a nil value after checking whether it was nil. 
