### PR TITLE
feat: segment snapshot chunks in buffer

### DIFF
--- a/influxdb3_write/src/chunk.rs
+++ b/influxdb3_write/src/chunk.rs
@@ -9,7 +9,6 @@ use schema::sort::SortKey;
 use std::any::Any;
 use std::sync::Arc;
 
-#[derive(Debug)]
 pub struct BufferChunk {
     pub batches: Vec<RecordBatch>,
     pub schema: Schema,
@@ -18,6 +17,20 @@ pub struct BufferChunk {
     pub sort_key: Option<SortKey>,
     pub id: data_types::ChunkId,
     pub chunk_order: data_types::ChunkOrder,
+}
+
+/// Custom `Debug` implementation for `BufferChunk`s that avoids serializing excessive information
+/// contained in the record batches and schema
+impl std::fmt::Debug for BufferChunk {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BufferChunk")
+            .field("stats", &self.stats)
+            .field("partition_id", &self.partition_id)
+            .field("sort_key", &self.sort_key)
+            .field("id", &self.id)
+            .field("chunk_order", &self.chunk_order)
+            .finish()
+    }
 }
 
 impl QueryChunk for BufferChunk {
@@ -62,7 +75,6 @@ impl QueryChunk for BufferChunk {
     }
 }
 
-#[derive(Debug)]
 pub struct ParquetChunk {
     pub schema: Schema,
     pub stats: Arc<ChunkStatistics>,
@@ -71,6 +83,21 @@ pub struct ParquetChunk {
     pub id: ChunkId,
     pub chunk_order: ChunkOrder,
     pub parquet_exec: ParquetExecInput,
+}
+
+/// Custom `Debug` implementation for `ParquetChunk`s that avoids serializing excessive information
+/// contained in the `ParquetExecInput` and schema
+impl std::fmt::Debug for ParquetChunk {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ParquetChunk")
+            .field("stats", &self.stats)
+            .field("partition_id", &self.partition_id)
+            .field("sort_key", &self.sort_key)
+            .field("id", &self.id)
+            .field("chunk_order", &self.chunk_order)
+            .field("object_meta", &self.parquet_exec.object_meta)
+            .finish()
+    }
 }
 
 impl QueryChunk for ParquetChunk {

--- a/influxdb3_write/src/write_buffer/queryable_buffer.rs
+++ b/influxdb3_write/src/write_buffer/queryable_buffer.rs
@@ -183,8 +183,11 @@ impl QueryableBuffer {
                     let table_def = db_schema
                         .table_definition_by_id(table_id)
                         .expect("table exists");
-                    let snapshot_chunks =
-                        table_buffer.snapshot(table_def, snapshot_details.end_time_marker);
+                    let snapshot_chunks = table_buffer.snapshot(
+                        table_def,
+                        snapshot_details.snapshot_sequence_number,
+                        snapshot_details.end_time_marker,
+                    );
 
                     for chunk in snapshot_chunks {
                         let table_name =
@@ -300,7 +303,7 @@ impl QueryableBuffer {
                         // then clear the buffer
                         if let Some(db) = buffer.db_to_table.get_mut(&database_id) {
                             if let Some(table) = db.get_mut(&table_id) {
-                                table.clear_snapshots();
+                                table.clear_snapshots(&snapshot_details.snapshot_sequence_number);
                             }
                         }
                     }


### PR DESCRIPTION
* https://github.com/influxdata/influxdb/commit/2c4f0af865306e5f08ebe5522d33e2287af33bce simplify the `Debug` implementations for the `BufferChunk` and `ParquetChunk` types to remove excessive information
* https://github.com/influxdata/influxdb/commit/4750379116e87a5415b12a1f21c9726f5bb65b35 use `PersistedSnapshotVersion` type in method that checks for database and table counts in a snapshot
* https://github.com/influxdata/influxdb/commit/e3cba7d25c111b563e7800a7695e76244c674548 when segmenting the buffer on snapshot, the resulting `SnapshotChunk`s are stored in a `HashMap<SnapshotSequenceNumber, Vec<SnapshotChunk>>`, instead of a single `Vec<SnapshotChunk>`.
  
  This prevents concurrent snapshots from clearing each other's respective `SnapshotChunk`s from the in-memory buffer.