### PR TITLE
chore: upgrade go 1.23.5 -> 1.23.8 [1.10]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ parameters:
     # when updating the go version, should also update the go version in go.mod
     description: docker tag for cross build container from quay.io . Created by https://github.com/influxdata/edge/tree/master/dockerfiles/cross-builder .
     type: string
-    default: go1.23.5-latest
+    default: go1.23.8-latest
 
   workflow:
     type: string


### PR DESCRIPTION
Closes https://github.com/influxdata/edge/issues/824

Upgrade Go version from 1.23.5 to 1.23.8.

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
