### PR TITLE
fix: rename influxdb3 to influxdb3-core when building packages

### DIFF
--- a/.circleci/packages/config.yaml
+++ b/.circleci/packages/config.yaml
@@ -94,7 +94,7 @@ sources:
     plat:   windows
 
 packages:
-  - name:        influxdb3
+  - name:        influxdb3-core
     description: Monolithic time-series database.
     license:     MIT/Apache-2.0
     vendor:      InfluxData


### PR DESCRIPTION
Helps with https://github.com/influxdata/influxdb/issues/26217

With this change, now have packages names like (tested locally):
```
influxdb3-core-3.0.0-0.beta.9998.aarch64.rpm
influxdb3-core_3.0.0-0.beta.9998_amd64.deb
influxdb3-core_3.0.0-0.beta.9998_arm64.deb
influxdb3-core-3.0.0-0.beta.9998_darwin_arm64.tar.gz
influxdb3-core-3.0.0-0.beta.9998_linux_amd64.tar.gz
influxdb3-core-3.0.0-0.beta.9998_linux_arm64.tar.gz
influxdb3-core-3.0.0-0.beta.9998-windows_amd64.zip
influxdb3-core-3.0.0-0.beta.9998.x86_64.rpm
```