### PR TITLE
fix: PlanOptimize is running too frequently (#26211)

### DIFF
--- a/tsdb/engine/tsm1/engine_test.go
+++ b/tsdb/engine/tsm1/engine_test.go
@@ -2893,11 +2893,15 @@ func (m *mockPlanner) SetAggressiveCompactionPointsPerBlock(aggressiveCompaction
 }
 func (m *mockPlanner) Plan(lastWrite time.Time) ([]tsm1.CompactionGroup, int64) { return nil, 0 }
 func (m *mockPlanner) PlanLevel(level int) ([]tsm1.CompactionGroup, int64)      { return nil, 0 }
-func (m *mockPlanner) PlanOptimize() ([]tsm1.CompactionGroup, int64, int64)     { return nil, 0, 0 }
-func (m *mockPlanner) Release(groups []tsm1.CompactionGroup)                    {}
-func (m *mockPlanner) FullyCompacted() (bool, string)                           { return false, "not compacted" }
-func (m *mockPlanner) ForceFull()                                               {}
-func (m *mockPlanner) SetFileStore(fs *tsm1.FileStore)                          {}
+func (m *mockPlanner) PlanOptimize(lastWrite time.Time) ([]tsm1.CompactionGroup, int64, int64) {
+	return nil, 0, 0
+}
+func (m *mockPlanner) Release(groups []tsm1.CompactionGroup) {}
+func (m *mockPlanner) FullyCompacted() (bool, string) {
+	return false, "not compacted"
+}
+func (m *mockPlanner) ForceFull()                      {}
+func (m *mockPlanner) SetFileStore(fs *tsm1.FileStore) {}
 
 // ParseTags returns an instance of Tags for a comma-delimited list of key/values.
 func ParseTags(s string) query.Tags {


### PR DESCRIPTION
PlanOptimize is being checked far too frequently. This PR is the simplest change that can be made in order to ensure that PlanOptimize is not being ran too much. To alleviate the frequency I've added a lastWrite parameter to PlanOptimize and added an additional test that mocks the edge cause out in the wild that led to this PR.

Previously in test cases for PlanOptimize I was not checked to see if certain cases would be picked up by Plan I've adjusted a few of the existing test cases after modifying Plan and PlanOptimize to have the same lastWrite time.

(cherry picked from commit 96e44cac735baa4d7a4d40ee4f9ff9e9658a2b59)
