### PR TITLE
chore(ci): update to handle release tags

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,10 +49,27 @@ any_filter: &any_filter
     branches:
       only: /.*/
 
+# This regex is used to trigger 'release builds' based on tags. For semver,
+# package upgrades, etc, the tags must conform to specific schema. Eg:
+#
+# - v3.0.0-0.alpha.1 (1st alpha release)
+# - v3.0.0-0.alpha.1.1 (2nd build of 1st alpha release; ie, no code changes)
+# - v3.0.0-0.alpha.2 (2nd alpha release)
+# - v3.0.0-0.beta.1 (1st beta release)
+# - v3.0.0-0.rc.1 (1st rc release)
+# - v3.0.0 (3.0.0 official release)
+# - v3.0.0-2 (2nd build of 3.0.0 official release; ie, no code changes)
+# - v3.0.1 (3.0.1 official release)
+# - v3.1.0 (3.1.0 official release)
+#
+# If the tag does not conform to the above, then ci-support/ci-packager-next,
+# will generate snapshat versions. For easier maintenance, this regex is more
+# open than ci-support/ci-packager-next (which enforces a number of
+# constraints). See .circleci/packages/config.yaml for details.
 release_filter: &release_filter
   filters:
     tags:
-      only: /^v(\d+)(?:\.(\d+))?(?:\.(\d+))?$/
+      only: /^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9]+(\.(alpha|beta|rc)\.[0-9]+(\.[0-9]+)?)?)?$/
     branches:
       ignore: /.*/
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -287,7 +287,7 @@ jobs:
   # Build a dev binary with the default cargo profile
   build-dev:
     docker:
-      - image: us-east1-docker.pkg.dev/influxdata-team-edge/ci-support/ci-cross-influxdb3@sha256:1f41029cb68a723c3b559a44bcf91e04b6a71b631b0886185562f4a90e1460ba
+      - image: us-east1-docker.pkg.dev/influxdata-team-edge/ci-support/ci-cross-influxdb3@sha256:e34ee8aafbc3b3bc9ddbe57eda2580a0263597160d766c86dc02ce038fba8300
         auth:
           username: _json_key
           password: $CISUPPORT_GCS_AUTHORIZATION
@@ -350,7 +350,7 @@ jobs:
   # Compile cargo "release" profile binaries for influxdb3 edge releases
   build-release:
     docker:
-      - image: us-east1-docker.pkg.dev/influxdata-team-edge/ci-support/ci-cross-influxdb3@sha256:1f41029cb68a723c3b559a44bcf91e04b6a71b631b0886185562f4a90e1460ba
+      - image: us-east1-docker.pkg.dev/influxdata-team-edge/ci-support/ci-cross-influxdb3@sha256:e34ee8aafbc3b3bc9ddbe57eda2580a0263597160d766c86dc02ce038fba8300
         auth:
           username: _json_key
           password: $CISUPPORT_GCS_AUTHORIZATION
@@ -437,7 +437,7 @@ jobs:
 
   build-packages:
     docker:
-      - image: us-east1-docker.pkg.dev/influxdata-team-edge/ci-support/ci-packager-next@sha256:db0cd91a5445c4287154cea1d4d5566735cb0d3b7b9e2a95724a83f9d979d497
+      - image: us-east1-docker.pkg.dev/influxdata-team-edge/ci-support/ci-packager-next@sha256:57495019df2dcb3c008987dabafb5566618ba5ab032857ddb2d0c04fb68fc019
         auth:
           username: _json_key
           password: $CISUPPORT_GCS_AUTHORIZATION

