### PR TITLE
fix: limit number of concurrent optimized compactions

### DIFF
--- a/tsdb/config.go
+++ b/tsdb/config.go
@@ -146,11 +146,16 @@ type Config struct {
 	// A value of 0 disables the limit.
 	MaxValuesPerTag int `toml:"max-values-per-tag"`
 
-	// MaxConcurrentCompactions is the maximum number of concurrent level and full compactions
+	// MaxConcurrentCompactions is the maximum number of concurrent level, full, and optimized compactions
 	// that can be running at one time across all shards.  Compactions scheduled to run when the
 	// limit is reached are blocked until a running compaction completes.  Snapshot compactions are
 	// not affected by this limit.  A value of 0 limits compactions to runtime.GOMAXPROCS(0).
 	MaxConcurrentCompactions int `toml:"max-concurrent-compactions"`
+
+	// MaxConcurrentOptimizedCompactions is the maximum number of concurrent optimized compactions
+	// that can be running across all shards. Optimized compactions scheduled to run when the limit
+	// is reached are aborted, saving them for a later compaction run.
+	MaxConcurrentOptimizedCompactions int `toml:"max-concurrent-optimized-compactions"`
 
 	// MaxIndexLogFileSize is the threshold, in bytes, when an index write-ahead log file will
 	// compact into an index file. Lower sizes will cause log files to be compacted more quickly

--- a/tsdb/engine.go
+++ b/tsdb/engine.go
@@ -176,6 +176,7 @@ type EngineOptions struct {
 	CompactionPlannerCreator    CompactionPlannerCreator
 	CompactionLimiter           limiter.Fixed
 	CompactionThroughputLimiter limiter.Rate
+	OptimizedCompactionLimiter  limiter.Fixed
 	WALEnabled                  bool
 	MonitorDisabled             bool
 

--- a/tsdb/engine/tsm1/compact.go
+++ b/tsdb/engine/tsm1/compact.go
@@ -270,12 +270,16 @@ func (c *DefaultPlanner) generationsFullyCompacted(gens tsmGenerations) (bool, s
 			aggressivePointsPerBlockCount := 0
 			filesUnderMaxTsmSizeCount := 0
 			for _, tsmFile := range gens[0].files {
-				if c.FileStore.BlockCount(tsmFile.Path, 1) >= c.aggressiveCompactionPointsPerBlock {
+				if c.FileStore.BlockCount(tsmFile.Path, 1) >= c.GetAggressiveCompactionPointsPerBlock() {
 					aggressivePointsPerBlockCount++
 				}
 				if tsmFile.Size < tsdb.MaxTSMFileSize {
 					filesUnderMaxTsmSizeCount++
 				}
+			}
+
+			if aggressivePointsPerBlockCount == len(gens[0].files) {
+				return true, "fully compacted because all files are at aggressivePointsPerBlock"
 			}
 
 			if filesUnderMaxTsmSizeCount > 1 && aggressivePointsPerBlockCount < len(gens[0].files) {

--- a/tsdb/engine/tsm1/compact_test.go
+++ b/tsdb/engine/tsm1/compact_test.go
@@ -2261,16 +2261,14 @@ func TestDefaultPlanner_PlanOptimize_NoLevel4(t *testing.T) {
 
 func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 	type PlanOptimizeTests struct {
-		name                            string
-		fs                              []tsm1.FileStat
-		bc                              []int
-		expectedFullyCompactedReasonExp string
-		expectedgenerationCount         int64
-		level1Groups                    []tsm1.PlannedCompactionGroup
-		level2Groups                    []tsm1.PlannedCompactionGroup
-		level3Groups                    []tsm1.PlannedCompactionGroup
-		level4Groups                    []tsm1.PlannedCompactionGroup
-		level5Groups                    []tsm1.PlannedCompactionGroup
+		name         string
+		fs           []tsm1.FileStat
+		bc           []int
+		level1Groups []tsm1.PlannedCompactionGroup
+		level2Groups []tsm1.PlannedCompactionGroup
+		level3Groups []tsm1.PlannedCompactionGroup
+		level4Groups []tsm1.PlannedCompactionGroup
+		level5Groups []tsm1.PlannedCompactionGroup
 	}
 
 	e, err := NewEngine(tsdb.InmemIndexName)
@@ -2339,8 +2337,6 @@ func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 				10,
 				5,
 			},
-			"not fully compacted and not idle because of more than one generation",
-			3,
 			[]tsm1.PlannedCompactionGroup{},
 			[]tsm1.PlannedCompactionGroup{},
 			[]tsm1.PlannedCompactionGroup{},
@@ -2384,8 +2380,6 @@ func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 				},
 			},
 			[]int{},
-			tsdb.SingleGenerationReasonText,
-			1,
 			[]tsm1.PlannedCompactionGroup{},
 			[]tsm1.PlannedCompactionGroup{},
 			[]tsm1.PlannedCompactionGroup{},
@@ -2419,8 +2413,6 @@ func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 				},
 			},
 			[]int{},
-			tsdb.SingleGenerationReasonText,
-			1,
 			[]tsm1.PlannedCompactionGroup{},
 			[]tsm1.PlannedCompactionGroup{},
 			[]tsm1.PlannedCompactionGroup{},
@@ -2456,8 +2448,6 @@ func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 				},
 			},
 			[]int{tsdb.DefaultMaxPointsPerBlock, tsdb.DefaultMaxPointsPerBlock, tsdb.DefaultMaxPointsPerBlock, tsdb.DefaultMaxPointsPerBlock},
-			tsdb.SingleGenerationReasonText,
-			1,
 			[]tsm1.PlannedCompactionGroup{},
 			[]tsm1.PlannedCompactionGroup{},
 			[]tsm1.PlannedCompactionGroup{},
@@ -2521,8 +2511,6 @@ func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 				tsdb.DefaultMaxPointsPerBlock,
 				tsdb.DefaultMaxPointsPerBlock,
 			},
-			tsdb.SingleGenerationReasonText,
-			1,
 			[]tsm1.PlannedCompactionGroup{},
 			[]tsm1.PlannedCompactionGroup{},
 			[]tsm1.PlannedCompactionGroup{},
@@ -2563,8 +2551,6 @@ func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 				tsdb.DefaultMaxPointsPerBlock,
 				tsdb.DefaultMaxPointsPerBlock,
 			},
-			tsdb.SingleGenerationReasonText,
-			1,
 			[]tsm1.PlannedCompactionGroup{},
 			[]tsm1.PlannedCompactionGroup{},
 			[]tsm1.PlannedCompactionGroup{},
@@ -2620,8 +2606,6 @@ func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 				},
 			},
 			[]int{},
-			"",
-			0,
 			[]tsm1.PlannedCompactionGroup{},
 			[]tsm1.PlannedCompactionGroup{},
 			[]tsm1.PlannedCompactionGroup{},
@@ -2647,8 +2631,6 @@ func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 				tsdb.DefaultAggressiveMaxPointsPerBlock,
 				tsdb.DefaultAggressiveMaxPointsPerBlock,
 			},
-			"",
-			0,
 			[]tsm1.PlannedCompactionGroup{},
 			[]tsm1.PlannedCompactionGroup{},
 			[]tsm1.PlannedCompactionGroup{},
@@ -2675,8 +2657,6 @@ func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 				tsdb.DefaultAggressiveMaxPointsPerBlock,
 				tsdb.DefaultMaxPointsPerBlock,
 			},
-			"",
-			0,
 			[]tsm1.PlannedCompactionGroup{},
 			[]tsm1.PlannedCompactionGroup{},
 			[]tsm1.PlannedCompactionGroup{},
@@ -2706,8 +2686,6 @@ func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 				tsdb.DefaultAggressiveMaxPointsPerBlock,
 				tsdb.DefaultAggressiveMaxPointsPerBlock,
 			},
-			"",
-			0,
 			[]tsm1.PlannedCompactionGroup{},
 			[]tsm1.PlannedCompactionGroup{},
 			[]tsm1.PlannedCompactionGroup{},
