### PR TITLE
feat: support deterministic load generator values

### DIFF
--- a/influxdb3_load_generator/src/commands/full.rs
+++ b/influxdb3_load_generator/src/commands/full.rs
@@ -8,7 +8,7 @@ use crate::commands::{query::run_query_load, write::run_write_load};
 use super::{common::InfluxDb3Config, query::QueryConfig, write::WriteConfig};
 
 #[derive(Debug, Parser)]
-pub(crate) struct Config {
+pub struct Config {
     /// Common InfluxDB 3 Core config
     #[clap(flatten)]
     common: InfluxDb3Config,
@@ -22,7 +22,7 @@ pub(crate) struct Config {
     write: WriteConfig,
 }
 
-pub(crate) async fn command(mut config: Config) -> Result<(), anyhow::Error> {
+pub async fn command(mut config: Config) -> Result<(), anyhow::Error> {
     let (client, mut load_config) = config
         .common
         .initialize_full(

--- a/influxdb3_load_generator/src/commands/query.rs
+++ b/influxdb3_load_generator/src/commands/query.rs
@@ -17,7 +17,7 @@ use super::common::InfluxDb3Config;
 
 #[derive(Debug, Parser)]
 #[clap(visible_alias = "q", trailing_var_arg = true)]
-pub(crate) struct Config {
+pub struct Config {
     /// Common InfluxDB 3 Core config
     #[clap(flatten)]
     common: InfluxDb3Config,
@@ -55,7 +55,7 @@ pub(crate) struct QueryConfig {
     query_response_format: Format,
 }
 
-pub(crate) async fn command(mut config: Config) -> Result<(), anyhow::Error> {
+pub async fn command(mut config: Config) -> Result<(), anyhow::Error> {
     let (client, mut load_config) = config
         .common
         .initialize_query(config.query.querier_spec_path.take())

--- a/influxdb3_load_generator/src/lib.rs
+++ b/influxdb3_load_generator/src/lib.rs
@@ -1,0 +1,12 @@
+pub mod line_protocol_generator;
+pub mod query_generator;
+pub mod report;
+pub mod specification;
+pub mod specs;
+
+pub mod commands {
+    pub mod common;
+    pub mod full;
+    pub mod query;
+    pub mod write;
+}

--- a/influxdb3_load_generator/src/main.rs
+++ b/influxdb3_load_generator/src/main.rs
@@ -9,19 +9,6 @@
     clippy::future_not_send
 )]
 
-pub mod line_protocol_generator;
-pub mod query_generator;
-pub mod report;
-pub mod specification;
-mod specs;
-
-pub mod commands {
-    pub mod common;
-    pub mod full;
-    pub mod query;
-    pub mod write;
-}
-
 use dotenvy::dotenv;
 use observability_deps::tracing::warn;
 use std::sync::{
@@ -29,6 +16,8 @@ use std::sync::{
     atomic::{AtomicUsize, Ordering},
 };
 use tokio::runtime::Runtime;
+
+use influxdb3_load_generator::commands;
 
 enum ReturnCode {
     Failure = 1,

--- a/influxdb3_load_generator/src/specification.rs
+++ b/influxdb3_load_generator/src/specification.rs
@@ -134,10 +134,15 @@ pub enum FieldKind {
     String(String),
     /// generate a random string of this length for every line this field is present
     StringRandom(usize),
+    /// generate a sequentially-incremented string for every line this field is present
+    StringSeq(String),
     /// output this integer value for every line this field is present
     Integer(i64),
     /// generate a random integer in this range for every line this field is present
     IntegerRange(i64, i64),
+    /// generate a sequentially-incremented integer starting from 0 for every line this field is
+    /// present
+    IntegerSeq,
     /// output this float value for every line this field is present
     Float(f64),
     /// generate a random float in this range for every line this field is present


### PR DESCRIPTION
This PR refactors the load generator to make it easier to use in a set of end-to-end tests I am writing for an Antithesis PoC. It includes the following changes:

* Add a lib target to the crate, make public all the methods & types needed in the binary target.
* Make a bunch of other types public (eg `Generator`, `GeneratorRunner`, `FieldValue`, etc) to support their use in a separate e2e crate
* Fix a bug in the load generator where a cardinality value less than the lines per sample value led to duplicate LP lines where the field values of the last generated LP line overwrites all the previous values.
  * The fix here was basically to give each line-per-sample a unique timestamp by incrementing the nanosecond for each generated line in a batch. It's worth noting we could potentially run into the same problem if a spec ends up with > 1_000_000 lines per sample. I think that's not very likely but I'll file a follow-up issue to take a closer look at that if necessary.
* Introduce the `GeneratorRunner` type to encapsulate state that was being passed around to multiple methods and simplify usage at the e2e level.
* Introduce two new measurement field variants: 
  * `FieldValue::Integer(IntegerValue::Sequential(u64))` - causes values to be written sequentially for each generated LP line starting from 0
  * `FieldValue::String(StringValue::Sequential(Arc<str>, u64))` - causes values to be written sequentially for each generated LP line starting with `{str}0`

The new measurement field variants are what enable writing long-running tests cases where we can assert on the values we expect to get from queries in a deterministic fashion; ie, we don't need to keep a buffer of written values, we just need to know the range of values written, query for them ordered by timestamp, then generate expected values incrementally as we iterate over the queried values in order to assert the expected and queryable values are the same.
