### PR TITLE
feat: catalog metrics to count operation types

### DIFF
--- a/influxdb3_catalog/src/catalog.rs
+++ b/influxdb3_catalog/src/catalog.rs
@@ -190,6 +190,11 @@ impl Catalog {
             })?;
 
         create_internal_db(&catalog).await;
+        catalog.metrics.operation_observer(
+            catalog
+                .subscribe_to_updates("catalog_operation_metrics")
+                .await,
+        );
         Ok(catalog)
     }
 

--- a/influxdb3_catalog/src/catalog/metrics.rs
+++ b/influxdb3_catalog/src/catalog/metrics.rs
@@ -1,15 +1,25 @@
 use std::sync::Arc;
 
-use metric::{Metric, Registry, U64Counter};
+use metric::{Attributes, Metric, Registry, U64Counter};
+
+use crate::{
+    channel::CatalogUpdateReceiver,
+    log::{CatalogBatch, DatabaseCatalogOp, NodeCatalogOp, TokenCatalogOp},
+};
 
 pub(super) const CATALOG_OPERATION_RETRIES_METRIC_NAME: &str =
     "influxdb3_catalog_operation_retries";
 const CATALOG_OPERATION_RETRIES_METRIC_DESCRIPTION: &str =
     "catalog updates that had to be retried because the catalog was updated elsewhere";
 
+pub(super) const CATALOG_OPERATIONS_METRIC_NAME: &str = "influxdb3_catalog_operations";
+const CATALOG_OPERATIONS_METRIC_DESCRIPTION: &str =
+    "counter of different catalog operations by their operation type";
+
 #[derive(Debug)]
 pub(super) struct CatalogMetrics {
     pub(super) catalog_operation_retries: U64Counter,
+    catalog_operations: OperationMetrics,
 }
 
 impl CatalogMetrics {
@@ -21,6 +31,97 @@ impl CatalogMetrics {
         let catalog_operation_retries = retries.recorder([]);
         Self {
             catalog_operation_retries,
+            catalog_operations: OperationMetrics::new(metric_registry),
+        }
+    }
+
+    pub(super) fn operation_observer(self: &Arc<Self>, mut recv: CatalogUpdateReceiver) {
+        let metrics = Arc::clone(self);
+        tokio::spawn(async move {
+            while let Some(update) = recv.recv().await {
+                for batch in update.batches() {
+                    match batch {
+                        CatalogBatch::Node(node_batch) => {
+                            for op in &node_batch.ops {
+                                metrics.catalog_operations.record(op);
+                            }
+                        }
+                        CatalogBatch::Database(database_batch) => {
+                            for op in &database_batch.ops {
+                                metrics.catalog_operations.record(op);
+                            }
+                        }
+                        CatalogBatch::Token(token_batch) => {
+                            for op in &token_batch.ops {
+                                metrics.catalog_operations.record(op)
+                            }
+                        }
+                    }
+                }
+            }
+        });
+    }
+}
+
+#[derive(Debug)]
+struct OperationMetrics {
+    operations: Metric<U64Counter>,
+}
+
+impl OperationMetrics {
+    fn new(registry: &Arc<Registry>) -> Self {
+        let operations: Metric<U64Counter> = registry.register_metric(
+            CATALOG_OPERATIONS_METRIC_NAME,
+            CATALOG_OPERATIONS_METRIC_DESCRIPTION,
+        );
+        Self { operations }
+    }
+
+    pub(super) fn record<O: AsMetricStr>(&self, op: &O) {
+        let attributes = Attributes::from(&[("type", op.as_metric_str())]);
+        self.operations.recorder(attributes).inc(1);
+    }
+}
+
+pub(super) trait AsMetricStr {
+    fn as_metric_str(&self) -> &'static str;
+}
+
+impl AsMetricStr for NodeCatalogOp {
+    fn as_metric_str(&self) -> &'static str {
+        match self {
+            NodeCatalogOp::RegisterNode(_) => "register_node",
+            NodeCatalogOp::StopNode(_) => "stop_node",
+        }
+    }
+}
+
+impl AsMetricStr for TokenCatalogOp {
+    fn as_metric_str(&self) -> &'static str {
+        match self {
+            TokenCatalogOp::CreateAdminToken(_) => "create_admin_token",
+            TokenCatalogOp::RegenerateAdminToken(_) => "regenerate_admin_token",
+            TokenCatalogOp::DeleteToken(_) => "delete_token",
+        }
+    }
+}
+
+impl AsMetricStr for DatabaseCatalogOp {
+    fn as_metric_str(&self) -> &'static str {
+        match self {
+            DatabaseCatalogOp::CreateDatabase(_) => "create_database",
+            DatabaseCatalogOp::SoftDeleteDatabase(_) => "soft_delete_database",
+            DatabaseCatalogOp::CreateTable(_) => "create_table",
+            DatabaseCatalogOp::SoftDeleteTable(_) => "soft_delete_table",
+            DatabaseCatalogOp::AddFields(_) => "add_fields",
+            DatabaseCatalogOp::CreateDistinctCache(_) => "create_distinct_cache",
+            DatabaseCatalogOp::DeleteDistinctCache(_) => "delete_distinct_cache",
+            DatabaseCatalogOp::CreateLastCache(_) => "create_last_cache",
+            DatabaseCatalogOp::DeleteLastCache(_) => "delete_last_cache",
+            DatabaseCatalogOp::CreateTrigger(_) => "create_trigger",
+            DatabaseCatalogOp::DeleteTrigger(_) => "delete_trigger",
+            DatabaseCatalogOp::EnableTrigger(_) => "enable_trigger",
+            DatabaseCatalogOp::DisableTrigger(_) => "disable_trigger",
         }
     }
 }
