### PR TITLE
chore: back-port changes to shutdown code from enterprise

### DIFF
--- a/influxdb3/tests/cli/mod.rs
+++ b/influxdb3/tests/cli/mod.rs
@@ -2886,7 +2886,7 @@ async fn test_wal_overwritten() {
 
     assert_contains!(
         result.to_string(),
-        "another process as written to the WAL ahead of this one"
+        "another process has written to the WAL ahead of this one"
     );
 
     // give p1 some time to shutdown:

--- a/influxdb3_shutdown/src/lib.rs
+++ b/influxdb3_shutdown/src/lib.rs
@@ -43,7 +43,9 @@ pub async fn wait_for_signal() {
 }
 
 /// Manage application shutdown
-#[derive(Debug)]
+///
+/// This deries `Clone`, as the underlying `tokio` types can be shared via clone.
+#[derive(Debug, Clone)]
 pub struct ShutdownManager {
     frontend_shutdown: CancellationToken,
     backend_shutdown: CancellationToken,

--- a/influxdb3_shutdown/src/lib.rs
+++ b/influxdb3_shutdown/src/lib.rs
@@ -14,12 +14,12 @@
 //! be used to [`wait_for_shutdown`][ShutdownToken::wait_for_shutdown] to trigger component-specific
 //! cleanup logic before signaling back via [`complete`][ShutdownToken::complete] to indicate that
 //! shutdown can proceed.
-use std::sync::Arc;
 
 use observability_deps::tracing::info;
 use parking_lot::Mutex;
 use tokio::sync::oneshot;
-use tokio_util::{sync::CancellationToken, task::TaskTracker};
+pub use tokio_util::sync::CancellationToken;
+use tokio_util::task::TaskTracker;
 
 /// Wait for a `SIGTERM` or `SIGINT` to stop the process on UNIX systems
 #[cfg(unix)]
@@ -109,12 +109,13 @@ impl ShutdownManager {
 
 /// A token that a component can obtain via [`register`][ShutdownManager::register]
 ///
-/// This implements [`Clone`] so that a component that obtains it can make copies as needed for
-/// sub-components or tasks  that may be responsible for triggering a shutdown internally.
-#[derive(Debug, Clone)]
+/// This does not implement `Clone` because there should only be a single instance of a given
+/// `ShutdownToken`. If you just need a copy of the `CancellationToken` for invoking shutdown, use
+/// [`ShutdownToken::clone_cancellation_token`].
+#[derive(Debug)]
 pub struct ShutdownToken {
     token: CancellationToken,
-    complete_tx: Arc<Mutex<Option<oneshot::Sender<()>>>>,
+    complete_tx: Mutex<Option<oneshot::Sender<()>>>,
 }
 
 impl ShutdownToken {
@@ -122,13 +123,18 @@ impl ShutdownToken {
     fn new(token: CancellationToken, complete_tx: oneshot::Sender<()>) -> Self {
         Self {
             token,
-            complete_tx: Arc::new(Mutex::new(Some(complete_tx))),
+            complete_tx: Mutex::new(Some(complete_tx)),
         }
     }
 
     /// Trigger application shutdown due to some unrecoverable state
     pub fn trigger_shutdown(&self) {
         self.token.cancel();
+    }
+
+    /// Get a clone of the cancellation token for triggering shutdown
+    pub fn clone_cancellation_token(&self) -> CancellationToken {
+        self.token.clone()
     }
 
     /// Future that completes when [`ShutdownManager`] that issued this token is shutdown


### PR DESCRIPTION
 While working the recent addition of the `influxdb3_shutdown` crate into Enterprise, I found a few gaps in its API. This brings those changes back to core. In summary,

* `ShutdownManager` is `Clone` - this works since the underlying types ([`CancellationToken`](https://docs.rs/tokio-util/latest/tokio_util/sync/struct.CancellationToken.html) and [`TaskTracker`](https://docs.rs/tokio-util/latest/tokio_util/task/task_tracker/struct.TaskTracker.html)) are shareable via clone.
* `ShutdownToken` is no longer `Clone`, but instead provides a `clone_cancellation_token` when just the ability to signal shutdown is needed. Cloning the `ShutdownToken` meant that when the clone was dropped, completion would be signalled and would lead to early process exit. This forces the waiting on and handling of the shutdown signal to be in a single place.

These changes are in use on this draft sync PR: https://github.com/influxdata/influxdb_pro/pull/674