### PR TITLE
feat: Add env vars for TLS options

### DIFF
--- a/influxdb3/src/commands/create.rs
+++ b/influxdb3/src/commands/create.rs
@@ -135,7 +135,7 @@ pub struct DatabaseConfig {
     pub database_name: String,
 
     /// An optional arg to use a custom ca for useful for testing with self signed certs
-    #[clap(long = "tls-ca")]
+    #[clap(long = "tls-ca", env = "INFLUXDB3_TLS_CA")]
     ca_cert: Option<PathBuf>,
 }
 
@@ -177,7 +177,7 @@ pub struct LastCacheConfig {
     cache_name: Option<String>,
 
     /// An optional arg to use a custom ca for useful for testing with self signed certs
-    #[clap(long = "tls-ca")]
+    #[clap(long = "tls-ca", env = "INFLUXDB3_TLS_CA")]
     ca_cert: Option<PathBuf>,
 }
 
@@ -214,7 +214,7 @@ pub struct DistinctCacheConfig {
     cache_name: Option<String>,
 
     /// An optional arg to use a custom ca for useful for testing with self signed certs
-    #[clap(long = "tls-ca")]
+    #[clap(long = "tls-ca", env = "INFLUXDB3_TLS_CA")]
     ca_cert: Option<PathBuf>,
 }
 
@@ -237,7 +237,7 @@ pub struct TableConfig {
     table_name: String,
 
     /// An optional arg to use a custom ca for useful for testing with self signed certs
-    #[clap(long = "tls-ca")]
+    #[clap(long = "tls-ca", env = "INFLUXDB3_TLS_CA")]
     ca_cert: Option<PathBuf>,
 }
 
@@ -271,7 +271,7 @@ pub struct TriggerConfig {
     trigger_name: String,
 
     /// An optional arg to use a custom ca for useful for testing with self signed certs
-    #[clap(long = "tls-ca")]
+    #[clap(long = "tls-ca", env = "INFLUXDB3_TLS_CA")]
     ca_cert: Option<PathBuf>,
 }
 

--- a/influxdb3/src/commands/create/token.rs
+++ b/influxdb3/src/commands/create/token.rs
@@ -38,7 +38,7 @@ pub struct AdminTokenConfig {
     pub auth_token: Option<Secret<String>>,
 
     /// An optional arg to use a custom ca for useful for testing with self signed certs
-    #[clap(long = "tls-ca")]
+    #[clap(long = "tls-ca", env = "INFLUXDB3_TLS_CA")]
     pub ca_cert: Option<PathBuf>,
 }
 

--- a/influxdb3/src/commands/delete.rs
+++ b/influxdb3/src/commands/delete.rs
@@ -116,7 +116,7 @@ pub struct DatabaseConfig {
     pub database_name: String,
 
     /// An optional arg to use a custom ca for useful for testing with self signed certs
-    #[clap(long = "tls-ca")]
+    #[clap(long = "tls-ca", env = "INFLUXDB3_TLS_CA")]
     ca_cert: Option<PathBuf>,
 }
 
@@ -134,7 +134,7 @@ pub struct LastCacheConfig {
     cache_name: String,
 
     /// An optional arg to use a custom ca for useful for testing with self signed certs
-    #[clap(long = "tls-ca")]
+    #[clap(long = "tls-ca", env = "INFLUXDB3_TLS_CA")]
     ca_cert: Option<PathBuf>,
 }
 
@@ -152,7 +152,7 @@ pub struct DistinctCacheConfig {
     cache_name: String,
 
     /// An optional arg to use a custom ca for useful for testing with self signed certs
-    #[clap(long = "tls-ca")]
+    #[clap(long = "tls-ca", env = "INFLUXDB3_TLS_CA")]
     ca_cert: Option<PathBuf>,
 }
 
@@ -165,7 +165,7 @@ pub struct TableConfig {
     table_name: String,
 
     /// An optional arg to use a custom ca for useful for testing with self signed certs
-    #[clap(long = "tls-ca")]
+    #[clap(long = "tls-ca", env = "INFLUXDB3_TLS_CA")]
     ca_cert: Option<PathBuf>,
 }
 
