### PR TITLE
feat: Remove Last Cache Size Limitation

### DIFF
--- a/influxdb3/src/commands/create.rs
+++ b/influxdb3/src/commands/create.rs
@@ -158,7 +158,9 @@ pub struct LastCacheConfig {
     value_columns: Option<Vec<String>>,
 
     /// The number of entries per unique key column combination the cache will store
-    #[clap(long = "count")]
+    ///
+    /// Higher values can increase memory usage significantly.
+    #[clap(long = "count", default = "1")]
     count: Option<LastCacheSize>,
 
     /// The time-to-live (TTL) for entries in a cache. This uses a humantime form for example: --ttl "10s",

--- a/influxdb3/src/commands/create.rs
+++ b/influxdb3/src/commands/create.rs
@@ -475,7 +475,7 @@ mod tests {
             "--ttl",
             "1 hour",
             "--count",
-            "5",
+            "15",
             "bar",
         ]);
         let super::SubCommand::LastCache(super::LastCacheConfig {
@@ -496,7 +496,7 @@ mod tests {
         assert!(cache_name.is_some_and(|n| n == "bar"));
         assert!(key_columns.is_some_and(|keys| keys == ["tag1", "tag2", "tag3"]));
         assert!(value_columns.is_some_and(|vals| vals == ["field1", "field2", "field3"]));
-        assert!(count.is_some_and(|c| c == 5));
+        assert!(count.is_some_and(|c| c == 15));
         assert!(ttl.is_some_and(|t| t.as_secs() == 3600));
     }
 

--- a/influxdb3/src/commands/create.rs
+++ b/influxdb3/src/commands/create.rs
@@ -145,7 +145,7 @@ pub struct LastCacheConfig {
     #[clap(short = 't', long = "table")]
     table: String,
 
-    /// Which columns in the table to use as keys in the cache. This is a comma separated list.
+    /// Which columns in the table to use as keys in the cache. This is a comma separated list
     ///
     /// Example: --key-columns "foo,bar,baz"
     #[clap(long = "key-columns", value_delimiter = ',')]
@@ -159,16 +159,15 @@ pub struct LastCacheConfig {
 
     /// The number of entries per unique key column combination the cache will store
     ///
-    /// Higher values can increase memory usage significantly.
-    #[clap(long = "count", default = "1")]
+    /// Higher values can increase memory usage significantly
+    #[clap(long = "count", default_value = "1")]
     count: Option<LastCacheSize>,
 
-    /// The time-to-live (TTL) for entries in a cache. This uses a humantime form for example: --ttl "10s",
-    /// --ttl "1min 30sec", --ttl "3 hours"
+    /// The time-to-live (TTL) for entries in a cache. This uses a humantime form: "10s", "1min 30sec", "3 hours"
     ///
     /// See the parse_duration docs for more details about acceptable forms:
     /// <https://docs.rs/humantime/2.1.0/humantime/fn.parse_duration.html>
-    #[clap(long = "ttl")]
+    #[clap(long = "ttl", default_value = "4 hours")]
     ttl: Option<Duration>,
 
     /// Give a name for the cache.

--- a/influxdb3/tests/server/configure.rs
+++ b/influxdb3/tests/server/configure.rs
@@ -528,8 +528,8 @@ async fn api_v3_configure_last_cache_create() {
             description: "Use an invalid cache size is a bad request",
             db: Some(db_name),
             table: Some(tbl_name),
-            cache_name: Some("too_big"),
-            count: Some(11),
+            cache_name: Some("too_small"),
+            count: Some(0),
             expected: StatusCode::BAD_REQUEST,
             ..Default::default()
         },

--- a/influxdb3_cache/src/last_cache/mod.rs
+++ b/influxdb3_cache/src/last_cache/mod.rs
@@ -911,7 +911,7 @@ mod tests {
 
         let table_def = writer.db_schema().table_definition("temp").unwrap();
 
-        // Create the last cache using defaults and a count of 10
+        // Create the last cache using defaults and a count of 15
         let mut cache = LastCache::new(CreateLastCacheArgs {
             table_def: Arc::clone(&table_def),
             count: LastCacheSize::new(10).unwrap(),
@@ -1224,7 +1224,7 @@ mod tests {
                 Some("test_cache_2"),
                 Some(&["t1"]),
                 Some(&["f1", "time"]),
-                LastCacheSize::new(5).unwrap(),
+                LastCacheSize::new(10).unwrap(),
                 LastCacheTtl::from_secs(60),
             )
             .await
@@ -1236,7 +1236,7 @@ mod tests {
                 Some("test_cache_3"),
                 Option::<&[&str]>::Some(&[]),
                 Some(&["f2", "time"]),
-                LastCacheSize::new(10).unwrap(),
+                LastCacheSize::new(100).unwrap(),
                 LastCacheTtl::from_secs(500),
             )
             .await

--- a/influxdb3_cache/src/last_cache/mod.rs
+++ b/influxdb3_cache/src/last_cache/mod.rs
@@ -911,7 +911,7 @@ mod tests {
 
         let table_def = writer.db_schema().table_definition("temp").unwrap();
 
-        // Create the last cache using defaults and a count of 15
+        // Create the last cache using defaults and a count of 10
         let mut cache = LastCache::new(CreateLastCacheArgs {
             table_def: Arc::clone(&table_def),
             count: LastCacheSize::new(10).unwrap(),

--- a/influxdb3_cache/src/last_cache/mod.rs
+++ b/influxdb3_cache/src/last_cache/mod.rs
@@ -1224,7 +1224,7 @@ mod tests {
                 Some("test_cache_2"),
                 Some(&["t1"]),
                 Some(&["f1", "time"]),
-                LastCacheSize::new(10).unwrap(),
+                LastCacheSize::new(5).unwrap(),
                 LastCacheTtl::from_secs(60),
             )
             .await

--- a/influxdb3_cache/src/last_cache/snapshots/influxdb3_cache__last_cache__tests__catalog_initialization.snap
+++ b/influxdb3_cache/src/last_cache/snapshots/influxdb3_cache__last_cache__tests__catalog_initialization.snap
@@ -249,7 +249,7 @@ expression: catalog.snapshot()
                             2,
                             3
                           ],
-                          "n": 10,
+                          "n": 100,
                           "ttl": 500
                         }
                       ]

--- a/influxdb3_catalog/src/error.rs
+++ b/influxdb3_catalog/src/error.rs
@@ -152,7 +152,7 @@ pub enum CatalogError {
     #[error("failed to parse trigger from {}", trigger_spec)]
     ProcessingEngineTriggerSpecParseError { trigger_spec: String },
 
-    #[error("last cache size must be from 1 to 10")]
+    #[error("last cache size must be greater than 0")]
     InvalidLastCacheSize,
 
     #[error("failed to parse trigger from {trigger_spec}{}", .context.as_ref().map(|context| format!(": {context}")).unwrap_or_default())]

--- a/influxdb3_catalog/src/log/versions/v2.rs
+++ b/influxdb3_catalog/src/log/versions/v2.rs
@@ -380,18 +380,15 @@ pub enum LastCacheValueColumnsDef {
     AllNonKeyColumns,
 }
 
-/// The maximum allowed size for a last cache
-pub const LAST_CACHE_MAX_SIZE: usize = 10;
-
 /// The size of the last cache
 ///
-/// Must be between 1 and [`LAST_CACHE_MAX_SIZE`]
+/// Must be greater than 0
 #[derive(Debug, Serialize, Eq, PartialEq, Clone, Copy)]
 pub struct LastCacheSize(pub(crate) usize);
 
 impl LastCacheSize {
     pub fn new(size: usize) -> Result<Self> {
-        if size == 0 || size > LAST_CACHE_MAX_SIZE {
+        if size == 0{
             Err(CatalogError::InvalidLastCacheSize)
         } else {
             Ok(Self(size))

--- a/influxdb3_catalog/src/log/versions/v2.rs
+++ b/influxdb3_catalog/src/log/versions/v2.rs
@@ -388,7 +388,7 @@ pub struct LastCacheSize(pub(crate) usize);
 
 impl LastCacheSize {
     pub fn new(size: usize) -> Result<Self> {
-        if size == 0{
+        if size == 0 {
             Err(CatalogError::InvalidLastCacheSize)
         } else {
             Ok(Self(size))


### PR DESCRIPTION
Removes limitation on cache size of 10 for Last Value Cache. 

- [X] Remove limiting code
- [X] Update CLI information (with caution on higher use)
- [X] Update tests for higher use, and invalid use of 0

Additionally, closes #25522 
