### PR TITLE
chore: 3.0.0-beta.1 release ready

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2739,7 +2739,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3"
-version = "0.1.0"
+version = "3.0.0-beta.1"
 dependencies = [
  "anyhow",
  "arrow",
@@ -2810,7 +2810,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_cache"
-version = "0.1.0"
+version = "3.0.0-beta.1"
 dependencies = [
  "anyhow",
  "arrow",
@@ -2845,7 +2845,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_catalog"
-version = "0.1.0"
+version = "3.0.0-beta.1"
 dependencies = [
  "anyhow",
  "arrow",
@@ -2884,7 +2884,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_clap_blocks"
-version = "0.1.0"
+version = "3.0.0-beta.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2917,7 +2917,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_client"
-version = "0.1.0"
+version = "3.0.0-beta.1"
 dependencies = [
  "bytes",
  "hashbrown 0.15.2",
@@ -2937,7 +2937,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_id"
-version = "0.1.0"
+version = "3.0.0-beta.1"
 dependencies = [
  "indexmap 2.7.0",
  "serde",
@@ -2946,7 +2946,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_internal_api"
-version = "0.1.0"
+version = "3.0.0-beta.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2962,7 +2962,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_load_generator"
-version = "0.1.0"
+version = "3.0.0-beta.1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2990,7 +2990,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_process"
-version = "0.1.0"
+version = "3.0.0-beta.1"
 dependencies = [
  "iox_time",
  "metric",
@@ -3003,7 +3003,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_processing_engine"
-version = "0.1.0"
+version = "3.0.0-beta.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3043,7 +3043,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_py_api"
-version = "0.1.0"
+version = "3.0.0-beta.1"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -3070,7 +3070,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_server"
-version = "0.1.0"
+version = "3.0.0-beta.1"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3156,7 +3156,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_sys_events"
-version = "0.1.0"
+version = "3.0.0-beta.1"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3175,7 +3175,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_telemetry"
-version = "0.1.0"
+version = "3.0.0-beta.1"
 dependencies = [
  "futures",
  "futures-util",
@@ -3196,7 +3196,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_test_helpers"
-version = "0.1.0"
+version = "3.0.0-beta.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3209,7 +3209,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_types"
-version = "0.1.0"
+version = "3.0.0-beta.1"
 dependencies = [
  "anyhow",
  "hashbrown 0.15.2",
@@ -3224,7 +3224,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_wal"
-version = "0.1.0"
+version = "3.0.0-beta.1"
 dependencies = [
  "async-trait",
  "bitcode",
@@ -3253,7 +3253,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_write"
-version = "0.1.0"
+version = "3.0.0-beta.1"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3509,7 +3509,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query_influxql_rewrite"
-version = "0.1.0"
+version = "3.0.0-beta.1"
 dependencies = [
  "influxdb_influxql_parser",
  "thiserror 1.0.69",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "0.1.0"
+version = "3.0.0-beta.1"
 authors = ["InfluxData OSS Developers"]
 edition = "2024"
 license = "MIT OR Apache-2.0"

--- a/influxdb3_process/build.rs
+++ b/influxdb3_process/build.rs
@@ -17,7 +17,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 fn get_git_hash() -> String {
     let git_hash = {
         let output = Command::new("git")
-            .args(["describe", "--always", "--dirty", "--abbrev=64"])
+            // We used `git describe`, but when you tag a build the commit hash goes missing when
+            // using describe. So, switching it to use `rev-parse` which is consistent with the
+            // `get_git_hash_short` below as well.
+            //
+            // And we already have cargo version appearing as a separate string so using `git
+            // describe` looks redundant on tagged release builds
+            .args(["rev-parse", "HEAD"])
             .output()
             .expect("failed to execute git rev-parse to read the current git hash");
 


### PR DESCRIPTION
This is a port of [enterprise](https://github.com/influxdata/influxdb_pro/pull/606) PR to get beta builds out