### PR TITLE
feat: improve control of logs on test harness

### DIFF
--- a/influxdb3/src/commands/serve.rs
+++ b/influxdb3/src/commands/serve.rs
@@ -389,6 +389,16 @@ pub struct Config {
         default_value = "tls-1.2"
     )]
     pub tls_minimum_version: TlsMinimumVersion,
+
+    /// Provide a file path to write the address that the server is listening on to.
+    ///
+    /// This is mainly intended for testing purposes and is not considered stable.
+    #[clap(
+        long = "tcp-listener-file-path",
+        env = "INFLUXDB3_TCP_LISTINER_FILE_PATH",
+        hide = true
+    )]
+    pub tcp_listener_file_path: Option<PathBuf>,
 }
 
 /// The minimum version of TLS to use for InfluxDB
@@ -767,6 +777,7 @@ pub async fn command(config: Config) -> Result<()> {
         frontend_shutdown.clone(),
         startup_timer,
         config.without_auth,
+        config.tcp_listener_file_path,
     )
     .fuse();
     let backend = shutdown_manager.join().fuse();

--- a/influxdb3/tests/server/mod.rs
+++ b/influxdb3/tests/server/mod.rs
@@ -1,7 +1,6 @@
 use std::{
     future::Future,
-    io::{BufRead, BufReader},
-    process::{Child, Command, Stdio},
+    process::{Child, Command},
     time::Duration,
 };
 
@@ -14,6 +13,8 @@ use influxdb3_client::Precision;
 use influxdb3_types::http::FieldType;
 use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 use reqwest::{Certificate, Response, tls::Version};
+use tempfile::TempDir;
+use tokio::io::AsyncReadExt;
 use tonic::transport::ClientTlsConfig;
 
 mod auth;
