### PR TITLE
docs: clarify default maxes for distinct cache

### DIFF
--- a/influxdb3/src/commands/create.rs
+++ b/influxdb3/src/commands/create.rs
@@ -200,11 +200,11 @@ pub struct DistinctCacheConfig {
     columns: Vec<String>,
 
     /// The maximum number of distinct value combinations to hold in the cache
-    #[clap(long = "max-cardinality")]
+    #[clap(long = "max-cardinality", default_value = "100000")]
     max_cardinality: Option<NonZeroUsize>,
 
     /// The maximum age of an entry in the cache entered as a human-readable duration, e.g., "30d", "24h"
-    #[clap(long = "max-age")]
+    #[clap(long = "max-age", default_value = "1d")]
     max_age: Option<humantime::Duration>,
 
     /// Give the name of the cache.


### PR DESCRIPTION
Tiny PR. Clarifies that the default max age for a Distinct Cache is 1d (86000 seconds) and default max cardinality is 100000.

Will have to move this into the new CLI help eventually. 

No ticket. Based on user feedback.