@@ -183,7 +183,7 @@ pub struct TriggerConfig {
     trigger_name: String,
 
     /// An optional arg to use a custom ca for useful for testing with self signed certs
-    #[clap(long = "tls-ca")]
+    #[clap(long = "tls-ca", env = "INFLUXDB3_TLS_CA")]
     ca_cert: Option<PathBuf>,
 }
 
@@ -207,7 +207,7 @@ pub struct TokenConfig {
     pub token_name: String,
 
     /// An optional arg to use a custom ca for useful for testing with self signed certs
-    #[clap(long = "tls-ca")]
+    #[clap(long = "tls-ca", env = "INFLUXDB3_TLS_CA")]
     ca_cert: Option<PathBuf>,
 }
 

--- a/influxdb3/src/commands/disable.rs
+++ b/influxdb3/src/commands/disable.rs
@@ -47,7 +47,7 @@ struct TriggerConfig {
     trigger_name: String,
 
     /// An optional arg to use a custom ca for useful for testing with self signed certs
-    #[clap(long = "tls-ca")]
+    #[clap(long = "tls-ca", env = "INFLUXDB3_TLS_CA")]
     pub ca_cert: Option<PathBuf>,
 }
 

--- a/influxdb3/src/commands/enable.rs
+++ b/influxdb3/src/commands/enable.rs
@@ -47,7 +47,7 @@ struct TriggerConfig {
     trigger_name: String,
 
     /// An optional arg to use a custom ca for useful for testing with self signed certs
-    #[clap(long = "tls-ca")]
+    #[clap(long = "tls-ca", env = "INFLUXDB3_TLS_CA")]
     pub ca_cert: Option<PathBuf>,
 }
 

--- a/influxdb3/src/commands/install.rs
+++ b/influxdb3/src/commands/install.rs
@@ -53,7 +53,7 @@ pub struct PackageConfig {
     packages: Vec<String>,
 
     /// An optional arg to use a custom ca for useful for testing with self signed certs
-    #[clap(long = "tls-ca")]
+    #[clap(long = "tls-ca", env = "INFLUXDB3_TLS_CA")]
     ca_cert: Option<PathBuf>,
 }
 

--- a/influxdb3/src/commands/query.rs
+++ b/influxdb3/src/commands/query.rs
@@ -74,7 +74,7 @@ pub struct Config {
     query: Option<String>,
 
     /// An optional arg to use a custom ca for useful for testing with self signed certs
-    #[clap(long = "tls-ca")]
+    #[clap(long = "tls-ca", env = "INFLUXDB3_TLS_CA")]
     ca_cert: Option<PathBuf>,
 }
 

--- a/influxdb3/src/commands/serve.rs
+++ b/influxdb3/src/commands/serve.rs
@@ -373,10 +373,10 @@ pub struct Config {
     #[clap(long = "query-file-limit", env = "INFLUXDB3_QUERY_FILE_LIMIT", action)]
     pub query_file_limit: Option<usize>,
 
-    #[clap(long = "tls-key")]
+    #[clap(long = "tls-key", env = "INFLUXDB3_TLS_KEY")]
     pub key_file: Option<PathBuf>,
 
-    #[clap(long = "tls-cert")]
+    #[clap(long = "tls-cert", env = "INFLUXDB3_TLS_CERT")]
     pub cert_file: Option<PathBuf>,
 }
 

--- a/influxdb3/src/commands/show.rs
+++ b/influxdb3/src/commands/show.rs
@@ -46,7 +46,7 @@ pub struct ShowTokensConfig {
     output_format: Format,
 
     /// An optional arg to use a custom ca for useful for testing with self signed certs
-    #[clap(long = "tls-ca")]
+    #[clap(long = "tls-ca", env = "INFLUXDB3_TLS_CA")]
     ca_cert: Option<PathBuf>,
 }
 
@@ -74,7 +74,7 @@ pub struct DatabaseConfig {
     output_format: Format,
 
     /// An optional arg to use a custom ca for useful for testing with self signed certs
-    #[clap(long = "tls-ca")]
+    #[clap(long = "tls-ca", env = "INFLUXDB3_TLS_CA")]
     ca_cert: Option<PathBuf>,
 }
 