@@ -2744,17 +2722,14 @@ func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 	}
 
 	type PlanOptimizeMixedTests struct {
-		name                            string
-		fs                              []tsm1.FileStat
-		bc                              []int
-		expectedFullyCompactedReasonExp string
-		expectedgenerationCount         int64
-		fullyCompacted                  bool
-		level1Groups                    []tsm1.PlannedCompactionGroup
-		level2Groups                    []tsm1.PlannedCompactionGroup
-		level3Groups                    []tsm1.PlannedCompactionGroup
-		level4Groups                    []tsm1.PlannedCompactionGroup
-		level5Groups                    []tsm1.PlannedCompactionGroup
+		name         string
+		fs           []tsm1.FileStat
+		bc           []int
+		level1Groups []tsm1.PlannedCompactionGroup
+		level2Groups []tsm1.PlannedCompactionGroup
+		level3Groups []tsm1.PlannedCompactionGroup
+		level4Groups []tsm1.PlannedCompactionGroup
+		level5Groups []tsm1.PlannedCompactionGroup
 	}
 
 	mixedPlanOptimizeTests := []PlanOptimizeMixedTests{
@@ -2770,9 +2745,6 @@ func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 				},
 			},
 			[]int{},
-			"",
-			0,
-			true,
 			[]tsm1.PlannedCompactionGroup{},
 			[]tsm1.PlannedCompactionGroup{},
 			[]tsm1.PlannedCompactionGroup{},
@@ -2798,9 +2770,6 @@ func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 				tsdb.DefaultAggressiveMaxPointsPerBlock,
 				tsdb.DefaultAggressiveMaxPointsPerBlock,
 			},
-			"",
-			0,
-			true,
 			[]tsm1.PlannedCompactionGroup{},
 			[]tsm1.PlannedCompactionGroup{},
 			[]tsm1.PlannedCompactionGroup{},
@@ -2827,9 +2796,6 @@ func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 				tsdb.DefaultAggressiveMaxPointsPerBlock,
 				tsdb.DefaultMaxPointsPerBlock,
 			},
-			"",
-			0,
-			true,
 			[]tsm1.PlannedCompactionGroup{},
 			[]tsm1.PlannedCompactionGroup{},
 			[]tsm1.PlannedCompactionGroup{},
@@ -2859,9 +2825,6 @@ func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 				tsdb.DefaultAggressiveMaxPointsPerBlock,
 				tsdb.DefaultAggressiveMaxPointsPerBlock,
 			},
-			tsdb.SingleGenerationReasonText,
-			1,
-			false,
 			[]tsm1.PlannedCompactionGroup{},
 			[]tsm1.PlannedCompactionGroup{},
 			[]tsm1.PlannedCompactionGroup{},

--- a/tsdb/engine/tsm1/compact_test.go
+++ b/tsdb/engine/tsm1/compact_test.go
@@ -2704,6 +2704,9 @@ func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 
 			cp := tsm1.NewDefaultPlanner(ffs, tsdb.DefaultCompactFullWriteColdDuration)
 
+			compacted, _ := cp.FullyCompacted()
+			require.True(t, compacted, "Should be fully compacted")
+
 			if len(test.bc) > 0 {
 				err := ffs.SetBlockCounts(test.bc)
 				require.NoError(t, err, "setting block counts")

--- a/tsdb/engine/tsm1/compact_test.go
+++ b/tsdb/engine/tsm1/compact_test.go
@@ -2467,10 +2467,10 @@ func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 					Size: 450 * 1024 * 1024,
 				},
 			}, []int{
-				tsdb.DefaultAggressiveMaxPointsPerBlock,
-				tsdb.DefaultMaxPointsPerBlock,
-				tsdb.DefaultMaxPointsPerBlock,
-			},
+			tsdb.DefaultAggressiveMaxPointsPerBlock,
+			tsdb.DefaultMaxPointsPerBlock,
+			tsdb.DefaultMaxPointsPerBlock,
+		},
 			tsdb.SingleGenerationReasonText,
 			1,
 		},
@@ -2546,9 +2546,9 @@ func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 					Size: 691 * 1024 * 1024,
 				},
 			}, []int{
-				tsdb.DefaultAggressiveMaxPointsPerBlock,
-				tsdb.DefaultAggressiveMaxPointsPerBlock,
-			}, "", 0,
+			tsdb.DefaultAggressiveMaxPointsPerBlock,
+			tsdb.DefaultAggressiveMaxPointsPerBlock,
+		}, "", 0,
 		},
 		{
 			// This test is added to account for a single generation that has a group size
@@ -2566,9 +2566,9 @@ func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 					Size: 691 * 1024 * 1024,
 				},
 			}, []int{
-				tsdb.DefaultAggressiveMaxPointsPerBlock,
-				tsdb.DefaultMaxPointsPerBlock,
-			},
+			tsdb.DefaultAggressiveMaxPointsPerBlock,
+			tsdb.DefaultMaxPointsPerBlock,
+		},
 			"",
 			0,
 		},
@@ -2590,10 +2590,10 @@ func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 					Size: 450 * 1024 * 1024,
 				},
 			}, []int{
-				tsdb.DefaultAggressiveMaxPointsPerBlock,
-				tsdb.DefaultAggressiveMaxPointsPerBlock,
-				tsdb.DefaultAggressiveMaxPointsPerBlock,
-			}, "", 0,
+			tsdb.DefaultAggressiveMaxPointsPerBlock,
+			tsdb.DefaultAggressiveMaxPointsPerBlock,
+			tsdb.DefaultAggressiveMaxPointsPerBlock,
+		}, "", 0,
 		},
 	}
 
@@ -2687,9 +2687,9 @@ func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 					Size: 691 * 1024 * 1024,
 				},
 			}, []int{
-				tsdb.DefaultAggressiveMaxPointsPerBlock,
-				tsdb.DefaultAggressiveMaxPointsPerBlock,
-			}, "", 0, true,
+			tsdb.DefaultAggressiveMaxPointsPerBlock,
+			tsdb.DefaultAggressiveMaxPointsPerBlock,
+		}, "", 0, true,
 		},
 		{
 			// This test is added to account for a single generation that has a group size
@@ -2707,9 +2707,9 @@ func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 					Size: 691 * 1024 * 1024,
 				},
 			}, []int{
-				tsdb.DefaultAggressiveMaxPointsPerBlock,
-				tsdb.DefaultMaxPointsPerBlock,
-			},
+			tsdb.DefaultAggressiveMaxPointsPerBlock,
+			tsdb.DefaultMaxPointsPerBlock,
+		},
 			"",
 			0, true,
 		},
@@ -2731,10 +2731,10 @@ func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 					Size: 450 * 1024 * 1024,
 				},
 			}, []int{
-				tsdb.DefaultAggressiveMaxPointsPerBlock,
-				tsdb.DefaultAggressiveMaxPointsPerBlock,
-				tsdb.DefaultAggressiveMaxPointsPerBlock,
-			}, tsdb.SingleGenerationReasonText, 1, false,
+			tsdb.DefaultAggressiveMaxPointsPerBlock,
+			tsdb.DefaultAggressiveMaxPointsPerBlock,
+			tsdb.DefaultAggressiveMaxPointsPerBlock,
+		}, tsdb.SingleGenerationReasonText, 1, false,
 		},
 	}
 