@@ -33,7 +134,10 @@ mod tests {
     use metric::{Attributes, Metric, Registry, U64Counter};
     use object_store::memory::InMemory;
 
-    use crate::catalog::Catalog;
+    use crate::{
+        catalog::{Catalog, Prompt, metrics::CATALOG_OPERATIONS_METRIC_NAME},
+        log::{FieldDataType, NodeMode},
+    };
 
     use super::CATALOG_OPERATION_RETRIES_METRIC_NAME;
 
@@ -91,5 +195,75 @@ mod tests {
         assert_eq!(0, o1.fetch());
         c1.create_database("bar").await.unwrap_err();
         assert_eq!(1, o1.fetch());
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn test_catalog_operation_counter() {
+        let metrics = Arc::new(Registry::new());
+        let os = Arc::new(InMemory::new());
+        let tp = Arc::new(MockProvider::new(Time::from_timestamp_nanos(0)));
+        let catalog = Catalog::new(
+            "node",
+            Arc::clone(&os) as _,
+            Arc::clone(&tp) as _,
+            Arc::clone(&metrics),
+        )
+        .await
+        .unwrap();
+        check_metric_empty(&metrics, "create_database");
+        catalog.create_database("foo").await.unwrap();
+        check_metric(&metrics, "create_database", 1);
+        catalog.create_database("bar").await.unwrap();
+        check_metric(&metrics, "create_database", 2);
+
+        let mut txn = catalog.begin("baz").unwrap();
+        txn.table_or_create("employees").unwrap();
+        txn.column_or_create("employees", "name", FieldDataType::String)
+            .unwrap();
+        txn.column_or_create("employees", "job_title", FieldDataType::String)
+            .unwrap();
+        txn.column_or_create("employees", "hire_date", FieldDataType::String)
+            .unwrap();
+        check_metric_empty(&metrics, "create_table");
+        check_metric_empty(&metrics, "add_fields");
+        let Prompt::Success(_) = catalog.commit(txn).await.unwrap() else {
+            panic!("transaction should commit");
+        };
+        check_metric(&metrics, "create_database", 3);
+        check_metric(&metrics, "create_table", 1);
+        check_metric(&metrics, "add_fields", 3);
+
+        check_metric_empty(&metrics, "register_node");
+        catalog
+            .register_node("node2", 4, vec![NodeMode::Core])
+            .await
+            .unwrap();
+        check_metric(&metrics, "register_node", 1);
+
+        check_metric_empty(&metrics, "create_admin_token");
+        catalog.create_admin_token(false).await.unwrap();
+        check_metric(&metrics, "create_admin_token", 1);
+    }
+
+    fn check_metric_empty(registry: &Arc<Registry>, operation_type: &'static str) {
+        let instrument = registry
+            .get_instrument::<Metric<U64Counter>>(CATALOG_OPERATIONS_METRIC_NAME)
+            .unwrap();
+        assert!(
+            instrument
+                .get_observer(&Attributes::from(&[("type", operation_type)]))
+                .is_none(),
+            "the metric was present for the operation '{operation_type}'"
+        );
+    }
+
+    fn check_metric(registry: &Arc<Registry>, operation_type: &'static str, expected: u64) {
+        let instrument = registry
+            .get_instrument::<Metric<U64Counter>>(CATALOG_OPERATIONS_METRIC_NAME)
+            .unwrap();
+        let observer = instrument
+            .get_observer(&Attributes::from(&[("type", operation_type)]))
+            .unwrap();
+        assert_eq!(expected, observer.fetch(), "metric check failed");
     }
 }


### PR DESCRIPTION
Closes #26225 

This adds the `influxdb3_catalog_operations_total` metric for tracking the number of catalog operations by their type.

They appear in the prometheus `/metrics` output like so:
```
# HELP influxdb3_catalog_operations_total counter of different catalog operations by their operation type
# TYPE influxdb3_catalog_operations_total counter
influxdb3_catalog_operations_total{type="create_database"} 1
influxdb3_catalog_operations_total{type="create_table"} 1
influxdb3_catalog_operations_total{type="register_node"} 1
```
