### PR TITLE
fix(install_influxdb.sh): use 'shasum -a 256' on OSX

### DIFF
--- a/install_influxdb.sh
+++ b/install_influxdb.sh
@@ -149,8 +149,15 @@ if [ -z "$dl_sha" ]; then
     printf "Could not find properly formatted SHA256 in '%s/influxdb3-${EDITION_TAG}.tar.gz.sha256'. Aborting.\n" "$INSTALL_LOC"
     exit 1
 fi
-printf "└─${DIM} sha256sum '%s/influxdb3-${EDITION_TAG}.tar.gz'" "$INSTALL_LOC"
-ch_sha=$(sha256sum "$INSTALL_LOC/influxdb3-${EDITION_TAG}.tar.gz" | cut -d ' ' -f 1)
+
+ch_sha=
+if [ "${OS}" = "Darwin" ]; then
+    printf "└─${DIM} shasum -a 256 '%s/influxdb3-${EDITION_TAG}.tar.gz'" "$INSTALL_LOC"
+    ch_sha=$(shasum -a 256 "$INSTALL_LOC/influxdb3-${EDITION_TAG}.tar.gz" | cut -d ' ' -f 1)
+else
+    printf "└─${DIM} sha256sum '%s/influxdb3-${EDITION_TAG}.tar.gz'" "$INSTALL_LOC"
+    ch_sha=$(sha256sum "$INSTALL_LOC/influxdb3-${EDITION_TAG}.tar.gz" | cut -d ' ' -f 1)
+fi
 if [ "$ch_sha" = "$dl_sha" ]; then
     printf " (OK: %s = %s)${NC}\n" "$ch_sha" "$dl_sha"
 else


### PR DESCRIPTION
sha256sum is present on some versions of OSX, but not all. Use 'shasum -a 256' on OSX since it should always be present.