@@ -2905,23 +2905,23 @@ func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 					Size: 400 * 1024 * 1024,
 				},
 			}, []int{
-				tsdb.DefaultAggressiveMaxPointsPerBlock,
-				tsdb.DefaultAggressiveMaxPointsPerBlock,
-				tsdb.DefaultAggressiveMaxPointsPerBlock,
+			tsdb.DefaultAggressiveMaxPointsPerBlock,
+			tsdb.DefaultAggressiveMaxPointsPerBlock,
+			tsdb.DefaultAggressiveMaxPointsPerBlock,
 
-				tsdb.DefaultAggressiveMaxPointsPerBlock,
-				tsdb.DefaultAggressiveMaxPointsPerBlock,
-				tsdb.DefaultMaxPointsPerBlock,
+			tsdb.DefaultAggressiveMaxPointsPerBlock,
+			tsdb.DefaultAggressiveMaxPointsPerBlock,
+			tsdb.DefaultMaxPointsPerBlock,
 
-				tsdb.DefaultAggressiveMaxPointsPerBlock,
-				tsdb.DefaultAggressiveMaxPointsPerBlock,
-				tsdb.DefaultMaxPointsPerBlock,
+			tsdb.DefaultAggressiveMaxPointsPerBlock,
+			tsdb.DefaultAggressiveMaxPointsPerBlock,
+			tsdb.DefaultMaxPointsPerBlock,
 
-				tsdb.DefaultMaxPointsPerBlock,
-				// Use some magic numbers but these are just small values for block counts
-				100,
-				10,
-			},
+			tsdb.DefaultMaxPointsPerBlock,
+			// Use some magic numbers but these are just small values for block counts
+			100,
+			10,
+		},
 		},
 		{
 			"1.12.0 RC0 Planner issue mock data from cluster",
@@ -4022,13 +4022,12 @@ func TestEnginePlanCompactions(t *testing.T) {
 		},
 	}
 	testBlockCountsAndResults := []struct {
-		blockCounts      []int
-		level1Groups     []tsm1.CompactionGroup
-		level2Groups     []tsm1.CompactionGroup
-		level3Groups     []tsm1.CompactionGroup
-		level4Groups     []tsm1.CompactionGroup
-		level5Groups     []tsm1.CompactionGroup
-		level5Aggressive bool
+		blockCounts  []int
+		level1Groups []tsm1.PlannedCompactionGroup
+		level2Groups []tsm1.PlannedCompactionGroup
+		level3Groups []tsm1.PlannedCompactionGroup
+		level4Groups []tsm1.PlannedCompactionGroup
+		level5Groups []tsm1.PlannedCompactionGroup
 	}{
 		{
 			blockCounts: []int{
@@ -4037,10 +4036,12 @@ func TestEnginePlanCompactions(t *testing.T) {
 				tsdb.DefaultMaxPointsPerBlock,
 				tsdb.DefaultMaxPointsPerBlock,
 			},
-			level5Groups: []tsm1.CompactionGroup{
-				{"01-05.tsm", "02-05.tsm", "03-05.tsm", "04-04.tsm"},
+			level5Groups: []tsm1.PlannedCompactionGroup{
+				{
+					tsm1.CompactionGroup{"01-05.tsm", "02-05.tsm", "03-05.tsm", "04-04.tsm"},
+					tsdb.DefaultAggressiveMaxPointsPerBlock,
+				},
 			},
-			level5Aggressive: false,
 		},
 		{
 			blockCounts: []int{
@@ -4049,10 +4050,12 @@ func TestEnginePlanCompactions(t *testing.T) {
 				tsdb.DefaultMaxPointsPerBlock,
 				tsdb.DefaultMaxPointsPerBlock,
 			},
-			level5Groups: []tsm1.CompactionGroup{
-				{"01-05.tsm", "02-05.tsm", "03-05.tsm", "04-05.tsm"},
+			level5Groups: []tsm1.PlannedCompactionGroup{
+				{
+					tsm1.CompactionGroup{"01-05.tsm", "02-05.tsm", "03-05.tsm", "04-05.tsm"},
+					tsdb.DefaultAggressiveMaxPointsPerBlock,
+				},
 			},
-			level5Aggressive: false,
 		},
 	}
 
@@ -4075,22 +4078,21 @@ func TestEnginePlanCompactions(t *testing.T) {
 		e.CompactionPlan = cp
 		e.Compactor.FileStore = ffs
 
-		level1Groups, level2Groups, Level3Groups, Level4Groups, Level5Groups, level5Aggressive := e.PlanCompactions()
-		compareLevelGroups(t, testBlockCountsAndResults[i].level1Groups, level1Groups, "unexpected level 1 group")
-		compareLevelGroups(t, testBlockCountsAndResults[i].level2Groups, level2Groups, "unexpected level 2 group")
-		compareLevelGroups(t, testBlockCountsAndResults[i].level3Groups, Level3Groups, "unexpected level 3 group")
-		compareLevelGroups(t, testBlockCountsAndResults[i].level4Groups, Level4Groups, "unexpected level 4 group")
-		compareLevelGroups(t, testBlockCountsAndResults[i].level5Groups, Level5Groups, "unexpected level 5 group")
-		require.Equal(t, testBlockCountsAndResults[i].level5Aggressive, level5Aggressive, "unexpected level5aggressive")
+		level1Groups, level2Groups, Level3Groups, Level4Groups, Level5Groups := e.PlanCompactions()
+		compareLevelGroups(t, testBlockCountsAndResults[i].level1Groups, level1Groups, "unexpected level 1 Group")
+		compareLevelGroups(t, testBlockCountsAndResults[i].level2Groups, level2Groups, "unexpected level 2 Group")
+		compareLevelGroups(t, testBlockCountsAndResults[i].level3Groups, Level3Groups, "unexpected level 3 Group")
+		compareLevelGroups(t, testBlockCountsAndResults[i].level4Groups, Level4Groups, "unexpected level 4 Group")
+		compareLevelGroups(t, testBlockCountsAndResults[i].level5Groups, Level5Groups, "unexpected level 5 Group")
 	}
 }
 
 // Necessary specialize comparison because require.Elements.Match thinks nested nil and zero length slices differ
-func compareLevelGroups(t *testing.T, exp, got []tsm1.CompactionGroup, message string) {
+func compareLevelGroups(t *testing.T, exp, got []tsm1.PlannedCompactionGroup, message string) {
 	require.Lenf(t, got, len(exp), "%s %s", message, " collection length mismatch")
-	for i := range exp {
-		require.Lenf(t, got[i], len(exp[i]), "%s %s", message, "length mismatch")
-		require.ElementsMatchf(t, got[i], exp[i], "%s %s", message, "mismatch")
+	for i, group := range exp {
+		require.Equal(t, group.Group, got[i].Group, message)
+		require.Equal(t, group.PointsPerBlock, got[i].PointsPerBlock, message)
 	}
 }
 

--- a/tsdb/engine/tsm1/compact_test.go
+++ b/tsdb/engine/tsm1/compact_test.go
@@ -2704,13 +2704,13 @@ func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 
 			cp := tsm1.NewDefaultPlanner(ffs, tsdb.DefaultCompactFullWriteColdDuration)
 
-			compacted, _ := cp.FullyCompacted()
-			require.True(t, compacted, "Should be fully compacted")
-
 			if len(test.bc) > 0 {
 				err := ffs.SetBlockCounts(test.bc)
 				require.NoError(t, err, "setting block counts")
 			}
+
+			compacted, _ := cp.FullyCompacted()
+			require.True(t, compacted, "Should be fully compacted")
 
 			e.CompactionPlan = cp
 			e.Compactor.FileStore = ffs

--- a/tsdb/engine/tsm1/compact_test.go
+++ b/tsdb/engine/tsm1/compact_test.go
@@ -3,7 +3,6 @@ package tsm1_test
 import (
 	"errors"
 	"fmt"
-	"golang.org/x/exp/slices"
 	"io/fs"
 	"math"
 	"os"
@@ -11,6 +10,8 @@ import (
 	"sort"
 	"testing"
 	"time"
+
+	"golang.org/x/exp/slices"
 
 	"github.com/influxdata/influxdb/tsdb"
 	"github.com/influxdata/influxdb/tsdb/engine/tsm1"
@@ -2467,10 +2468,10 @@ func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 					Size: 450 * 1024 * 1024,
 				},
 			}, []int{
-			tsdb.DefaultAggressiveMaxPointsPerBlock,
-			tsdb.DefaultMaxPointsPerBlock,
-			tsdb.DefaultMaxPointsPerBlock,
-		},
+				tsdb.DefaultAggressiveMaxPointsPerBlock,
+				tsdb.DefaultMaxPointsPerBlock,
+				tsdb.DefaultMaxPointsPerBlock,
+			},
 			tsdb.SingleGenerationReasonText,
 			1,
 		},
@@ -2546,9 +2547,9 @@ func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 					Size: 691 * 1024 * 1024,
 				},
 			}, []int{
-			tsdb.DefaultAggressiveMaxPointsPerBlock,
-			tsdb.DefaultAggressiveMaxPointsPerBlock,
-		}, "", 0,
+				tsdb.DefaultAggressiveMaxPointsPerBlock,
+				tsdb.DefaultAggressiveMaxPointsPerBlock,
+			}, "", 0,
 		},
 		{
 			// This test is added to account for a single generation that has a group size
@@ -2566,9 +2567,9 @@ func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 					Size: 691 * 1024 * 1024,
 				},
 			}, []int{
-			tsdb.DefaultAggressiveMaxPointsPerBlock,
-			tsdb.DefaultMaxPointsPerBlock,
-		},
+				tsdb.DefaultAggressiveMaxPointsPerBlock,
+				tsdb.DefaultMaxPointsPerBlock,
+			},
 			"",
 			0,
 		},
