### PR TITLE
feat: catalog operation duration metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2890,6 +2890,7 @@ dependencies = [
  "influxdb3_wal",
  "insta",
  "iox_time",
+ "metric",
  "object_store",
  "observability_deps",
  "parking_lot",

--- a/influxdb3/src/commands/serve.rs
+++ b/influxdb3/src/commands/serve.rs
@@ -549,6 +549,7 @@ pub async fn command(config: Config) -> Result<()> {
         config.node_identifier_prefix.as_str(),
         Arc::clone(&object_store),
         Arc::<SystemProvider>::clone(&time_provider),
+        Arc::clone(&metrics),
         shutdown_manager.register(),
     )
     .await?;

--- a/influxdb3_cache/src/last_cache/mod.rs
+++ b/influxdb3_cache/src/last_cache/mod.rs
@@ -1180,6 +1180,7 @@ mod tests {
                 node_id,
                 Arc::clone(&obj_store) as _,
                 Arc::new(MockProvider::new(Time::from_timestamp_nanos(0))),
+                Default::default(),
             )
             .await
             .unwrap(),

--- a/influxdb3_cache/src/test_helpers.rs
+++ b/influxdb3_cache/src/test_helpers.rs
@@ -22,6 +22,7 @@ impl TestWriter {
                     "test-host",
                     Arc::new(InMemory::new()),
                     Arc::new(MockProvider::new(Time::from_timestamp_nanos(0))),
+                    Default::default(),
                 )
                 .await
                 .unwrap(),

--- a/influxdb3_catalog/Cargo.toml
+++ b/influxdb3_catalog/Cargo.toml
@@ -8,9 +8,10 @@ license.workspace = true
 [dependencies]
 # Core Crates
 influxdb-line-protocol.workspace = true
-observability_deps.workspace = true
-schema = { workspace = true }
 iox_time.workspace = true
+metric.workspace = true
+observability_deps.workspace = true
+schema.workspace = true
 
 # Local deps
 influxdb3_authz = { path = "../influxdb3_authz/" }

--- a/influxdb3_catalog/src/catalog/metrics.rs
+++ b/influxdb3_catalog/src/catalog/metrics.rs
@@ -1,0 +1,238 @@
+use std::{sync::Arc, time::Instant};
+
+use hashbrown::HashMap;
+use metric::{Attributes, DurationHistogram, Metric, Registry};
+use parking_lot::{MappedMutexGuard, Mutex, MutexGuard};
+
+pub(super) const CATALOG_OPERATIONS_DURATION: &str = "influxdb3_catalog_operations_duration";
+
+#[derive(Debug)]
+pub(super) struct CatalogMetrics {
+    metric_registry: Arc<Registry>,
+    /// Mutex'd map of the operation kind, e.g., "create_database", to the metrics for that operation
+    metrics: Mutex<HashMap<&'static str, Metrics>>,
+}
+
+impl CatalogMetrics {
+    pub(super) fn new(metric_registry: Arc<Registry>) -> Self {
+        Self {
+            metric_registry,
+            metrics: Default::default(),
+        }
+    }
+
+    pub(super) fn recorder(self: &Arc<Self>, operation: &'static str) -> MetricsRecorder {
+        MetricsRecorder {
+            metrics: Arc::clone(self),
+            start_instant: Instant::now(),
+            status: Default::default(),
+            operation,
+        }
+    }
+
+    fn metrics(&self, operation: &'static str) -> MappedMutexGuard<'_, Metrics> {
+        MutexGuard::map(self.metrics.lock(), |metrics| {
+            let (_, m) = metrics
+                .raw_entry_mut()
+                .from_key(&operation)
+                .or_insert_with(|| {
+                    let attributes = Attributes::from(&[("type", operation)]);
+                    (operation, Metrics::new(&self.metric_registry, attributes))
+                });
+            m
+        })
+    }
+}
+
+#[derive(Debug)]
+struct Metrics {
+    operations: OperationMetrics,
+}
+
+impl Metrics {
+    fn new(registry: &Registry, attributes: impl Into<Attributes>) -> Self {
+        let duration: Metric<DurationHistogram> = registry.register_metric(
+            CATALOG_OPERATIONS_DURATION,
+            "time taken to perform catalog operations",
+        );
+        let operations = OperationMetrics::new(&duration, attributes.into());
+        Self { operations }
+    }
+}
+
+#[derive(Debug)]
+struct OperationMetrics {
+    success: DurationHistogram,
+    bad_request: DurationHistogram,
+    persist_failure: DurationHistogram,
+    broadcast_failure: DurationHistogram,
+}
+
+impl OperationMetrics {
+    fn new(metric: &Metric<DurationHistogram>, mut attributes: Attributes) -> Self {
+        attributes.insert("status", "success");
+        let success = metric.recorder(attributes.clone());
+
+        attributes.insert("status", "persist_failure");
+        let persist_failure = metric.recorder(attributes.clone());
+
+        attributes.insert("status", "bad_request");
+        let bad_request = metric.recorder(attributes.clone());
+
+        attributes.insert("status", "broadcast_failure");
+        let broadcast_failure = metric.recorder(attributes.clone());
+
+        Self {
+            success,
+            bad_request,
+            persist_failure,
+            broadcast_failure,
+        }
+    }
+}
+
+#[derive(Debug, Default)]
+pub(super) enum OperationStatus {
+    #[default]
+    Success,
+    BadRequest,
+    PersistFailure,
+    BroadcastFailure,
+}
+
+#[derive(Debug)]
+pub(super) struct MetricsRecorder {
+    metrics: Arc<CatalogMetrics>,
+    start_instant: Instant,
+    status: Mutex<OperationStatus>,
+    operation: &'static str,
+}
+
+impl MetricsRecorder {
+    pub(super) fn set_status(&self, status: OperationStatus) {
+        *self.status.lock() = status;
+    }
+}
+
+impl Drop for MetricsRecorder {
+    fn drop(&mut self) {
+        let metrics = self.metrics.metrics(self.operation);
+        let duration = self.start_instant.elapsed();
+        match *self.status.lock() {
+            OperationStatus::Success => metrics.operations.success.record(duration),
+            OperationStatus::BadRequest => metrics.operations.bad_request.record(duration),
+            OperationStatus::PersistFailure => metrics.operations.persist_failure.record(duration),
+            OperationStatus::BroadcastFailure => {
+                metrics.operations.broadcast_failure.record(duration)
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use iox_time::{MockProvider, Time};
+    use metric::{Attributes, DurationHistogram, Metric, Registry};
+    use object_store::memory::InMemory;
+
+    use crate::{catalog::Catalog, log::FieldDataType};
+
+    use super::CATALOG_OPERATIONS_DURATION;
+
+    #[tokio::test]
+    async fn test_catalog_metrics() {
+        let metric_registry = Arc::new(Registry::new());
+        let catalog = Catalog::new(
+            "nog",
+            Arc::new(InMemory::new()),
+            Arc::new(MockProvider::new(Time::from_timestamp_nanos(0))),
+            Arc::clone(&metric_registry),
+        )
+        .await
+        .unwrap();
+
+        let durations_observer = metric_registry
+            .get_instrument::<Metric<DurationHistogram>>(CATALOG_OPERATIONS_DURATION)
+            .unwrap();
+
+        assert_eq!(
+            // 1 because of the _internal db:
+            1,
+            durations_observer
+                .get_observer(&Attributes::from(&[
+                    ("type", "create_database"),
+                    ("status", "success")
+                ]))
+                .unwrap()
+                .fetch()
+                .sample_count()
+        );
+
+        catalog.create_database("foo").await.unwrap();
+
+        assert_eq!(
+            2,
+            durations_observer
+                .get_observer(&Attributes::from(&[
+                    ("type", "create_database"),
+                    ("status", "success")
+                ]))
+                .unwrap()
+                .fetch()
+                .sample_count()
+        );
+
+        assert!(
+            durations_observer
+                .get_observer(&Attributes::from(&[
+                    ("type", "create_table"),
+                    ("status", "success")
+                ]))
+                .is_none()
+        );
+
+        catalog
+            .create_table("foo", "bar", &["t"], &[("f", FieldDataType::String)])
+            .await
+            .unwrap();
+
+        assert_eq!(
+            1,
+            durations_observer
+                .get_observer(&Attributes::from(&[
+                    ("type", "create_table"),
+                    ("status", "success")
+                ]))
+                .unwrap()
+                .fetch()
+                .sample_count()
+        );
+
+        // create a database that already exists, should fail:
+        assert_eq!(
+            0,
+            durations_observer
+                .get_observer(&Attributes::from(&[
+                    ("type", "create_database"),
+                    ("status", "bad_request")
+                ]))
+                .unwrap()
+                .fetch()
+                .sample_count()
+        );
+        catalog.create_database("foo").await.unwrap_err();
+        assert_eq!(
+            1,
+            durations_observer
+                .get_observer(&Attributes::from(&[
+                    ("type", "create_database"),
+                    ("status", "bad_request")
+                ]))
+                .unwrap()
+                .fetch()
+                .sample_count()
+        );
+    }
+}

--- a/influxdb3_processing_engine/src/lib.rs
+++ b/influxdb3_processing_engine/src/lib.rs
@@ -981,6 +981,7 @@ mod tests {
                 "test_host",
                 Arc::clone(&object_store),
                 Arc::clone(&time_provider),
+                Default::default(),
             )
             .await
             .unwrap(),

--- a/influxdb3_processing_engine/src/plugins.rs
+++ b/influxdb3_processing_engine/src/plugins.rs
@@ -1075,9 +1075,14 @@ mod tests {
             Arc::clone(&time_provider),
             Duration::from_secs(10),
         )));
-        let catalog = Catalog::new("foo", Arc::new(InMemory::new()), time_provider)
-            .await
-            .unwrap();
+        let catalog = Catalog::new(
+            "foo",
+            Arc::new(InMemory::new()),
+            time_provider,
+            Default::default(),
+        )
+        .await
+        .unwrap();
         let code = r#"
 def process_writes(influxdb3_local, table_batches, args=None):
     influxdb3_local.info("arg1: " + args["arg1"])
@@ -1174,9 +1179,14 @@ def process_writes(influxdb3_local, table_batches, args=None):
             Duration::from_secs(10),
         )));
         let catalog = Arc::new(
-            Catalog::new("foo", Arc::new(InMemory::new()), time_provider)
-                .await
-                .unwrap(),
+            Catalog::new(
+                "foo",
+                Arc::new(InMemory::new()),
+                time_provider,
+                Default::default(),
+            )
+            .await
+            .unwrap(),
         );
         let namespace = NamespaceName::new("foodb").unwrap();
         let validator =

