### PR TITLE
fix: empty writes do not corrupt wal

### DIFF
--- a/influxdb3_server/src/http.rs
+++ b/influxdb3_server/src/http.rs
@@ -340,6 +340,10 @@ impl IntoResponse for Error {
                     .body(body)
                     .unwrap()
             }
+            Self::WriteBuffer(err @ WriteBufferError::EmptyWrite) => Response::builder()
+                .status(StatusCode::BAD_REQUEST)
+                .body(Body::from(err.to_string()))
+                .unwrap(),
             Self::WriteBuffer(err @ WriteBufferError::ColumnDoesNotExist(_)) => {
                 let err: ErrorMessage<()> = ErrorMessage {
                     error: err.to_string(),


### PR DESCRIPTION
Closes #26222

Prevents empty writes, or writes that only contain invalid lines from creating an empty `WriteBatch` in the WAL, which results in a corrupted WAL file.

This includes the reproducer from #26222 with updates to the test to check for correct behaviour.