### PR TITLE
feat: enable auth by default

### DIFF
--- a/influxdb3/src/commands/create.rs
+++ b/influxdb3/src/commands/create.rs
@@ -374,17 +374,13 @@ pub async fn command(config: Config) -> Result<(), Box<dyn Error>> {
             match handle_token_creation(client, token_commands).await {
                 Ok(response) => {
                     println!(
-                        "\
+                        "\n\
                         Token: {token}\n\
-                        Hashed Token: {hashed}\n\n\
-                        Start the server with the Hashed Token provided as the `--bearer-token` argument:\n\n
-                        `influxdb3 serve --bearer-token {hashed} --node-id <NODE_ID> [OPTIONS]`\n\n\
+                            \n\
                         HTTP requests require the following header: \"Authorization: Bearer {token}\"\n\
-                        This will grant you access to every HTTP endpoint or deny it otherwise.
+                        This will grant you access to HTTP/GRPC API.
                     ",
                         token = response.token,
-                        hashed = response.hash,
-
                     );
                 }
                 Err(err) => {

--- a/influxdb3/tests/cli/mod.rs
+++ b/influxdb3/tests/cli/mod.rs
@@ -2876,10 +2876,7 @@ async fn test_create_admin_token() {
         .run(vec!["create", "token", "--admin"], args)
         .unwrap();
     println!("{:?}", result);
-    assert_contains!(
-        &result,
-        "This will grant you access to every HTTP endpoint or deny it otherwise"
-    );
+    assert_contains!(&result, "This will grant you access to HTTP/GRPC API");
 }
 
 #[test_log::test(tokio::test)]
@@ -2889,10 +2886,7 @@ async fn test_create_admin_token_allowed_once() {
     let result = server
         .run(vec!["create", "token", "--admin"], args)
         .unwrap();
-    assert_contains!(
-        &result,
-        "This will grant you access to every HTTP endpoint or deny it otherwise"
-    );
+    assert_contains!(&result, "This will grant you access to HTTP/GRPC API");
 
     let result = server
         .run(vec!["create", "token", "--admin"], args)
@@ -2924,10 +2918,7 @@ async fn test_regenerate_admin_token() {
             &["--regenerate", "--tls-ca", "../testing-certs/rootCA.pem"],
         )
         .unwrap();
-    assert_contains!(
-        &result,
-        "This will grant you access to every HTTP endpoint or deny it otherwise"
-    );
+    assert_contains!(&result, "This will grant you access to HTTP/GRPC API");
     let old_token = server.token().expect("admin token to be present");
     let new_token = parse_token(result);
     assert!(old_token != &new_token);
@@ -2963,10 +2954,7 @@ async fn test_delete_token() {
             args,
         )
         .unwrap();
-    assert_contains!(
-        &result,
-        "This will grant you access to every HTTP endpoint or deny it otherwise"
-    );
+    assert_contains!(&result, "This will grant you access to HTTP/GRPC API");
     let token = parse_token(result);
 
     let result = server
@@ -2997,8 +2985,5 @@ async fn test_delete_token() {
             args,
         )
         .unwrap();
-    assert_contains!(
-        &result,
-        "This will grant you access to every HTTP endpoint or deny it otherwise"
-    );
+    assert_contains!(&result, "This will grant you access to HTTP/GRPC API");
 }

--- a/influxdb3/tests/cli/mod.rs
+++ b/influxdb3/tests/cli/mod.rs
@@ -2870,7 +2870,11 @@ async fn test_wal_overwritten() {
 
 #[test_log::test(tokio::test)]
 async fn test_create_admin_token() {
-    let server = TestServer::spawn().await;
+    let server = TestServer::configure()
+        .with_auth()
+        .with_no_admin_token()
+        .spawn()
+        .await;
     let args = &["--tls-ca", "../testing-certs/rootCA.pem"];
     let result = server
         .run(vec!["create", "token", "--admin"], args)
@@ -2881,7 +2885,11 @@ async fn test_create_admin_token() {
 
 #[test_log::test(tokio::test)]
 async fn test_create_admin_token_allowed_once() {
-    let server = TestServer::spawn().await;
+    let server = TestServer::configure()
+        .with_auth()
+        .with_no_admin_token()
+        .spawn()
+        .await;
     let args = &["--tls-ca", "../testing-certs/rootCA.pem"];
     let result = server
         .run(vec!["create", "token", "--admin"], args)
@@ -2940,7 +2948,11 @@ async fn test_regenerate_admin_token() {
 
 #[test_log::test(tokio::test)]
 async fn test_delete_token() {
-    let server = TestServer::spawn().await;
+    let server = TestServer::configure()
+        .with_auth()
+        .with_no_admin_token()
+        .spawn()
+        .await;
     let args = &[];
     let result = server
         .run(

--- a/influxdb3/tests/server/mod.rs
+++ b/influxdb3/tests/server/mod.rs
@@ -112,14 +112,10 @@ impl TestConfig {
 impl ConfigProvider for TestConfig {
     fn as_args(&self) -> Vec<String> {
         let mut args = vec![];
-        if let Some((token, _)) = &self.auth_token {
-            // TODO: --bearer-token will be deprecated soon
-            args.append(&mut vec!["--bearer-token".to_string(), token.to_owned()]);
+        if !self.auth {
+            args.append(&mut vec!["--without-auth".to_string()]);
         }
-        if self.auth {
-            // TODO: --bearer-token will be deprecated soon
-            args.append(&mut vec!["--bearer-token".to_string(), "foo".to_string()]);
-        }
+
         if let Some(plugin_dir) = &self.plugin_dir {
             args.append(&mut vec!["--plugin-dir".to_string(), plugin_dir.to_owned()]);
         }

--- a/influxdb3/tests/server/mod.rs
+++ b/influxdb3/tests/server/mod.rs
@@ -37,6 +37,9 @@ pub trait ConfigProvider {
     /// Get if auth is enabled
     fn auth_enabled(&self) -> bool;
 
+    /// Get if admin token needs to be generated
+    fn should_generate_admin_token(&self) -> bool;
+
     /// Spawn a new [`TestServer`] with this configuration
     ///
     /// This will run the `influxdb3 serve` command and bind its HTTP address to a random port
@@ -54,6 +57,7 @@ pub trait ConfigProvider {
 pub struct TestConfig {
     auth_token: Option<(String, String)>,
     auth: bool,
+    without_admin_token: bool,
     node_id: Option<String>,
     plugin_dir: Option<String>,
     virtual_env_dir: Option<String>,
@@ -73,9 +77,15 @@ impl TestConfig {
         self
     }
 
-    /// Set the auth token for this [`TestServer`]
+    /// Set the auth (setting this will auto generate admin token)
     pub fn with_auth(mut self) -> Self {
         self.auth = true;
+        self
+    }
+
+    /// Set the auth token for this [`TestServer`]
+    pub fn with_no_admin_token(mut self) -> Self {
+        self.without_admin_token = true;
         self
     }
 
@@ -159,6 +169,10 @@ impl ConfigProvider for TestConfig {
 
     fn auth_enabled(&self) -> bool {
         self.auth
+    }
+
+    fn should_generate_admin_token(&self) -> bool {
+        self.without_admin_token
     }
 }
 
@@ -268,7 +282,8 @@ impl TestServer {
 
         server.wait_until_ready().await;
 
-        let (mut server, token) = if config.auth_enabled() {
+        let (mut server, token) = if config.auth_enabled() && !config.should_generate_admin_token()
+        {
             let result = server
                 .run(
                     vec!["create", "token", "--admin"],

--- a/influxdb3_server/src/http.rs
+++ b/influxdb3_server/src/http.rs
@@ -1676,7 +1676,13 @@ pub(crate) async fn route_request(
     let method = req.method().clone();
     let uri = req.uri().clone();
 
-    if uri.path() != all_paths::API_V3_CONFIGURE_ADMIN_TOKEN {
+    // admin token creation, health, ping and metrics endpoints aren't guarded
+    if uri.path() != all_paths::API_V3_CONFIGURE_ADMIN_TOKEN
+        && uri.path() != all_paths::API_V3_HEALTH
+        && uri.path() != all_paths::API_V1_HEALTH
+        && uri.path() != all_paths::API_METRICS
+        && uri.path() != all_paths::API_PING
+    {
         trace!(?uri, "authenticating request");
         if let Some(authentication_error) = authenticate(&http_server, &mut req).await {
             return authentication_error;

--- a/influxdb3_server/src/http.rs
+++ b/influxdb3_server/src/http.rs
@@ -865,10 +865,6 @@ impl HttpApi {
                 return Err(Error::InfluxqlNoDatabase);
             };
 
-            // if started_without_auth && database == INTERNAL_DB_NAME {
-            //     return Err(Error::UnsupportedMethod);
-            // }
-            //
             self.query_executor
                 .query_influxql(&database, query_str, statement, params, span_ctx, None)
                 .await?
@@ -1686,13 +1682,8 @@ pub(crate) async fn route_request(
             .unwrap());
     }
 
-    // admin token creation, health, ping and metrics endpoints aren't guarded
-    if uri.path() != all_paths::API_V3_CONFIGURE_ADMIN_TOKEN
-        && uri.path() != all_paths::API_V3_HEALTH
-        && uri.path() != all_paths::API_V1_HEALTH
-        && uri.path() != all_paths::API_METRICS
-        && uri.path() != all_paths::API_PING
-    {
+    // admin token creation
+    if uri.path() != all_paths::API_V3_CONFIGURE_ADMIN_TOKEN {
         trace!(?uri, "authenticating request");
         if let Some(authentication_error) = authenticate(&http_server, &mut req).await {
             return authentication_error;

--- a/influxdb3_server/src/system_tables/mod.rs
+++ b/influxdb3_server/src/system_tables/mod.rs
@@ -93,6 +93,7 @@ impl AllSystemSchemaTablesProvider {
         buffer: Arc<dyn WriteBuffer>,
         sys_events_store: Arc<SysEventStore>,
         catalog: Arc<Catalog>,
+        started_with_auth: bool,
     ) -> Self {
         let mut tables = HashMap::<&'static str, Arc<dyn TableProvider>>::new();
         let queries = Arc::new(SystemTableProvider::new(Arc::new(QueriesTable::new(
@@ -133,6 +134,7 @@ impl AllSystemSchemaTablesProvider {
                 TOKENS_TABLE_NAME,
                 Arc::new(SystemTableProvider::new(Arc::new(TokenSystemTable::new(
                     Arc::clone(&catalog),
+                    started_with_auth,
                 )))),
             );
         }


### PR DESCRIPTION
- Removes `--bearer-token` support and starts the server with auth by default.
- Adds `--without-auth` switch to start the server without any auth

when auth is turned off,
- disallow token endpoints (returns 405)
- remove hash column when querying tokens system table

Test runs

- Start with `--bearer-token` (fails)

```
❯ cargo run -- serve --node-id node-1 --object-store file --data-dir /home/praveen/projects/influx/test-data/  --disable-telemetry-upload --snapshotted-wal-files-to-keep 10 --force-snapshot-mem-threshold 4000 --log-filter 'info,iox_query=debug,influxdb3_server::query_executor=warn,influxdb3_server::http=warn,influxdb3_wal=debug,influxdb3_write::write_buffer::queryable_buffer=debug,influxdb3_write::write_buffer::table_buffer=debug,influxdb3::write_buffer=debug,influxdb3_enterprise=debug' --gen1-duration 10m --bearer-token "foo"
   Compiling pyo3-build-config v0.24.1
   Compiling pyo3-macros-backend v0.24.1
   Compiling pyo3-ffi v0.24.1
   Compiling pyo3 v0.24.1
   Compiling pyo3-macros v0.24.1
   Compiling influxdb3_py_api v3.0.0-beta.4 (/home/praveen/projects/influx/influxdb/influxdb3_py_api)
   Compiling influxdb3_write v3.0.0-beta.4 (/home/praveen/projects/influx/influxdb/influxdb3_write)
   Compiling influxdb3_processing_engine v3.0.0-beta.4 (/home/praveen/projects/influx/influxdb/influxdb3_processing_engine)
   Compiling influxdb3_server v3.0.0-beta.4 (/home/praveen/projects/influx/influxdb/influxdb3_server)
   Compiling influxdb3 v3.0.0-beta.4 (/home/praveen/projects/influx/influxdb/influxdb3)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 19.14s
     Running `target/debug/influxdb3 serve --node-id node-1 --object-store file --data-dir /home/praveen/projects/influx/test-data/ --disable-telemetry-upload --snapshotted-wal-files-to-keep 10 --force-snapshot-mem-threshold 4000 --log-filter 'info,iox_query=debug,influxdb3_server::query_executor=warn,influxdb3_server::http=warn,influxdb3_wal=debug,influxdb3_write::write_buffer::queryable_buffer=debug,influxdb3_write::write_buffer::table_buffer=debug,influxdb3::write_buffer=debug,influxdb3_enterprise=debug' --gen1-duration 10m --bearer-token foo`
error: unexpected argument '--bearer-token' found

```

- Start with auth (i.e not pass in `--bearer-token`) and list tokens using admin token

```
❯ cargo run -- show tokens  --token apiv3_ParisF6RJ3_LKr7J8sPMJd8NG9SgaRHYzq08vLGN8EqB-b5u4VUsRRwz9thyJVyd40FECeScD8gkQQ6VXEPyfw
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.23s
     Running `target/debug/influxdb3 show tokens --token apiv3_ParisF6RJ3_LKr7J8sPMJd8NG9SgaRHYzq08vLGN8EqB-b5u4VUsRRwz9thyJVyd40FECeScD8gkQQ6VXEPyfw`
+----------+--------+----------------------------------------------------------------------------------------------------------------------------------+-------------------------+-------------+---------------------+------------+---------------------+--------+-------------+
| token_id | name   | hash                                                                                                                             | created_at              | description | created_by_token_id | updated_at | updated_by_token_id | expiry | permissions |
+----------+--------+----------------------------------------------------------------------------------------------------------------------------------+-------------------------+-------------+---------------------+------------+---------------------+--------+-------------+
| 1        | _admin | ee2be8bee93497bf6b2e4fda382fcb993e1891b7aea761ba89fb5cc4b2b3484a3e89cf898eed1ef2b61a220d30ac69897ead36f77824d0b420973a5e6d165d77 | 2025-04-10T16:14:50.221 |             |                     |            |                     |        | *:*:*       |
+----------+--------+----------------------------------------------------------------------------------------------------------------------------------+-------------------------+-------------+---------------------+------------+---------------------+--------+-------------+

```

- Turn auth off (using `--without-auth` switch) and then list the tokens - missing hash column 

```
❯ cargo run -- show tokens  --token apiv3_ParisF6RJ3_LKr7J8sPMJd8NG9SgaRHYzq08vLGN8EqB-b5u4VUsRRwz9thyJVyd40FECeScD8gkQQ6VXEPyfw
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.21s
     Running `target/debug/influxdb3 show tokens --token apiv3_ParisF6RJ3_LKr7J8sPMJd8NG9SgaRHYzq08vLGN8EqB-b5u4VUsRRwz9thyJVyd40FECeScD8gkQQ6VXEPyfw`
+----------+--------+-------------------------+-------------+---------------------+------------+---------------------+--------+-------------+
| token_id | name   | created_at              | description | created_by_token_id | updated_at | updated_by_token_id | expiry | permissions |
+----------+--------+-------------------------+-------------+---------------------+------------+---------------------+--------+-------------+
| 1        | _admin | 2025-04-10T16:14:50.221 |             |                     |            |                     |        | *:*:*       |
+----------+--------+-------------------------+-------------+---------------------+------------+---------------------+--------+-------------+

```

- Without auth, following commands also return a 405

```
❯ cargo run -- create token --admin
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.23s
     Running `target/debug/influxdb3 create token --admin`
Failed to create token, error: ApiError { code: 405, message: "" }

❯ cargo run -- create token --admin --regenerate
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.21s
     Running `target/debug/influxdb3 create token --admin --regenerate`
Failed to create token, error: ApiError { code: 405, message: "" }

❯ cargo run -- delete token --token-name _admin
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.21s
     Running `target/debug/influxdb3 delete token --token-name _admin`
Are you sure you want to delete "_admin"? Enter 'yes' to confirm
yes
Delete command failed: server responded with error [405 Method Not Allowed]:

```

- All the system endpoints (`/health`, `/api/v1/health`, `/metrics`, `/ping`) require a token now
```
❯ curl -LI http://localhost:8181/health
HTTP/1.1 401 Unauthorized
date: Fri, 11 Apr 2025 15:21:17 GMT

influxdb on  praveen/enable-auth-by-default [$!?] is 📦 v3.0.0-beta.4 via 🦀 v1.85.0 on ☁️  (us-east-1)
❯ curl -LI http://localhost:8181/api/v1/health
HTTP/1.1 401 Unauthorized
date: Fri, 11 Apr 2025 15:24:39 GMT


influxdb on  praveen/enable-auth-by-default [$!?] is 📦 v3.0.0-beta.4 via 🦀 v1.85.0 on ☁️  (us-east-1)
❯ curl -LI http://localhost:8181/metrics
HTTP/1.1 401 Unauthorized
date: Fri, 11 Apr 2025 15:24:44 GMT


influxdb on  praveen/enable-auth-by-default [$!?] is 📦 v3.0.0-beta.4 via 🦀 v1.85.0 on ☁️  (us-east-1)
❯ curl -LI http://localhost:8181/ping
HTTP/1.1 401 Unauthorized
date: Fri, 11 Apr 2025 15:24:50 GMT


❯ curl -H "Authorization: Bearer apiv3_ParisF6RJ3_LKr7J8sPMJd8NG9SgaRHYzq08vLGN8EqB-b5u4VUsRRwz9thyJVyd40FECeScD8gkQQ6VXEPyfw" http://localhost:8181/health
OK

influxdb on  praveen/enable-auth-by-default [$!?] is 📦 v3.0.0-beta.4 via 🦀 v1.85.0 on ☁️  (us-east-1)
❯ curl -H "Authorization: Bearer apiv3_ParisF6RJ3_LKr7J8sPMJd8NG9SgaRHYzq08vLGN8EqB-b5u4VUsRRwz9thyJVyd40FECeScD8gkQQ6VXEPyfw" http://localhost:8181/ping
{"version":"3.0.0-beta.4","revision":"b472e14625"}

❯ curl -H "Authorization: Bearer apiv3_ParisF6RJ3_LKr7J8sPMJd8NG9SgaRHYzq08vLGN8EqB-b5u4VUsRRwz9thyJVyd40FECeScD8gkQQ6VXEPyfw" http://localhost:8181/api/v1/health
OK

❯ curl -H "Authorization: Bearer apiv3_ParisF6RJ3_LKr7J8sPMJd8NG9SgaRHYzq08vLGN8EqB-b5u4VUsRRwz9thyJVyd40FECeScD8gkQQ6VXEPyfw" http://localhost:8181/metrics
# HELP datafusion_mem_pool_bytes Number of bytes within the datafusion memory pool
# TYPE datafusion_mem_pool_bytes gauge


```