--- a/influxdb3_server/src/lib.rs
+++ b/influxdb3_server/src/lib.rs
@@ -754,6 +754,7 @@ mod tests {
                 sample_node_id,
                 Arc::clone(&object_store),
                 Arc::clone(&time_provider) as _,
+                Default::default(),
             )
             .await
             .unwrap(),

--- a/influxdb3_server/src/query_executor/mod.rs
+++ b/influxdb3_server/src/query_executor/mod.rs
@@ -820,6 +820,7 @@ mod tests {
                 node_id,
                 Arc::clone(&object_store),
                 Arc::clone(&time_provider) as _,
+                Default::default(),
             )
             .await
             .unwrap(),

--- a/influxdb3_write/src/write_buffer/mod.rs
+++ b/influxdb3_write/src/write_buffer/mod.rs
@@ -693,7 +693,7 @@ mod tests {
         let obj_store = Arc::new(InMemory::new());
         let time_provider = Arc::new(MockProvider::new(Time::from_timestamp_nanos(0)));
         let catalog = Arc::new(
-            Catalog::new(node_id, obj_store, time_provider)
+            Catalog::new(node_id, obj_store, time_provider, Default::default())
                 .await
                 .unwrap(),
         );
@@ -740,7 +740,7 @@ mod tests {
         let obj_store = Arc::new(InMemory::new());
         let time_provider = Arc::new(MockProvider::new(Time::from_timestamp_nanos(0)));
         let catalog = Arc::new(
-            Catalog::new("test_host", obj_store, time_provider)
+            Catalog::new("test_host", obj_store, time_provider, Default::default())
                 .await
                 .unwrap(),
         );
@@ -854,6 +854,7 @@ mod tests {
                 "test_host",
                 catalog.object_store(),
                 Arc::clone(&time_provider),
+                Default::default(),
             )
             .await
             .unwrap(),
@@ -945,6 +946,7 @@ mod tests {
                     "test_host",
                     Arc::clone(&obj_store),
                     Arc::clone(&time_provider),
+                    Default::default(),
                 )
                 .await
                 .unwrap(),
@@ -1203,6 +1205,7 @@ mod tests {
                 "test_host",
                 Arc::clone(&obj_store) as _,
                 Arc::clone(&time_provider),
+                Default::default(),
             )
             .await
             .unwrap(),
@@ -3144,6 +3147,7 @@ mod tests {
                 "test_host",
                 Arc::clone(&object_store),
                 Arc::clone(&time_provider),
+                Default::default(),
             )
             .await
             .unwrap(),

--- a/influxdb3_write/src/write_buffer/queryable_buffer.rs
+++ b/influxdb3_write/src/write_buffer/queryable_buffer.rs
@@ -651,6 +651,7 @@ mod tests {
                 "hosta",
                 Arc::clone(&object_store),
                 Arc::clone(&time_provider) as _,
+                Default::default(),
             )
             .await
             .unwrap(),

--- a/influxdb3_write/src/write_buffer/table_buffer.rs
+++ b/influxdb3_write/src/write_buffer/table_buffer.rs
@@ -611,7 +611,7 @@ mod tests {
             let obj_store = Arc::new(InMemory::new());
             let time_provider = Arc::new(MockProvider::new(Time::from_timestamp_nanos(0)));
             let catalog = Arc::new(
-                Catalog::new("test-node", obj_store, time_provider)
+                Catalog::new("test-node", obj_store, time_provider, Default::default())
                     .await
                     .expect("should initialize catalog"),
             );

--- a/influxdb3_write/src/write_buffer/validator.rs
+++ b/influxdb3_write/src/write_buffer/validator.rs
@@ -410,7 +410,7 @@ mod tests {
         let time_provider = Arc::new(MockProvider::new(Time::from_timestamp_nanos(0)));
         let namespace = NamespaceName::new("test").unwrap();
         let catalog = Arc::new(
-            Catalog::new(node_id, obj_store, time_provider)
+            Catalog::new(node_id, obj_store, time_provider, Default::default())
                 .await
                 .unwrap(),
         );


### PR DESCRIPTION
Track per-operation duration metrics for operations against the catalog. These will add metrics like the following to the `/metrics` prometheus endpoint:
```
...
influxdb3_catalog_operations_duration_seconds_bucket{status="success",type="create_database",le="5"} 1
influxdb3_catalog_operations_duration_seconds_bucket{status="success",type="create_database",le="10"} 1
influxdb3_catalog_operations_duration_seconds_bucket{status="success",type="create_database",le="inf"} 1
influxdb3_catalog_operations_duration_seconds_sum{status="success",type="create_database"} 0.000622208
influxdb3_catalog_operations_duration_seconds_count{status="success",type="create_database"} 1
```

The metrics track a `status`, which can be one of: `success`, `bad_request`, `permit_failure`, or `broadcast_failure`. These correspond to the success/failure modes of a catalog operation.

Added a test to check that metrics are tracked.

Part of #26225
