### PR TITLE
fix: Ensure `iox` table schema is sorted for SHOW TABLES

### DIFF
--- a/influxdb3/tests/cli/api.rs
+++ b/influxdb3/tests/cli/api.rs
@@ -143,7 +143,7 @@ impl CreateTableQuery<'_> {
             .into_iter()
             .map(|(name, dt)| {
                 (
-                    name.into(),
+                    name,
                     match dt.as_ref() {
                         "utf8" => FieldType::Utf8,
                         "bool" => FieldType::Bool,

--- a/influxdb3/tests/cli/api.rs
+++ b/influxdb3/tests/cli/api.rs
@@ -1,6 +1,7 @@
 use crate::server::TestServer;
 use anyhow::{Result, bail};
 use assert_cmd::cargo::CommandCargoExt;
+use influxdb3_types::http::FieldType;
 use serde_json::Value;
 use std::io::Write;
 use std::process::{Command, Stdio};
@@ -134,6 +135,35 @@ impl CreateTableQuery<'_> {
     pub fn add_field(mut self, name: impl Into<String>, data_type: impl Into<String>) -> Self {
         self.fields.push((name.into(), data_type.into()));
         self
+    }
+
+    pub async fn run_api(self) -> Result<(), influxdb3_client::Error> {
+        let fields = self
+            .fields
+            .into_iter()
+            .map(|(name, dt)| {
+                (
+                    name.into(),
+                    match dt.as_ref() {
+                        "utf8" => FieldType::Utf8,
+                        "bool" => FieldType::Bool,
+                        "int64" => FieldType::Int64,
+                        "float64" => FieldType::Float64,
+                        "uint64" => FieldType::UInt64,
+                        _ => panic!("invalid field type"),
+                    },
+                )
+            })
+            .collect();
+
+        self.server
+            .api_v3_create_table(
+                self.db_name.as_str(),
+                self.table_name.as_str(),
+                self.tags,
+                fields,
+            )
+            .await
     }
 
     pub fn run(self) -> Result<String> {

--- a/influxdb3/tests/server/query.rs
+++ b/influxdb3/tests/server/query.rs
@@ -1916,3 +1916,31 @@ async fn api_query_with_default_browser_header() {
         resp
     );
 }
+
+#[tokio::test]
+async fn api_v3_query_show_tables_ordering() {
+    let server = TestServer::spawn().await;
+
+    let tables = [
+        "xxx",
+        "table_002",
+        "table_009",
+        "table_001",
+        "table_003",
+        "table_006",
+        "aaa",
+    ];
+
+    for table in tables {
+        server.create_table("foo", table).run_api().await.unwrap();
+    }
+
+    let output = server
+        .api_v3_query_sql(&[("db", "foo"), ("format", "pretty"), ("q", "SHOW TABLES")])
+        .await
+        .text()
+        .await
+        .unwrap();
+
+    insta::assert_snapshot!(output);
+}

--- a/influxdb3/tests/server/snapshots/lib__server__query__api_v3_query_show_tables_ordering.snap
+++ b/influxdb3/tests/server/snapshots/lib__server__query__api_v3_query_show_tables_ordering.snap
@@ -1,0 +1,26 @@
+---
+source: influxdb3/tests/server/query.rs
+expression: output
+---
++---------------+--------------------+----------------------------+------------+
+| table_catalog | table_schema       | table_name                 | table_type |
++---------------+--------------------+----------------------------+------------+
+| public        | iox                | aaa                        | BASE TABLE |
+| public        | iox                | table_001                  | BASE TABLE |
+| public        | iox                | table_002                  | BASE TABLE |
+| public        | iox                | table_003                  | BASE TABLE |
+| public        | iox                | table_006                  | BASE TABLE |
+| public        | iox                | table_009                  | BASE TABLE |
+| public        | iox                | xxx                        | BASE TABLE |
+| public        | system             | distinct_caches            | BASE TABLE |
+| public        | system             | last_caches                | BASE TABLE |
+| public        | system             | parquet_files              | BASE TABLE |
+| public        | system             | processing_engine_logs     | BASE TABLE |
+| public        | system             | processing_engine_triggers | BASE TABLE |
+| public        | system             | queries                    | BASE TABLE |
+| public        | information_schema | tables                     | VIEW       |
+| public        | information_schema | views                      | VIEW       |
+| public        | information_schema | columns                    | VIEW       |
+| public        | information_schema | df_settings                | VIEW       |
+| public        | information_schema | schemata                   | VIEW       |
++---------------+--------------------+----------------------------+------------+

--- a/influxdb3_server/src/query_executor/mod.rs
+++ b/influxdb3_server/src/query_executor/mod.rs
@@ -639,11 +639,14 @@ impl SchemaProvider for Database {
     }
 
     fn table_names(&self) -> Vec<String> {
-        self.db_schema
+        let mut names = self
+            .db_schema
             .table_names()
             .iter()
             .map(|t| t.to_string())
-            .collect()
+            .collect::<Vec<_>>();
+        names.sort();
+        names
     }
 
     async fn table(


### PR DESCRIPTION
Closes #25860

Teaches the `iox` table provider to sort the output of the `table_names` API, so that `SHOW TABLES` sorts the output.

## Testing

Introduced a new unit test to verify the output is sorted for `SHOW TABLES`