### PR TITLE
fix: Do not panic when using an unexpected cursor type

### DIFF
--- a/storage/reads/array_cursor.gen.go
+++ b/storage/reads/array_cursor.gen.go
@@ -24,101 +24,113 @@ const (
 	MaxPointsPerBlock = 1000
 )
 
-func newLimitArrayCursor(cur cursors.Cursor) cursors.Cursor {
+func newLimitArrayCursor(cur cursors.Cursor) (cursors.Cursor, error) {
 	switch cur := cur.(type) {
 
 	case cursors.FloatArrayCursor:
-		return newFloatLimitArrayCursor(cur)
+		return newFloatLimitArrayCursor(cur), nil
 
 	case cursors.IntegerArrayCursor:
-		return newIntegerLimitArrayCursor(cur)
+		return newIntegerLimitArrayCursor(cur), nil
 
 	case cursors.UnsignedArrayCursor:
-		return newUnsignedLimitArrayCursor(cur)
+		return newUnsignedLimitArrayCursor(cur), nil
 
 	case cursors.StringArrayCursor:
-		return newStringLimitArrayCursor(cur)
+		return newStringLimitArrayCursor(cur), nil
 
 	case cursors.BooleanArrayCursor:
-		return newBooleanLimitArrayCursor(cur)
+		return newBooleanLimitArrayCursor(cur), nil
 
 	default:
-		panic(fmt.Sprintf("unreachable: %T", cur))
+		return nil, &errors2.Error{
+			Code: errors2.EInvalid,
+			Msg:  fmt.Sprintf("unreachable: %s", arrayCursorType(cur)),
+		}
 	}
 }
 
-func newWindowFirstArrayCursor(cur cursors.Cursor, window interval.Window) cursors.Cursor {
+func newWindowFirstArrayCursor(cur cursors.Cursor, window interval.Window) (cursors.Cursor, error) {
 	if window.IsZero() {
 		return newLimitArrayCursor(cur)
 	}
 	switch cur := cur.(type) {
 
 	case cursors.FloatArrayCursor:
-		return newFloatWindowFirstArrayCursor(cur, window)
+		return newFloatWindowFirstArrayCursor(cur, window), nil
 
 	case cursors.IntegerArrayCursor:
-		return newIntegerWindowFirstArrayCursor(cur, window)
+		return newIntegerWindowFirstArrayCursor(cur, window), nil
 
 	case cursors.UnsignedArrayCursor:
-		return newUnsignedWindowFirstArrayCursor(cur, window)
+		return newUnsignedWindowFirstArrayCursor(cur, window), nil
 
 	case cursors.StringArrayCursor:
-		return newStringWindowFirstArrayCursor(cur, window)
+		return newStringWindowFirstArrayCursor(cur, window), nil
 
 	case cursors.BooleanArrayCursor:
-		return newBooleanWindowFirstArrayCursor(cur, window)
+		return newBooleanWindowFirstArrayCursor(cur, window), nil
 
 	default:
-		panic(fmt.Sprintf("unreachable: %T", cur))
+		return nil, &errors2.Error{
+			Code: errors2.EInvalid,
+			Msg:  fmt.Sprintf("unreachable: %s", arrayCursorType(cur)),
+		}
 	}
 }
 
-func newWindowLastArrayCursor(cur cursors.Cursor, window interval.Window) cursors.Cursor {
+func newWindowLastArrayCursor(cur cursors.Cursor, window interval.Window) (cursors.Cursor, error) {
 	if window.IsZero() {
 		return newLimitArrayCursor(cur)
 	}
 	switch cur := cur.(type) {
 
 	case cursors.FloatArrayCursor:
-		return newFloatWindowLastArrayCursor(cur, window)
+		return newFloatWindowLastArrayCursor(cur, window), nil
 
 	case cursors.IntegerArrayCursor:
-		return newIntegerWindowLastArrayCursor(cur, window)
+		return newIntegerWindowLastArrayCursor(cur, window), nil
 
 	case cursors.UnsignedArrayCursor:
-		return newUnsignedWindowLastArrayCursor(cur, window)
+		return newUnsignedWindowLastArrayCursor(cur, window), nil
 
 	case cursors.StringArrayCursor:
-		return newStringWindowLastArrayCursor(cur, window)
+		return newStringWindowLastArrayCursor(cur, window), nil
 
 	case cursors.BooleanArrayCursor:
-		return newBooleanWindowLastArrayCursor(cur, window)
+		return newBooleanWindowLastArrayCursor(cur, window), nil
 
 	default:
-		panic(fmt.Sprintf("unreachable: %T", cur))
+		return nil, &errors2.Error{
+			Code: errors2.EInvalid,
+			Msg:  fmt.Sprintf("unreachable: %s", arrayCursorType(cur)),
+		}
 	}
 }
 
-func newWindowCountArrayCursor(cur cursors.Cursor, window interval.Window) cursors.Cursor {
+func newWindowCountArrayCursor(cur cursors.Cursor, window interval.Window) (cursors.Cursor, error) {
 	switch cur := cur.(type) {
 
 	case cursors.FloatArrayCursor:
-		return newFloatWindowCountArrayCursor(cur, window)
+		return newFloatWindowCountArrayCursor(cur, window), nil
 
 	case cursors.IntegerArrayCursor:
-		return newIntegerWindowCountArrayCursor(cur, window)
+		return newIntegerWindowCountArrayCursor(cur, window), nil
 
 	case cursors.UnsignedArrayCursor:
-		return newUnsignedWindowCountArrayCursor(cur, window)
+		return newUnsignedWindowCountArrayCursor(cur, window), nil
 
 	case cursors.StringArrayCursor:
-		return newStringWindowCountArrayCursor(cur, window)
+		return newStringWindowCountArrayCursor(cur, window), nil
 
 	case cursors.BooleanArrayCursor:
-		return newBooleanWindowCountArrayCursor(cur, window)
+		return newBooleanWindowCountArrayCursor(cur, window), nil
 
 	default:
-		panic(fmt.Sprintf("unreachable: %T", cur))
+		return nil, &errors2.Error{
+			Code: errors2.EInvalid,
+			Msg:  fmt.Sprintf("unreachable: %s", arrayCursorType(cur)),
+		}
 	}
 }
 
@@ -142,37 +154,43 @@ func newWindowSumArrayCursor(cur cursors.Cursor, window interval.Window) (cursor
 	}
 }
 
-func newWindowMinArrayCursor(cur cursors.Cursor, window interval.Window) cursors.Cursor {
+func newWindowMinArrayCursor(cur cursors.Cursor, window interval.Window) (cursors.Cursor, error) {
 	switch cur := cur.(type) {
 
 	case cursors.FloatArrayCursor:
-		return newFloatWindowMinArrayCursor(cur, window)
+		return newFloatWindowMinArrayCursor(cur, window), nil
 
 	case cursors.IntegerArrayCursor:
-		return newIntegerWindowMinArrayCursor(cur, window)
+		return newIntegerWindowMinArrayCursor(cur, window), nil
 
 	case cursors.UnsignedArrayCursor:
-		return newUnsignedWindowMinArrayCursor(cur, window)
+		return newUnsignedWindowMinArrayCursor(cur, window), nil
 
 	default:
-		panic(fmt.Sprintf("unsupported for aggregate min: %T", cur))
+		return nil, &errors2.Error{
+			Code: errors2.EInvalid,
+			Msg:  fmt.Sprintf("unsupported for aggregate min: %s", arrayCursorType(cur)),
+		}
 	}
 }
 
-func newWindowMaxArrayCursor(cur cursors.Cursor, window interval.Window) cursors.Cursor {
+func newWindowMaxArrayCursor(cur cursors.Cursor, window interval.Window) (cursors.Cursor, error) {
 	switch cur := cur.(type) {
 
 	case cursors.FloatArrayCursor:
-		return newFloatWindowMaxArrayCursor(cur, window)
+		return newFloatWindowMaxArrayCursor(cur, window), nil
 
 	case cursors.IntegerArrayCursor:
-		return newIntegerWindowMaxArrayCursor(cur, window)
+		return newIntegerWindowMaxArrayCursor(cur, window), nil
 
 	case cursors.UnsignedArrayCursor:
-		return newUnsignedWindowMaxArrayCursor(cur, window)
+		return newUnsignedWindowMaxArrayCursor(cur, window), nil
 
 	default:
-		panic(fmt.Sprintf("unsupported for aggregate max: %T", cur))
+		return nil, &errors2.Error{
+			Code: errors2.EInvalid,
+			Msg:  fmt.Sprintf("unsupported for aggregate max: %s", arrayCursorType(cur)),
+		}
 	}
 }
 

--- a/storage/reads/array_cursor.gen.go.tmpl
+++ b/storage/reads/array_cursor.gen.go.tmpl
@@ -18,53 +18,65 @@ const (
 	MaxPointsPerBlock = 1000
 )
 
-func newLimitArrayCursor(cur cursors.Cursor) cursors.Cursor {
+func newLimitArrayCursor(cur cursors.Cursor) (cursors.Cursor, error) {
 	switch cur := cur.(type) {
 {{range .}}{{/* every type supports limit */}}
 	case cursors.{{.Name}}ArrayCursor:
-		return new{{.Name}}LimitArrayCursor(cur)
+		return new{{.Name}}LimitArrayCursor(cur), nil
 {{end}}
 	default:
-		panic(fmt.Sprintf("unreachable: %T", cur))
+		return nil, &errors2.Error{
+			Code: errors2.EInvalid,
+			Msg: fmt.Sprintf("unreachable: %s", arrayCursorType(cur)),
+		}
 	}
 }
 
-func newWindowFirstArrayCursor(cur cursors.Cursor, window interval.Window) cursors.Cursor {
+func newWindowFirstArrayCursor(cur cursors.Cursor, window interval.Window) (cursors.Cursor, error) {
 	if window.IsZero() {
 		return newLimitArrayCursor(cur)
 	}
 	switch cur := cur.(type) {
 {{range .}}{{/* every type supports first */}}
 	case cursors.{{.Name}}ArrayCursor:
-		return new{{.Name}}WindowFirstArrayCursor(cur, window)
+		return new{{.Name}}WindowFirstArrayCursor(cur, window), nil
 {{end}}
 	default:
-		panic(fmt.Sprintf("unreachable: %T", cur))
+		return nil, &errors2.Error{
+			Code: errors2.EInvalid,
+			Msg: fmt.Sprintf("unreachable: %s", arrayCursorType(cur)),
+		}
 	}
 }
 
-func newWindowLastArrayCursor(cur cursors.Cursor, window interval.Window) cursors.Cursor {
+func newWindowLastArrayCursor(cur cursors.Cursor, window interval.Window) (cursors.Cursor, error) {
 	if window.IsZero() {
 		return newLimitArrayCursor(cur)
 	}
 	switch cur := cur.(type) {
 {{range .}}{{/* every type supports last */}}
 	case cursors.{{.Name}}ArrayCursor:
-		return new{{.Name}}WindowLastArrayCursor(cur, window)
+		return new{{.Name}}WindowLastArrayCursor(cur, window), nil
 {{end}}
 	default:
-		panic(fmt.Sprintf("unreachable: %T", cur))
+		return nil, &errors2.Error{
+			Code: errors2.EInvalid,
+			Msg: fmt.Sprintf("unreachable: %s", arrayCursorType(cur)),
+		}
 	}
 }
 
-func newWindowCountArrayCursor(cur cursors.Cursor, window interval.Window) cursors.Cursor {
+func newWindowCountArrayCursor(cur cursors.Cursor, window interval.Window) (cursors.Cursor, error) {
 	switch cur := cur.(type) {
 {{range .}}{{/* every type supports count */}}
 	case cursors.{{.Name}}ArrayCursor:
-		return new{{.Name}}WindowCountArrayCursor(cur, window)
+		return new{{.Name}}WindowCountArrayCursor(cur, window), nil
 {{end}}
 	default:
-		panic(fmt.Sprintf("unreachable: %T", cur))
+		return nil, &errors2.Error{
+			Code: errors2.EInvalid,
+			Msg: fmt.Sprintf("unreachable: %s", arrayCursorType(cur)),
+		}
 	}
 }
 
@@ -87,35 +99,41 @@ func newWindowSumArrayCursor(cur cursors.Cursor, window interval.Window) (cursor
 	}
 }
 
-func newWindowMinArrayCursor(cur cursors.Cursor, window interval.Window) cursors.Cursor {
+func newWindowMinArrayCursor(cur cursors.Cursor, window interval.Window) (cursors.Cursor, error) {
 	switch cur := cur.(type) {
 {{range .}}
 {{$Type := .Name}}
 {{range .Aggs}}
 {{if eq .Name "Min"}}
 	case cursors.{{$Type}}ArrayCursor:
-		return new{{$Type}}WindowMinArrayCursor(cur, window)
+		return new{{$Type}}WindowMinArrayCursor(cur, window), nil
 {{end}}
 {{end}}{{/* for each supported agg fn */}}
 {{end}}{{/* for each field type */}}
 	default:
-		panic(fmt.Sprintf("unsupported for aggregate min: %T", cur))
+		return nil, &errors2.Error{
+			Code: errors2.EInvalid,
+			Msg: fmt.Sprintf("unsupported for aggregate min: %s", arrayCursorType(cur)),
+		}
 	}
 }
 
-func newWindowMaxArrayCursor(cur cursors.Cursor, window interval.Window) cursors.Cursor {
+func newWindowMaxArrayCursor(cur cursors.Cursor, window interval.Window) (cursors.Cursor, error) {
 	switch cur := cur.(type) {
 {{range .}}
 {{$Type := .Name}}
 {{range .Aggs}}
 {{if eq .Name "Max"}}
 	case cursors.{{$Type}}ArrayCursor:
-		return new{{$Type}}WindowMaxArrayCursor(cur, window)
+		return new{{$Type}}WindowMaxArrayCursor(cur, window), nil
 {{end}}
 {{end}}{{/* for each supported agg fn */}}
 {{end}}{{/* for each field type */}}
 	default:
-		panic(fmt.Sprintf("unsupported for aggregate max: %T", cur))
+		return nil, &errors2.Error{
+			Code: errors2.EInvalid,
+			Msg: fmt.Sprintf("unsupported for aggregate max: %s", arrayCursorType(cur)),
+		}
 	}
 }
 

--- a/storage/reads/array_cursor.go
+++ b/storage/reads/array_cursor.go
@@ -20,7 +20,7 @@ func (v *singleValue) Value(key string) (interface{}, bool) {
 func newAggregateArrayCursor(ctx context.Context, agg *datatypes.Aggregate, cursor cursors.Cursor) (cursors.Cursor, error) {
 	switch agg.Type {
 	case datatypes.Aggregate_AggregateTypeFirst, datatypes.Aggregate_AggregateTypeLast:
-		return newLimitArrayCursor(cursor), nil
+		return newLimitArrayCursor(cursor)
 	}
 	return newWindowAggregateArrayCursor(ctx, agg, interval.Window{}, cursor)
 }
@@ -32,17 +32,17 @@ func newWindowAggregateArrayCursor(ctx context.Context, agg *datatypes.Aggregate
 
 	switch agg.Type {
 	case datatypes.Aggregate_AggregateTypeCount:
-		return newWindowCountArrayCursor(cursor, window), nil
+		return newWindowCountArrayCursor(cursor, window)
 	case datatypes.Aggregate_AggregateTypeSum:
 		return newWindowSumArrayCursor(cursor, window)
 	case datatypes.Aggregate_AggregateTypeFirst:
-		return newWindowFirstArrayCursor(cursor, window), nil
+		return newWindowFirstArrayCursor(cursor, window)
 	case datatypes.Aggregate_AggregateTypeLast:
-		return newWindowLastArrayCursor(cursor, window), nil
+		return newWindowLastArrayCursor(cursor, window)
 	case datatypes.Aggregate_AggregateTypeMin:
-		return newWindowMinArrayCursor(cursor, window), nil
+		return newWindowMinArrayCursor(cursor, window)
 	case datatypes.Aggregate_AggregateTypeMax:
-		return newWindowMaxArrayCursor(cursor, window), nil
+		return newWindowMaxArrayCursor(cursor, window)
 	case datatypes.Aggregate_AggregateTypeMean:
 		return newWindowMeanArrayCursor(cursor, window)
 	default:


### PR DESCRIPTION
This PR is used to alleviate the erroneous panic we are seeing corresponding with https://github.com/influxdata/influxdb/issues/26142 There should not be a panic and instead we should be throwing an error.

