### PR TITLE
feat: Add support for CORS requests from a browser

### DIFF
--- a/influxdb3_server/Cargo.toml
+++ b/influxdb3_server/Cargo.toml
@@ -69,6 +69,7 @@ flate2.workspace = true
 futures.workspace = true
 hashbrown.workspace = true
 hex.workspace = true
+http.workspace = true
 hyper.workspace = true
 hyper-rustls.workspace = true
 humantime.workspace = true


### PR DESCRIPTION
This commit adds support for CORS by modifying our requests to make preflight checks valid and to handle responses containing the necessary headers for browsers to access the data they need. We keep what we accept as open as this is essentially what requests to the server are normally like and we gate the requests with an auth token.

Closes #26313

This is honestly quite hard to test unless we have a whole headless browser setup going on which for one test seems a bit excessive and it's unlikely this code will change much if at all once committed.

Here you can see that the request to the server fails based off main
![Screenshot from 2025-04-22 15-31-25](https://github.com/user-attachments/assets/8d4cb1a8-e55d-45ff-866b-a50682313492)

Here the same request passes with CORS headers enabled
![Screenshot from 2025-04-22 15-30-06](https://github.com/user-attachments/assets/66b857d2-8693-4b79-a19e-ece890d37613)
