### PR TITLE
feat: catalog metrics retry counter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2908,6 +2908,7 @@ dependencies = [
  "influxdb3_wal",
  "insta",
  "iox_time",
+ "metric",
  "object_store",
  "observability_deps",
  "parking_lot",

--- a/influxdb3/src/commands/serve.rs
+++ b/influxdb3/src/commands/serve.rs
@@ -566,6 +566,7 @@ pub async fn command(config: Config) -> Result<()> {
         config.node_identifier_prefix.as_str(),
         Arc::clone(&object_store),
         Arc::<SystemProvider>::clone(&time_provider),
+        Arc::clone(&metrics),
         shutdown_manager.register(),
     )
     .await?;

--- a/influxdb3_cache/src/last_cache/mod.rs
+++ b/influxdb3_cache/src/last_cache/mod.rs
@@ -1180,6 +1180,7 @@ mod tests {
                 node_id,
                 Arc::clone(&obj_store) as _,
                 Arc::new(MockProvider::new(Time::from_timestamp_nanos(0))),
+                Default::default(),
             )
             .await
             .unwrap(),

--- a/influxdb3_cache/src/test_helpers.rs
+++ b/influxdb3_cache/src/test_helpers.rs
@@ -22,6 +22,7 @@ impl TestWriter {
                     "test-host",
                     Arc::new(InMemory::new()),
                     Arc::new(MockProvider::new(Time::from_timestamp_nanos(0))),
+                    Default::default(),
                 )
                 .await
                 .unwrap(),

--- a/influxdb3_catalog/Cargo.toml
+++ b/influxdb3_catalog/Cargo.toml
@@ -8,9 +8,10 @@ license.workspace = true
 [dependencies]
 # Core Crates
 influxdb-line-protocol.workspace = true
-observability_deps.workspace = true
-schema = { workspace = true }
 iox_time.workspace = true
+metric.workspace = true
+observability_deps.workspace = true
+schema.workspace = true
 
 # Local deps
 influxdb3_authz = { path = "../influxdb3_authz/" }

--- a/influxdb3_catalog/src/catalog/metrics.rs
+++ b/influxdb3_catalog/src/catalog/metrics.rs
@@ -1,0 +1,95 @@
+use std::sync::Arc;
+
+use metric::{Metric, Registry, U64Counter};
+
+pub(super) const CATALOG_OPERATION_RETRIES_METRIC_NAME: &str =
+    "influxdb3_catalog_operation_retries";
+const CATALOG_OPERATION_RETRIES_METRIC_DESCRIPTION: &str =
+    "catalog updates that had to be retried because the catalog was updated elsewhere";
+
+#[derive(Debug)]
+pub(super) struct CatalogMetrics {
+    pub(super) catalog_operation_retries: U64Counter,
+}
+
+impl CatalogMetrics {
+    pub(super) fn new(metric_registry: &Arc<Registry>) -> Self {
+        let retries: Metric<U64Counter> = metric_registry.register_metric(
+            CATALOG_OPERATION_RETRIES_METRIC_NAME,
+            CATALOG_OPERATION_RETRIES_METRIC_DESCRIPTION,
+        );
+        let catalog_operation_retries = retries.recorder([]);
+        Self {
+            catalog_operation_retries,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use iox_time::{MockProvider, Time};
+    use metric::{Attributes, Metric, Registry, U64Counter};
+    use object_store::memory::InMemory;
+
+    use crate::catalog::Catalog;
+
+    use super::CATALOG_OPERATION_RETRIES_METRIC_NAME;
+
+    #[tokio::test]
+    async fn test_catalog_retry_metrics() {
+        let os = Arc::new(InMemory::new());
+        let tp = Arc::new(MockProvider::new(Time::from_timestamp_nanos(0)));
+
+        // create two catalogs, both pointing at the same object store, but with their own metric
+        // registry/instrument/observer
+
+        // first:
+        let m1 = Arc::new(Registry::new());
+        let c1 = Catalog::new(
+            "node",
+            Arc::clone(&os) as _,
+            Arc::clone(&tp) as _,
+            Arc::clone(&m1),
+        )
+        .await
+        .unwrap();
+        let i1 = m1
+            .get_instrument::<Metric<U64Counter>>(CATALOG_OPERATION_RETRIES_METRIC_NAME)
+            .unwrap();
+        let o1 = i1.get_observer(&Attributes::from([])).unwrap();
+
+        // second:
+        let m2 = Arc::new(Registry::new());
+        let c2 = Catalog::new(
+            "node",
+            Arc::clone(&os) as _,
+            Arc::clone(&tp) as _,
+            Arc::clone(&m2),
+        )
+        .await
+        .unwrap();
+        let i2 = m2
+            .get_instrument::<Metric<U64Counter>>(CATALOG_OPERATION_RETRIES_METRIC_NAME)
+            .unwrap();
+        let o2 = i2.get_observer(&Attributes::from([])).unwrap();
+
+        // create db on 1, should not require any retries:
+        assert_eq!(0, o1.fetch());
+        c1.create_database("foo").await.unwrap();
+        assert_eq!(0, o1.fetch());
+
+        // create a different db on 2, this will require a retry since the catalog was updated
+        // previously on object store, and will succeed...
+        assert_eq!(0, o2.fetch());
+        c2.create_database("bar").await.unwrap();
+        assert_eq!(1, o2.fetch());
+
+        // create the "bar" db on 1 now, this will require a retry since the catalog was updated on
+        // object store by 2, but will fail...
+        assert_eq!(0, o1.fetch());
+        c1.create_database("bar").await.unwrap_err();
+        assert_eq!(1, o1.fetch());
+    }
+}

--- a/influxdb3_processing_engine/src/lib.rs
+++ b/influxdb3_processing_engine/src/lib.rs
@@ -981,6 +981,7 @@ mod tests {
                 "test_host",
                 Arc::clone(&object_store),
                 Arc::clone(&time_provider),
+                Default::default(),
             )
             .await
             .unwrap(),

--- a/influxdb3_processing_engine/src/plugins.rs
+++ b/influxdb3_processing_engine/src/plugins.rs
@@ -1075,9 +1075,14 @@ mod tests {
             Arc::clone(&time_provider),
             Duration::from_secs(10),
         )));
-        let catalog = Catalog::new("foo", Arc::new(InMemory::new()), time_provider)
-            .await
-            .unwrap();
+        let catalog = Catalog::new(
+            "foo",
+            Arc::new(InMemory::new()),
+            time_provider,
+            Default::default(),
+        )
+        .await
+        .unwrap();
         let code = r#"
 def process_writes(influxdb3_local, table_batches, args=None):
     influxdb3_local.info("arg1: " + args["arg1"])
@@ -1174,9 +1179,14 @@ def process_writes(influxdb3_local, table_batches, args=None):
             Duration::from_secs(10),
         )));
         let catalog = Arc::new(
-            Catalog::new("foo", Arc::new(InMemory::new()), time_provider)
-                .await
-                .unwrap(),
+            Catalog::new(
+                "foo",
+                Arc::new(InMemory::new()),
+                time_provider,
+                Default::default(),
+            )
+            .await
+            .unwrap(),
         );
         let namespace = NamespaceName::new("foodb").unwrap();
         let validator =