@@ -2590,10 +2591,10 @@ func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 					Size: 450 * 1024 * 1024,
 				},
 			}, []int{
-			tsdb.DefaultAggressiveMaxPointsPerBlock,
-			tsdb.DefaultAggressiveMaxPointsPerBlock,
-			tsdb.DefaultAggressiveMaxPointsPerBlock,
-		}, "", 0,
+				tsdb.DefaultAggressiveMaxPointsPerBlock,
+				tsdb.DefaultAggressiveMaxPointsPerBlock,
+				tsdb.DefaultAggressiveMaxPointsPerBlock,
+			}, "", 0,
 		},
 	}
 
@@ -2687,9 +2688,9 @@ func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 					Size: 691 * 1024 * 1024,
 				},
 			}, []int{
-			tsdb.DefaultAggressiveMaxPointsPerBlock,
-			tsdb.DefaultAggressiveMaxPointsPerBlock,
-		}, "", 0, true,
+				tsdb.DefaultAggressiveMaxPointsPerBlock,
+				tsdb.DefaultAggressiveMaxPointsPerBlock,
+			}, "", 0, true,
 		},
 		{
 			// This test is added to account for a single generation that has a group size
@@ -2707,9 +2708,9 @@ func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 					Size: 691 * 1024 * 1024,
 				},
 			}, []int{
-			tsdb.DefaultAggressiveMaxPointsPerBlock,
-			tsdb.DefaultMaxPointsPerBlock,
-		},
+				tsdb.DefaultAggressiveMaxPointsPerBlock,
+				tsdb.DefaultMaxPointsPerBlock,
+			},
 			"",
 			0, true,
 		},
@@ -2731,10 +2732,10 @@ func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 					Size: 450 * 1024 * 1024,
 				},
 			}, []int{
-			tsdb.DefaultAggressiveMaxPointsPerBlock,
-			tsdb.DefaultAggressiveMaxPointsPerBlock,
-			tsdb.DefaultAggressiveMaxPointsPerBlock,
-		}, tsdb.SingleGenerationReasonText, 1, false,
+				tsdb.DefaultAggressiveMaxPointsPerBlock,
+				tsdb.DefaultAggressiveMaxPointsPerBlock,
+				tsdb.DefaultAggressiveMaxPointsPerBlock,
+			}, tsdb.SingleGenerationReasonText, 1, false,
 		},
 	}
 
@@ -2905,23 +2906,23 @@ func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 					Size: 400 * 1024 * 1024,
 				},
 			}, []int{
-			tsdb.DefaultAggressiveMaxPointsPerBlock,
-			tsdb.DefaultAggressiveMaxPointsPerBlock,
-			tsdb.DefaultAggressiveMaxPointsPerBlock,
+				tsdb.DefaultAggressiveMaxPointsPerBlock,
+				tsdb.DefaultAggressiveMaxPointsPerBlock,
+				tsdb.DefaultAggressiveMaxPointsPerBlock,
 
-			tsdb.DefaultAggressiveMaxPointsPerBlock,
-			tsdb.DefaultAggressiveMaxPointsPerBlock,
-			tsdb.DefaultMaxPointsPerBlock,
+				tsdb.DefaultAggressiveMaxPointsPerBlock,
+				tsdb.DefaultAggressiveMaxPointsPerBlock,
+				tsdb.DefaultMaxPointsPerBlock,
 
-			tsdb.DefaultAggressiveMaxPointsPerBlock,
-			tsdb.DefaultAggressiveMaxPointsPerBlock,
-			tsdb.DefaultMaxPointsPerBlock,
+				tsdb.DefaultAggressiveMaxPointsPerBlock,
+				tsdb.DefaultAggressiveMaxPointsPerBlock,
+				tsdb.DefaultMaxPointsPerBlock,
 
-			tsdb.DefaultMaxPointsPerBlock,
-			// Use some magic numbers but these are just small values for block counts
-			100,
-			10,
-		},
+				tsdb.DefaultMaxPointsPerBlock,
+				// Use some magic numbers but these are just small values for block counts
+				100,
+				10,
+			},
 		},
 		{
 			"1.12.0 RC0 Planner issue mock data from cluster",

--- a/tsdb/engine/tsm1/compact_test.go
+++ b/tsdb/engine/tsm1/compact_test.go
@@ -11,8 +11,6 @@ import (
 	"testing"
 	"time"
 
-	"golang.org/x/exp/slices"
-
 	"github.com/influxdata/influxdb/tsdb"
 	"github.com/influxdata/influxdb/tsdb/engine/tsm1"
 	"github.com/stretchr/testify/assert"
@@ -2268,7 +2266,19 @@ func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 		bc                              []int
 		expectedFullyCompactedReasonExp string
 		expectedgenerationCount         int64
+		level1Groups                    []tsm1.PlannedCompactionGroup
+		level2Groups                    []tsm1.PlannedCompactionGroup
+		level3Groups                    []tsm1.PlannedCompactionGroup
+		level4Groups                    []tsm1.PlannedCompactionGroup
+		level5Groups                    []tsm1.PlannedCompactionGroup
 	}
+
+	e, err := NewEngine(tsdb.InmemIndexName)
+	require.NoError(t, err, "open engine")
+	e.SetEnabled(false)
+	defer func() { require.NoError(t, e.Close(), "close engine") }()
+	e.Compactor = tsm1.NewCompactor()
+	defer e.Compactor.Close()
 
 	furtherCompactedTests := []PlanOptimizeTests{
 		// Large multi generation group with files at and under 2GB
@@ -2331,6 +2341,26 @@ func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 			},
 			"not fully compacted and not idle because of more than one generation",
 			3,
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{
+				{
+					tsm1.CompactionGroup{"01-05.tsm1",
+						"01-06.tsm1",
+						"01-07.tsm1",
+						"01-08.tsm1",
+						"02-05.tsm1",
+						"02-06.tsm1",
+						"02-07.tsm1",
+						"02-08.tsm1",
+						"03-04.tsm1",
+						"03-05.tsm1",
+					},
+					tsdb.DefaultMaxPointsPerBlock,
+				},
+			},
 		},
 		// ~650mb group size
 		{
@@ -2356,6 +2386,20 @@ func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 			[]int{},
 			tsdb.SingleGenerationReasonText,
 			1,
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{
+				{
+					tsm1.CompactionGroup{"01-05.tsm1",
+						"01-06.tsm1",
+						"01-07.tsm1",
+						"01-08.tsm1",
+					},
+					tsdb.DefaultAggressiveMaxPointsPerBlock,
+				},
+			},
 		},
 		// ~650 MB total group size with generations under 4
 		{
@@ -2377,6 +2421,19 @@ func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 			[]int{},
 			tsdb.SingleGenerationReasonText,
 			1,
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{
+				{
+					tsm1.CompactionGroup{"01-02.tsm1",
+						"01-03.tsm1",
+						"01-04.tsm1",
+					},
+					tsdb.DefaultAggressiveMaxPointsPerBlock,
+				},
+			},
 		},
 		{
 			"Small group size with single generation all at DefaultMaxPointsPerBlock",
@@ -2397,9 +2454,24 @@ func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 					Path: "01-08.tsm1",
 					Size: 50 * 1024 * 1024,
 				},