--- a/.circleci/packages/config.yaml
+++ b/.circleci/packages/config.yaml
@@ -1,5 +1,73 @@
+# https://github.com/influxdata/ci-support/blob/main/ci-packager-next/fs/usr/bin/packager
+# uses this to calculate the version used for tarball, zip and Linux package
+# versions and git tags for this repo (https://github.com/influxdata/influxdb)
+# are used by .circleci/config.yml's 'release_filter' to determine which CI
+# jobs to run. Be default, packager will set the version to
+# 3.0.0+snapshot-<git sha> based on CIRCLE_SHA1. If CIRCLE_TAG matches one of
+# these, then packager will set the version based on the tag:
+#
+# | tag                | filename          | deb               | rpm                        |
+# |--------------------|-------------------|-------------------| -------------------------- |
+# | v3.0.0-0.alpha.1   | 3.0.0-0.alpha.1   | 3.0.0-0.alpha.1   | ver=3.0.0, rel=0.alpha.1   |
+# | v3.0.0-0.alpha.1.1 | 3.0.0-0.alpha.1.1 | 3.0.0-0.alpha.1.1 | ver=3.0.0, rel=0.alpha.1.1 |
+# | v3.0.0-0.alpha.2   | 3.0.0-0.alpha.2   | 3.0.0-0.alpha.2   | ver=3.0.0, rel=0.alpha.2   |
+# | v3.0.0-0.beta.1    | 3.0.0-0.beta.1    | 3.0.0-0.beta.1    | ver=3.0.0, rel=0.beta.1    |
+# | v3.0.0-0.beta.1.1  | 3.0.0-0.beta.1.1  | 3.0.0-0.beta.1.1  | ver=3.0.0, rel=0.beta.1.1  |
+# | v3.0.0-0.beta.2    | 3.0.0-0.beta.2    | 3.0.0-0.beta.2    | ver=3.0.0, rel=0.beta.2    |
+# | v3.0.0-0.rc.1      | 3.0.0-0.rc.1      | 3.0.0-0.rc.1      | ver=3.0.0, rel=0.rc.1      |
+# | v3.0.0             | 3.0.0             | 3.0.0-1           | ver=3.0.0, rel=1           |
+# | v3.0.0-2           | 3.0.0-2           | 3.0.0-2           | ver=3.0.0, rel=2           |
+#
+# In this manner:
+# - v3.0.0-0.alpha.1 < v3.0.0-0.alpha.1.1
+# - v3.0.0-0.alpha.1.1 < v3.0.0-0.alpha.2
+# - v3.0.0-0.alpha.2 < v3.0.0-0.beta.1
+# - v3.0.0-0.beta.1 < v3.0.0-0.beta.1.1
+# - v3.0.0-0.beta.1.1 < v3.0.0-0.beta.2
+# - v3.0.0-0.beta.2 < v3.0.0-0.rc.1
+# - v3.0.0-0.rc.1 < v3.0.0
+# - v3.0.0 < v3.0.0-2
+#
+# (use 'dpkg --compare-versions X lt Y && echo yes' for debs and
+# 'rpmdev-vercmp X Y | grep " < " && echo yes' for rpms)
+#
+# We use the following tag schema that supports semver as well as Linux package
+# version semantics (see https://github.com/influxdata/influxdb/pull/24751 for
+# context):
+#
+# v3.M.m[-B[.Q.q.b]]  # eg, v3.0.0, v3.0.0-2, v3.0.0-0.beta.1 or v3.0.0-0.beta.1.1
+#  | | |  |  | | |
+#  | | |  |  | |  ----------> quality release package build number
+#  | | |  |  |  ------------> quality release number
+#  | | |  |   --------------> release quality
+#  | | |   -----------------> package build number
+#  | |  --------------------> influxdb3 micro version
+#  |  ----------------------> influxdb3 minor version
+#   ------------------------> major version
+#
+# Importantly:
+# - the tag should start with 'v' (for semver tagging convention)
+# - changes in v3.M.m follow semver and indicate there are code changes
+# - '-B' should be omitted for a new v3.M.n released semver (eg, v3.0.0, not
+#   v3.0.0-1); specified starting with '2' for new package builds for this
+#   release semver (eg, v3.0.0-2, v3.0.0-3, etc); and specified with '0' for
+#   pre-release quality builds (eg, v3.0.0-0.rc.1).
+# - 'Q' is optional but when specified, 'Q' may be one of 'alpha', 'beta' or
+#   'rc'. Furthermore, when 'Q' is set:
+#   - 'B' and 'q' must also be specified with 'q' starting at '1' (eg,
+#     v3.0.0-0.alpha.1, v3.0.0-0.alpha.2, etc)
+#   - 'b' may also be specified with 'Q' and when specified, should start with
+#     '1' (eg, v3.0.0-0.alpha.1.1, v3.0.0-0.alpha.1.2, etc)
+# - changes to 'M', 'm', 'Q' and 'q' indicate influxdb code changes compared to
+#   prior tags, while 'B' and 'b' indicate only packaging changes.
+#
+# By following these rules, packager should set package versions that are
+# upgradable (eg, in package repositories).
+#
+# The CIRCLE_TAG regex enforces these rules, falling back to
+# 3.0.0+snapshot-<git hash> if it doesn't match.
 version:
