### PR TITLE
feat: improve dropped point logging

### DIFF
--- a/coordinator/points_writer.go
+++ b/coordinator/points_writer.go
@@ -126,7 +126,7 @@ type DroppedPoint struct {
 }
 
 func (d *DroppedPoint) String() string {
-	return fmt.Sprintf("point %s at %s dropped because it violates a %s at %s", d.Point.Key(), d.Point.Time(), d.Reason.String(), d.ViolatedBound)
+	return fmt.Sprintf("point %s at %s dropped because it violates a %s at %s", d.Point.Key(), d.Point.Time().UTC().Format(time.RFC3339Nano), d.Reason.String(), d.ViolatedBound.UTC().Format(time.RFC3339Nano))
 }
 
 // ShardMapping contains a mapping of shards to points.

--- a/coordinator/points_writer.go
+++ b/coordinator/points_writer.go
@@ -95,12 +95,48 @@ func NewPointsWriter() *PointsWriter {
 	}
 }
 
+type BoundType int
+
+const (
+	WithinBounds BoundType = iota
+	RetentionPolicyBound
+	WriteWindowUpperBound
+	WriteWindowLowerBound
+)
+
+func (b BoundType) String() string {
+	switch b {
+	case RetentionPolicyBound:
+		return "Retention Policy Lower Bound"
+	case WriteWindowUpperBound:
+		return "Write Window Upper Bound"
+	case WriteWindowLowerBound:
+		return "Write Window Lower Bound"
+	case WithinBounds:
+		return "Within Bounds"
+	default:
+		return "Unknown"
+	}
+}
+
+type DroppedPoint struct {
+	Point         models.Point
+	ViolatedBound time.Time
+	Reason        BoundType
+}
+
+func (d *DroppedPoint) String() string {
+	return fmt.Sprintf("point %s at %s dropped because it violates a %s at %s", d.Point.Key(), d.Point.Time(), d.Reason.String(), d.ViolatedBound)
+}
+
 // ShardMapping contains a mapping of shards to points.
 type ShardMapping struct {
-	n       int
-	Points  map[uint64][]models.Point  // The points associated with a shard ID
-	Shards  map[uint64]*meta.ShardInfo // The shards that have been mapped, keyed by shard ID
-	Dropped []models.Point             // Points that were dropped
+	n            int
+	Points       map[uint64][]models.Point  // The points associated with a shard ID
+	Shards       map[uint64]*meta.ShardInfo // The shards that have been mapped, keyed by shard ID
+	MaxDropped   DroppedPoint
+	MinDropped   DroppedPoint
+	CountDropped int
 }
 
 // NewShardMapping creates an empty ShardMapping.
@@ -110,6 +146,26 @@ func NewShardMapping(n int) *ShardMapping {
 		Points: map[uint64][]models.Point{},
 		Shards: map[uint64]*meta.ShardInfo{},
 	}
+}
+
+func (s *ShardMapping) AddDropped(p models.Point, t time.Time, b BoundType) {
+	if s.MaxDropped.Point == nil || p.Time().After(s.MaxDropped.Point.Time()) {
+		s.MaxDropped = DroppedPoint{Point: p, ViolatedBound: t, Reason: b}
+	}
+	if s.MinDropped.Point == nil || p.Time().Before(s.MinDropped.Point.Time()) {
+		s.MinDropped = DroppedPoint{Point: p, ViolatedBound: t, Reason: b}
+	}
+	s.CountDropped++
+}
+
+func (s *ShardMapping) SummariseDropped() string {
+	if s.CountDropped == 0 {
+		return ""
+	}
+	return fmt.Sprintf("dropped %d points outside retention policy or write window: %s to %s",
+		s.CountDropped,
+		s.MinDropped.String(),
+		s.MaxDropped.String())
 }
 
 // MapPoint adds the point to the ShardMapping, associated with the given shardInfo.
@@ -147,14 +203,14 @@ func NewWriteWindow(rp *meta.RetentionPolicyInfo) *WriteWindow {
 	return w
 }
 
