### PR TITLE
fix: update token creation output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2806,6 +2806,7 @@ dependencies = [
  "pretty_assertions",
  "rand",
  "rcgen",
+ "regex",
  "reqwest 0.11.27",
  "rustls 0.22.4",
  "secrecy",

--- a/influxdb3/Cargo.toml
+++ b/influxdb3/Cargo.toml
@@ -98,6 +98,7 @@ hyper.workspace = true
 insta.workspace = true
 pretty_assertions.workspace = true
 rcgen.workspace = true
+regex.workspace = true
 reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/influxdb3/src/commands/create.rs
+++ b/influxdb3/src/commands/create.rs
@@ -9,6 +9,7 @@ use influxdb3_catalog::log::TriggerSpecificationDefinition;
 use influxdb3_client::Client;
 use influxdb3_types::http::LastCacheSize;
 use influxdb3_types::http::LastCacheTtl;
+use owo_colors::OwoColorize;
 use secrecy::ExposeSecret;
 use secrecy::Secret;
 use serde_json::json;
@@ -391,20 +392,18 @@ pub async fn command(config: Config) -> Result<(), Box<dyn Error>> {
                         println!("{}", stringified);
                     }
                     token::TokenOutputFormat::Text => {
-
-                        let red = "\x1b[1;31m";
-                        let bold = "\x1b[1m";
-                        let underline = "\x1b[1;4m";
-                        let reset = "\x1b[0m";
                         let token = response.token;
-
+                        let title = format!("{}", "New token created successfully!".underline());
+                        let token_label = format!("{}", "Token:".bold());
+                        let header_label = format!("{}", "HTTP Requests Header:".bold());
+                        let important_label = format!("{}", "IMPORTANT:".red().bold());
+                        let important_message =
+                            "Store this token securely, as it will not be shown again.";
                         println!(
-                            "\n\
-                            {}New token created successfully!{}\n\n\
-                            {}Token:{} {}\n\
-                            {}HTTP Requests Header:{} Authorization: Bearer {}\n\n\
-                            {}IMPORTANT:{} Store this token securely, as it will not be shown again.\n",
-                            underline, reset, bold, reset, token, bold, reset, token, red, reset
+                            "\n{title}\n\n\
+                            {token_label} {token}\n\
+                            {header_label} Authorization: Bearer {token}\n\n\
+                            {important_label} {important_message}\n"
                         );
                     }
                 },

--- a/influxdb3/src/commands/create.rs
+++ b/influxdb3/src/commands/create.rs
@@ -391,17 +391,20 @@ pub async fn command(config: Config) -> Result<(), Box<dyn Error>> {
                         println!("{}", stringified);
                     }
                     token::TokenOutputFormat::Text => {
+
+                        let red = "\x1b[1;31m";
+                        let bold = "\x1b[1m";
+                        let underline = "\x1b[1;4m";
+                        let reset = "\x1b[0m";
+                        let token = response.token;
+
                         println!(
                             "\n\
-                            {underline}New token created successfully!{reset}\n\n\
-                            {bold}Token:{reset} {token}\n\
-                            {bold}HTTP Requests Header:{reset} Authorization: Bearer {token}\n\n\
-                            {red}IMPORTANT:{reset} Store this token securely, as it will not be shown again.\n",
-                            red = "\x1b[1;31m",
-                            bold = "\x1b[1m",
-                            underline = "\x1b[1;4m",
-                            reset = "\x1b[0m",
-                            token = response.token,
+                            {}New token created successfully!{}\n\n\
+                            {}Token:{} {}\n\
+                            {}HTTP Requests Header:{} Authorization: Bearer {}\n\n\
+                            {}IMPORTANT:{} Store this token securely, as it will not be shown again.\n",
+                            underline, reset, bold, reset, token, bold, reset, token, red, reset
                         );
                     }
                 },

--- a/influxdb3/src/commands/create.rs
+++ b/influxdb3/src/commands/create.rs
@@ -397,7 +397,10 @@ pub async fn command(config: Config) -> Result<(), Box<dyn Error>> {
                             {bold}Token:{reset} {token}\n\
                             {bold}HTTP Requests Header:{reset} Authorization: Bearer {token}\n\n\
                             {red}IMPORTANT:{reset} Store this token securely, as it will not be shown again.\n",
-                            red = "\x1b[1;31m", bold = "\x1b[1m", underline = "\x1b[1;4m", reset = "\x1b[0m",
+                            red = "\x1b[1;31m",
+                            bold = "\x1b[1m",
+                            underline = "\x1b[1;4m",
+                            reset = "\x1b[0m",
                             token = response.token,
                         );
                     }

--- a/influxdb3/src/commands/create.rs
+++ b/influxdb3/src/commands/create.rs
@@ -404,7 +404,6 @@ pub async fn command(config: Config) -> Result<(), Box<dyn Error>> {
                             token = response.token,
                         );
                     }