-			}, []int{tsdb.DefaultMaxPointsPerBlock, tsdb.DefaultMaxPointsPerBlock, tsdb.DefaultMaxPointsPerBlock, tsdb.DefaultMaxPointsPerBlock},
+			},
+			[]int{tsdb.DefaultMaxPointsPerBlock, tsdb.DefaultMaxPointsPerBlock, tsdb.DefaultMaxPointsPerBlock, tsdb.DefaultMaxPointsPerBlock},
 			tsdb.SingleGenerationReasonText,
 			1,
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{
+				{
+					tsm1.CompactionGroup{"01-05.tsm1",
+						"01-06.tsm1",
+						"01-07.tsm1",
+						"01-08.tsm1",
+					},
+					tsdb.DefaultAggressiveMaxPointsPerBlock,
+				},
+			},
 		},
 		// > 2 GB total group size
 		// 50% of files are at aggressive max block size
@@ -2451,6 +2523,24 @@ func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 			},
 			tsdb.SingleGenerationReasonText,
 			1,
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{
+				{
+					tsm1.CompactionGroup{"01-05.tsm1",
+						"01-06.tsm1",
+						"01-07.tsm1",
+						"01-08.tsm1",
+						"01-09.tsm1",
+						"01-10.tsm1",
+						"01-11.tsm1",
+						"01-12.tsm1",
+					},
+					tsdb.DefaultAggressiveMaxPointsPerBlock,
+				},
+			},
 		},
 		{
 			"Group size over 2GB with single generation",
@@ -2467,39 +2557,31 @@ func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 					Path: "01-15.tsm1",
 					Size: 450 * 1024 * 1024,
 				},
-			}, []int{
+			},
+			[]int{
 				tsdb.DefaultAggressiveMaxPointsPerBlock,
 				tsdb.DefaultMaxPointsPerBlock,
 				tsdb.DefaultMaxPointsPerBlock,
 			},
 			tsdb.SingleGenerationReasonText,
 			1,
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{
+				{
+					tsm1.CompactionGroup{"01-13.tsm1",
+						"01-14.tsm1",
+						"01-15.tsm1",
+					},
+					tsdb.DefaultAggressiveMaxPointsPerBlock,
+				},
+			},
 		},
 	}
 
-	expectedNotFullyCompacted := func(cp *tsm1.DefaultPlanner, reasonExp string, generationCountExp int64) {
-		compacted, reason := cp.FullyCompacted()
-		require.Equal(t, reason, reasonExp, "fullyCompacted reason")
-		require.False(t, compacted, "is fully compacted")
-
-		_, cgLen := cp.PlanLevel(1)
-		require.Zero(t, cgLen, "compaction group length; PlanLevel(1)")
-		_, cgLen = cp.PlanLevel(2)
-		require.Zero(t, cgLen, "compaction group length; PlanLevel(2)")
-		_, cgLen = cp.PlanLevel(3)
-		require.Zero(t, cgLen, "compaction group length; PlanLevel(3)")
-
-		tsmP, pLenP := cp.Plan(time.Now().Add(-tsdb.DefaultCompactFullWriteColdDuration + 1))
-		require.Zero(t, len(tsmP), "compaction group; Plan()")
-		require.Zero(t, pLenP, "compaction group length; Plan()")
-
-		_, cgLen, genLen := cp.PlanOptimize(time.Now().Add(-tsdb.DefaultCompactFullWriteColdDuration + 1))
-		require.Equal(t, int64(1), cgLen, "compaction group length")
-		require.Equal(t, generationCountExp, genLen, "generation count")
-
-	}
-
-	for _, test := range furtherCompactedTests {
+	for i, test := range furtherCompactedTests {
 		t.Run(test.name, func(t *testing.T) {
 			ffs := &fakeFileStore{
 				PathsFn: func() []tsm1.FileStat {
@@ -2507,13 +2589,21 @@ func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 				},
 			}
 
+			cp := tsm1.NewDefaultPlanner(ffs, tsdb.DefaultCompactFullWriteColdDuration)
+
 			if len(test.bc) > 0 {
 				err := ffs.SetBlockCounts(test.bc)
 				require.NoError(t, err, "setting block counts")
 			}
 
-			cp := tsm1.NewDefaultPlanner(ffs, tsdb.DefaultCompactFullWriteColdDuration)
-			expectedNotFullyCompacted(cp, test.expectedFullyCompactedReasonExp, test.expectedgenerationCount)
+			e.CompactionPlan = cp
+			e.Compactor.FileStore = ffs
+			level1Groups, level2Groups, level3Groups, level4Groups, level5Groups := e.PlanCompactions()
+			compareLevelGroups(t, furtherCompactedTests[i].level1Groups, level1Groups, "unexpected level 1 Group")
+			compareLevelGroups(t, furtherCompactedTests[i].level2Groups, level2Groups, "unexpected level 2 Group")
+			compareLevelGroups(t, furtherCompactedTests[i].level3Groups, level3Groups, "unexpected level 3 Group")
+			compareLevelGroups(t, furtherCompactedTests[i].level4Groups, level4Groups, "unexpected level 4 Group")
+			compareLevelGroups(t, furtherCompactedTests[i].level5Groups, level5Groups, "unexpected level 5 Group")
 		})
 	}
 
@@ -2530,7 +2620,13 @@ func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 				},
 			},
 			[]int{},
-			"", 0,
+			"",
+			0,
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
 		},
 		{
 			// This test is added to account for a single generation that has a group size
@@ -2546,10 +2642,18 @@ func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 					Path: "01-14.tsm1",
 					Size: 691 * 1024 * 1024,
 				},
-			}, []int{
+			},
+			[]int{
 				tsdb.DefaultAggressiveMaxPointsPerBlock,
 				tsdb.DefaultAggressiveMaxPointsPerBlock,
-			}, "", 0,
+			},
+			"",
+			0,
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
 		},
 		{
 			// This test is added to account for a single generation that has a group size
@@ -2566,12 +2670,18 @@ func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 					Path: "01-14.tsm1",
 					Size: 691 * 1024 * 1024,
 				},
-			}, []int{
+			},
+			[]int{
 				tsdb.DefaultAggressiveMaxPointsPerBlock,
 				tsdb.DefaultMaxPointsPerBlock,
 			},
 			"",
 			0,
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
 		},
 		{
 			// This test is added to account for a single generation that has a group size
@@ -2590,37 +2700,23 @@ func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 					Path: "01-15.tsm1",
 					Size: 450 * 1024 * 1024,
 				},
-			}, []int{
+			},
+			[]int{
 				tsdb.DefaultAggressiveMaxPointsPerBlock,
 				tsdb.DefaultAggressiveMaxPointsPerBlock,
 				tsdb.DefaultAggressiveMaxPointsPerBlock,
-			}, "", 0,
+			},
+			"",
+			0,
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
 		},
 	}
 
