### PR TITLE
feat: additional info when started --without-auth

### DIFF
--- a/influxdb3/src/commands/serve.rs
+++ b/influxdb3/src/commands/serve.rs
@@ -697,6 +697,12 @@ pub async fn command(config: Config) -> Result<()> {
         Arc::clone(&telemetry_store),
     );
 
+    if config.without_auth {
+        warn!(
+            "server started without auth (`--without-auth` switch), all token creation and regeneration of admin token endpoints are disabled"
+        );
+    }
+
     let query_executor = Arc::new(QueryExecutorImpl::new(CreateQueryExecutorArgs {
         catalog: write_buffer.catalog(),
         write_buffer: Arc::clone(&write_buffer),

--- a/influxdb3/tests/cli/mod.rs
+++ b/influxdb3/tests/cli/mod.rs
@@ -3089,3 +3089,18 @@ async fn test_delete_token() {
         .unwrap();
     assert_contains!(&result, "This will grant you access to HTTP/GRPC API");
 }
+
+#[test_log::test(tokio::test)]
+async fn test_create_admin_token_endpoint_disabled() {
+    let server = TestServer::configure().spawn().await;
+    let args = &["--tls-ca", "../testing-certs/rootCA.pem"];
+    let expected = "code: 405, message: \"endpoint disabled, started without auth\"";
+
+    let run_args = vec!["create", "token", "--admin"];
+    let result = server.run(run_args, args).unwrap();
+    assert_contains!(&result, expected);
+
+    let regen_args = vec!["create", "token", "--admin", "--regenerate"];
+    let result = server.run_with_confirmation(regen_args, args).unwrap();
+    assert_contains!(&result, expected);
+}

--- a/influxdb3_server/src/http.rs
+++ b/influxdb3_server/src/http.rs
@@ -1695,7 +1695,7 @@ pub(crate) async fn route_request(
     if started_without_auth && uri.path().starts_with(all_paths::API_V3_CONFIGURE_TOKEN) {
         return Ok(Response::builder()
             .status(StatusCode::METHOD_NOT_ALLOWED)
-            .body("".into())
+            .body("endpoint disabled, started without auth".into())
             .unwrap());
     }
 


### PR DESCRIPTION
- return 405 message body to indicate the endpoints are disabled
- extra log to say server has been started without auth