### PR TITLE
chore: check if build is dirty and fail

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -325,6 +325,13 @@ jobs:
           name: Cargo build
           command: |
             target-env cargo build --target=<< parameters.target >> --workspace
+      - run:
+          # this runs diff twice, once to report the changes so that it's easier to see the changed file in circleci
+          # if it is dirty build should fail with exit 1
+          name: check build is dirty
+          command: |
+            git diff --exit-code
+            git diff --exit-code --quiet || exit 1
       - when:
           # this defaults to false, but can set it by triggering a pipeline (see above)
           condition: << pipeline.parameters.persist_debug >>
@@ -420,6 +427,13 @@ jobs:
                   # re-sign after install_name_tool since osxcross won't do it
                   echo "Running: /usr/local/bin/rcodesign sign '${PWD}/target/<< parameters.target >>/<< parameters.profile >>/influxdb3'"
                   /usr/local/bin/rcodesign sign "${PWD}/target/<< parameters.target >>/<< parameters.profile >>/influxdb3"
+      - run:
+          # this runs diff twice, once to report the changes so that it's easier to see the changed file in circleci
+          # if it is dirty build should fail with exit 1
+          name: check build is dirty
+          command: |
+            git diff --exit-code
+            git diff --exit-code --quiet || exit 1
       - run:
           name: tar build artifacts
           command: |


### PR DESCRIPTION
This is to enable checking if build is dirty due to changes to git versioned file during the build process. This used to be reported in the `influxdb3 --version` which in turn was relying on `git describe`. Because,

- we don't want the final `revision` string to contain `-dirty` and
- `git describe` does more than just report the commit hash used to tag a release

it was switched to use `git rev-parse` in [commit](https://github.com/influxdata/influxdb/pull/26167/files#diff-52906b695490184d379b6c26ce97a2b340b3cbbe924d00e50a0fbcd34136d277). 

Now with this PR, instead of reporting it's been dirtied the pipeline itself checks and stops the job if it detects any changes. 


**Test**

Tested locally and checked if the script works by manually `ssh`ing into circle ci instance and introducing changes. 
```
root@instance:~/project# echo "FOO" >> README.md
root@instance:~/project# git diff --exit-code --quiet || exit 1
logout
```

Given this relies on changes introduced during build this is the best I could come up with for testing it.

Update:

As per @jdstrand idea, I introduced a write before the `git diff` check and you can see the build failure here,

https://app.circleci.com/pipelines/github/influxdata/influxdb/44879/workflows/e3c22709-dfde-4e94-91c8-08203000b6a9/jobs/425044

The actual update to circleci config,

```
      - run:
          name: add a change (temporary)
          command: |
            echo "FOO" >> README.md
      - run:
          # this runs diff twice, once to report the changes so that it's easier to see the changed file in circleci
          # if it is dirty build should fail with exit 1
          name: check build is dirty
          command: |
            git diff --exit-code
            git diff --exit-code --quiet || exit 1

```
