### PR TITLE
fix: maybe fix flakiness for parquet cache test

### DIFF
--- a/influxdb3_write/src/write_buffer/mod.rs
+++ b/influxdb3_write/src/write_buffer/mod.rs
@@ -2833,6 +2833,9 @@ mod tests {
             &batches
         );
 
+        // Give the cache a little time to populate before making another request
+        tokio::time::sleep(Duration::from_secs(1)).await;
+
         assert!(inner_store.total_read_request_count(&path) > 0);
         let expected_req_counts = inner_store.total_read_request_count(&path);
 


### PR DESCRIPTION
This adds a sleep so that the parquet cache has a little bit of time to populate before we make another request to the query buffer. Sometimes it does not populate and so we have a race condition where the new request comes in and actually goes to object store. This is fine in practice because it would also take time to fill the cache in production as well. I haven't really seen the test fail since adding this, but triggering it in the first place is really hard and in practice does not happen all that often.