-	expectedFullyCompacted := func(cp *tsm1.DefaultPlanner, reasonExp string) {
-		compacted, reason := cp.FullyCompacted()
-		require.Equal(t, reason, reasonExp, "fullyCompacted reason")
-		require.True(t, compacted, "is fully compacted")
-
-		_, cgLen := cp.PlanLevel(1)
-		require.Zero(t, cgLen, "compaction group length; PlanLevel(1)")
-		_, cgLen = cp.PlanLevel(2)
-		require.Zero(t, cgLen, "compaction group length; PlanLevel(2)")
-		_, cgLen = cp.PlanLevel(3)
-		require.Zero(t, cgLen, "compaction group length; PlanLevel(3)")
-
-		tsmP, pLenP := cp.Plan(time.Now().Add(-time.Second))
-		require.Zero(t, len(tsmP), "compaction group; Plan()")
-		require.Zero(t, pLenP, "compaction group length; Plan()")
-
-		cgroup, cgLen, genLen := cp.PlanOptimize(time.Now().Add(-tsdb.DefaultCompactFullWriteColdDuration + 1))
-		require.Equal(t, []tsm1.CompactionGroup(nil), cgroup, "compaction group")
-		require.Zero(t, cgLen, "compaction group length")
-		require.Zero(t, genLen, "generation count")
-	}
-
-	for _, test := range areFullyCompactedTests {
+	for i, test := range areFullyCompactedTests {
 		t.Run(test.name, func(t *testing.T) {
 			ffs := &fakeFileStore{
 				PathsFn: func() []tsm1.FileStat {
@@ -2628,24 +2724,22 @@ func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 				},
 			}
 
+			cp := tsm1.NewDefaultPlanner(ffs, tsdb.DefaultCompactFullWriteColdDuration)
+
 			if len(test.bc) > 0 {
 				err := ffs.SetBlockCounts(test.bc)
 				require.NoError(t, err, "setting block counts")
 			}
 
-			cp := tsm1.NewDefaultPlanner(ffs, tsdb.DefaultCompactFullWriteColdDuration)
-			expectedFullyCompacted(cp, test.expectedFullyCompactedReasonExp)
+			e.CompactionPlan = cp
+			e.Compactor.FileStore = ffs
 
-			// Reverse test files and re-run tests
-			slices.Reverse(test.fs)
-			if len(test.bc) > 0 {
-				slices.Reverse(test.bc)
-				err := ffs.SetBlockCounts(test.bc)
-				require.NoError(t, err, "setting reverse block counts")
-			}
-
-			cp = tsm1.NewDefaultPlanner(ffs, tsdb.DefaultCompactFullWriteColdDuration)
-			expectedFullyCompacted(cp, test.expectedFullyCompactedReasonExp)
+			level1Groups, level2Groups, level3Groups, level4Groups, level5Groups := e.PlanCompactions()
+			compareLevelGroups(t, areFullyCompactedTests[i].level1Groups, level1Groups, "unexpected level 1 Group")
+			compareLevelGroups(t, areFullyCompactedTests[i].level2Groups, level2Groups, "unexpected level 2 Group")
+			compareLevelGroups(t, areFullyCompactedTests[i].level3Groups, level3Groups, "unexpected level 3 Group")
+			compareLevelGroups(t, areFullyCompactedTests[i].level4Groups, level4Groups, "unexpected level 4 Group")
+			compareLevelGroups(t, areFullyCompactedTests[i].level5Groups, level5Groups, "unexpected level 5 Group")
 		})
 	}
 
@@ -2656,6 +2750,11 @@ func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 		expectedFullyCompactedReasonExp string
 		expectedgenerationCount         int64
 		fullyCompacted                  bool
+		level1Groups                    []tsm1.PlannedCompactionGroup
+		level2Groups                    []tsm1.PlannedCompactionGroup
+		level3Groups                    []tsm1.PlannedCompactionGroup
+		level4Groups                    []tsm1.PlannedCompactionGroup
+		level5Groups                    []tsm1.PlannedCompactionGroup
 	}
 
 	mixedPlanOptimizeTests := []PlanOptimizeMixedTests{
@@ -2671,7 +2770,14 @@ func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 				},
 			},
 			[]int{},
-			"", 0, true,
+			"",
+			0,
+			true,
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
 		},
 		{
 			// This test is added to account for a single generation that has a group size
@@ -2687,10 +2793,19 @@ func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 					Path: "01-14.tsm1",
 					Size: 691 * 1024 * 1024,
 				},
-			}, []int{
+			},
+			[]int{
 				tsdb.DefaultAggressiveMaxPointsPerBlock,
 				tsdb.DefaultAggressiveMaxPointsPerBlock,
-			}, "", 0, true,
+			},
+			"",
+			0,
+			true,
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
 		},
 		{
 			// This test is added to account for a single generation that has a group size
@@ -2707,12 +2822,19 @@ func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 					Path: "01-14.tsm1",
 					Size: 691 * 1024 * 1024,
 				},
-			}, []int{
+			},
+			[]int{
 				tsdb.DefaultAggressiveMaxPointsPerBlock,
 				tsdb.DefaultMaxPointsPerBlock,
 			},
 			"",
-			0, true,
+			0,
+			true,
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
 		},
 		{
 			// This test is added to account for a single generation that has a group size
@@ -2731,33 +2853,28 @@ func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 					Path: "01-15.tsm1",
 					Size: 450 * 1024 * 1024,
 				},
-			}, []int{
+			},
+			[]int{
 				tsdb.DefaultAggressiveMaxPointsPerBlock,
 				tsdb.DefaultAggressiveMaxPointsPerBlock,
 				tsdb.DefaultAggressiveMaxPointsPerBlock,
-			}, tsdb.SingleGenerationReasonText, 1, false,
+			},
+			tsdb.SingleGenerationReasonText,
+			1,
+			false,
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
 		},
-	}
-
-	mixedPlanOptimizeTestRunner := func(cp *tsm1.DefaultPlanner, reasonExp string, fullyCompacted bool) {
-		compacted, reason := cp.FullyCompacted()
-		require.Equal(t, reason, reasonExp, "fullyCompacted reason")
-		require.Equal(t, compacted, fullyCompacted, "is fully compacted")
-
-		// Ensure that no level planning takes place
-		_, cgLen := cp.PlanLevel(1)
-		require.Zero(t, cgLen, "compaction group length; PlanLevel(1)")
-		_, cgLen = cp.PlanLevel(2)
-		require.Zero(t, cgLen, "compaction group length; PlanLevel(2)")
-		_, cgLen = cp.PlanLevel(3)
-		require.Zero(t, cgLen, "compaction group length; PlanLevel(3)")
 	}
 
 	// These tests will decrease the max points per block for aggressive compaction.
 	// For SetAggressiveCompactionPointsPerBlock we are using 10x the default to
 	// mock an administrator setting the max points per block to 100_000 and overriding
 	// the default of 10_000.