-  - match: '^v[0-9]+.[0-9]+.[0-9]+(-[0-9]+.(alpha|beta|rc).[0-9]+(.[0-9]+)?)?$'
+  - match: '^v[0-9]+\.[0-9]+\.[0-9]+(-([2-9]|[1-9][0-9]+|0\.(alpha|beta|rc)\.[1-9][0-9]*(\.[1-9][0-9]*)?))?$'
     value: '{{env.CIRCLE_TAG[1:]}}'
   - match: '.*'
     value: '3.0.0+snapshot-{{env.CIRCLE_SHA1[:8]}}'


### PR DESCRIPTION
This updates:

* `.circleci/packages/config.yaml` to add a stricter regex for release images that conforms to https://github.com/influxdata/influxdb_pro/pull/606#issuecomment-2734361619 with documentation
* `.circleci/config.yml` to use the latest ci-support images (to fix an issue with `v3.0.0` and deb packages observed in preparing this PR)
* `.circleci/config.yml` to update release_filter (a looser regex than `.circleci/packages/config.yaml` for easier maintenance; `.circleci/packages/config.yaml` needs to be the most precise version so it can create packages correctly) and add some documentation on how to set tags (based on and referring to `.circleci/packages/config.yaml`)

The `.circleci/packages/config.yaml` updates were verified by running the updated `ci-support` locally. The regexes were verified by creating a test script and running it.

<details>

```bash
#!/bin/bash
set -e

# copy from .circleci/packages/config.yaml
packager_regex="^v[0-9]+\.[0-9]+\.[0-9]+(-([2-9]|[1-9][0-9]+|0\.(alpha|beta|rc)\.[1-9][0-9]*(\.[1-9][0-9]*)?))?$"
# copy from .circleci/config.yml
circleci_regex="/^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9]+(\.(alpha|beta|rc)\.[0-9]+(\.[0-9]+)?)?)?$/"

valid_tags="v3.0.0-0.alpha.1 v3.0.0-0.alpha.1.1 v3.0.0-0.alpha.1.2 v3.0.0-0.alpha.2 v3.0.0-0.beta.1 v3.0.0-0.beta.1.1 v3.0.0-0.beta.2 v3.0.0-0.rc.1 v3.0.0 v3.0.0-2 v3.0.1 v3.1.0"
invalid_tags="3.0.0 3.0.0-0.beta.1 v3 v3.0 v3.0. v3.0.0-0 v3.0.0-1 v3.0.0-0.foo.1 v3.0.0-1.alpha.1 v3.0.0-0.alpha.0 v3.0.0-0.alpha.1.0"

echo "# Valid tags (packager)"
for tag in $valid_tags ; do
    printf "%s is valid tag: " "$tag"
    python3 -c "import re, sys; print(bool(re.match(r'$packager_regex', sys.argv[1])))" "$tag"
done

echo
echo "# Invalid tags (packager)"
for badtag in $invalid_tags ; do
    printf "%s is valid tag: " "$badtag"
    python3 -c "import re, sys; print(bool(re.match(r'$packager_regex', sys.argv[1])))" "$badtag"
done

echo
echo "# Valid tags (java.util.regex.Pattern (CircleCI))"
tmpdir=$(mktemp -d)
cd "$tmpdir"

# convert to string that java expects
java_regex=$(echo "${circleci_regex}" | sed -e 's#^/\(.*\)/$#\1#' -e 's/\\/\\\\/g')

cat > RegexMatcher.java <<EOM
public class RegexMatcher {
    public static void main(String[] args) {
        if (args.length < 1) {
            System.out.println("Please provide an argument to match.");
            System.exit(1);
        }

        String r = "$java_regex";
        boolean b = java.util.regex.Pattern.matches(r, args[0]);
        System.out.println(b);
    }
}
EOM
javac RegexMatcher.java
for tag in $valid_tags ; do
    printf "%s is valid tag: " "$tag"
    java RegexMatcher "$tag"
done

cd - >/dev/null
rm -rf "$tmpdir"

echo
echo "# Valid versions (deb)"
last=
for tag in $valid_tags ; do
    v=$(echo "$tag" | sed 's/^v//')
    # note, 3.0.0-1 is generated by packager for the v3.0.0 tag
    if echo "$v" | grep -vq '\-' ; then
        v="${v}-1"
    fi

    if [ -z "$last" ]; then
        last="$v"
	continue
    fi

    printf "dpkg --compare-versions %s lt %s: " "$last" "$v"
    if dpkg --compare-versions "$last" lt "$v" ; then
        echo yes
    else
        echo NO
    fi

    last="$v"
done
```

