### PR TITLE
feat: catalog updates state to stopped on shutdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2864,6 +2864,7 @@ dependencies = [
  "indexmap 2.7.0",
  "influxdb-line-protocol",
  "influxdb3_id",
+ "influxdb3_shutdown",
  "influxdb3_test_helpers",
  "influxdb3_wal",
  "insta",

--- a/influxdb3/src/commands/serve.rs
+++ b/influxdb3/src/commands/serve.rs
@@ -545,14 +545,13 @@ pub async fn command(config: Config) -> Result<()> {
         snapshot_size: config.wal_snapshot_size,
     };
 
-    let catalog = Arc::new(
-        Catalog::new(
-            config.node_identifier_prefix.as_str(),
-            Arc::clone(&object_store),
-            Arc::<SystemProvider>::clone(&time_provider),
-        )
-        .await?,
-    );
+    let catalog = Catalog::new_with_shutdown(
+        config.node_identifier_prefix.as_str(),
+        Arc::clone(&object_store),
+        Arc::<SystemProvider>::clone(&time_provider),
+        shutdown_manager.register(),
+    )
+    .await?;
     info!(catalog_uuid = ?catalog.catalog_uuid(), "catalog initialized");
 
     let _ = catalog

--- a/influxdb3_catalog/Cargo.toml
+++ b/influxdb3_catalog/Cargo.toml
@@ -14,6 +14,7 @@ iox_time.workspace = true
 
 # Local deps
 influxdb3_id = { path = "../influxdb3_id" }
+influxdb3_shutdown = { path = "../influxdb3_shutdown" }
 influxdb3_wal = { path = "../influxdb3_wal" }
 
 # crates.io dependencies

--- a/influxdb3_catalog/src/log/versions/v2.rs
+++ b/influxdb3_catalog/src/log/versions/v2.rs
@@ -134,6 +134,7 @@ impl Ord for OrderedCatalogBatch {
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub enum NodeCatalogOp {
     RegisterNode(RegisterNodeLog),
+    StopNode(StopNodeLog),
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
@@ -176,6 +177,12 @@ pub struct RegisterNodeLog {
     pub registered_time_ns: i64,
     pub core_count: u64,
     pub mode: Vec<NodeMode>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub struct StopNodeLog {
+    pub node_id: Arc<str>,
+    pub stopped_time_ns: i64,
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize)]


### PR DESCRIPTION
This is a back-port of changes from enterprise to make it so that node state in the catalog is set to `Stopped` when the node shuts down gracefully.

I tested this manually. It is mainly needed so that when upgrading to Enterprise, the node is in a `Stopped` state in the catalog, so that there is no forced delay for an `ingest` node.