--- a/influxdb3_server/src/lib.rs
+++ b/influxdb3_server/src/lib.rs
@@ -813,6 +813,7 @@ mod tests {
                 sample_node_id,
                 Arc::clone(&object_store),
                 Arc::clone(&time_provider) as _,
+                Default::default(),
             )
             .await
             .unwrap(),

--- a/influxdb3_server/src/query_executor/mod.rs
+++ b/influxdb3_server/src/query_executor/mod.rs
@@ -825,6 +825,7 @@ mod tests {
                 node_id,
                 Arc::clone(&object_store),
                 Arc::clone(&time_provider) as _,
+                Default::default(),
             )
             .await
             .unwrap(),

--- a/influxdb3_write/src/write_buffer/mod.rs
+++ b/influxdb3_write/src/write_buffer/mod.rs
@@ -693,7 +693,7 @@ mod tests {
         let obj_store = Arc::new(InMemory::new());
         let time_provider = Arc::new(MockProvider::new(Time::from_timestamp_nanos(0)));
         let catalog = Arc::new(
-            Catalog::new(node_id, obj_store, time_provider)
+            Catalog::new(node_id, obj_store, time_provider, Default::default())
                 .await
                 .unwrap(),
         );
@@ -740,7 +740,7 @@ mod tests {
         let obj_store = Arc::new(InMemory::new());
         let time_provider = Arc::new(MockProvider::new(Time::from_timestamp_nanos(0)));
         let catalog = Arc::new(
-            Catalog::new("test_host", obj_store, time_provider)
+            Catalog::new("test_host", obj_store, time_provider, Default::default())
                 .await
                 .unwrap(),
         );
@@ -854,6 +854,7 @@ mod tests {
                 "test_host",
                 catalog.object_store(),
                 Arc::clone(&time_provider),
+                Default::default(),
             )
             .await
             .unwrap(),
@@ -945,6 +946,7 @@ mod tests {
                     "test_host",
                     Arc::clone(&obj_store),
                     Arc::clone(&time_provider),
+                    Default::default(),
                 )
                 .await
                 .unwrap(),
@@ -1203,6 +1205,7 @@ mod tests {
                 "test_host",
                 Arc::clone(&obj_store) as _,
                 Arc::clone(&time_provider),
+                Default::default(),
             )
             .await
             .unwrap(),
@@ -3144,6 +3147,7 @@ mod tests {
                 "test_host",
                 Arc::clone(&object_store),
                 Arc::clone(&time_provider),
+                Default::default(),
             )
             .await
             .unwrap(),

--- a/influxdb3_write/src/write_buffer/queryable_buffer.rs
+++ b/influxdb3_write/src/write_buffer/queryable_buffer.rs
@@ -651,6 +651,7 @@ mod tests {
                 "hosta",
                 Arc::clone(&object_store),
                 Arc::clone(&time_provider) as _,
+                Default::default(),
             )
             .await
             .unwrap(),

--- a/influxdb3_write/src/write_buffer/table_buffer.rs
+++ b/influxdb3_write/src/write_buffer/table_buffer.rs
@@ -611,7 +611,7 @@ mod tests {
             let obj_store = Arc::new(InMemory::new());
             let time_provider = Arc::new(MockProvider::new(Time::from_timestamp_nanos(0)));
             let catalog = Arc::new(
-                Catalog::new("test-node", obj_store, time_provider)
+                Catalog::new("test-node", obj_store, time_provider, Default::default())
                     .await
                     .expect("should initialize catalog"),
             );

--- a/influxdb3_write/src/write_buffer/validator.rs
+++ b/influxdb3_write/src/write_buffer/validator.rs
@@ -410,7 +410,7 @@ mod tests {
         let time_provider = Arc::new(MockProvider::new(Time::from_timestamp_nanos(0)));
         let namespace = NamespaceName::new("test").unwrap();
         let catalog = Arc::new(
-            Catalog::new(node_id, obj_store, time_provider)
+            Catalog::new(node_id, obj_store, time_provider, Default::default())
                 .await
                 .unwrap(),
         );


### PR DESCRIPTION
Part of #26225

Adds a metric for tracking the number of times a catalog update needed to be retried if the catalog was updated by another HTTP request or process.

The metric is included in the `/metrics` API output:
```
# HELP influxdb3_catalog_operation_retries_total catalog updates that had to be retried because the catalog was updated elsewhere
# TYPE influxdb3_catalog_operation_retries_total counter
influxdb3_catalog_operation_retries_total 0
```