### PR TITLE
feat: handle graceful shutdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2766,6 +2766,7 @@ dependencies = [
  "influxdb3_process",
  "influxdb3_processing_engine",
  "influxdb3_server",
+ "influxdb3_shutdown",
  "influxdb3_sys_events",
  "influxdb3_telemetry",
  "influxdb3_types",
@@ -3021,6 +3022,7 @@ dependencies = [
  "influxdb3_client",
  "influxdb3_internal_api",
  "influxdb3_py_api",
+ "influxdb3_shutdown",
  "influxdb3_sys_events",
  "influxdb3_types",
  "influxdb3_wal",
@@ -3104,6 +3106,7 @@ dependencies = [
  "influxdb3_process",
  "influxdb3_processing_engine",
  "influxdb3_py_api",
+ "influxdb3_shutdown",
  "influxdb3_sys_events",
  "influxdb3_telemetry",
  "influxdb3_types",
@@ -3158,8 +3161,12 @@ dependencies = [
 name = "influxdb3_shutdown"
 version = "3.0.0-beta.2"
 dependencies = [
+ "futures",
+ "futures-util",
  "observability_deps",
+ "parking_lot",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -3247,6 +3254,7 @@ dependencies = [
  "indexmap 2.7.0",
  "influxdb-line-protocol",
  "influxdb3_id",
+ "influxdb3_shutdown",
  "iox_time",
  "object_store",
  "observability_deps",
@@ -3289,6 +3297,7 @@ dependencies = [
  "influxdb3_id",
  "influxdb3_internal_api",
  "influxdb3_py_api",
+ "influxdb3_shutdown",
  "influxdb3_sys_events",
  "influxdb3_telemetry",
  "influxdb3_test_helpers",
@@ -6558,6 +6567,8 @@ dependencies = [
  "futures-core",
  "futures-io",
  "futures-sink",
+ "futures-util",
+ "hashbrown 0.14.5",
  "pin-project-lite",
  "tokio",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3155,6 +3155,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "influxdb3_shutdown"
+version = "3.0.0-beta.2"
+dependencies = [
+ "observability_deps",
+ "tokio",
+]
+
+[[package]]
 name = "influxdb3_sys_events"
 version = "3.0.0-beta.2"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
     "influxdb3_process",
     "influxdb3_processing_engine",
     "influxdb3_py_api",
-    "influxdb3_server",
+    "influxdb3_server", "influxdb3_shutdown",
     "influxdb3_telemetry",
     "influxdb3_test_helpers", "influxdb3_types",
     "influxdb3_wal",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,9 +12,11 @@ members = [
     "influxdb3_process",
     "influxdb3_processing_engine",
     "influxdb3_py_api",
-    "influxdb3_server", "influxdb3_shutdown",
+    "influxdb3_server",
+    "influxdb3_shutdown",
     "influxdb3_telemetry",
-    "influxdb3_test_helpers", "influxdb3_types",
+    "influxdb3_test_helpers",
+    "influxdb3_types",
     "influxdb3_wal",
     "influxdb3_write",
     "iox_query_influxql_rewrite",
@@ -120,7 +122,7 @@ tempfile = "3.14.0"
 test-log = { version = "0.2.16", features = ["trace"] }
 thiserror = "1.0"
 tokio = { version = "1.43", features = ["full"] }
-tokio-util = "0.7.13"
+tokio-util = { version = "0.7.13", features = ["rt"] }
 tonic = { version = "0.11.0", features = ["tls", "tls-roots"] }
 tonic-build = "0.11.0"
 tonic-health = "0.11.0"

--- a/influxdb3/Cargo.toml
+++ b/influxdb3/Cargo.toml
@@ -30,11 +30,12 @@ influxdb3_clap_blocks = { path = "../influxdb3_clap_blocks" }
 influxdb3_process = { path = "../influxdb3_process", default-features = false }
 influxdb3_processing_engine = {path = "../influxdb3_processing_engine"}
 influxdb3_server = { path = "../influxdb3_server" }
-influxdb3_wal = { path = "../influxdb3_wal" }
-influxdb3_write = { path = "../influxdb3_write" }
+influxdb3_shutdown = { path = "../influxdb3_shutdown" }
+influxdb3_sys_events = { path = "../influxdb3_sys_events" }
 influxdb3_telemetry = { path = "../influxdb3_telemetry" }
 influxdb3_types = { path = "../influxdb3_types" }
-influxdb3_sys_events = { path = "../influxdb3_sys_events" }
+influxdb3_wal = { path = "../influxdb3_wal" }
+influxdb3_write = { path = "../influxdb3_write" }
 
 # Crates.io dependencies
 anyhow.workspace = true
@@ -42,6 +43,7 @@ backtrace.workspace = true
 base64.workspace = true
 clap.workspace = true
 dotenvy.workspace = true
+futures.workspace = true
 hashbrown.workspace = true
 hex.workspace = true
 humantime.workspace = true

--- a/influxdb3_processing_engine/Cargo.toml
+++ b/influxdb3_processing_engine/Cargo.toml
@@ -22,6 +22,7 @@ influxdb3_client = { path = "../influxdb3_client" }
 influxdb3_internal_api = { path = "../influxdb3_internal_api" }
 influxdb3_py_api = { path = "../influxdb3_py_api" }
 influxdb3_types = { path = "../influxdb3_types" }
+influxdb3_shutdown = { path = "../influxdb3_shutdown"}
 influxdb3_sys_events = { path = "../influxdb3_sys_events"}
 influxdb3_wal = { path = "../influxdb3_wal" }
 influxdb3_write = { path = "../influxdb3_write" }

--- a/influxdb3_processing_engine/src/lib.rs
+++ b/influxdb3_processing_engine/src/lib.rs
@@ -754,6 +754,7 @@ mod tests {
     use influxdb3_catalog::catalog::Catalog;
     use influxdb3_catalog::log::{TriggerSettings, TriggerSpecificationDefinition};
     use influxdb3_internal_api::query_executor::UnimplementedQueryExecutor;
+    use influxdb3_shutdown::ShutdownManager;
     use influxdb3_sys_events::SysEventStore;
     use influxdb3_wal::{Gen1Duration, WalConfig};
     use influxdb3_write::persister::Persister;
@@ -993,6 +994,7 @@ mod tests {
         )
         .await
         .unwrap();
+        let shutdown = ShutdownManager::new_testing();
         let wbuf = WriteBufferImpl::new(WriteBufferImplArgs {
             persister,
             catalog: Arc::clone(&catalog),
@@ -1005,6 +1007,7 @@ mod tests {
             metric_registry: Arc::clone(&metric_registry),
             snapshotted_wal_files_to_keep: 10,
             query_file_limit: None,
+            shutdown: shutdown.register(),
         })
         .await
         .unwrap();

--- a/influxdb3_server/Cargo.toml
+++ b/influxdb3_server/Cargo.toml
@@ -41,13 +41,14 @@ influxdb3_id = { path = "../influxdb3_id" }
 influxdb3_internal_api = { path = "../influxdb3_internal_api" }
 influxdb3_process = { path = "../influxdb3_process", default-features = false }
 influxdb3_processing_engine = { path = "../influxdb3_processing_engine" }
-influxdb3_types = { path = "../influxdb3_types"}
 influxdb3_py_api = {path = "../influxdb3_py_api"}
+influxdb3_sys_events = { path = "../influxdb3_sys_events" }
+influxdb3_shutdown = { path = "../influxdb3_shutdown" }
+influxdb3_telemetry = { path = "../influxdb3_telemetry" }
+influxdb3_types = { path = "../influxdb3_types"}
 influxdb3_wal = { path = "../influxdb3_wal"}
 influxdb3_write = { path = "../influxdb3_write" }
 iox_query_influxql_rewrite = { path = "../iox_query_influxql_rewrite" }
-influxdb3_sys_events = { path = "../influxdb3_sys_events" }
-influxdb3_telemetry = { path = "../influxdb3_telemetry" }
 
 # crates.io Dependencies
 anyhow.workspace = true

--- a/influxdb3_server/src/query_executor/mod.rs
+++ b/influxdb3_server/src/query_executor/mod.rs
@@ -750,6 +750,7 @@ mod tests {
     };
     use influxdb3_catalog::catalog::Catalog;
     use influxdb3_internal_api::query_executor::QueryExecutor;
+    use influxdb3_shutdown::ShutdownManager;
     use influxdb3_sys_events::SysEventStore;
     use influxdb3_telemetry::store::TelemetryStore;
     use influxdb3_wal::{Gen1Duration, WalConfig};
@@ -822,6 +823,7 @@ mod tests {
             .await
             .unwrap(),
         );
+        let shutdown = ShutdownManager::new_testing();
         let write_buffer_impl = WriteBufferImpl::new(WriteBufferImplArgs {
             persister,
             catalog: Arc::clone(&catalog),
@@ -846,6 +848,7 @@ mod tests {
             metric_registry: Default::default(),
             snapshotted_wal_files_to_keep: 1,
             query_file_limit,
+            shutdown: shutdown.register(),
         })
         .await
         .unwrap();

--- a/influxdb3_shutdown/Cargo.toml
+++ b/influxdb3_shutdown/Cargo.toml
@@ -10,7 +10,11 @@ license.workspace = true
 observability_deps.workspace = true
 
 # crates.io dependencies
+futures.workspace = true
+futures-util.workspace = true
+parking_lot.workspace = true
 tokio.workspace = true
+tokio-util.workspace = true
 
 [lints]
 workspace = true

--- a/influxdb3_shutdown/Cargo.toml
+++ b/influxdb3_shutdown/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "influxdb3_shutdown"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[dependencies]
+# influxdb3_core dependencies
+observability_deps.workspace = true
+
+# crates.io dependencies
+tokio.workspace = true
+
+[lints]
+workspace = true

--- a/influxdb3_shutdown/src/lib.rs
+++ b/influxdb3_shutdown/src/lib.rs
@@ -1,10 +1,27 @@
+//! Manage application shutdown
+//!
+//! This crate provides a set of types for managing graceful application shutdown.
+//!
+//! # Coordinate shutdown with the [`ShutdownManager`] type
+//!
+//! The [`ShutdownManager`] is used to coordinate shutdown of the process in an ordered fashion.
+//! When a shutdown is signaled externally, e.g., `ctrl+c`, or internally by some error state, then
+//! there may be processes running on the backend that need to be gracefully stopped before the
+//! HTTP/gRPC frontend. For example, if the WAL has writes buffered, it needs to flush the buffer to
+//! object store and respond to the write request before the HTTP/gRPC frontend is taken down.
+//!
+//! Components can [`register`][ShutdownManager::register] to receive a [`ShutdownToken`], which can
+//! be used to [`wait_for_shutdown`][ShutdownToken::wait_for_shutdown] to trigger component-specific
+//! cleanup logic before signaling back via [`complete`][ShutdownToken::complete] to indicate that
+//! shutdown can proceed.
 use std::sync::Arc;
 
-use observability_deps::tracing::{debug, info};
+use observability_deps::tracing::info;
 use parking_lot::Mutex;
 use tokio::sync::oneshot;
 use tokio_util::{sync::CancellationToken, task::TaskTracker};
 
+/// Wait for a `SIGTERM` or `SIGINT` to stop the process on UNIX systems
 #[cfg(unix)]
 pub async fn wait_for_signal() {
     use tokio::signal::unix::{SignalKind, signal};
@@ -18,12 +35,14 @@ pub async fn wait_for_signal() {
     }
 }
 
+/// Wait for a `ctrl+c` to stop the process on Windows systems
 #[cfg(windows)]
 pub async fn wait_for_signal() {
     let _ = tokio::signal::ctrl_c().await;
     info!("Received SIGINT");
 }
 
+/// Manage application shutdown
 #[derive(Debug)]
 pub struct ShutdownManager {
     frontend_shutdown: CancellationToken,
@@ -32,6 +51,10 @@ pub struct ShutdownManager {
 }
 
 impl ShutdownManager {
+    /// Create a [`ShutdownManager`]
+    ///
+    /// Accepts a [`CancellationToken`] which the `ShutdownManager` will signal cancellation to
+    /// after the backend has cleanly shutdown.
     pub fn new(frontend_shutdown: CancellationToken) -> Self {
         Self {
             frontend_shutdown,
@@ -40,6 +63,10 @@ impl ShutdownManager {
         }
     }
 
+    /// Create a [`ShutdownManager`] for testing purposes
+    ///
+    /// This handles creation of the frontend [`CancellationToken`] for tests where `tokio-util` is
+    /// not a dependency, or hanlding of the frontend shutdown is not necessary.
     pub fn new_testing() -> Self {
         Self {
             frontend_shutdown: CancellationToken::new(),
@@ -49,33 +76,47 @@ impl ShutdownManager {
     }
 
     /// Register a task that needs to perform work before the process may exit
+    ///
+    /// Provides a [`ShutdownToken`] which the caller is responsible for handling. The caller must
+    /// invoke [`complete`][ShutdownToken::complete] in order for process shutdown to succeed.
     pub fn register(&self) -> ShutdownToken {
         let (tx, rx) = oneshot::channel();
-        debug!("spawning task...");
         self.tasks.spawn(rx);
-        debug!("spawning task... done.");
         ShutdownToken::new(self.backend_shutdown.clone(), tx)
     }
 
     /// Waits for registered tasks to complete before signaling shutdown to frontend
+    ///
+    /// The future returned will complete when all registered tasks have signaled completion via
+    /// [`complete`][ShutdownToken::complete]
     pub async fn join(&self) {
         self.tasks.close();
         self.tasks.wait().await;
         self.frontend_shutdown.cancel();
     }
 
+    /// Invoke application shutdown
+    ///
+    /// This will signal backend shutdown and wake the
+    /// [`wait_for_shutdown`][ShutdownToken::wait_for_shutdown] future so that registered tasks can
+    /// clean up before indicating completion.
     pub fn shutdown(&self) {
         self.backend_shutdown.cancel();
     }
 }
 
-#[derive(Debug)]
+/// A token that a component can obtain via [`register`][ShutdownManager::register]
+///
+/// This implements [`Clone`] so that a component that obtains it can make copies as needed for
+/// sub-components or tasks  that may be responsible for triggering a shutdown internally.
+#[derive(Debug, Clone)]
 pub struct ShutdownToken {
     token: CancellationToken,
     complete_tx: Arc<Mutex<Option<oneshot::Sender<()>>>>,
 }
 
 impl ShutdownToken {
+    /// Create a new [`ShutdownToken`]
     fn new(token: CancellationToken, complete_tx: oneshot::Sender<()>) -> Self {
         Self {
             token,
@@ -83,13 +124,69 @@ impl ShutdownToken {
         }
     }
 
+    /// Trigger application shutdown due to some unrecoverable state
+    pub fn trigger_shutdown(&self) {
+        self.token.cancel();
+    }
+
+    /// Future that completes when [`ShutdownManager`] that issued this token is shutdown
     pub async fn wait_for_shutdown(&self) {
         self.token.cancelled().await;
     }
 
+    /// Signal back to the [`ShutdownManager`] that the component that owns this token is finished
+    /// cleaning up and it is safe for the process to exit
     pub fn complete(&self) {
         if let Some(s) = self.complete_tx.lock().take() {
             let _ = s.send(());
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        sync::atomic::{AtomicBool, Ordering},
+        time::Duration,
+    };
+
+    use futures::FutureExt;
+    use tokio_util::sync::CancellationToken;
+
+    use crate::ShutdownManager;
+
+    #[tokio::test]
+    async fn test_shutdown_order() {
+        let frontend_token = CancellationToken::new();
+        let shutdown_manager = ShutdownManager::new(frontend_token.clone());
+
+        static CLEAN: AtomicBool = AtomicBool::new(false);
+
+        let token = shutdown_manager.register();
+        tokio::spawn(async move {
+            loop {
+                futures::select! {
+                    _ = token.wait_for_shutdown().fuse() => {
+                        CLEAN.store(true, Ordering::SeqCst);
+                        token.complete();
+                        break;
+                    }
+                    _ = tokio::time::sleep(Duration::from_millis(10)).fuse() => {
+                        // sleeping... 😴
+                    }
+                }
+            }
+        });
+
+        shutdown_manager.shutdown();
+        shutdown_manager.join().await;
+        assert!(
+            CLEAN.load(Ordering::SeqCst),
+            "backend shutdown did not compelte"
+        );
+        assert!(
+            frontend_token.is_cancelled(),
+            "frontend shutdown was not triggered"
+        );
     }
 }

--- a/influxdb3_shutdown/src/lib.rs
+++ b/influxdb3_shutdown/src/lib.rs
@@ -1,0 +1,20 @@
+use observability_deps::tracing::info;
+
+#[cfg(unix)]
+pub async fn wait_for_signal() {
+    use tokio::signal::unix::{SignalKind, signal};
+
+    let mut term = signal(SignalKind::terminate()).expect("failed to register signal handler");
+    let mut int = signal(SignalKind::interrupt()).expect("failed to register signal handler");
+
+    tokio::select! {
+        _ = term.recv() => info!("Received SIGTERM"),
+        _ = int.recv() => info!("Received SIGINT"),
+    }
+}
+
+#[cfg(windows)]
+pub async fn wait_for_signal() {
+    let _ = tokio::signal::ctrl_c().await;
+    info!("Received SIGINT");
+}

--- a/influxdb3_shutdown/src/lib.rs
+++ b/influxdb3_shutdown/src/lib.rs
@@ -1,4 +1,9 @@
-use observability_deps::tracing::info;
+use std::sync::Arc;
+
+use observability_deps::tracing::{debug, info};
+use parking_lot::Mutex;
+use tokio::sync::oneshot;
+use tokio_util::{sync::CancellationToken, task::TaskTracker};
 
 #[cfg(unix)]
 pub async fn wait_for_signal() {
@@ -17,4 +22,74 @@ pub async fn wait_for_signal() {
 pub async fn wait_for_signal() {
     let _ = tokio::signal::ctrl_c().await;
     info!("Received SIGINT");
+}
+
+#[derive(Debug)]
+pub struct ShutdownManager {
+    frontend_shutdown: CancellationToken,
+    backend_shutdown: CancellationToken,
+    tasks: TaskTracker,
+}
+
+impl ShutdownManager {
+    pub fn new(frontend_shutdown: CancellationToken) -> Self {
+        Self {
+            frontend_shutdown,
+            backend_shutdown: CancellationToken::new(),
+            tasks: TaskTracker::new(),
+        }
+    }
+
+    pub fn new_testing() -> Self {
+        Self {
+            frontend_shutdown: CancellationToken::new(),
+            backend_shutdown: CancellationToken::new(),
+            tasks: TaskTracker::new(),
+        }
+    }
+
+    /// Register a task that needs to perform work before the process may exit
+    pub fn register(&self) -> ShutdownToken {
+        let (tx, rx) = oneshot::channel();
+        debug!("spawning task...");
+        self.tasks.spawn(rx);
+        debug!("spawning task... done.");
+        ShutdownToken::new(self.backend_shutdown.clone(), tx)
+    }
+
+    /// Waits for registered tasks to complete before signaling shutdown to frontend
+    pub async fn join(&self) {
+        self.tasks.close();
+        self.tasks.wait().await;
+        self.frontend_shutdown.cancel();
+    }
+
+    pub fn shutdown(&self) {
+        self.backend_shutdown.cancel();
+    }
+}
+
+#[derive(Debug)]
+pub struct ShutdownToken {
+    token: CancellationToken,
+    complete_tx: Arc<Mutex<Option<oneshot::Sender<()>>>>,
+}
+
+impl ShutdownToken {
+    fn new(token: CancellationToken, complete_tx: oneshot::Sender<()>) -> Self {
+        Self {
+            token,
+            complete_tx: Arc::new(Mutex::new(Some(complete_tx))),
+        }
+    }
+
+    pub async fn wait_for_shutdown(&self) {
+        self.token.cancelled().await;
+    }
+
+    pub fn complete(&self) {
+        if let Some(s) = self.complete_tx.lock().take() {
+            let _ = s.send(());
+        }
+    }
 }

--- a/influxdb3_wal/Cargo.toml
+++ b/influxdb3_wal/Cargo.toml
@@ -15,6 +15,7 @@ schema.workspace =  true
 
 # Local Crates
 influxdb3_id = { path = "../influxdb3_id" }
+influxdb3_shutdown = { path = "../influxdb3_shutdown" }
 
 # crates.io dependencies
 async-trait.workspace = true

--- a/influxdb3_write/Cargo.toml
+++ b/influxdb3_write/Cargo.toml
@@ -29,12 +29,13 @@ influxdb3_cache = { path = "../influxdb3_cache" }
 influxdb3_catalog = { path = "../influxdb3_catalog" }
 influxdb3_id = { path = "../influxdb3_id" }
 influxdb3_internal_api = { path = "../influxdb3_internal_api" }
-influxdb3_test_helpers = { path = "../influxdb3_test_helpers" }
-influxdb3_wal = { path = "../influxdb3_wal" }
-influxdb3_telemetry = { path = "../influxdb3_telemetry" }
-influxdb3_types = { path = "../influxdb3_types" }
-influxdb3_sys_events = { path = "../influxdb3_sys_events" }
 influxdb3_py_api = {path = "../influxdb3_py_api"}
+influxdb3_sys_events = { path = "../influxdb3_sys_events" }
+influxdb3_shutdown = { path = "../influxdb3_shutdown" }
+influxdb3_telemetry = { path = "../influxdb3_telemetry" }
+influxdb3_test_helpers = { path = "../influxdb3_test_helpers" }
+influxdb3_types = { path = "../influxdb3_types" }
+influxdb3_wal = { path = "../influxdb3_wal" }
 
 # crates.io dependencies
 anyhow.workspace = true


### PR DESCRIPTION
Closes #26175

Provides a new crate `influxdb3_shutdown` which provides helpers for managing clean process shutdown.

* [`wait_for_signal`](https://github.com/influxdata/influxdb/blob/56190f9ee2150e5b6aa45b683361c94f657112b7/influxdb3_shutdown/src/lib.rs#L24-L43) method that provides a system dependent future for waiting for a `Ctrl+C` signal
* The [`ShutdownManager`](https://github.com/influxdata/influxdb/blob/56190f9ee2150e5b6aa45b683361c94f657112b7/influxdb3_shutdown/src/lib.rs#L45-L51) which is used to coordinate application shutdown.

This is currently only used in the WAL, where it triggers the WAL shutdown so that the buffer is flushed and responses to waiting requests are returned before exiting the process. Other components than the WAL that need to do cleanup before proper shutdown can utilize this feature.

### Future work

The [`trigger_shutdown`](https://github.com/influxdata/influxdb/blob/56190f9ee2150e5b6aa45b683361c94f657112b7/influxdb3_shutdown/src/lib.rs#L127-L130) method can be used for https://github.com/influxdata/influxdb/issues/26161