### PR TITLE
feat(processing_engine): Store triggers by DbId and TriggerId instead of name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3019,6 +3019,7 @@ dependencies = [
  "influxdb3_cache",
  "influxdb3_catalog",
  "influxdb3_client",
+ "influxdb3_id",
  "influxdb3_internal_api",
  "influxdb3_py_api",
  "influxdb3_sys_events",

--- a/influxdb3/tests/cli/mod.rs
+++ b/influxdb3/tests/cli/mod.rs
@@ -2516,7 +2516,7 @@ def process_scheduled_call(influxdb3_local, schedule_time, args=None):
         .unwrap();
 
     // Wait for trigger to run several times
-    tokio::time::sleep(std::time::Duration::from_millis(3100)).await;
+    tokio::time::sleep(std::time::Duration::from_millis(5000)).await;
 
     // Query to see what values were written before disabling
     let first_query_result = server
@@ -2535,7 +2535,7 @@ def process_scheduled_call(influxdb3_local, schedule_time, args=None):
     server.enable_trigger(db_name, trigger_name).run().unwrap();
 
     // Wait for trigger to run again
-    tokio::time::sleep(std::time::Duration::from_millis(1100)).await;
+    tokio::time::sleep(std::time::Duration::from_millis(5000)).await;
 
     // Query results after re-enabling
     let second_query_result = server

--- a/influxdb3_catalog/src/catalog.rs
+++ b/influxdb3_catalog/src/catalog.rs
@@ -300,9 +300,8 @@ impl Catalog {
         self.inner.read().db_exists(db_id)
     }
 
-    /// Get active triggers by database and trigger name
-    // NOTE: this could be id-based in future
-    pub fn active_triggers(&self) -> Vec<(Arc<str>, Arc<str>)> {
+    /// Get active triggers by database ID and trigger ID
+    pub fn active_triggers(&self) -> Vec<(DbId, TriggerId)> {
         let inner = self.inner.read();
         let result = inner
             .databases
@@ -314,7 +313,7 @@ impl Catalog {
                         if trigger.disabled {
                             None
                         } else {
-                            Some((Arc::clone(&db.name), Arc::clone(&trigger.trigger_name)))
+                            Some((db.id, trigger.trigger_id))
                         }
                     })
             })

--- a/influxdb3_catalog/src/catalog/update.rs
+++ b/influxdb3_catalog/src/catalog/update.rs
@@ -539,6 +539,7 @@ impl Catalog {
                 db.id,
                 db.name(),
                 vec![DatabaseCatalogOp::CreateTrigger(TriggerDefinition {
+                    database_id: db.id,
                     trigger_id,
                     trigger_name: trigger_name.into(),
                     plugin_filename: plugin_filename.to_string(),

--- a/influxdb3_catalog/src/log.rs
+++ b/influxdb3_catalog/src/log.rs
@@ -642,6 +642,7 @@ pub struct TriggerDefinition {
     pub trigger_id: TriggerId,
     pub trigger_name: Arc<str>,
     pub plugin_filename: String,
+    pub database_id: DbId,
     pub database_name: Arc<str>,
     pub node_id: Arc<str>,
     pub trigger: TriggerSpecificationDefinition,

--- a/influxdb3_catalog/src/snapshot.rs
+++ b/influxdb3_catalog/src/snapshot.rs
@@ -211,6 +211,7 @@ impl Snapshot for TableDefinition {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub(crate) struct ProcessingEngineTriggerSnapshot {
+    pub database_id: DbId,
     pub trigger_id: TriggerId,
     pub trigger_name: Arc<str>,
     pub node_id: Arc<str>,
@@ -227,6 +228,7 @@ impl Snapshot for TriggerDefinition {
 
     fn snapshot(&self) -> Self::Serialized {
         Self::Serialized {
+            database_id: self.database_id,
             trigger_id: self.trigger_id,
             trigger_name: Arc::clone(&self.trigger_name),
             node_id: Arc::clone(&self.node_id),
@@ -241,6 +243,7 @@ impl Snapshot for TriggerDefinition {
 
     fn from_snapshot(snap: Self::Serialized) -> Self {
         Self {
+            database_id: snap.database_id,
             trigger_id: snap.trigger_id,
             trigger_name: snap.trigger_name,
             node_id: snap.node_id,

--- a/influxdb3_processing_engine/Cargo.toml
+++ b/influxdb3_processing_engine/Cargo.toml
@@ -19,6 +19,7 @@ hyper.workspace = true
 iox_time.workspace = true
 influxdb3_catalog = { path = "../influxdb3_catalog" }
 influxdb3_client = { path = "../influxdb3_client" }
+influxdb3_id = { path = "../influxdb3_id" }
 influxdb3_internal_api = { path = "../influxdb3_internal_api" }
 influxdb3_py_api = { path = "../influxdb3_py_api" }
 influxdb3_types = { path = "../influxdb3_types" }

--- a/influxdb3_processing_engine/src/manager.rs
+++ b/influxdb3_processing_engine/src/manager.rs
@@ -1,12 +1,13 @@
 use crate::environment::PluginEnvironmentError;
 use influxdb3_catalog::CatalogError;
+use influxdb3_id::{DbId, TriggerId};
 use std::fmt::Debug;
 use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum ProcessingEngineError {
     #[error("database not found: {0}")]
-    DatabaseNotFound(String),
+    DatabaseNotFound(DbId),
 
     #[error("catalog update error: {0}")]
     CatalogUpdateError(#[from] CatalogError),
@@ -23,10 +24,10 @@ pub enum ProcessingEngineError {
     #[error("plugin error: {0}")]
     PluginError(#[from] crate::plugins::PluginError),
 
-    #[error("failed to shutdown trigger {trigger_name} in database {database}")]
+    #[error("failed to shutdown trigger {trigger_id} in database {database_id}")]
     TriggerShutdownError {
-        database: String,
-        trigger_name: String,
+        database_id: DbId,
+        trigger_id: TriggerId,
     },
 
     #[error("request trigger not found")]
@@ -37,4 +38,7 @@ pub enum ProcessingEngineError {
 
     #[error("error installing python packages: {0}")]
     PythonPackageError(#[from] PluginEnvironmentError),
+
+    #[error("trigger not found: {0}")]
+    TriggerNotFound(TriggerId),
 }


### PR DESCRIPTION
Attempts to close #https://github.com/influxdata/influxdb/issues/26153

Describe your proposed changes here.

1. Fixed type safety in `PluginChannels` struct:
   - Changed `schedule_triggers` type from `HashMap<String, HashMap<String, mpsc::Sender<ScheduleEvent>>>` to `HashMap<(DbId, TriggerId), mpsc::Sender<ScheduleEvent>>` to properly handle schedule events

2. Improved trigger removal logic in `remove_trigger` method:
   - Removed incorrect attempt to get and remove from trigger maps
   - Now directly removing entries from HashMaps using correct keys
   - For WAL and schedule triggers: using tuple key `(db_id, trigger_id)`
   - For request triggers: using path string directly

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