-	for _, test := range mixedPlanOptimizeTests {
+	for i, test := range mixedPlanOptimizeTests {
 		t.Run(test.name, func(t *testing.T) {
 			ffs := &fakeFileStore{
 				PathsFn: func() []tsm1.FileStat {
@@ -2765,35 +2882,36 @@ func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 				},
 			}
 
+			cp := tsm1.NewDefaultPlanner(ffs, tsdb.DefaultCompactFullWriteColdDuration)
+
 			if len(test.bc) > 0 {
 				err := ffs.SetBlockCounts(test.bc)
 				require.NoError(t, err, "setting block counts")
 			}
 
-			cp := tsm1.NewDefaultPlanner(ffs, tsdb.DefaultCompactFullWriteColdDuration)
-			cp.SetAggressiveCompactionPointsPerBlock(tsdb.DefaultAggressiveMaxPointsPerBlock * 10)
-			mixedPlanOptimizeTestRunner(cp, test.expectedFullyCompactedReasonExp, test.fullyCompacted)
+			e.CompactionPlan = cp
+			e.Compactor.FileStore = ffs
 
-			// Reverse test files and re-run tests
-			slices.Reverse(test.fs)
-			if len(test.bc) > 0 {
-				slices.Reverse(test.bc)
-				err := ffs.SetBlockCounts(test.bc)
-				require.NoError(t, err, "setting reverse block counts")
-			}
-
-			cp = tsm1.NewDefaultPlanner(ffs, tsdb.DefaultCompactFullWriteColdDuration)
-			cp.SetAggressiveCompactionPointsPerBlock(tsdb.DefaultAggressiveMaxPointsPerBlock * 10)
-			mixedPlanOptimizeTestRunner(cp, test.expectedFullyCompactedReasonExp, test.fullyCompacted)
+			level1Groups, level2Groups, level3Groups, level4Groups, level5Groups := e.PlanCompactions()
+			compareLevelGroups(t, mixedPlanOptimizeTests[i].level1Groups, level1Groups, "unexpected level 1 Group")
+			compareLevelGroups(t, mixedPlanOptimizeTests[i].level2Groups, level2Groups, "unexpected level 2 Group")
+			compareLevelGroups(t, mixedPlanOptimizeTests[i].level3Groups, level3Groups, "unexpected level 3 Group")
+			compareLevelGroups(t, mixedPlanOptimizeTests[i].level4Groups, level4Groups, "unexpected level 4 Group")
+			compareLevelGroups(t, mixedPlanOptimizeTests[i].level5Groups, level5Groups, "unexpected level 5 Group")
 		})
 	}
 
 	// The following tests ensure that if Plan() is scheduled
 	// for a shard than PlanOptimize() should not be scheduled for that shard
 	type PlanBeforePlanOptimizeTests struct {
-		name string
-		fs   []tsm1.FileStat
-		bc   []int
+		name         string
+		fs           []tsm1.FileStat
+		bc           []int
+		level1Groups []tsm1.PlannedCompactionGroup
+		level2Groups []tsm1.PlannedCompactionGroup
+		level3Groups []tsm1.PlannedCompactionGroup
+		level4Groups []tsm1.PlannedCompactionGroup
+		level5Groups []tsm1.PlannedCompactionGroup
 	}
 
 	planBeforePlanOptimized := []PlanBeforePlanOptimizeTests{
@@ -2841,14 +2959,36 @@ func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 					Size: 2048 * 1024 * 1024,
 				},
 				{
-					Path: "03-04.tsm1",
+					Path: "03-05.tsm1",
 					Size: 600 * 1024 * 1024,
 				},
 				{
 					Path: "03-06.tsm1",
 					Size: 500 * 1024 * 1024,
 				},
-			}, []int{},
+			},
+			[]int{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{
+				{
+					tsm1.CompactionGroup{"01-05.tsm1",
+						"01-06.tsm1",
+						"01-07.tsm1",
+						"01-08.tsm1",
+						"02-05.tsm1",
+						"02-06.tsm1",
+						"02-07.tsm1",
+						"02-08.tsm1",
+						"03-03.tsm1",
+						"03-04.tsm1",
+						"03-05.tsm1",
+						"03-06.tsm1"},
+					tsdb.DefaultMaxPointsPerBlock,
+				},
+			},
+			[]tsm1.PlannedCompactionGroup{},
 		},
 		{
 			// This test will mock a 'backfill' condition where we have a single
@@ -2905,7 +3045,8 @@ func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 					Path: "03-03.tsm1",
 					Size: 400 * 1024 * 1024,
 				},
-			}, []int{
+			},
+			[]int{
 				tsdb.DefaultAggressiveMaxPointsPerBlock,
 				tsdb.DefaultAggressiveMaxPointsPerBlock,
 				tsdb.DefaultAggressiveMaxPointsPerBlock,
@@ -2922,6 +3063,16 @@ func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 				// Use some magic numbers but these are just small values for block counts
 				100,
 				10,
+			},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{
+				{
+					tsm1.CompactionGroup{
+						"02-04.tsm1", "02-05.tsm1", "02-06.tsm1", "03-02.tsm1", "03-03.tsm1", "03-03.tsm1", "03-04.tsm1", "04-01.tsm1", "04-02.tsm1",
+					}, tsdb.DefaultAggressiveMaxPointsPerBlock},
 			},
 		},
 		{
@@ -3248,31 +3399,101 @@ func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 					Size: 1717986918,
 				},
 			}, []int{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{
+				{
+					tsm1.CompactionGroup{
+						"000029202-000000004.tsm",
+						"000029202-000000005.tsm",
+						"000029202-000000006.tsm",
+						"000029202-000000007.tsm",
+						"000029202-000000008.tsm",
+						"000029202-000000009.tsm",
+						"000029202-000000010.tsm",
+						"000029202-000000011.tsm",
+						"000029202-000000012.tsm",
+						"000029202-000000013.tsm",
+						"000029202-000000014.tsm",
+						"000029202-000000015.tsm",
+						"000029202-000000016.tsm",
+						"000029202-000000017.tsm",
+						"000029202-000000018.tsm",
+						"000029202-000000019.tsm",
+						"000029202-000000020.tsm",
+						"000029202-000000021.tsm",
+						"000029202-000000022.tsm",
+						"000029202-000000023.tsm",
+						"000029202-000000024.tsm",
+						"000029202-000000025.tsm",
+						"000029202-000000026.tsm",
+						"000029202-000000027.tsm",
+						"000029202-000000028.tsm",
+						"000029202-000000029.tsm",
+						"000029202-000000030.tsm",
+						"000029202-000000031.tsm",
+						"000029202-000000032.tsm",
+						"000029202-000000033.tsm",
+						"000029202-000000034.tsm",
+						"000029202-000000035.tsm",
+						"000029202-000000036.tsm",
+						"000029202-000000037.tsm",
+						"000029202-000000038.tsm",
+						"000029202-000000039.tsm",
+						"000029202-000000040.tsm",
+						"000029202-000000041.tsm",
+						"000029202-000000042.tsm",
+						"000029202-000000043.tsm",
+						"000029202-000000044.tsm",
+						"000029202-000000045.tsm",
+						"000029202-000000046.tsm",
+						"000029235-000000003.tsm",
+						"000029267-000000003.tsm",
+						"000029268-000000001.tsm",
+						"000029268-000000002.tsm",
+						"000029268-000000003.tsm",
+						"000029268-000000004.tsm",
+						"000029268-000000005.tsm",
+						"000029268-000000006.tsm",
+						"000029268-000000007.tsm",
+						"000029268-000000008.tsm",
+						"000029268-000000009.tsm",
+						"000029268-000000010.tsm",
+						"000029268-000000011.tsm",
+						"000029268-000000012.tsm",
+						"000029268-000000013.tsm",
+						"000029268-000000014.tsm",
+						"000029268-000000015.tsm",
+						"000029268-000000016.tsm",
+						"000029268-000000017.tsm",
+						"000029268-000000018.tsm",
+						"000029268-000000019.tsm",
+						"000029268-000000020.tsm",
+						"000029268-000000021.tsm",
+						"000029268-000000022.tsm",
+						"000029268-000000023.tsm",
+						"000029268-000000024.tsm",
+						"000029268-000000025.tsm",
+						"000029268-000000026.tsm",
+						"000029268-000000027.tsm",
+						"000029268-000000028.tsm",
+						"000029268-000000029.tsm",
+						"000029268-000000030.tsm",
+						"000029268-000000031.tsm",
+						"000029268-000000032.tsm",
+						"000029268-000000033.tsm",
+						"000029268-000000034.tsm",
+						"000029268-000000035.tsm",
+					},
+					tsdb.DefaultMaxPointsPerBlock,
+				},
+			},
+			[]tsm1.PlannedCompactionGroup{},
 		},
 	}
 
