### PR TITLE
fix: `--tags` argument is optional and now requires at least one tag

### DIFF
--- a/influxdb3/src/commands/create.rs
+++ b/influxdb3/src/commands/create.rs
@@ -220,9 +220,9 @@ pub struct DistinctCacheConfig {
 
 #[derive(Debug, clap::Args)]
 pub struct TableConfig {
-    #[clap(long = "tags", required = true, value_delimiter = ',')]
+    #[clap(long = "tags", value_delimiter = ',', num_args = 1..)]
     /// The list of tag names to be created for the table. Tags are alphanumeric, can contain - and _, and start with a letter or number
-    tags: Vec<String>,
+    tags: Option<Vec<String>>,
 
     #[clap(short = 'f', long = "fields", value_parser = parse_key_val::<String, DataType>, value_delimiter = ',')]
     /// The list of field names and their data type to be created for the table. Fields are alphanumeric, can contain - and _, and start with a letter or number
@@ -362,7 +362,12 @@ pub async fn command(config: Config) -> Result<(), Box<dyn Error>> {
             ..
         }) => {
             client
-                .api_v3_configure_table_create(&database_name, &table_name, tags, fields)
+                .api_v3_configure_table_create(
+                    &database_name,
+                    &table_name,
+                    tags.unwrap_or_default(),
+                    fields,
+                )
                 .await?;
 
             println!(

--- a/influxdb3/tests/cli/api.rs
+++ b/influxdb3/tests/cli/api.rs
@@ -152,11 +152,14 @@ impl CreateTableQuery<'_> {
             "--database",
             &self.db_name,
             &self.table_name,
-            "--tags",
-            &tags_arg,
             "--tls-ca",
             "../testing-certs/rootCA.pem",
         ];
+
+        if !self.tags.is_empty() {
+            args.push("--tags");
+            args.push(&tags_arg);
+        }
 
         if !self.fields.is_empty() {
             args.push("--fields");

--- a/influxdb3/tests/cli/mod.rs
+++ b/influxdb3/tests/cli/mod.rs
@@ -418,6 +418,48 @@ async fn test_create_table_fail_existing() {
 }
 
 #[test_log::test(tokio::test)]
+async fn test_create_table_tags_not_required() {
+    let server = TestServer::spawn().await;
+    let db_name = "foo";
+    let table_name = "bar";
+
+    // Create database
+    let result = server.create_database(db_name).run().unwrap();
+    debug!(result = ?result, "create database");
+    assert_contains!(&result, "Database \"foo\" created successfully");
+
+    // Create table successfully
+    let result = server.create_table(db_name, table_name).run().unwrap();
+
+    assert_contains!(&result, "Table \"foo\".\"bar\" created successfully");
+}
+
+#[test_log::test(tokio::test)]
+async fn test_create_table_fail_empty_tags() {
+    let server = TestServer::spawn().await;
+    let db_name = "foo";
+    let table_name = "bar";
+
+    // Create database
+    let result = server.create_database(db_name).run().unwrap();
+    debug!(result = ?result, "create database");
+    assert_contains!(&result, "Database \"foo\" created successfully");
+
+    // Create table successfully
+    let result = server
+        .run(
+            vec!["create", "table"],
+            &["--database", db_name, table_name, "--tags"],
+        )
+        .unwrap_err();
+
+    assert_contains!(
+        result.to_string(),
+        "error: a value is required for '--tags <TAGS>...' but none was supplied"
+    );
+}
+
+#[test_log::test(tokio::test)]
 async fn test_delete_table() {
     let server = TestServer::spawn().await;
     let db_name = "foo";


### PR DESCRIPTION
Closes #25824

- Changes `--tags` option for `create table` to optional
- When `--tags` is specified, requires a minimum of 1 tag be specified

> [!WARNING]
>
> Requiring a tag when `--tags` is specified is a breaking change of the CLI. The intent is now clearer and the error is specific when `--tag` is specified without additional arguments.

# Testing

## Help

No longer lists `--tags` in the required **usage**.

**Before**

```
Create a new table in a database

Usage: influxdb3 create table [OPTIONS] --tags <TAGS> --database <DATABASE_NAME> <TABLE_NAME>
```

**After**

```
Create a new table in a database

Usage: influxdb3 create table [OPTIONS] --database <DATABASE_NAME> <TABLE_NAME>
```

## No tags

```
influxdb3 create table cats --database dev
Table "dev"."cats" created successfully
```

```
influxdb3 query 'show columns from cats'
+---------------+--------------+------------+-------------+-----------------------------+-------------+
| table_catalog | table_schema | table_name | column_name | data_type                   | is_nullable |
+---------------+--------------+------------+-------------+-----------------------------+-------------+
| public        | iox          | cats       | time        | Timestamp(Nanosecond, None) | NO          |
+---------------+--------------+------------+-------------+-----------------------------+-------------+
```

## Multiple tags

```
influxdb3 create table cats --database dev --tags a,b
Table "dev"."cats" created successfully
```

```
influxdb3 query 'show columns from cats'
+---------------+--------------+------------+-------------+-----------------------------+-------------+
| table_catalog | table_schema | table_name | column_name | data_type                   | is_nullable |
+---------------+--------------+------------+-------------+-----------------------------+-------------+
| public        | iox          | cats       | a           | Dictionary(Int32, Utf8)     | YES         |
| public        | iox          | cats       | b           | Dictionary(Int32, Utf8)     | YES         |
| public        | iox          | cats       | time        | Timestamp(Nanosecond, None) | NO          |
+---------------+--------------+------------+-------------+-----------------------------+-------------+
```

## Requires at least one tag

```sh
influxdb3 create table cats --database dev --tags
error: a value is required for '--tags <TAGS>...' but none was supplied
```