--- a/influxdb3/src/commands/show/system.rs
+++ b/influxdb3/src/commands/show/system.rs
@@ -89,7 +89,7 @@ pub struct TableListConfig {
     output_format: Format,
 
     /// An optional arg to use a custom ca for useful for testing with self signed certs
-    #[clap(long = "tls-ca")]
+    #[clap(long = "tls-ca", env = "INFLUXDB3_TLS_CA")]
     ca_cert: Option<PathBuf>,
 }
 
@@ -150,7 +150,7 @@ pub struct TableConfig {
     output_format: Format,
 
     /// An optional arg to use a custom ca for useful for testing with self signed certs
-    #[clap(long = "tls-ca")]
+    #[clap(long = "tls-ca", env = "INFLUXDB3_TLS_CA")]
     ca_cert: Option<PathBuf>,
 }
 
@@ -242,7 +242,7 @@ pub struct SummaryConfig {
     output_format: Format,
 
     /// An optional arg to use a custom ca for useful for testing with self signed certs
-    #[clap(long = "tls-ca")]
+    #[clap(long = "tls-ca", env = "INFLUXDB3_TLS_CA")]
     ca_cert: Option<PathBuf>,
 }
 

--- a/influxdb3/src/commands/test.rs
+++ b/influxdb3/src/commands/test.rs
@@ -75,7 +75,7 @@ pub struct WalPluginConfig {
     #[clap(long = "cache-name")]
     pub cache_name: Option<String>,
     /// An optional arg to use a custom ca for useful for testing with self signed certs
-    #[clap(long = "tls-ca")]
+    #[clap(long = "tls-ca", env = "INFLUXDB3_TLS_CA")]
     pub ca_cert: Option<PathBuf>,
 }
 
@@ -96,7 +96,7 @@ pub struct SchedulePluginConfig {
     #[clap(long = "cache-name")]
     pub cache_name: Option<String>,
     /// An optional arg to use a custom ca for useful for testing with self signed certs
-    #[clap(long = "tls-ca")]
+    #[clap(long = "tls-ca", env = "INFLUXDB3_TLS_CA")]
     pub ca_cert: Option<PathBuf>,
 }
 

--- a/influxdb3/src/commands/write.rs
+++ b/influxdb3/src/commands/write.rs
@@ -61,7 +61,7 @@ pub struct Config {
     precision: Option<Precision>,
 
     /// An optional arg to use a custom ca for useful for testing with self signed certs
-    #[clap(long = "tls-ca")]
+    #[clap(long = "tls-ca", env = "INFLUXDB3_TLS_CA")]
     ca_cert: Option<PathBuf>,
 }
 

--- a/influxdb3/src/help/serve.txt
+++ b/influxdb3/src/help/serve.txt
@@ -27,6 +27,10 @@ Examples
                                   [env: INFLUXDB3_HTTP_BIND_ADDR=]
   --log-filter <FILTER>            Logs: filter directive [env: LOG_FILTER=]
   --without-auth                   Run InfluxDB 3 server without authorization
+  --tls-key <KEY_FILE>             The path to the key file for TLS to be enabled
+                                  [env: INFLUXDB3_TLS_KEY=]
+  --tls-cert <CERT_FILE>           The path to the cert file for TLS to be enabled
+                                  [env: INFLUXDB3_TLS_CERT=]
 
 {}
   --object-store <STORE>           Object storage to use [default: memory]

--- a/influxdb3/src/help/serve_all.txt
+++ b/influxdb3/src/help/serve_all.txt
@@ -23,6 +23,10 @@ Examples:
                                   [env: INFLUXDB3_HTTP_BIND_ADDR=]
   --log-filter <FILTER>            Logs: filter directive [env: LOG_FILTER=]
   --without-auth                   Run InfluxDB 3 server without authorization
+  --tls-key <KEY_FILE>             The path to the key file for TLS to be enabled
+                                  [env: INFLUXDB3_TLS_KEY=]
+  --tls-cert <CERT_FILE>           The path to the cert file for TLS to be enabled
+                                  [env: INFLUXDB3_TLS_CERT=]
 
 {}
   --object-store <STORE>           Object storage to use [default: memory]


### PR DESCRIPTION
This commit is a follow up to #26246 and adds env vars to all of the TLS options in Core/Enterprise. This allows users to specify things like a CA file so that they don't need to run every single command with it specified. Same with the cert and key files. This is also nice for letting users configure environments like a Docker container with an env var rather than with command line args.

Closes #26253 