### PR TITLE
chore: version bump for 3.0.1 (#26282)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2756,7 +2756,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "anyhow",
  "arrow",
@@ -2830,7 +2830,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_authz"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "async-trait",
  "authz",
@@ -2847,7 +2847,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_cache"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "anyhow",
  "arrow",
@@ -2882,7 +2882,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_catalog"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "anyhow",
  "arrow",
@@ -2928,7 +2928,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_clap_blocks"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2961,7 +2961,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_client"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "bytes",
  "hashbrown 0.15.2",
@@ -2981,7 +2981,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_id"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "indexmap 2.7.0",
  "serde",
@@ -2990,7 +2990,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_internal_api"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3006,7 +3006,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_load_generator"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3034,7 +3034,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_process"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "iox_time",
  "metric",
@@ -3047,7 +3047,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_processing_engine"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3088,7 +3088,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_py_api"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -3115,7 +3115,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_server"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3205,7 +3205,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_shutdown"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "futures",
  "futures-util",
@@ -3217,7 +3217,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_sys_events"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3236,7 +3236,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_telemetry"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "futures",
  "futures-util",
@@ -3257,7 +3257,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_test_helpers"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3270,7 +3270,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_types"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3288,7 +3288,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_wal"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "async-trait",
  "bitcode",
@@ -3318,7 +3318,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_write"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3575,7 +3575,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query_influxql_rewrite"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "influxdb_influxql_parser",
  "thiserror 1.0.69",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ exclude = [
 ]
 
 [workspace.package]
-version = "3.0.0"
+version = "3.0.1"
 authors = ["InfluxData OSS Developers"]
 edition = "2024"
 license = "MIT OR Apache-2.0"

--- a/install_influxdb.sh
+++ b/install_influxdb.sh
@@ -16,7 +16,7 @@ INSTALL_LOC=~/.influxdb
 BINARY_NAME="influxdb3"
 PORT=8181
 
-INFLUXDB_VERSION="3.0.0"
+INFLUXDB_VERSION="3.0.1"
 EDITION="Core"
 EDITION_TAG="core"
 if [ "$1" = "enterprise" ]; then


### PR DESCRIPTION
Updates the version in Cargo and the install script.