-
                 },
                 Err(err) => {
                     println!("Failed to create token, error: {:?}", err);

--- a/influxdb3/src/commands/create.rs
+++ b/influxdb3/src/commands/create.rs
@@ -381,7 +381,8 @@ pub async fn command(config: Config) -> Result<(), Box<dyn Error>> {
                 Ok(response) => match output_format {
                     token::TokenOutputFormat::Json => {
                         let help_msg = format!(
-                            "HTTP requests require the following header: \"Authorization: Bearer {}\"",
+                            "Store this token securely, as it will not be shown again. \
+                            HTTP requests require the following header: \"Authorization: Bearer {}\"",
                             response.token
                         );
                         let json = json!({"token": response.token, "help_msg": help_msg});
@@ -391,15 +392,16 @@ pub async fn command(config: Config) -> Result<(), Box<dyn Error>> {
                     }
                     token::TokenOutputFormat::Text => {
                         println!(
-                                "\n\
-                                Token: {token}\n\
-                                    \n\
-                                HTTP requests require the following header: \"Authorization: Bearer {token}\"\n\
-                                This will grant you access to HTTP/GRPC API.
-                            ",
-                                token = response.token,
-                            );
+                            "\n\
+                            {underline}New token created successfully!{reset}\n\n\
+                            {bold}Token:{reset} {token}\n\
+                            {bold}HTTP Requests Header:{reset} Authorization: Bearer {token}\n\n\
+                            {red}IMPORTANT:{reset} Store this token securely, as it will not be shown again.\n",
+                            red = "\x1b[1;31m", bold = "\x1b[1m", underline = "\x1b[1;4m", reset = "\x1b[0m",
+                            token = response.token,
+                        );
                     }
+
                 },
                 Err(err) => {
                     println!("Failed to create token, error: {:?}", err);

--- a/influxdb3/tests/cli/mod.rs
+++ b/influxdb3/tests/cli/mod.rs
@@ -2930,7 +2930,7 @@ async fn test_create_admin_token() {
         .run(vec!["create", "token", "--admin"], args)
         .unwrap();
     println!("{:?}", result);
-    assert_contains!(&result, "This will grant you access to HTTP/GRPC API");
+    assert_contains!(&result, "New token created successfully!");
 }
 
 #[test_log::test(tokio::test)]
@@ -2970,7 +2970,7 @@ async fn test_create_admin_token_json_format() {
             ],
         )
         .unwrap();
-    assert_contains!(&result, "This will grant you access to HTTP/GRPC API");
+    assert_contains!(&result, "New token created successfully!");
 }
 
 #[test_log::test(tokio::test)]
@@ -2984,7 +2984,7 @@ async fn test_create_admin_token_allowed_once() {
     let result = server
         .run(vec!["create", "token", "--admin"], args)
         .unwrap();
-    assert_contains!(&result, "This will grant you access to HTTP/GRPC API");
+    assert_contains!(&result, "New token created successfully!");
 
     let result = server
         .run(vec!["create", "token", "--admin"], args)
@@ -3016,7 +3016,7 @@ async fn test_regenerate_admin_token() {
             &["--regenerate", "--tls-ca", "../testing-certs/rootCA.pem"],
         )
         .unwrap();
-    assert_contains!(&result, "This will grant you access to HTTP/GRPC API");
+    assert_contains!(&result, "New token created successfully!");
     let old_token = server.token().expect("admin token to be present");
     let new_token = parse_token(result);
     assert!(old_token != &new_token);
@@ -3056,7 +3056,7 @@ async fn test_delete_token() {
             args,
         )
         .unwrap();
-    assert_contains!(&result, "This will grant you access to HTTP/GRPC API");
+    assert_contains!(&result, "New token created successfully!");
     let token = parse_token(result);
 
     let result = server
@@ -3087,5 +3087,5 @@ async fn test_delete_token() {
             args,
         )
         .unwrap();
-    assert_contains!(&result, "This will grant you access to HTTP/GRPC API");
+    assert_contains!(&result, "New token created successfully!");
 }


### PR DESCRIPTION
Updates the output to more clearly identify the success of the command, the output of the command, and the importance of storing the token. 

Uses ANSI for styling, so it's non-terminal specific, but requires Regex for parsing now. 

## Current vs New
### Current Output
The current design is very nondescript, doesn't mention the importance of saving the token, and is easily lost as CLI outputs and commands grow.
<img width="1131" alt="image" src="https://github.com/user-attachments/assets/6c3a1af5-2810-4f65-b1d2-f3076e7c2af2" />

### New Output
The new design is specifically calls out success of creating a token, more cleanly identifies the token itself, and also very clearly mentions that it should be stored securely.
<img width="960" alt="image" src="https://github.com/user-attachments/assets/06418711-a554-490b-9763-b59d234bbb0d" />

## Alternatives Considered
### Additional Coloring
The green could have been helpful, but I feel pollutes the UX with too much visual overload with an additional color. 
<img width="976" alt="image" src="https://github.com/user-attachments/assets/209f159d-6f48-4129-9fd6-635db0de747f" />

### Boxing
Additionally, tried an example with the left bars to more cleanly display results. This looks nice, but on smaller terminals it would force wrap arounds which simply would look far less clean than not at all.
<img width="976" alt="image" src="https://github.com/user-attachments/assets/e3d7965f-8df7-4ae7-ba88-28244861a424" />