-func (w *WriteWindow) WithinWindow(t time.Time) bool {
+func (w *WriteWindow) WithinWindow(t time.Time) (bool, time.Time, BoundType) {
 	if w.checkBefore && t.Before(w.before) {
-		return false
+		return false, w.before, WriteWindowLowerBound
 	}
 	if w.checkAfter && t.After(w.after) {
-		return false
+		return false, w.after, WriteWindowUpperBound
 	}
-	return true
+	return true, time.Time{}, WithinBounds
 }
 
 // Open opens the communication channel with the point writer.
@@ -229,7 +285,8 @@ func (w *PointsWriter) MapShards(wp *WritePointsRequest) (*ShardMapping, error) 
 		// Either the point is outside the scope of the RP, we already have
 		// a suitable shard group for the point, or it is outside the write window
 		// for the RP, and we don't want to unnecessarily create a shard for it
-		if p.Time().Before(min) || list.Covers(p.Time()) || !ww.WithinWindow(p.Time()) {
+		withinWindow, _, _ := ww.WithinWindow(p.Time())
+		if p.Time().Before(min) || list.Covers(p.Time()) || !withinWindow {
 			continue
 		}
 
@@ -249,10 +306,15 @@ func (w *PointsWriter) MapShards(wp *WritePointsRequest) (*ShardMapping, error) 
 	mapping := NewShardMapping(len(wp.Points))
 	for _, p := range wp.Points {
 		sg := list.ShardGroupAt(p.Time())
-		if sg == nil || !ww.WithinWindow(p.Time()) {
+		if sg == nil {
 			// We didn't create a shard group because the point was outside the
-			// scope of the RP, or the point is outside the write window for the RP.
-			mapping.Dropped = append(mapping.Dropped, p)
+			// scope of the RP
+			mapping.AddDropped(p, min, RetentionPolicyBound)
+			atomic.AddInt64(&w.stats.WriteDropped, 1)
+			continue
+		} else if withinWindow, bound, reason := ww.WithinWindow(p.Time()); !withinWindow {
+			// The point is outside the write window for the RP.
+			mapping.AddDropped(p, bound, reason)
 			atomic.AddInt64(&w.stats.WriteDropped, 1)
 			continue
 		} else if len(sg.Shards) <= 0 {
@@ -420,9 +482,9 @@ func (w *PointsWriter) WritePointsPrivileged(writeCtx tsdb.WriteContext, databas
 	w.Subscriber.Send(pts)
 	atomic.AddInt64(&w.stats.SubWriteOK, 1)
 
-	if err == nil && len(shardMappings.Dropped) > 0 {
-		err = tsdb.PartialWriteError{Reason: "points beyond retention policy or outside permissible write window",
-			Dropped:         len(shardMappings.Dropped),
+	if err == nil && shardMappings.CountDropped > 0 {
+		err = tsdb.PartialWriteError{Reason: shardMappings.SummariseDropped(),
+			Dropped:         shardMappings.CountDropped,
 			Database:        database,
 			RetentionPolicy: retentionPolicy,
 		}

--- a/coordinator/points_writer.go
+++ b/coordinator/points_writer.go
@@ -160,9 +160,7 @@ func (s *ShardMapping) AddDropped(p models.Point, t time.Time, b BoundType) {
 	switch b {
 	case RetentionPolicyBound:
 		s.RetentionDropped++
-	case WriteWindowLowerBound:
-		s.WriteWindowDropped++
-	case WriteWindowUpperBound:
+	case WriteWindowLowerBound, WriteWindowUpperBound:
 		s.WriteWindowDropped++
 	}
 }

--- a/coordinator/points_writer_test.go
+++ b/coordinator/points_writer_test.go
@@ -142,8 +142,8 @@ func MapPoints(t *testing.T, c *coordinator.PointsWriter, pr *coordinator.WriteP
 			}
 		}
 	verify(p, values)
-	require.Equal(t, shardMappings.CountDropped, droppedCount, "wrong number of points dropped")
-	if shardMappings.CountDropped > 0 {
+	require.Equal(t, shardMappings.Dropped(), droppedCount, "wrong number of points dropped")
+	if shardMappings.Dropped() > 0 {
 		require.Equal(t, minDropped.Point, shardMappings.MinDropped.Point, "minimum dropped point mismatch")
 		require.Equal(t, minDropped.Reason, shardMappings.MinDropped.Reason, "minimum dropped reason mismatch")
 		require.Equal(t, maxDropped.Point, shardMappings.MaxDropped.Point, "maximum dropped point mismatch")
@@ -339,7 +339,7 @@ func TestPointsWriter_MapShards_Invalid(t *testing.T) {
 		t.Errorf("MapShards() len mismatch. got %v, exp %v", got, exp)
 	}
 
-	if got, exp := shardMappings.CountDropped, 1; got != exp {
+	if got, exp := shardMappings.RetentionDropped, 1; got != exp {
 		t.Fatalf("MapShard() dropped mismatch: got %v, exp %v", got, exp)
 	}
 
@@ -520,7 +520,7 @@ func TestPointsWriter_WritePoints_Dropped(t *testing.T) {
 		t.Errorf("PointsWriter.WritePoints(): got %v, exp %v", err, tsdb.PartialWriteError{})
 	}
 	require.Equal(t, 1, pwErr.Dropped, "wrong number of points dropped")
-	require.ErrorContains(t, pwErr, "dropped 1 points outside retention policy or write window")
+	require.ErrorContains(t, pwErr, "dropped 1 points outside retention policy and 0 points outside write window")
 	require.ErrorContains(t, pwErr, "Retention Policy Lower Bound")
 }
 


### PR DESCRIPTION
Log the reason for a point being dropped,
the type of boundary violated, and the
time that was the boundary. Prints the
maximum and minimum points (by time)
that were dropped

closes https://github.com/influxdata/influxdb/issues/26252