### PR TITLE
chore: back-port catalog limit refactor from enterprise

### DIFF
--- a/influxdb3/tests/cli/api.rs
+++ b/influxdb3/tests/cli/api.rs
@@ -122,11 +122,11 @@ impl CreateTableQuery<'_> {
 
     pub fn with_fields(
         mut self,
-        fields: impl IntoIterator<Item = (impl Into<String>, String)>,
+        fields: impl IntoIterator<Item = (impl Into<String>, impl Into<String>)>,
     ) -> Self {
         self.fields = fields
             .into_iter()
-            .map(|(name, dt)| (name.into(), dt))
+            .map(|(name, dt)| (name.into(), dt.into()))
             .collect();
         self
     }

--- a/influxdb3_catalog/src/error.rs
+++ b/influxdb3_catalog/src/error.rs
@@ -3,7 +3,10 @@ use std::sync::Arc;
 use anyhow::anyhow;
 use schema::InfluxColumnType;
 
-use crate::{catalog::Catalog, channel::SubscriptionError, object_store::ObjectStoreCatalogError};
+use crate::{
+    catalog::NUM_TAG_COLUMNS_LIMIT, channel::SubscriptionError,
+    object_store::ObjectStoreCatalogError,
+};
 
 #[derive(Debug, thiserror::Error)]
 pub enum CatalogError {
@@ -44,29 +47,20 @@ pub enum CatalogError {
     #[error("invalid node registration")]
     InvalidNodeRegistration,
 
-    #[error(
-        "Update to schema would exceed number of columns per table limit of {} columns",
-        Catalog::NUM_COLUMNS_PER_TABLE_LIMIT - 1
-    )]
-    TooManyColumns,
+    #[error("Update to schema would exceed number of columns per table limit of {0} columns")]
+    TooManyColumns(usize),
 
     #[error(
         "Update to schema would exceed number of tag columns per table limit of {} columns",
-        Catalog::NUM_TAG_COLUMNS_LIMIT
+        NUM_TAG_COLUMNS_LIMIT
     )]
     TooManyTagColumns,
 
-    #[error(
-        "Update to schema would exceed number of tables limit of {} tables",
-        Catalog::NUM_TABLES_LIMIT
-    )]
-    TooManyTables,
+    #[error("Update to schema would exceed number of tables limit of {0} tables")]
+    TooManyTables(usize),
 
-    #[error(
-        "Adding a new database would exceed limit of {} databases",
-        Catalog::NUM_DBS_LIMIT
-    )]
-    TooManyDbs,
+    #[error("Adding a new database would exceed limit of {0} databases")]
+    TooManyDbs(usize),
 
     #[error("Table {} not in DB schema for {}", table_name, db_name)]
     TableNotFound {

--- a/influxdb3_server/src/http.rs
+++ b/influxdb3_server/src/http.rs
@@ -274,7 +274,10 @@ impl IntoResponse for CatalogError {
                 .status(StatusCode::BAD_REQUEST)
                 .body(Body::from(self.to_string()))
                 .unwrap(),
-            Self::TooManyColumns | Self::TooManyTables | Self::TooManyDbs => {
+            Self::TooManyColumns(_)
+            | Self::TooManyTables(_)
+            | Self::TooManyDbs(_)
+            | Self::TooManyTagColumns => {
                 let err: ErrorMessage<()> = ErrorMessage {
                     error: self.to_string(),
                     data: None,


### PR DESCRIPTION
This back-ports some changes to how limits are enforced on the catalog from enterprise. There were some changes that would catch some potential bugs.

See https://github.com/influxdata/influxdb_pro/issues/567
See https://github.com/influxdata/influxdb_pro/pull/758
