### PR TITLE
feat: allow token deletes

### DIFF
--- a/influxdb3_catalog/src/catalog.rs
+++ b/influxdb3_catalog/src/catalog.rs
@@ -833,6 +833,11 @@ impl InnerCatalog {
                     )?;
                     true
                 }
+                TokenCatalogOp::DeleteToken(delete_token_details) => {
+                    self.tokens
+                        .delete_token(delete_token_details.token_name.to_owned())?;
+                    true
+                }
             };
         }
 
@@ -1803,6 +1808,16 @@ impl TokenRepository {
         updatable.updated_by = Some(token_id);
         self.repo.update(token_id, token_info)?;
         self.hash_lookup_map.insert(token_id, hash);
+        Ok(())
+    }
+
+    pub(crate) fn delete_token(&mut self, token_name: String) -> Result<()> {
+        let token_id = self
+            .repo
+            .name_to_id(&token_name)
+            .ok_or_else(|| CatalogError::NotFound)?;
+        self.repo.remove(&token_id);
+        self.hash_lookup_map.remove_by_left(&token_id);
         Ok(())
     }
 }

--- a/influxdb3_catalog/src/log/versions/v2.rs
+++ b/influxdb3_catalog/src/log/versions/v2.rs
@@ -813,6 +813,7 @@ pub struct TokenBatch {
 pub enum TokenCatalogOp {
     CreateAdminToken(CreateAdminTokenDetails),
     RegenerateAdminToken(RegenerateAdminTokenDetails),
+    DeleteToken(DeleteTokenDetails),
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
@@ -830,4 +831,9 @@ pub struct RegenerateAdminTokenDetails {
     pub token_id: TokenId,
     pub hash: Vec<u8>,
     pub updated_at: i64,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub struct DeleteTokenDetails {
+    pub token_name: String,
 }

--- a/influxdb3_client/src/lib.rs
+++ b/influxdb3_client/src/lib.rs
@@ -669,6 +669,25 @@ impl Client {
         response_json
     }
 
+    /// Delete token `DELETE /api/v3/configure/token?token_name=foo` API
+    pub async fn api_v3_configure_token_delete(
+        &self,
+        token_name: impl AsRef<str> + Send,
+    ) -> Result<()> {
+        let _bytes = self
+            .send_json_get_bytes(
+                Method::DELETE,
+                "/api/v3/configure/token",
+                None::<()>,
+                Some(TokenDeleteRequest {
+                    token_name: token_name.as_ref().to_owned(),
+                }),
+                None,
+            )
+            .await?;
+        Ok(())
+    }
+
     /// Serialize the given `B` to json then send the request and return the resulting bytes.
     async fn send_json_get_bytes<B, Q>(
         &self,

--- a/influxdb3_server/src/all_paths.rs
+++ b/influxdb3_server/src/all_paths.rs
@@ -23,6 +23,7 @@ pub(crate) const API_V3_CONFIGURE_DATABASE: &str = "/api/v3/configure/database";
 pub(crate) const API_V3_CONFIGURE_TABLE: &str = "/api/v3/configure/table";
 pub(crate) const API_METRICS: &str = "/metrics";
 pub(crate) const API_PING: &str = "/ping";
+pub(crate) const API_V3_CONFIGURE_TOKEN: &str = "/api/v3/configure/token";
 pub(crate) const API_V3_CONFIGURE_ADMIN_TOKEN: &str = "/api/v3/configure/token/admin";
 pub(crate) const API_V3_CONFIGURE_ADMIN_TOKEN_REGENERATE: &str =
     "/api/v3/configure/token/admin/regenerate";

--- a/influxdb3_types/src/http.rs
+++ b/influxdb3_types/src/http.rs
@@ -357,7 +357,7 @@ impl From<iox_http::write::WriteParams> for WriteParams {
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct CreateTokenWithPermissionsResponse {
-    id: u64,
+    pub id: u64,
     name: Arc<str>,
     pub token: Arc<str>,
     pub hash: Arc<str>,
@@ -379,4 +379,9 @@ impl CreateTokenWithPermissionsResponse {
             expiry,
         })
     }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct TokenDeleteRequest {
+    pub token_name: String,
 }


### PR DESCRIPTION
This commit allows deletion of tokens by name. Below is an example,

`influxdb3 delete token --token-name _admin --token $CURRENT_ADMIN_TOKEN`

It needs user confirmation before proceeding with the delete

Tests:

- Show tokens
```
❯ cargo run -- show tokens  --token apiv3__qE6zywPt1voBTbT5HVAFCxtHALe0PgWnhmPL3FdP4QEHdwqD6TfQaYhFUnLNpa_5k6B4T8jYxj5cInmASvUbw
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.24s
     Running `target/debug/influxdb3 show tokens --token apiv3__qE6zywPt1voBTbT5HVAFCxtHALe0PgWnhmPL3FdP4QEHdwqD6TfQaYhFUnLNpa_5k6B4T8jYxj5cInmASvUbw`
+----------+--------+----------------------------------------------------------------------------------------------------------------------------------+-------------------------+-------------+---------------------+------------+---------------------+--------+-------------+
| token_id | name   | hash                                                                                                                             | created_at              | description | created_by_token_id | updated_at | updated_by_token_id | expiry | permissions |
+----------+--------+----------------------------------------------------------------------------------------------------------------------------------+-------------------------+-------------+---------------------+------------+---------------------+--------+-------------+
| 0        | _admin | 8cb63fbdb6ba88e126d06ae023f04226f3229bc40ee12bc938f4df56e94600fdfb6d5c5752915793b56116ab17bfdb7d4eaee0f6b7974af6b30b35f0ab93ceb5 | 2025-04-10T16:06:51.408 |             |                     |            |                     |        | *:*:*       |
+----------+--------+----------------------------------------------------------------------------------------------------------------------------------+-------------------------+-------------+---------------------+------------+---------------------+--------+-------------+

```

- Delete token
```
❯ cargo run -- delete token --token-name _admin --token apiv3__qE6zywPt1voBTbT5HVAFCxtHALe0PgWnhmPL3FdP4QEHdwqD6TfQaYhFUnLNpa_5k6B4T8jYxj5cInmASvUbw
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.21s
     Running `target/debug/influxdb3 delete token --token-name _admin --token apiv3__qE6zywPt1voBTbT5HVAFCxtHALe0PgWnhmPL3FdP4QEHdwqD6TfQaYhFUnLNpa_5k6B4T8jYxj5cInmASvUbw`
Are you sure you want to delete "_admin"? Enter 'yes' to confirm
yes
Token "_admin" deleted successfully
```

- Create `_admin` token again
```
❯ cargo run -- create token --admin
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.21s
     Running `target/debug/influxdb3 create token --admin`
Token: apiv3_ParisF6RJ3_LKr7J8sPMJd8NG9SgaRHYzq08vLGN8EqB-b5u4VUsRRwz9thyJVyd40FECeScD8gkQQ6VXEPyfw
Hashed Token: ee2be8bee93497bf6b2e4fda382fcb993e1891b7aea761ba89fb5cc4b2b3484a3e89cf898eed1ef2b61a220d30ac69897ead36f77824d0b420973a5e6d165d77

Start the server with the Hashed Token provided as the `--bearer-token` argument:


                        `influxdb3 serve --bearer-token ee2be8bee93497bf6b2e4fda382fcb993e1891b7aea761ba89fb5cc4b2b3484a3e89cf898eed1ef2b61a220d30ac69897ead36f77824d0b420973a5e6d165d77 --node-id <NODE_ID> [OPTIONS]`

HTTP requests require the following header: "Authorization: Bearer apiv3_ParisF6RJ3_LKr7J8sPMJd8NG9SgaRHYzq08vLGN8EqB-b5u4VUsRRwz9thyJVyd40FECeScD8gkQQ6VXEPyfw"
This will grant you access to every HTTP endpoint or deny it otherwise.

```

- Show tokens (confirm token id has changed)

```
❯ cargo run -- show tokens  --token apiv3_ParisF6RJ3_LKr7J8sPMJd8NG9SgaRHYzq08vLGN8EqB-b5u4VUsRRwz9thyJVyd40FECeScD8gkQQ6VXEPyfw
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.21s
     Running `target/debug/influxdb3 show tokens --token apiv3_ParisF6RJ3_LKr7J8sPMJd8NG9SgaRHYzq08vLGN8EqB-b5u4VUsRRwz9thyJVyd40FECeScD8gkQQ6VXEPyfw`
+----------+--------+----------------------------------------------------------------------------------------------------------------------------------+-------------------------+-------------+---------------------+------------+---------------------+--------+-------------+
| token_id | name   | hash                                                                                                                             | created_at              | description | created_by_token_id | updated_at | updated_by_token_id | expiry | permissions |
+----------+--------+----------------------------------------------------------------------------------------------------------------------------------+-------------------------+-------------+---------------------+------------+---------------------+--------+-------------+
| 1        | _admin | ee2be8bee93497bf6b2e4fda382fcb993e1891b7aea761ba89fb5cc4b2b3484a3e89cf898eed1ef2b61a220d30ac69897ead36f77824d0b420973a5e6d165d77 | 2025-04-10T16:14:50.221 |             |                     |            |                     |        | *:*:*       |
+----------+--------+----------------------------------------------------------------------------------------------------------------------------------+-------------------------+-------------+---------------------+------------+---------------------+--------+-------------+

```