### PR TITLE
fix: Consistent thread arguments with influxdb3_pro

### DIFF
--- a/influxdb3/src/help/influxdb3_all.txt
+++ b/influxdb3/src/help/influxdb3_all.txt
@@ -1,7 +1,7 @@
 InfluxDB 3 Core Server and Command Line Tools
 
 # Example to run the InfluxDB 3 Core server:
-  influxdb3 serve --node-id my_node_name --object-store file --data-dir ~/.influxdb3_data 
+  influxdb3 serve --node-id my_node_name --object-store file --data-dir ~/.influxdb3_data
 
 {} {} [OPTIONS] [COMMAND]
 
@@ -9,44 +9,44 @@ InfluxDB 3 Core Server and Command Line Tools
   {}     Run the InfluxDB 3 Core server
   {}  Perform a query against a running InfluxDB 3 Core server
   {}  Perform a set of writes to a running InfluxDB 3 Core server
-  
+
 {}
   {}    Create a resource such as a database or auth token
   {}      List resources on the InfluxDB 3 Core server
   {}    Delete a resource such as a database or table
   {}    Enable a resource such as a trigger
   {}   Disable a resource such as a trigger
-  
+
 {}
   {}   Install Python packages for the Processing Engine
   {}      Test that Processing Engine plugins work the way you expect
 
 {}
-  --io-runtime-type <TYPE>          IO tokio runtime type [env: INFLUXDB3_IO_RUNTIME_TYPE=] 
-                                    [default: multi-thread] 
+  --io-runtime-type <TYPE>          IO tokio runtime type [env: INFLUXDB3_IO_RUNTIME_TYPE=]
+                                    [default: multi-thread]
                                     [possible values: current-thread, multi-thread, multi-thread-alt]
-  --io-runtime-disable-lifo-slot <BOOL>  
-                                     Disable LIFO slot of IO runtime 
+  --io-runtime-disable-lifo-slot <BOOL>
+                                     Disable LIFO slot of IO runtime
                                      [env: INFLUXDB3_IO_RUNTIME_DISABLE_LIFO_SLOT=]
                                      [possible values: true, false]
-  --io-runtime-event-interval <N>   Scheduler ticks before polling for external events 
+  --io-runtime-event-interval <N>   Scheduler ticks before polling for external events
                                      [env: INFLUXDB3_IO_RUNTIME_EVENT_INTERVAL=]
-  --io-runtime-global-queue-interval <N>  
-                                     Scheduler ticks before polling global task queue 
+  --io-runtime-global-queue-interval <N>
+                                     Scheduler ticks before polling global task queue
                                      [env: INFLUXDB3_IO_RUNTIME_GLOBAL_QUEUE_INTERVAL=]
-  --io-runtime-max-blocking-threads <N>  
-                                     Thread limit for IO runtime 
+  --io-runtime-max-blocking-threads <N>
+                                     Thread limit for IO runtime
                                      [env: INFLUXDB3_IO_RUNTIME_MAX_BLOCKING_THREADS=]
-  --io-runtime-max-io-events-per-tick <N>  
-                                     Max events processed per tick 
+  --io-runtime-max-io-events-per-tick <N>
+                                     Max events processed per tick
                                      [env: INFLUXDB3_IO_RUNTIME_MAX_IO_EVENTS_PER_TICK=]
-  --io-runtime-thread-keep-alive <DURATION>  
-                                     Blocking pool thread timeout 
+  --io-runtime-thread-keep-alive <DURATION>
+                                     Blocking pool thread timeout
                                      [env: INFLUXDB3_IO_RUNTIME_THREAD_KEEP_ALIVE=]
-  --io-runtime-thread-priority <PRIORITY>  
-                                     Thread priority for runtime workers 
+  --io-runtime-thread-priority <PRIORITY>
+                                     Thread priority for runtime workers
                                      [env: INFLUXDB3_IO_RUNTIME_THREAD_PRIORITY=]
-  --num-threads <N>                  Set maximum IO runtime threads [env: INFLUXDB3_NUM_THREADS=]
+  --num-io-threads <N>               Set maximum IO runtime threads [env: INFLUXDB3_NUM_THREADS=]
 
 {}
   -h, --help        Print help information

--- a/influxdb3/src/main.rs
+++ b/influxdb3/src/main.rs
@@ -12,7 +12,7 @@ clippy::future_not_send
 
 use clap::Parser;
 use dotenvy::dotenv;
-use influxdb3_clap_blocks::tokio::TokioIoConfig;
+use influxdb3_clap_blocks::tokio::{TokioDatafusionConfig, TokioIoConfig};
 use influxdb3_process::VERSION_STRING;
 use observability_deps::tracing::warn;
 use owo_colors::OwoColorize;
@@ -126,6 +126,10 @@ fn main() -> Result<(), std::io::Error> {
     // We must check for the help flags first else clap will complain if we do not
     // have certain args set when we call `Config::parse()` f.ex `influxdb3 serve -h` will fail with our current derive as `--node-id` is required. This would be confusing as many users will expect to just be able to pass `-h` and get some help spat out. The joys of manually implementing `-h/--help/--help-all`
     maybe_print_help();
+
+    // Copy deprecated environment variables
+    TokioIoConfig::copy_deprecated_env_aliases();
+    TokioDatafusionConfig::copy_deprecated_env_aliases();
 
     // Note the help code above *must* run before this function call
     let config = Config::parse();


### PR DESCRIPTION
Closes #26270

Introduces thread arguments consistent with InfluxDB3 Pro.

> [!IMPORTANT]
>
> If the old environment variables are used, a warning will be displayed on the console with the recommended replacement.
>
> ```sh
> influxdb3 serve
> ```
> ```text
> WARN: Use of deprecated environment variable INFLUXDB3_NUM_THREADS: replace with INFLUXDB3_NUM_IO_THREADS
> WARN: Use of deprecated environment variable INFLUXDB3_DATAFUSION_NUM_THREADS: replace with INFLUXDB3_NUM_DATAFUSION_THREADS
> ```
