### PR TITLE
fix: group by tag columns with escape quotes

### DIFF
--- a/influxdb3_server/src/http/v1.rs
+++ b/influxdb3_server/src/http/v1.rs
@@ -1002,7 +1002,9 @@ impl GroupByEval {
             .iter()
             .filter_map(|dim| match dim {
                 Dimension::Time(_) => None,
-                Dimension::VarRef(tag) => Some(Ok(GroupByEvalType::Tag(tag.to_string()))),
+                Dimension::VarRef(tag) => {
+                    Some(Ok(GroupByEvalType::Tag(tag.name.as_str().to_string())))
+                }
                 Dimension::Regex(regex) => Some(
                     Regex::new(regex.as_str())
                         .map(GroupByEvalType::Regex)


### PR DESCRIPTION
Closes #26216 
Closes #26218 

`GROUP BY` identifiers that were escape quoted, e.g., `\"name\"`, were not having the quotes removed when compared to columns in the `Schema` during `GROUP BY` evaluation. This uses the `Identifier::as_str` method to exclude the quotes.

The reproducer from #26128 is included in this PR.