### PR TITLE
chore: cleanup token create CLI message

### DIFF
--- a/influxdb3/src/commands/create.rs
+++ b/influxdb3/src/commands/create.rs
@@ -346,9 +346,10 @@ pub async fn command(config: Config) -> Result<(), Box<dyn Error>> {
                 "\
                 Token: {token}\n\
                 Hashed Token: {hashed}\n\n\
-                Start the server with `influxdb3 serve --bearer-token {hashed} --object-store file --data-dir ~/.influxdb3 --node-id YOUR_HOST_NAME`\n\n\
+                Start the server with the Hashed Token provided as the `--bearer-token` argument:\n\n
+                `influxdb3 serve --bearer-token {hashed} --node-id <NODE_ID> [OPTIONS]`\n\n\
                 HTTP requests require the following header: \"Authorization: Bearer {token}\"\n\
-                This will grant you access to every HTTP endpoint or deny it otherwise
+                This will grant you access to every HTTP endpoint or deny it otherwise.
             ",
                 hashed = hex::encode(&Sha512::digest(&token)[..])
             );


### PR DESCRIPTION
No issue for this. An internal tester expressed some confusion around the `influxdb3 create token` command output with respect to the default arguments chosen by the install script:
1. By default, the data dir is completely different `--data-dir /home/ubuntu/.influxdb/data` than the install script
2. It states to use _my host name_ for `--node-id` when it uses `node0` by default.

This PR simplifies the output to not make any assumptions about their object store configuration and changing the placeholder for `--node-id` to be `<NODE_ID>` instead of `MY_HOST_NAME`.

I do not think there is a way to get the actual `--node-id` for their server.

### Reference

* [Slack thread](https://influxdata.slack.com/archives/C084G9LR2HL/p1742253589376809)