### PR TITLE
feat: expose `--format json` for token creation cmd

### DIFF
--- a/influxdb3/src/commands/create.rs
+++ b/influxdb3/src/commands/create.rs
@@ -391,7 +391,7 @@ pub async fn command(config: Config) -> Result<(), Box<dyn Error>> {
                                 "HTTP requests require the following header: \"Authorization: Bearer {}\"",
                                 response.token
                             );
-                            let json = json!({"token": response.token, "hashed_token": response.hash, "help_msg": help_msg});
+                            let json = json!({"token": response.token, "help_msg": help_msg});
                             let stringified = serde_json::to_string_pretty(&json)
                                 .expect("token details to be parseable");
                             println!("{}", stringified);

--- a/influxdb3/src/commands/create.rs
+++ b/influxdb3/src/commands/create.rs
@@ -11,12 +11,14 @@ use influxdb3_types::http::LastCacheSize;
 use influxdb3_types::http::LastCacheTtl;
 use secrecy::ExposeSecret;
 use secrecy::Secret;
+use serde_json::json;
 use std::error::Error;
 use std::num::NonZeroUsize;
 use std::path::PathBuf;
 use std::str;
 use token::AdminTokenConfig;
 use token::TokenCommands;
+use token::TokenSubCommand;
 use token::handle_token_creation;
 use url::Url;
 
@@ -376,17 +378,36 @@ pub async fn command(config: Config) -> Result<(), Box<dyn Error>> {
             );
         }
         SubCommand::Token(token_commands) => {
+            let output_format = match token_commands.commands {
+                TokenSubCommand::Admin(AdminTokenConfig { ref format, .. }) => format.clone(),
+            }
+            .unwrap_or(token::TokenOutputFormat::Text);
+
             match handle_token_creation(client, token_commands).await {
                 Ok(response) => {
-                    println!(
-                        "\n\
-                        Token: {token}\n\
-                            \n\
-                        HTTP requests require the following header: \"Authorization: Bearer {token}\"\n\
-                        This will grant you access to HTTP/GRPC API.
-                    ",
-                        token = response.token,
-                    );
+                    match output_format {
+                        token::TokenOutputFormat::Json => {
+                            let help_msg = format!(
+                                "HTTP requests require the following header: \"Authorization: Bearer {}\"",
+                                response.token
+                            );
+                            let json = json!({"token": response.token, "hashed_token": response.hash, "help_msg": help_msg});
+                            let stringified = serde_json::to_string_pretty(&json)
+                                .expect("token details to be parseable");
+                            println!("{}", stringified);
+                        }
+                        token::TokenOutputFormat::Text => {
+                            println!(
+                                "\n\
+                                Token: {token}\n\
+                                    \n\
+                                HTTP requests require the following header: \"Authorization: Bearer {token}\"\n\
+                                This will grant you access to HTTP/GRPC API.
+                            ",
+                                token = response.token,
+                            );
+                        }
+                    };
                 }
                 Err(err) => {
                     println!("Failed to create token, error: {:?}", err);

--- a/influxdb3/src/commands/create/token.rs
+++ b/influxdb3/src/commands/create/token.rs
@@ -1,6 +1,6 @@
 use std::{error::Error, io, path::PathBuf};
 
-use clap::Parser;
+use clap::{Parser, ValueEnum};
 use influxdb3_client::Client;
 use influxdb3_types::http::CreateTokenWithPermissionsResponse;
 use secrecy::Secret;
@@ -40,6 +40,16 @@ pub struct AdminTokenConfig {
     /// An optional arg to use a custom ca for useful for testing with self signed certs
     #[clap(long = "tls-ca", env = "INFLUXDB3_TLS_CA")]
     pub ca_cert: Option<PathBuf>,
+
+    /// Output format for token, supports just json or text
+    #[clap(long)]
+    pub format: Option<TokenOutputFormat>,
+}
+
+#[derive(Debug, ValueEnum, Clone)]
+pub enum TokenOutputFormat {
+    Json,
+    Text,
 }
 
 pub(crate) async fn handle_token_creation(

--- a/influxdb3/tests/cli/mod.rs
+++ b/influxdb3/tests/cli/mod.rs
@@ -2926,6 +2926,28 @@ async fn test_create_admin_token() {
 }
 
 #[test_log::test(tokio::test)]
+async fn test_create_admin_token_json_format() {
+    let server = TestServer::configure()
+        .with_auth()
+        .with_no_admin_token()
+        .spawn()
+        .await;
+    let args = &[
+        "--tls-ca",
+        "../testing-certs/rootCA.pem",
+        "--format",
+        "json",
+    ];
+    let result = server
+        .run(vec!["create", "token", "--admin"], args)
+        .unwrap();
+
+    let value: Value =
+        serde_json::from_str(&result).expect("token creation response should be in json format");
+    assert!(value.get("token").is_some());
+}
+
+#[test_log::test(tokio::test)]
 async fn test_create_admin_token_allowed_once() {
     let server = TestServer::configure()
         .with_auth()

--- a/influxdb3/tests/cli/mod.rs
+++ b/influxdb3/tests/cli/mod.rs
@@ -2944,7 +2944,25 @@ async fn test_create_admin_token_json_format() {
 
     let value: Value =
         serde_json::from_str(&result).expect("token creation response should be in json format");
-    assert!(value.get("token").is_some());
+    let token = value
+        .get("token")
+        .expect("token to be present")
+        .as_str()
+        .expect("token to be a str");
+    // check if the token generated works by using it to regenerate
+    let result = server
+        .run_with_confirmation(
+            vec!["create", "token", "--admin"],
+            &[
+                "--regenerate",
+                "--tls-ca",
+                "../testing-certs/rootCA.pem",
+                "--token",
+                token,
+            ],
+        )
+        .unwrap();
+    assert_contains!(&result, "This will grant you access to HTTP/GRPC API");
 }
 
 #[test_log::test(tokio::test)]


### PR DESCRIPTION
closes: https://github.com/influxdata/influxdb/issues/25913

### Test

```
cargo run -- create token --admin --format json
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.21s
     Running `target/debug/influxdb3 create token --admin --format json`
{
  "hashed_token": "c0d5ab879856384becbd77b326e0d160a01ca9270c4c38599a65be99f236d55bfd21360da8e1042e181a68df44c9c1663a8dd384067814fd215322a5ad3aea61",
  "help_msg": "HTTP requests require the following header: \"Authorization: Bearer apiv3_MjgUZqQRNbzQgt6byYic8t1K_H9crv0d5ZS_bWhJxZxB6FSeXetjFni-X2vEiXFN7DGU0WaIjnGd-fu6-NHQRA\"",
  "token": "apiv3_MjgUZqQRNbzQgt6byYic8t1K_H9crv0d5ZS_bWhJxZxB6FSeXetjFni-X2vEiXFN7DGU0WaIjnGd-fu6-NHQRA"
}

```

I've also included `help_msg`, although I suspect if someone is choosing to use `--format json` they're already aware of how to set HTTP authorization but I still added it just to make sure it clearly indicates how to set it up. It can be removed if we decide that it is not required as part of this payload.