Eg:
```
$ bash /tmp/test_versions
# Valid tags (packager)
v3.0.0-0.alpha.1 is valid tag: True
v3.0.0-0.alpha.1.1 is valid tag: True
v3.0.0-0.alpha.1.2 is valid tag: True
v3.0.0-0.alpha.2 is valid tag: True
v3.0.0-0.beta.1 is valid tag: True
v3.0.0-0.beta.1.1 is valid tag: True
v3.0.0-0.beta.2 is valid tag: True
v3.0.0-0.rc.1 is valid tag: True
v3.0.0 is valid tag: True
v3.0.0-2 is valid tag: True
v3.0.1 is valid tag: True
v3.1.0 is valid tag: True

# Invalid tags (packager)
3.0.0 is valid tag: False
3.0.0-0.beta.1 is valid tag: False
v3 is valid tag: False
v3.0 is valid tag: False
v3.0. is valid tag: False
v3.0.0-0 is valid tag: False
v3.0.0-1 is valid tag: False
v3.0.0-0.foo.1 is valid tag: False
v3.0.0-1.alpha.1 is valid tag: False
v3.0.0-0.alpha.0 is valid tag: False
v3.0.0-0.alpha.1.0 is valid tag: False

# Valid tags (java.util.regex.Pattern (CircleCI))
v3.0.0-0.alpha.1 is valid tag: true
v3.0.0-0.alpha.1.1 is valid tag: true
v3.0.0-0.alpha.1.2 is valid tag: true
v3.0.0-0.alpha.2 is valid tag: true
v3.0.0-0.beta.1 is valid tag: true
v3.0.0-0.beta.1.1 is valid tag: true
v3.0.0-0.beta.2 is valid tag: true
v3.0.0-0.rc.1 is valid tag: true
v3.0.0 is valid tag: true
v3.0.0-2 is valid tag: true
v3.0.1 is valid tag: true
v3.1.0 is valid tag: true

# Valid versions (deb)
dpkg --compare-versions 3.0.0-0.alpha.1 lt 3.0.0-0.alpha.1.1: yes
dpkg --compare-versions 3.0.0-0.alpha.1.1 lt 3.0.0-0.alpha.1.2: yes
dpkg --compare-versions 3.0.0-0.alpha.1.2 lt 3.0.0-0.alpha.2: yes
dpkg --compare-versions 3.0.0-0.alpha.2 lt 3.0.0-0.beta.1: yes
dpkg --compare-versions 3.0.0-0.beta.1 lt 3.0.0-0.beta.1.1: yes
dpkg --compare-versions 3.0.0-0.beta.1.1 lt 3.0.0-0.beta.2: yes
dpkg --compare-versions 3.0.0-0.beta.2 lt 3.0.0-0.rc.1: yes
dpkg --compare-versions 3.0.0-0.rc.1 lt 3.0.0-1: yes
dpkg --compare-versions 3.0.0-1 lt 3.0.0-2: yes
dpkg --compare-versions 3.0.0-2 lt 3.0.1-1: yes
dpkg --compare-versions 3.0.1-1 lt 3.1.0-1: yes
```

</details>

Note, I did NOT test this with by pushing a conforming tag.