-	planBeforePlanOptimizedRunner := func(cp *tsm1.DefaultPlanner) {
-		// Ensure that no level planning takes place
-		_, cgLen := cp.PlanLevel(1)
-		require.Zero(t, cgLen, "compaction group length; PlanLevel(1)")
-		_, cgLen = cp.PlanLevel(2)
-		require.Zero(t, cgLen, "compaction group length; PlanLevel(2)")
-		_, cgLen = cp.PlanLevel(3)
-		require.Zero(t, cgLen, "compaction group length; PlanLevel(3)")
-
-		// Plan should schedule
-		tsmP, pLenP := cp.Plan(time.Now().Add(-tsdb.DefaultCompactFullWriteColdDuration + 1))
-		require.Equal(t, 1, len(tsmP), "compaction group; Plan()")
-		require.Equal(t, int64(1), pLenP, "compaction group length; Plan()")
-
-		// PlanOptimize should not schedule
-		cgroup, cgLen, genLen := cp.PlanOptimize(time.Now().Add(-tsdb.DefaultCompactFullWriteColdDuration + 1))
-		require.Equal(t, []tsm1.CompactionGroup(nil), cgroup, "compaction group")
-		require.Zero(t, cgLen, "compaction group length")
-		require.Zero(t, genLen, "generation count")
-	}
-
-	for _, test := range planBeforePlanOptimized {
+	for i, test := range planBeforePlanOptimized {
 		t.Run(test.name, func(t *testing.T) {
 			ffs := &fakeFileStore{
 				PathsFn: func() []tsm1.FileStat {
@@ -3280,13 +3501,22 @@ func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 				},
 			}
 
+			cp := tsm1.NewDefaultPlanner(ffs, tsdb.DefaultCompactFullWriteColdDuration)
+
 			if len(test.bc) > 0 {
 				err := ffs.SetBlockCounts(test.bc)
 				require.NoError(t, err, "setting block counts")
 			}
 
-			cp := tsm1.NewDefaultPlanner(ffs, tsdb.DefaultCompactFullWriteColdDuration)
-			planBeforePlanOptimizedRunner(cp)
+			e.CompactionPlan = cp
+			e.Compactor.FileStore = ffs
+
+			level1Groups, level2Groups, level3Groups, level4Groups, level5Groups := e.PlanCompactions()
+			compareLevelGroups(t, planBeforePlanOptimized[i].level1Groups, level1Groups, "unexpected level 1 Group")
+			compareLevelGroups(t, planBeforePlanOptimized[i].level2Groups, level2Groups, "unexpected level 2 Group")
+			compareLevelGroups(t, planBeforePlanOptimized[i].level3Groups, level3Groups, "unexpected level 3 Group")
+			compareLevelGroups(t, planBeforePlanOptimized[i].level4Groups, level4Groups, "unexpected level 4 Group")
+			compareLevelGroups(t, planBeforePlanOptimized[i].level5Groups, level5Groups, "unexpected level 5 Group")
 		})
 	}
 }
@@ -4076,6 +4306,7 @@ func TestEnginePlanCompactions(t *testing.T) {
 		}
 		cp := tsm1.NewDefaultPlanner(ffs, tsdb.DefaultCompactFullWriteColdDuration)
 		require.NoError(t, ffs.SetBlockCounts(testBlockCountsAndResults[i].blockCounts), "failed setting block counts")
+		e.MaxPointsPerBlock = tsdb.DefaultMaxPointsPerBlock
 		e.CompactionPlan = cp
 		e.Compactor.FileStore = ffs
 
@@ -4088,7 +4319,6 @@ func TestEnginePlanCompactions(t *testing.T) {
 	}
 }
 
-// Necessary specialize comparison because require.Elements.Match thinks nested nil and zero length slices differ
 func compareLevelGroups(t *testing.T, exp, got []tsm1.PlannedCompactionGroup, message string) {
 	require.Lenf(t, got, len(exp), "%s %s", message, " collection length mismatch")
 	for i, group := range exp {

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -2118,26 +2118,6 @@ func (e *Engine) ShouldCompactCache(t time.Time) bool {
 	return t.Sub(e.Cache.LastWriteTime()) > e.CacheFlushWriteColdDuration
 }
 
-// isSingleGeneration returns true if a group contains files from a single generation.
-func (e *Engine) isSingleGeneration(group CompactionGroup) bool {
-	minGen := math.MaxInt
-	maxGen := math.MinInt
-	for _, f := range group {
-		if gen, _, err := e.FileStore.ParseFileName(f); err != nil {
-			e.logger.Error("error parsing TSM file name", zap.Error(err), zap.String("file", f))
-			return false
-		} else {
-			minGen = min(minGen, gen)
-			maxGen = max(maxGen, gen)
-			if minGen != maxGen {
-				break
-			}
-		}
-	}
-
-	return minGen == maxGen
-}
-
 // isFileOptimized returns true if a TSM file appears to have already been previously optimized.
 // If file appears previously optimized, a description of the heuristic used to determine this is also returned.
 func (e *Engine) isFileOptimized(f string) (bool, string) {

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -2330,7 +2330,8 @@ func (e *Engine) PlanCompactions() (
 
 	for _, group := range l1Groups {
 		level1Groups = append(level1Groups, PlannedCompactionGroup{
-			Group: group,
+			Group:          group,
+			PointsPerBlock: tsdb.DefaultMaxPointsPerBlock,
 		})
 	}
 

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -2148,9 +2148,9 @@ func (e *Engine) isFileOptimized(f string) (bool, string) {
 	}
 }
 
-// isGroupOptimized returns true if any file in a compaction group appears to be have been previously optimized.
+// IsGroupOptimized returns true if any file in a compaction group appears to be have been previously optimized.
 // The name of the first optimized file found along with the heuristic used to determine this is returned.
-func (e *Engine) isGroupOptimized(group CompactionGroup) (optimized bool, file string, heuristic string) {
+func (e *Engine) IsGroupOptimized(group CompactionGroup) (optimized bool, file string, heuristic string) {
 	for _, f := range group {
 		if isOpt, heur := e.isFileOptimized(f); isOpt {
 			return true, f, heur
@@ -2218,7 +2218,7 @@ func (e *Engine) compact(wg *sync.WaitGroup) {
 			level4Groups := make([]CompactionGroup, 0, len(initialLevellevel4Groups))
 			level5Groups := make([]CompactionGroup, 0, len(initialLevellevel4Groups))
 			for _, group := range initialLevellevel4Groups {
-				if isOpt, filename, heur := e.isGroupOptimized(group); isOpt {
+				if isOpt, filename, heur := e.IsGroupOptimized(group); isOpt {
 					e.logger.Info("Promoting full compaction level 4 group to optimized level 5 compaction group because it contains an already optimized TSM file",
 						zap.String("optimized_file", filename), zap.String("heuristic", heur), zap.Strings("files", group))
 					level5Groups = append(level5Groups, group)
@@ -2301,7 +2301,7 @@ func (e *Engine) compact(wg *sync.WaitGroup) {
 					if level5Aggressive {
 						log.Info("Planning aggressive optimized compaction because all level 5 is planned for aggressive")
 						aggressive = true
-					} else if isOpt, filename, heur := e.isGroupOptimized(theGroup); isOpt {
+					} else if isOpt, filename, heur := e.IsGroupOptimized(theGroup); isOpt {
 						log.Info("Planning aggressive optimized compaction because group contains an already aggressively optimized TSM file", zap.String("file", filename), zap.String("heuristic", heur))
 						aggressive = true
 					}

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -507,6 +507,19 @@ func (s *Store) loadShards() error {
 
 	s.EngineOptions.CompactionLimiter = limiter.NewFixed(lim)
 
+	// Setup optimized limiter.
+	optLim := s.EngineOptions.Config.MaxConcurrentOptimizedCompactions
+	if optLim <= 0 {
+		optLim = 1
+	}
+
+	// Don't allow more optimized compactions to run than overall compactions.
+	if optLim > lim {
+		optLim = lim
+	}
+
+	s.EngineOptions.OptimizedCompactionLimiter = limiter.NewFixed(optLim)
+
 	compactionSettings := []zapcore.Field{zap.Int("max_concurrent_compactions", lim)}
 	throughput := int(s.EngineOptions.Config.CompactThroughput)
 	throughputBurst := int(s.EngineOptions.Config.CompactThroughputBurst)


### PR DESCRIPTION
Limit number of concurrent optimized compactions so that level compactions do not get starved. Starved level compactions result in a sudden increase in disk usage.

Add [data] max-concurrent-optimized-compactions for configuring maximum number of concurrent optimized compactions. Default value is 1.

Closes: #26315
