### PR TITLE
fix: distinct cache counting bug

### DIFF
--- a/influxdb3_cache/src/distinct_cache/cache.rs
+++ b/influxdb3_cache/src/distinct_cache/cache.rs
@@ -167,7 +167,7 @@ impl DistinctCache {
             ?predicates,
             ?projection,
             ?limit,
-            ">>> distinct cache record batches"
+            "distinct cache record batches"
         );
         let n_columns = projection
             .as_ref()
@@ -410,6 +410,7 @@ impl Node {
                 } else if next_predicates.is_empty() && next_builders.is_empty() {
                     if let Some(builder) = builder {
                         builder.append_value(value.0);
+                        total_count += 1;
                     }
                 }
                 if let Some(new_limit) = limit.checked_sub(count) {
@@ -417,10 +418,8 @@ impl Node {
                 } else {
                     break;
                 }
-            } else {
-                if let Some(builder) = builder {
-                    builder.append_value(value.0);
-                }
+            } else if let Some(builder) = builder {
+                builder.append_value(value.0);
                 total_count += 1;
             }
         }

--- a/influxdb3_cache/src/distinct_cache/mod.rs
+++ b/influxdb3_cache/src/distinct_cache/mod.rs
@@ -1144,8 +1144,28 @@ mod tests {
                 "+----------+",
                 "| t2       |",
                 "+----------+",
-                "| \"(0, 1]\"|",
+                "| \"(0, 1]\" |",
                 "+----------+",
+            ],
+            &results
+        );
+
+        // should be able to query with projection and a WHERE clause:
+        let results = ctx
+            .sql("select t2, t3 from distinct_cache('bar', 'foo') where t1 = 'BB'")
+            .await
+            .unwrap()
+            .collect()
+            .await
+            .unwrap();
+
+        assert_batches_eq!(
+            [
+                "+----------+--------------+",
+                "| t2       | t3           |",
+                "+----------+--------------+",
+                "| \"(0, 1]\" | \"(2.0, 4.0]\" |",
+                "+----------+--------------+",
             ],
             &results
         );

--- a/influxdb3_catalog/src/catalog.rs
+++ b/influxdb3_catalog/src/catalog.rs
@@ -224,6 +224,10 @@ impl Catalog {
         Ok(catalog)
     }
 
+    pub fn time_provider(&self) -> Arc<dyn TimeProvider> {
+        Arc::clone(&self.time_provider)
+    }
+
     pub fn set_state_shutdown(&self) {
         *self.state.lock() = CatalogState::Shutdown;
     }


### PR DESCRIPTION
Closes #26318

Includes and fixes the reproducer for #26318 originally added in https://github.com/influxdata/influxdb/pull/26331/commits/cf79b28071d3256e06e8c288e59648362e5ef915

The distinct cache was not counting the number of results properly when a projection on one column was used in conjunction with a `WHERE` predicate on another column.