### PR TITLE
feat: ask for confirmation when regenerating token

### DIFF
--- a/influxdb3/src/commands/create/token.rs
+++ b/influxdb3/src/commands/create/token.rs
@@ -1,4 +1,4 @@
-use std::{error::Error, path::PathBuf};
+use std::{error::Error, io, path::PathBuf};
 
 use clap::Parser;
 use influxdb3_client::Client;
@@ -58,10 +58,17 @@ pub(crate) async fn handle_admin_token_creation(
     config: AdminTokenConfig,
 ) -> Result<CreateTokenWithPermissionsResponse, Box<dyn Error>> {
     let json_body = if config.regenerate {
-        client
-            .api_v3_configure_regenerate_admin_token()
-            .await?
-            .expect("token creation to return full token info")
+        println!("Are you sure you want to regenerate admin token? Enter 'yes' to confirm",);
+        let mut confirmation = String::new();
+        let _ = io::stdin().read_line(&mut confirmation);
+        if confirmation.trim() == "yes" {
+            client
+                .api_v3_configure_regenerate_admin_token()
+                .await?
+                .expect("token creation to return full token info")
+        } else {
+            return Err("Cannot regenerate token without confirmation".into());
+        }
     } else {
         client
             .api_v3_configure_create_admin_token()

--- a/influxdb3/tests/cli/mod.rs
+++ b/influxdb3/tests/cli/mod.rs
@@ -2921,7 +2921,7 @@ async fn test_regenerate_admin_token() {
 
     // regenerating token is allowed
     let result = server
-        .run(
+        .run_with_confirmation(
             vec!["create", "token", "--admin"],
             &["--regenerate", "--tls-ca", "../testing-certs/rootCA.pem"],
         )

--- a/influxdb3/tests/server/mod.rs
+++ b/influxdb3/tests/server/mod.rs
@@ -578,7 +578,8 @@ pub async fn write_lp_to_db(
 pub fn parse_token(result: String) -> String {
     let all_lines: Vec<&str> = result.split('\n').collect();
     let token = all_lines
-        .first()
+        .iter()
+        .find(|line| line.starts_with("Token:"))
         .expect("token line to be present")
         .replace("Token: ", "");
     token


### PR DESCRIPTION
Before this commit regenerating token didn't require confirmation, it is corrected in this PR

Test:

```
❯ cargo run -- create token --admin --regenerate  --token apiv3_EFnUPcaYl5L1kgL9DHWn2ndHCZszLJ_u1_C07hxbbijPdyxU-peBpocrkYw8DesXF5ABZPIHcSgAOpemWIVaaw
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.21s
     Running `target/debug/influxdb3 create token --admin --regenerate --token apiv3_EFnUPcaYl5L1kgL9DHWn2ndHCZszLJ_u1_C07hxbbijPdyxU-peBpocrkYw8DesXF5ABZPIHcSgAOpemWIVaaw`
Are you sure you want to regenerate admin token? Enter 'yes' to confirm
yes

Token: apiv3_3wraFGruQJd9dptX0bs-HZOUrAcmP2MZdp9yC7jwxUNlMb8fGlJwuafE3DD_lXrrf6teky3ciOSVWV31JZKLSA

HTTP requests require the following header: "Authorization: Bearer apiv3_3wraFGruQJd9dptX0bs-HZOUrAcmP2MZdp9yC7jwxUNlMb8fGlJwuafE3DD_lXrrf6teky3ciOSVWV31JZKLSA"
This will grant you access to HTTP/GRPC API.

``` 