### PR TITLE
refactor: remove Option from catalog update APIs

### DIFF
--- a/influxdb3_catalog/src/catalog/update.rs
+++ b/influxdb3_catalog/src/catalog/update.rs
@@ -97,7 +97,7 @@ impl Catalog {
         node_id: &str,
         core_count: u64,
         mode: Vec<NodeMode>,
-    ) -> Result<Option<OrderedCatalogBatch>> {
+    ) -> Result<OrderedCatalogBatch> {
         info!(node_id, core_count, mode = ?mode, "register node");
         self.catalog_update_with_retry(|| {
             let time_ns = self.time_provider.now().timestamp_nanos();
@@ -155,10 +155,7 @@ impl Catalog {
         .await
     }
 
-    pub async fn update_node_state_stopped(
-        &self,
-        node_id: &str,
-    ) -> Result<Option<OrderedCatalogBatch>> {
+    pub async fn update_node_state_stopped(&self, node_id: &str) -> Result<OrderedCatalogBatch> {
         info!(node_id, "updating node state to Stopped in catalog");
         self.catalog_update_with_retry(|| {
             let time_ns = self.time_provider.now().timestamp_nanos();
@@ -178,7 +175,7 @@ impl Catalog {
         .await
     }
 
-    pub async fn create_database(&self, name: &str) -> Result<Option<OrderedCatalogBatch>> {
+    pub async fn create_database(&self, name: &str) -> Result<OrderedCatalogBatch> {
         info!(name, "create database");
         self.catalog_update_with_retry(|| {
             let (_, Some(batch)) =
@@ -191,7 +188,7 @@ impl Catalog {
         .await
     }
 
-    pub async fn soft_delete_database(&self, name: &str) -> Result<Option<OrderedCatalogBatch>> {
+    pub async fn soft_delete_database(&self, name: &str) -> Result<OrderedCatalogBatch> {
         info!(name, "soft delete database");
         self.catalog_update_with_retry(|| {
             let Some(db) = self.db_schema(name) else {
@@ -224,7 +221,7 @@ impl Catalog {
         table_name: &str,
         tags: &[impl AsRef<str> + Send + Sync],
         fields: &[(impl AsRef<str> + Send + Sync, FieldDataType)],
-    ) -> Result<Option<OrderedCatalogBatch>> {
+    ) -> Result<OrderedCatalogBatch> {
         info!(db_name, table_name, "create table");
         self.catalog_update_with_retry(|| {
             let mut txn = self.begin(db_name)?;
@@ -238,7 +235,7 @@ impl Catalog {
         &self,
         db_name: &str,
         table_name: &str,
-    ) -> Result<Option<OrderedCatalogBatch>> {
+    ) -> Result<OrderedCatalogBatch> {
         info!(db_name, table_name, "soft delete database");
         self.catalog_update_with_retry(|| {
             let Some(db) = self.db_schema(db_name) else {
@@ -272,7 +269,7 @@ impl Catalog {
         columns: &[impl AsRef<str> + Send + Sync],
         max_cardinality: MaxCardinality,
         max_age_seconds: MaxAge,
-    ) -> Result<Option<OrderedCatalogBatch>> {
+    ) -> Result<OrderedCatalogBatch> {
         info!(db_name, table_name, cache_name = ?cache_name, "create distinct cache");
         self.catalog_update_with_retry(|| {
             let Some(db) = self.db_schema(db_name) else {
@@ -352,7 +349,7 @@ impl Catalog {
         db_name: &str,
         table_name: &str,
         cache_name: &str,
-    ) -> Result<Option<OrderedCatalogBatch>> {
+    ) -> Result<OrderedCatalogBatch> {
         info!(db_name, table_name, cache_name, "delete distinct cache");
         self.catalog_update_with_retry(|| {
             let Some(db) = self.db_schema(db_name) else {
@@ -391,7 +388,7 @@ impl Catalog {
         value_columns: Option<&[impl AsRef<str> + Send + Sync]>,
         count: LastCacheSize,
         ttl: LastCacheTtl,
-    ) -> Result<Option<OrderedCatalogBatch>> {
+    ) -> Result<OrderedCatalogBatch> {
         info!(db_name, table_name, cache_name = ?cache_name, "create last cache");
         self.catalog_update_with_retry(|| {
             let Some(db) = self.db_schema(db_name) else {
@@ -505,7 +502,7 @@ impl Catalog {
         db_name: &str,
         table_name: &str,
         cache_name: &str,
-    ) -> Result<Option<OrderedCatalogBatch>> {
+    ) -> Result<OrderedCatalogBatch> {
         info!(db_name, table_name, cache_name, "delete last cache");
         self.catalog_update_with_retry(|| {
             let Some(db) = self.db_schema(db_name) else {
@@ -544,7 +541,7 @@ impl Catalog {
         trigger_settings: TriggerSettings,
         trigger_arguments: &Option<HashMap<String, String>>,
         disabled: bool,
-    ) -> Result<Option<OrderedCatalogBatch>> {
+    ) -> Result<OrderedCatalogBatch> {
         info!(db_name, trigger_name, "create processing engine trigger");
         self.catalog_update_with_retry(|| {
             let Some(mut db) = self.db_schema(db_name) else {
@@ -582,7 +579,7 @@ impl Catalog {
         db_name: &str,
         trigger_name: &str,
         force: bool,
-    ) -> Result<Option<OrderedCatalogBatch>> {
+    ) -> Result<OrderedCatalogBatch> {
         info!(db_name, trigger_name, "delete processing engine trigger");
         self.catalog_update_with_retry(|| {
             let Some(db) = self.db_schema(db_name) else {
@@ -614,7 +611,7 @@ impl Catalog {
         &self,
         db_name: &str,
         trigger_name: &str,
-    ) -> Result<Option<OrderedCatalogBatch>> {
+    ) -> Result<OrderedCatalogBatch> {
         info!(db_name, trigger_name, "enable processing engine trigger");
         self.catalog_update_with_retry(|| {
             let Some(db) = self.db_schema(db_name) else {
@@ -645,7 +642,7 @@ impl Catalog {
         &self,
         db_name: &str,
         trigger_name: &str,
-    ) -> Result<Option<OrderedCatalogBatch>> {
+    ) -> Result<OrderedCatalogBatch> {
         info!(db_name, trigger_name, "disable processing engine trigger");
         self.catalog_update_with_retry(|| {
             let Some(db) = self.db_schema(db_name) else {
@@ -672,7 +669,7 @@ impl Catalog {
         .await
     }
 
-    pub async fn delete_token(&self, token_name: &str) -> Result<Option<OrderedCatalogBatch>> {
+    pub async fn delete_token(&self, token_name: &str) -> Result<OrderedCatalogBatch> {
         info!(token_name, "delete token");
         self.catalog_update_with_retry(|| {
             if !self.inner.read().tokens.repo().contains_name(token_name) {
@@ -693,7 +690,7 @@ impl Catalog {
     pub(crate) async fn catalog_update_with_retry<F>(
         &self,
         batch_creator_fn: F,
-    ) -> Result<Option<OrderedCatalogBatch>>
+    ) -> Result<OrderedCatalogBatch>
     where
         F: Fn() -> Result<CatalogBatch>,
     {
@@ -719,7 +716,7 @@ impl Catalog {
                             self.background_checkpoint(&ordered_batch);
                             self.broadcast_update(ordered_batch.clone().into_batch())
                                 .await?;
-                            return Ok(Some(ordered_batch));
+                            return Ok(ordered_batch);
                         }
                     }
                 }

--- a/influxdb3_server/src/http.rs
+++ b/influxdb3_server/src/http.rs
@@ -903,13 +903,9 @@ impl HttpApi {
             )
             .await
         {
-            Ok(Some(batch)) => Response::builder()
+            Ok(batch) => Response::builder()
                 .status(StatusCode::CREATED)
                 .body(Body::from(serde_json::to_vec(&batch)?))
-                .map_err(Into::into),
-            Ok(None) => Response::builder()
-                .status(StatusCode::NO_CONTENT)
-                .body(Body::empty())
                 .map_err(Into::into),
             Err(error) => Err(error.into()),
         }
@@ -961,13 +957,9 @@ impl HttpApi {
             )
             .await
         {
-            Ok(Some(batch)) => Response::builder()
+            Ok(batch) => Response::builder()
                 .status(StatusCode::CREATED)
                 .body(Body::from(serde_json::to_vec(&batch)?))
-                .map_err(Into::into),
-            Ok(None) => Response::builder()
-                .status(StatusCode::NO_CONTENT)
-                .body(Body::empty())
                 .map_err(Into::into),
             Err(error) => Err(error.into()),
         }


### PR DESCRIPTION
Catalog update APIs were returning an `Option` that was not necessary. It was always `Some`, so this removes the `Option` from the API to make the intent clear - if there is an update made by the requested change, the result is `Ok(OrderedCatalogBatch)`; whereas if the requested change is erroneous, or would not produce a change, the response is `Err(...)`.

No issue.
