### PR TITLE
feat: limit tag columns per table to 250

### DIFF
--- a/influxdb3_catalog/src/error.rs
+++ b/influxdb3_catalog/src/error.rs
@@ -51,6 +51,12 @@ pub enum CatalogError {
     TooManyColumns,
 
     #[error(
+        "Update to schema would exceed number of tag columns per table limit of {} columns",
+        Catalog::NUM_TAG_COLUMNS_LIMIT
+    )]
+    TooManyTagColumns,
+
+    #[error(
         "Update to schema would exceed number of tables limit of {} tables",
         Catalog::NUM_TABLES_LIMIT
     )]


### PR DESCRIPTION
Adding this limit to ensure future compatibility with planned storage updates. I don't expect that any existing users would hit this as the system would very likely fall over if they have even close to this number of tags.