### PR TITLE
refactor: ensure shutdown complete via Drop impl

### DIFF
--- a/influxdb3/src/commands/serve.rs
+++ b/influxdb3/src/commands/serve.rs
@@ -718,7 +718,7 @@ pub async fn command(config: Config) -> Result<()> {
                 //
                 // The select! could also pick this branch in the event that the frontend and
                 // backend stop at the same time. That shouldn't be an issue so long as the frontend
-                // so long as the frontend has indeed stopped.
+                // has indeed stopped.
                 if frontend_shutdown.is_cancelled() {
                     break;
                 }

--- a/influxdb3_wal/src/lib.rs
+++ b/influxdb3_wal/src/lib.rs
@@ -577,6 +577,5 @@ pub fn background_wal_flush<W: Wal>(
                 }
             }
         }
-        shutdown.complete();
     })
 }


### PR DESCRIPTION
This ensures a ShutdownToken will invoke `complete` by calling it from its `Drop` implementation. This means registered components are not required to signal completion, but can if needed.

Some comments and other cleanup refactoring was done as well.

Follows #26197 