@@ -179,15 +180,18 @@ impl ConfigProvider for TestConfig {
 
 /// A running instance of the `influxdb3 serve` process
 ///
-/// Logs will be emitted to stdout/stderr if the TEST_LOG environment variable is set, e.g.,
+/// Logs will be emitted to stdout/stderr if the `TEST_LOG` environment variable is set, e.g.,
 /// ```
 /// TEST_LOG= cargo nextest run -p influxdb3 --nocapture
 /// ```
-/// This will forward the value provided in `TEST_LOG` to the `LOG_FILTER` env var on the running
-/// `influxdb` binary. By default, a log filter of `info` is used, which would provide similar
-/// output to what is seen in production, however, per-crate filters can be provided via this
-/// argument, e.g., `info,influxdb3_write=debug` would emit logs at `INFO` level for all crates
-/// except for the `influxdb3_write` crate, which will emit logs at the `DEBUG` level.
+///
+/// This also respects the RUST_LOG environment variable, which is typically used to set the
+/// log filter for tracing/tests.
+///
+/// - `TEST_LOG=` (empty) will result in `INFO` logs being emitted
+/// - `TEST_LOG=<filter>` will result in the provided `<filter>` being used as the `LOG_FILTER`
+/// - if both `TEST_LOG` and `RUST_LOG` are set, the value provided in `RUST_LOG` will be used
+///   as the `LOG_FILTER`
 pub struct TestServer {
     auth_token: Option<String>,
     bind_addr: String,
@@ -211,59 +215,72 @@ impl TestServer {
 
     async fn spawn_inner(config: &impl ConfigProvider) -> Self {
         create_certs().await;
+        // Create a temporary file for storing the TCP Listener address. We start the server with
+        // a bind address of 0.0.0.0:0, which will have the OS assign a randomly available port.
+        //
+        // To determine which port is selected, the server will write the listener address to the
+        // file path provided in the --tcp-listener-file-path argument, which we use below to assign
+        // the bind address for the TestServer harness.
+        //
+        // The file is deleted when it goes out of scope (the end of this method) by the TempDir type.
+        let tmp_dir = TempDir::new().unwrap();
+        let tmp_dir_path = tmp_dir.into_path();
+        let tcp_addr_file = tmp_dir_path.join("tcp-listener");
         let mut command = Command::cargo_bin("influxdb3").expect("create the influxdb3 command");
         let command = command
             .arg("serve")
             .arg("--disable-telemetry-upload")
-            // bind to port 0 to get a random port assigned:
             .args(["--http-bind", "0.0.0.0:0"])
             .args(["--wal-flush-interval", "10ms"])
             .args(["--wal-snapshot-size", "1"])
             .args(["--tls-cert", "../testing-certs/localhost.pem"])
             .args(["--tls-key", "../testing-certs/localhost.key"])
-            .args(config.as_args())
-            .stdout(Stdio::piped());
+            .args([
+                "--tcp-listener-file-path",
+                tcp_addr_file
+                    .to_str()
+                    .expect("valid tcp listener file path"),
+            ])
+            .args(config.as_args());
 
-        // Use the TEST_LOG env var to determine if logs are emitted from the spawned process
-        let emit_logs = if std::env::var("TEST_LOG").is_ok() {
-            // use "info" filter, as would be used in production:
-            command.env("LOG_FILTER", "info");
-            true
-        } else {
-            false
-        };
+        // Determine the LOG_FILTER that is passed down to the process, if necessary
+        match (std::env::var("TEST_LOG"), std::env::var("RUST_LOG")) {
+            (Ok(t), Ok(r)) if t.is_empty() && r.is_empty() => {
+                command.env("LOG_FILTER", "info");
+            }
+            (Ok(t), Err(_)) if t.is_empty() => {
+                command.env("LOG_FILTER", "info");
+            }
+            (Ok(filter), Err(_)) | (Ok(_), Ok(filter)) => {
+                command.env("LOG_FILTER", filter);
+            }
+            (Err(_), _) => (),
+        }
 
-        let mut server_process = command.spawn().expect("spawn the influxdb3 server process");
+        let server_process = command.spawn().expect("spawn the influxdb3 server process");
 
-        // pipe stdout so we can get the randomly assigned port from the log output:
-        let process_stdout = server_process
-            .stdout
-            .take()
-            .expect("should acquire stdout from process");
-
-        let mut lines = BufReader::new(process_stdout).lines();
         let bind_addr = loop {
-            let Some(Ok(line)) = lines.next() else {
-                panic!("stdout closed unexpectedly");
-            };
-            if emit_logs {
-                println!("{line}");
-            }
-            if line.contains("startup time") {
-                if let Some(address) = line.split("address=").last() {
-                    break address.to_string();
+            match tokio::fs::File::open(&tcp_addr_file).await {
+                Ok(mut file) => {
+                    let mut buf = String::new();
+                    file.read_to_string(&mut buf)
+                        .await
+                        .expect("read from tcp listener file");
+                    if buf.is_empty() {
+                        tokio::time::sleep(Duration::from_millis(10)).await;
+                        continue;
+                    } else {
+                        break buf;
+                    }
+                }
+                Err(error) if matches!(error.kind(), std::io::ErrorKind::NotFound) => {
+                    tokio::time::sleep(Duration::from_millis(10)).await;
+                }
+                Err(error) => {
+                    panic!("unexpected error while checking for tcp listener file: {error:?}")
                 }
             }
         };
-
-        tokio::task::spawn_blocking(move || {
-            for line in lines {
-                let line = line.expect("io error while getting line from stdout");
-                if emit_logs {
-                    println!("{line}");
-                }
-            }
-        });
 
         let http_client = reqwest::ClientBuilder::new()
             .min_tls_version(Version::TLS_1_3)


### PR DESCRIPTION
No issue for this. I was working on https://github.com/influxdata/influxdb/issues/26216 and decided to make this change.

This alters the logging behaviour and UX for the [`TestServer`](https://github.com/influxdata/influxdb/blob/6fb4112dc3c51c9723eefd50077e439aa1b9771d/influxdb3/tests/server/mod.rs#L195-L200) harness that is used in our integration tests in the `influxdb3` crate.

### Changes

The primary change is the addition of a CLI argument for the `serve` command (`--tcp-listener-file-path`) that the server will use to write out the listener address that it is listening for TCP connections on.

The argument is hidden and defaults to `None`.

This can be used by our test harness, which uses a bind address of `0.0.0.0:0` in order to select a randomly available port.

The test harness creates a temporary file and waits for it to be written to acquire the selected address of the underlying process.

### Why this is an improvement

Previously, the `TestServer` was doing some weird business to capture the stdout of the running process and grab the log line that displays the listener address. This created a couple of issues:
* we couldn't customize the log filter on the running process via the normal means of setting the `RUST_LOG` environment variable
* the re-emitted logs were not formatted in the terminal and therefore were difficult to read

### Usage

The `TEST_LOG` environment variable is still respected, and is required in order to have logs emitted by the underlying `influxdb3` process.

One can run tests like so:
```
TEST_LOG= cargo nextest run -p influxdb3 --nocapture
```
This will have the underlying process emit logs at the `INFO` level (and above). This is how it operated before this PR.

Or, providing a filter:
```
TEST_LOG=influxdb3=debug,info cargo nextest run -p influxdb3 --nocapture
```
This will pass the provided filter down to the underlying `influxdb3` process (`influxdb3=debug,info`)

The `RUST_LOG` enfironment variable is also respected, so
```
TEST_LOG= RUST_LOG=influxdb3=debug,info cargo nextest run -p influxdb3 --nocapture
```
Will enable log output for the underlying `influxdb3` process while passing the filter provided to `RUST_LOG` to the underlying process.