### PR TITLE
chore: update to go 1.23.8 (1.12) (#26309)

### DIFF
--- a/tsdb/config.go
+++ b/tsdb/config.go
@@ -146,11 +146,16 @@ type Config struct {
 	// A value of 0 disables the limit.
 	MaxValuesPerTag int `toml:"max-values-per-tag"`
 
-	// MaxConcurrentCompactions is the maximum number of concurrent level and full compactions
+	// MaxConcurrentCompactions is the maximum number of concurrent level, full, and optimized compactions
 	// that can be running at one time across all shards.  Compactions scheduled to run when the
 	// limit is reached are blocked until a running compaction completes.  Snapshot compactions are
 	// not affected by this limit.  A value of 0 limits compactions to runtime.GOMAXPROCS(0).
 	MaxConcurrentCompactions int `toml:"max-concurrent-compactions"`
+
+	// MaxConcurrentOptimizedCompactions is the maximum number of concurrent optimized compactions
+	// that can be running across all shards. Optimized compactions scheduled to run when the limit
+	// is reached are aborted, saving them for a later compaction run.
+	MaxConcurrentOptimizedCompactions int `toml:"max-concurrent-optimized-compactions"`
 
 	// MaxIndexLogFileSize is the threshold, in bytes, when an index write-ahead log file will
 	// compact into an index file. Lower sizes will cause log files to be compacted more quickly

--- a/tsdb/engine.go
+++ b/tsdb/engine.go
@@ -176,6 +176,7 @@ type EngineOptions struct {
 	CompactionPlannerCreator    CompactionPlannerCreator
 	CompactionLimiter           limiter.Fixed
 	CompactionThroughputLimiter limiter.Rate
+	OptimizedCompactionLimiter  limiter.Fixed
 	WALEnabled                  bool
 	MonitorDisabled             bool
 

--- a/tsdb/engine/tsm1/compact.go
+++ b/tsdb/engine/tsm1/compact.go
@@ -270,12 +270,16 @@ func (c *DefaultPlanner) generationsFullyCompacted(gens tsmGenerations) (bool, s
 			aggressivePointsPerBlockCount := 0
 			filesUnderMaxTsmSizeCount := 0
 			for _, tsmFile := range gens[0].files {
-				if c.FileStore.BlockCount(tsmFile.Path, 1) >= c.aggressiveCompactionPointsPerBlock {
+				if c.FileStore.BlockCount(tsmFile.Path, 1) >= c.GetAggressiveCompactionPointsPerBlock() {
 					aggressivePointsPerBlockCount++
 				}
 				if tsmFile.Size < tsdb.MaxTSMFileSize {
 					filesUnderMaxTsmSizeCount++
 				}
+			}
+
+			if aggressivePointsPerBlockCount == len(gens[0].files) {
+				return true, "fully compacted because all files are at aggressivePointsPerBlock"
 			}
 
 			if filesUnderMaxTsmSizeCount > 1 && aggressivePointsPerBlockCount < len(gens[0].files) {

--- a/tsdb/engine/tsm1/compact_test.go
+++ b/tsdb/engine/tsm1/compact_test.go
@@ -3,7 +3,6 @@ package tsm1_test
 import (
 	"errors"
 	"fmt"
-	"golang.org/x/exp/slices"
 	"io/fs"
 	"math"
 	"os"
@@ -2262,12 +2261,22 @@ func TestDefaultPlanner_PlanOptimize_NoLevel4(t *testing.T) {
 
 func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 	type PlanOptimizeTests struct {
-		name                            string
-		fs                              []tsm1.FileStat
-		bc                              []int
-		expectedFullyCompactedReasonExp string
-		expectedgenerationCount         int64
+		name         string
+		fs           []tsm1.FileStat
+		bc           []int
+		level1Groups []tsm1.PlannedCompactionGroup
+		level2Groups []tsm1.PlannedCompactionGroup
+		level3Groups []tsm1.PlannedCompactionGroup
+		level4Groups []tsm1.PlannedCompactionGroup
+		level5Groups []tsm1.PlannedCompactionGroup
 	}
+
+	e, err := NewEngine(tsdb.InmemIndexName)
+	require.NoError(t, err, "open engine")
+	e.SetEnabled(false)
+	defer func() { require.NoError(t, e.Close(), "close engine") }()
+	e.Compactor = tsm1.NewCompactor()
+	defer e.Compactor.Close()
 
 	furtherCompactedTests := []PlanOptimizeTests{
 		// Large multi generation group with files at and under 2GB
@@ -2328,8 +2337,26 @@ func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 				10,
 				5,
 			},
-			"not fully compacted and not idle because of more than one generation",
-			3,
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{
+				{
+					tsm1.CompactionGroup{"01-05.tsm1",
+						"01-06.tsm1",
+						"01-07.tsm1",
+						"01-08.tsm1",
+						"02-05.tsm1",
+						"02-06.tsm1",
+						"02-07.tsm1",
+						"02-08.tsm1",
+						"03-04.tsm1",
+						"03-05.tsm1",
+					},
+					tsdb.DefaultMaxPointsPerBlock,
+				},
+			},
 		},
 		// ~650mb group size
 		{
@@ -2353,8 +2380,20 @@ func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 				},
 			},
 			[]int{},
-			tsdb.SingleGenerationReasonText,
-			1,
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{
+				{
+					tsm1.CompactionGroup{"01-05.tsm1",
+						"01-06.tsm1",
+						"01-07.tsm1",
+						"01-08.tsm1",
+					},
+					tsdb.DefaultAggressiveMaxPointsPerBlock,
+				},
+			},
 		},
 		// ~650 MB total group size with generations under 4
 		{
@@ -2374,8 +2413,19 @@ func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 				},
 			},
 			[]int{},
-			tsdb.SingleGenerationReasonText,
-			1,
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{
+				{
+					tsm1.CompactionGroup{"01-02.tsm1",
+						"01-03.tsm1",
+						"01-04.tsm1",
+					},
+					tsdb.DefaultAggressiveMaxPointsPerBlock,
+				},
+			},
 		},
 		{
 			"Small group size with single generation all at DefaultMaxPointsPerBlock",
@@ -2396,9 +2446,22 @@ func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 					Path: "01-08.tsm1",
 					Size: 50 * 1024 * 1024,
 				},
-			}, []int{tsdb.DefaultMaxPointsPerBlock, tsdb.DefaultMaxPointsPerBlock, tsdb.DefaultMaxPointsPerBlock, tsdb.DefaultMaxPointsPerBlock},
-			tsdb.SingleGenerationReasonText,
-			1,
+			},
+			[]int{tsdb.DefaultMaxPointsPerBlock, tsdb.DefaultMaxPointsPerBlock, tsdb.DefaultMaxPointsPerBlock, tsdb.DefaultMaxPointsPerBlock},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{
+				{
+					tsm1.CompactionGroup{"01-05.tsm1",
+						"01-06.tsm1",
+						"01-07.tsm1",
+						"01-08.tsm1",
+					},
+					tsdb.DefaultAggressiveMaxPointsPerBlock,
+				},
+			},
 		},
 		// > 2 GB total group size
 		// 50% of files are at aggressive max block size
@@ -2448,8 +2511,24 @@ func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 				tsdb.DefaultMaxPointsPerBlock,
 				tsdb.DefaultMaxPointsPerBlock,
 			},
-			tsdb.SingleGenerationReasonText,
-			1,
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{
+				{
+					tsm1.CompactionGroup{"01-05.tsm1",
+						"01-06.tsm1",
+						"01-07.tsm1",
+						"01-08.tsm1",
+						"01-09.tsm1",
+						"01-10.tsm1",
+						"01-11.tsm1",
+						"01-12.tsm1",
+					},
+					tsdb.DefaultAggressiveMaxPointsPerBlock,
+				},
+			},
 		},
 		{
 			"Group size over 2GB with single generation",
@@ -2466,39 +2545,29 @@ func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 					Path: "01-15.tsm1",
 					Size: 450 * 1024 * 1024,
 				},
-			}, []int{
+			},
+			[]int{
 				tsdb.DefaultAggressiveMaxPointsPerBlock,
 				tsdb.DefaultMaxPointsPerBlock,
 				tsdb.DefaultMaxPointsPerBlock,
 			},
-			tsdb.SingleGenerationReasonText,
-			1,
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{
+				{
+					tsm1.CompactionGroup{"01-13.tsm1",
+						"01-14.tsm1",
+						"01-15.tsm1",
+					},
+					tsdb.DefaultAggressiveMaxPointsPerBlock,
+				},
+			},
 		},
 	}
 
-	expectedNotFullyCompacted := func(cp *tsm1.DefaultPlanner, reasonExp string, generationCountExp int64) {
-		compacted, reason := cp.FullyCompacted()
-		require.Equal(t, reason, reasonExp, "fullyCompacted reason")
-		require.False(t, compacted, "is fully compacted")
-
-		_, cgLen := cp.PlanLevel(1)
-		require.Zero(t, cgLen, "compaction group length; PlanLevel(1)")
-		_, cgLen = cp.PlanLevel(2)
-		require.Zero(t, cgLen, "compaction group length; PlanLevel(2)")
-		_, cgLen = cp.PlanLevel(3)
-		require.Zero(t, cgLen, "compaction group length; PlanLevel(3)")
-
-		tsmP, pLenP := cp.Plan(time.Now().Add(-tsdb.DefaultCompactFullWriteColdDuration + 1))
-		require.Zero(t, len(tsmP), "compaction group; Plan()")
-		require.Zero(t, pLenP, "compaction group length; Plan()")
-
-		_, cgLen, genLen := cp.PlanOptimize(time.Now().Add(-tsdb.DefaultCompactFullWriteColdDuration + 1))
-		require.Equal(t, int64(1), cgLen, "compaction group length")
-		require.Equal(t, generationCountExp, genLen, "generation count")
-
-	}
-
-	for _, test := range furtherCompactedTests {
+	for i, test := range furtherCompactedTests {
 		t.Run(test.name, func(t *testing.T) {
 			ffs := &fakeFileStore{
 				PathsFn: func() []tsm1.FileStat {
@@ -2506,13 +2575,21 @@ func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 				},
 			}
 
+			cp := tsm1.NewDefaultPlanner(ffs, tsdb.DefaultCompactFullWriteColdDuration)
+
 			if len(test.bc) > 0 {
 				err := ffs.SetBlockCounts(test.bc)
 				require.NoError(t, err, "setting block counts")
 			}
 
-			cp := tsm1.NewDefaultPlanner(ffs, tsdb.DefaultCompactFullWriteColdDuration)
-			expectedNotFullyCompacted(cp, test.expectedFullyCompactedReasonExp, test.expectedgenerationCount)
+			e.CompactionPlan = cp
+			e.Compactor.FileStore = ffs
+			level1Groups, level2Groups, level3Groups, level4Groups, level5Groups := e.PlanCompactions()
+			compareLevelGroups(t, furtherCompactedTests[i].level1Groups, level1Groups, "unexpected level 1 Group")
+			compareLevelGroups(t, furtherCompactedTests[i].level2Groups, level2Groups, "unexpected level 2 Group")
+			compareLevelGroups(t, furtherCompactedTests[i].level3Groups, level3Groups, "unexpected level 3 Group")
+			compareLevelGroups(t, furtherCompactedTests[i].level4Groups, level4Groups, "unexpected level 4 Group")
+			compareLevelGroups(t, furtherCompactedTests[i].level5Groups, level5Groups, "unexpected level 5 Group")
 		})
 	}
 
@@ -2529,7 +2606,11 @@ func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 				},
 			},
 			[]int{},
-			"", 0,
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
 		},
 		{
 			// This test is added to account for a single generation that has a group size
@@ -2545,10 +2626,16 @@ func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 					Path: "01-14.tsm1",
 					Size: 691 * 1024 * 1024,
 				},
-			}, []int{
+			},
+			[]int{
 				tsdb.DefaultAggressiveMaxPointsPerBlock,
 				tsdb.DefaultAggressiveMaxPointsPerBlock,
-			}, "", 0,
+			},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
 		},
 		{
 			// This test is added to account for a single generation that has a group size
@@ -2565,12 +2652,16 @@ func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 					Path: "01-14.tsm1",
 					Size: 691 * 1024 * 1024,
 				},
-			}, []int{
+			},
+			[]int{
 				tsdb.DefaultAggressiveMaxPointsPerBlock,
 				tsdb.DefaultMaxPointsPerBlock,
 			},
-			"",
-			0,
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
 		},
 		{
 			// This test is added to account for a single generation that has a group size
@@ -2589,37 +2680,21 @@ func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 					Path: "01-15.tsm1",
 					Size: 450 * 1024 * 1024,
 				},
-			}, []int{
+			},
+			[]int{
 				tsdb.DefaultAggressiveMaxPointsPerBlock,
 				tsdb.DefaultAggressiveMaxPointsPerBlock,
 				tsdb.DefaultAggressiveMaxPointsPerBlock,
-			}, "", 0,
+			},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
 		},
 	}
 
-	expectedFullyCompacted := func(cp *tsm1.DefaultPlanner, reasonExp string) {
-		compacted, reason := cp.FullyCompacted()
-		require.Equal(t, reason, reasonExp, "fullyCompacted reason")
-		require.True(t, compacted, "is fully compacted")
-
-		_, cgLen := cp.PlanLevel(1)
-		require.Zero(t, cgLen, "compaction group length; PlanLevel(1)")
-		_, cgLen = cp.PlanLevel(2)
-		require.Zero(t, cgLen, "compaction group length; PlanLevel(2)")
-		_, cgLen = cp.PlanLevel(3)
-		require.Zero(t, cgLen, "compaction group length; PlanLevel(3)")
-
-		tsmP, pLenP := cp.Plan(time.Now().Add(-time.Second))
-		require.Zero(t, len(tsmP), "compaction group; Plan()")
-		require.Zero(t, pLenP, "compaction group length; Plan()")
-
-		cgroup, cgLen, genLen := cp.PlanOptimize(time.Now().Add(-tsdb.DefaultCompactFullWriteColdDuration + 1))
-		require.Equal(t, []tsm1.CompactionGroup(nil), cgroup, "compaction group")
-		require.Zero(t, cgLen, "compaction group length")
-		require.Zero(t, genLen, "generation count")
-	}
-
-	for _, test := range areFullyCompactedTests {
+	for i, test := range areFullyCompactedTests {
 		t.Run(test.name, func(t *testing.T) {
 			ffs := &fakeFileStore{
 				PathsFn: func() []tsm1.FileStat {
@@ -2627,34 +2702,37 @@ func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 				},
 			}
 
+			cp := tsm1.NewDefaultPlanner(ffs, tsdb.DefaultCompactFullWriteColdDuration)
+
 			if len(test.bc) > 0 {
 				err := ffs.SetBlockCounts(test.bc)
 				require.NoError(t, err, "setting block counts")
 			}
 
-			cp := tsm1.NewDefaultPlanner(ffs, tsdb.DefaultCompactFullWriteColdDuration)
-			expectedFullyCompacted(cp, test.expectedFullyCompactedReasonExp)
+			compacted, _ := cp.FullyCompacted()
+			require.True(t, compacted, "Should be fully compacted")
 
-			// Reverse test files and re-run tests
-			slices.Reverse(test.fs)
-			if len(test.bc) > 0 {
-				slices.Reverse(test.bc)
-				err := ffs.SetBlockCounts(test.bc)
-				require.NoError(t, err, "setting reverse block counts")
-			}
+			e.CompactionPlan = cp
+			e.Compactor.FileStore = ffs
 
-			cp = tsm1.NewDefaultPlanner(ffs, tsdb.DefaultCompactFullWriteColdDuration)
-			expectedFullyCompacted(cp, test.expectedFullyCompactedReasonExp)
+			level1Groups, level2Groups, level3Groups, level4Groups, level5Groups := e.PlanCompactions()
+			compareLevelGroups(t, areFullyCompactedTests[i].level1Groups, level1Groups, "unexpected level 1 Group")
+			compareLevelGroups(t, areFullyCompactedTests[i].level2Groups, level2Groups, "unexpected level 2 Group")
+			compareLevelGroups(t, areFullyCompactedTests[i].level3Groups, level3Groups, "unexpected level 3 Group")
+			compareLevelGroups(t, areFullyCompactedTests[i].level4Groups, level4Groups, "unexpected level 4 Group")
+			compareLevelGroups(t, areFullyCompactedTests[i].level5Groups, level5Groups, "unexpected level 5 Group")
 		})
 	}
 
 	type PlanOptimizeMixedTests struct {
-		name                            string
-		fs                              []tsm1.FileStat
-		bc                              []int
-		expectedFullyCompactedReasonExp string
-		expectedgenerationCount         int64
-		fullyCompacted                  bool
+		name         string
+		fs           []tsm1.FileStat
+		bc           []int
+		level1Groups []tsm1.PlannedCompactionGroup
+		level2Groups []tsm1.PlannedCompactionGroup
+		level3Groups []tsm1.PlannedCompactionGroup
+		level4Groups []tsm1.PlannedCompactionGroup
+		level5Groups []tsm1.PlannedCompactionGroup
 	}
 
 	mixedPlanOptimizeTests := []PlanOptimizeMixedTests{
@@ -2670,7 +2748,11 @@ func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 				},
 			},
 			[]int{},
-			"", 0, true,
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
 		},
 		{
 			// This test is added to account for a single generation that has a group size
@@ -2686,10 +2768,16 @@ func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 					Path: "01-14.tsm1",
 					Size: 691 * 1024 * 1024,
 				},
-			}, []int{
+			},
+			[]int{
 				tsdb.DefaultAggressiveMaxPointsPerBlock,
 				tsdb.DefaultAggressiveMaxPointsPerBlock,
-			}, "", 0, true,
+			},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
 		},
 		{
 			// This test is added to account for a single generation that has a group size
@@ -2706,12 +2794,16 @@ func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 					Path: "01-14.tsm1",
 					Size: 691 * 1024 * 1024,
 				},
-			}, []int{
+			},
+			[]int{
 				tsdb.DefaultAggressiveMaxPointsPerBlock,
 				tsdb.DefaultMaxPointsPerBlock,
 			},
-			"",
-			0, true,
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
 		},
 		{
 			// This test is added to account for a single generation that has a group size
@@ -2730,33 +2822,25 @@ func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 					Path: "01-15.tsm1",
 					Size: 450 * 1024 * 1024,
 				},
-			}, []int{
+			},
+			[]int{
 				tsdb.DefaultAggressiveMaxPointsPerBlock,
 				tsdb.DefaultAggressiveMaxPointsPerBlock,
 				tsdb.DefaultAggressiveMaxPointsPerBlock,
-			}, tsdb.SingleGenerationReasonText, 1, false,
+			},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
 		},
-	}
-
-	mixedPlanOptimizeTestRunner := func(cp *tsm1.DefaultPlanner, reasonExp string, fullyCompacted bool) {
-		compacted, reason := cp.FullyCompacted()
-		require.Equal(t, reason, reasonExp, "fullyCompacted reason")
-		require.Equal(t, compacted, fullyCompacted, "is fully compacted")
-
-		// Ensure that no level planning takes place
-		_, cgLen := cp.PlanLevel(1)
-		require.Zero(t, cgLen, "compaction group length; PlanLevel(1)")
-		_, cgLen = cp.PlanLevel(2)
-		require.Zero(t, cgLen, "compaction group length; PlanLevel(2)")
-		_, cgLen = cp.PlanLevel(3)
-		require.Zero(t, cgLen, "compaction group length; PlanLevel(3)")
 	}
 
 	// These tests will decrease the max points per block for aggressive compaction.
 	// For SetAggressiveCompactionPointsPerBlock we are using 10x the default to
 	// mock an administrator setting the max points per block to 100_000 and overriding
 	// the default of 10_000.
-	for _, test := range mixedPlanOptimizeTests {
+	for i, test := range mixedPlanOptimizeTests {
 		t.Run(test.name, func(t *testing.T) {
 			ffs := &fakeFileStore{
 				PathsFn: func() []tsm1.FileStat {
@@ -2764,35 +2848,36 @@ func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 				},
 			}
 
+			cp := tsm1.NewDefaultPlanner(ffs, tsdb.DefaultCompactFullWriteColdDuration)
+
 			if len(test.bc) > 0 {
 				err := ffs.SetBlockCounts(test.bc)
 				require.NoError(t, err, "setting block counts")
 			}
 
-			cp := tsm1.NewDefaultPlanner(ffs, tsdb.DefaultCompactFullWriteColdDuration)
-			cp.SetAggressiveCompactionPointsPerBlock(tsdb.DefaultAggressiveMaxPointsPerBlock * 10)
-			mixedPlanOptimizeTestRunner(cp, test.expectedFullyCompactedReasonExp, test.fullyCompacted)
+			e.CompactionPlan = cp
+			e.Compactor.FileStore = ffs
 
-			// Reverse test files and re-run tests
-			slices.Reverse(test.fs)
-			if len(test.bc) > 0 {
-				slices.Reverse(test.bc)
-				err := ffs.SetBlockCounts(test.bc)
-				require.NoError(t, err, "setting reverse block counts")
-			}
-
-			cp = tsm1.NewDefaultPlanner(ffs, tsdb.DefaultCompactFullWriteColdDuration)
-			cp.SetAggressiveCompactionPointsPerBlock(tsdb.DefaultAggressiveMaxPointsPerBlock * 10)
-			mixedPlanOptimizeTestRunner(cp, test.expectedFullyCompactedReasonExp, test.fullyCompacted)
+			level1Groups, level2Groups, level3Groups, level4Groups, level5Groups := e.PlanCompactions()
+			compareLevelGroups(t, mixedPlanOptimizeTests[i].level1Groups, level1Groups, "unexpected level 1 Group")
+			compareLevelGroups(t, mixedPlanOptimizeTests[i].level2Groups, level2Groups, "unexpected level 2 Group")
+			compareLevelGroups(t, mixedPlanOptimizeTests[i].level3Groups, level3Groups, "unexpected level 3 Group")
+			compareLevelGroups(t, mixedPlanOptimizeTests[i].level4Groups, level4Groups, "unexpected level 4 Group")
+			compareLevelGroups(t, mixedPlanOptimizeTests[i].level5Groups, level5Groups, "unexpected level 5 Group")
 		})
 	}
 
 	// The following tests ensure that if Plan() is scheduled
 	// for a shard than PlanOptimize() should not be scheduled for that shard
 	type PlanBeforePlanOptimizeTests struct {
-		name string
-		fs   []tsm1.FileStat
-		bc   []int
+		name         string
+		fs           []tsm1.FileStat
+		bc           []int
+		level1Groups []tsm1.PlannedCompactionGroup
+		level2Groups []tsm1.PlannedCompactionGroup
+		level3Groups []tsm1.PlannedCompactionGroup
+		level4Groups []tsm1.PlannedCompactionGroup
+		level5Groups []tsm1.PlannedCompactionGroup
 	}
 
 	planBeforePlanOptimized := []PlanBeforePlanOptimizeTests{
@@ -2840,14 +2925,36 @@ func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 					Size: 2048 * 1024 * 1024,
 				},
 				{
-					Path: "03-04.tsm1",
+					Path: "03-05.tsm1",
 					Size: 600 * 1024 * 1024,
 				},
 				{
 					Path: "03-06.tsm1",
 					Size: 500 * 1024 * 1024,
 				},
-			}, []int{},
+			},
+			[]int{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{
+				{
+					tsm1.CompactionGroup{"01-05.tsm1",
+						"01-06.tsm1",
+						"01-07.tsm1",
+						"01-08.tsm1",
+						"02-05.tsm1",
+						"02-06.tsm1",
+						"02-07.tsm1",
+						"02-08.tsm1",
+						"03-03.tsm1",
+						"03-04.tsm1",
+						"03-05.tsm1",
+						"03-06.tsm1"},
+					tsdb.DefaultMaxPointsPerBlock,
+				},
+			},
+			[]tsm1.PlannedCompactionGroup{},
 		},
 		{
 			// This test will mock a 'backfill' condition where we have a single
@@ -2904,7 +3011,8 @@ func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 					Path: "03-03.tsm1",
 					Size: 400 * 1024 * 1024,
 				},
-			}, []int{
+			},
+			[]int{
 				tsdb.DefaultAggressiveMaxPointsPerBlock,
 				tsdb.DefaultAggressiveMaxPointsPerBlock,
 				tsdb.DefaultAggressiveMaxPointsPerBlock,
@@ -2921,6 +3029,16 @@ func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 				// Use some magic numbers but these are just small values for block counts
 				100,
 				10,
+			},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{
+				{
+					tsm1.CompactionGroup{
+						"02-04.tsm1", "02-05.tsm1", "02-06.tsm1", "03-02.tsm1", "03-03.tsm1", "03-03.tsm1", "03-04.tsm1", "04-01.tsm1", "04-02.tsm1",
+					}, tsdb.DefaultAggressiveMaxPointsPerBlock},
 			},
 		},
 		{
@@ -3247,31 +3365,101 @@ func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 					Size: 1717986918,
 				},
 			}, []int{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{},
+			[]tsm1.PlannedCompactionGroup{
+				{
+					tsm1.CompactionGroup{
+						"000029202-000000004.tsm",
+						"000029202-000000005.tsm",
+						"000029202-000000006.tsm",
+						"000029202-000000007.tsm",
+						"000029202-000000008.tsm",
+						"000029202-000000009.tsm",
+						"000029202-000000010.tsm",
+						"000029202-000000011.tsm",
+						"000029202-000000012.tsm",
+						"000029202-000000013.tsm",
+						"000029202-000000014.tsm",
+						"000029202-000000015.tsm",
+						"000029202-000000016.tsm",
+						"000029202-000000017.tsm",
+						"000029202-000000018.tsm",
+						"000029202-000000019.tsm",
+						"000029202-000000020.tsm",
+						"000029202-000000021.tsm",
+						"000029202-000000022.tsm",
+						"000029202-000000023.tsm",
+						"000029202-000000024.tsm",
+						"000029202-000000025.tsm",
+						"000029202-000000026.tsm",
+						"000029202-000000027.tsm",
+						"000029202-000000028.tsm",
+						"000029202-000000029.tsm",
+						"000029202-000000030.tsm",
+						"000029202-000000031.tsm",
+						"000029202-000000032.tsm",
+						"000029202-000000033.tsm",
+						"000029202-000000034.tsm",
+						"000029202-000000035.tsm",
+						"000029202-000000036.tsm",
+						"000029202-000000037.tsm",
+						"000029202-000000038.tsm",
+						"000029202-000000039.tsm",
+						"000029202-000000040.tsm",
+						"000029202-000000041.tsm",
+						"000029202-000000042.tsm",
+						"000029202-000000043.tsm",
+						"000029202-000000044.tsm",
+						"000029202-000000045.tsm",
+						"000029202-000000046.tsm",
+						"000029235-000000003.tsm",
+						"000029267-000000003.tsm",
+						"000029268-000000001.tsm",
+						"000029268-000000002.tsm",
+						"000029268-000000003.tsm",
+						"000029268-000000004.tsm",
+						"000029268-000000005.tsm",
+						"000029268-000000006.tsm",
+						"000029268-000000007.tsm",
+						"000029268-000000008.tsm",
+						"000029268-000000009.tsm",
+						"000029268-000000010.tsm",
+						"000029268-000000011.tsm",
+						"000029268-000000012.tsm",
+						"000029268-000000013.tsm",
+						"000029268-000000014.tsm",
+						"000029268-000000015.tsm",
+						"000029268-000000016.tsm",
+						"000029268-000000017.tsm",
+						"000029268-000000018.tsm",
+						"000029268-000000019.tsm",
+						"000029268-000000020.tsm",
+						"000029268-000000021.tsm",
+						"000029268-000000022.tsm",
+						"000029268-000000023.tsm",
+						"000029268-000000024.tsm",
+						"000029268-000000025.tsm",
+						"000029268-000000026.tsm",
+						"000029268-000000027.tsm",
+						"000029268-000000028.tsm",
+						"000029268-000000029.tsm",
+						"000029268-000000030.tsm",
+						"000029268-000000031.tsm",
+						"000029268-000000032.tsm",
+						"000029268-000000033.tsm",
+						"000029268-000000034.tsm",
+						"000029268-000000035.tsm",
+					},
+					tsdb.DefaultMaxPointsPerBlock,
+				},
+			},
+			[]tsm1.PlannedCompactionGroup{},
 		},
 	}
 
-	planBeforePlanOptimizedRunner := func(cp *tsm1.DefaultPlanner) {
-		// Ensure that no level planning takes place
-		_, cgLen := cp.PlanLevel(1)
-		require.Zero(t, cgLen, "compaction group length; PlanLevel(1)")
-		_, cgLen = cp.PlanLevel(2)
-		require.Zero(t, cgLen, "compaction group length; PlanLevel(2)")
-		_, cgLen = cp.PlanLevel(3)
-		require.Zero(t, cgLen, "compaction group length; PlanLevel(3)")
-
-		// Plan should schedule
-		tsmP, pLenP := cp.Plan(time.Now().Add(-tsdb.DefaultCompactFullWriteColdDuration + 1))
-		require.Equal(t, 1, len(tsmP), "compaction group; Plan()")
-		require.Equal(t, int64(1), pLenP, "compaction group length; Plan()")
-
-		// PlanOptimize should not schedule
-		cgroup, cgLen, genLen := cp.PlanOptimize(time.Now().Add(-tsdb.DefaultCompactFullWriteColdDuration + 1))
-		require.Equal(t, []tsm1.CompactionGroup(nil), cgroup, "compaction group")
-		require.Zero(t, cgLen, "compaction group length")
-		require.Zero(t, genLen, "generation count")
-	}
-
-	for _, test := range planBeforePlanOptimized {
+	for i, test := range planBeforePlanOptimized {
 		t.Run(test.name, func(t *testing.T) {
 			ffs := &fakeFileStore{
 				PathsFn: func() []tsm1.FileStat {
@@ -3279,13 +3467,22 @@ func TestDefaultPlanner_PlanOptimize_Test(t *testing.T) {
 				},
 			}
 
+			cp := tsm1.NewDefaultPlanner(ffs, tsdb.DefaultCompactFullWriteColdDuration)
+
 			if len(test.bc) > 0 {
 				err := ffs.SetBlockCounts(test.bc)
 				require.NoError(t, err, "setting block counts")
 			}
 
-			cp := tsm1.NewDefaultPlanner(ffs, tsdb.DefaultCompactFullWriteColdDuration)
-			planBeforePlanOptimizedRunner(cp)
+			e.CompactionPlan = cp
+			e.Compactor.FileStore = ffs
+
+			level1Groups, level2Groups, level3Groups, level4Groups, level5Groups := e.PlanCompactions()
+			compareLevelGroups(t, planBeforePlanOptimized[i].level1Groups, level1Groups, "unexpected level 1 Group")
+			compareLevelGroups(t, planBeforePlanOptimized[i].level2Groups, level2Groups, "unexpected level 2 Group")
+			compareLevelGroups(t, planBeforePlanOptimized[i].level3Groups, level3Groups, "unexpected level 3 Group")
+			compareLevelGroups(t, planBeforePlanOptimized[i].level4Groups, level4Groups, "unexpected level 4 Group")
+			compareLevelGroups(t, planBeforePlanOptimized[i].level5Groups, level5Groups, "unexpected level 5 Group")
 		})
 	}
 }
@@ -3894,6 +4091,206 @@ func TestDefaultPlanner_Plan_ForceFull(t *testing.T) {
 	}
 	cp.Release(tsm)
 
+}
+
+func TestIsGroupOptimized(t *testing.T) {
+	testSet := []tsm1.FileStat{
+		{
+			Path: "01-05.tsm",
+			Size: 256 * 1024 * 1024,
+		},
+		{
+			Path: "02-05.tsm",
+			Size: 256 * 1024 * 1024,
+		},
+		{
+			Path: "03-05.tsm",
+			Size: 256 * 1024 * 1024,
+		},
+		{
+			Path: "04-04.tsm",
+			Size: 256 * 1024 * 1024,
+		},
+	}
+	blockCounts := []struct {
+		blockCounts   []int
+		optimizedName string
+	}{
+		{
+			blockCounts: []int{
+				tsdb.DefaultMaxPointsPerBlock,
+				tsdb.DefaultMaxPointsPerBlock,
+				tsdb.DefaultMaxPointsPerBlock,
+				tsdb.DefaultMaxPointsPerBlock,
+			},
+			optimizedName: "",
+		},
+		{
+			blockCounts: []int{
+				tsdb.DefaultAggressiveMaxPointsPerBlock,
+				tsdb.DefaultMaxPointsPerBlock,
+				tsdb.DefaultMaxPointsPerBlock,
+				tsdb.DefaultMaxPointsPerBlock,
+			},
+			optimizedName: "01-05.tsm",
+		},
+		{
+			blockCounts: []int{
+				tsdb.DefaultMaxPointsPerBlock,
+				tsdb.DefaultAggressiveMaxPointsPerBlock,
+				tsdb.DefaultMaxPointsPerBlock,
+				tsdb.DefaultMaxPointsPerBlock,
+			},
+			optimizedName: "02-05.tsm",
+		},
+		{
+			blockCounts: []int{
+				tsdb.DefaultMaxPointsPerBlock,
+				tsdb.DefaultMaxPointsPerBlock,
+				tsdb.DefaultMaxPointsPerBlock,
+				tsdb.DefaultAggressiveMaxPointsPerBlock,
+			},
+			optimizedName: "04-04.tsm",
+		},
+	}
+
+	ffs := &fakeFileStore{
+		PathsFn: func() []tsm1.FileStat {
+			return testSet
+		},
+	}
+	cp := tsm1.NewDefaultPlanner(ffs, tsdb.DefaultCompactFullWriteColdDuration)
+
+	e := MustOpenEngine(tsdb.InmemIndexName)
+	e.CompactionPlan = cp
+	e.Compactor = tsm1.NewCompactor()
+	e.Compactor.FileStore = ffs
+
+	fileGroup := make([]string, 0, len(testSet))
+	for j := 0; j < len(testSet); j++ {
+		fileGroup = append(fileGroup, testSet[j].Path)
+	}
+
+	for i := 0; i < len(blockCounts); i++ {
+		require.NoError(t, ffs.SetBlockCounts(blockCounts[i].blockCounts), "failed setting block counts")
+		ok, fName, _ := e.IsGroupOptimized(fileGroup)
+		require.Equal(t, blockCounts[i].optimizedName != "", ok, "unexpected result for optimization check")
+		require.Equal(t, blockCounts[i].optimizedName, fName, "unexpected file name in optimization check")
+	}
+}
+
+func TestEnginePlanCompactions(t *testing.T) {
+	testFileSets := [][]tsm1.FileStat{
+		[]tsm1.FileStat{
+			{
+				Path: "01-05.tsm",
+				Size: 256 * 1024 * 1024,
+			},
+			{
+				Path: "02-05.tsm",
+				Size: 256 * 1024 * 1024,
+			},
+			{
+				Path: "03-05.tsm",
+				Size: 256 * 1024 * 1024,
+			},
+			{
+				Path: "04-04.tsm",
+				Size: 256 * 1024 * 1024,
+			},
+		},
+		[]tsm1.FileStat{
+			{
+				Path: "01-05.tsm",
+				Size: 256 * 1024 * 1024,
+			},
+			{
+				Path: "02-05.tsm",
+				Size: 256 * 1024 * 1024,
+			},
+			{
+				Path: "03-05.tsm",
+				Size: 256 * 1024 * 1024,
+			},
+			{
+				Path: "04-05.tsm",
+				Size: 256 * 1024 * 1024,
+			},
+		},
+	}
+	testBlockCountsAndResults := []struct {
+		blockCounts  []int
+		level1Groups []tsm1.PlannedCompactionGroup
+		level2Groups []tsm1.PlannedCompactionGroup
+		level3Groups []tsm1.PlannedCompactionGroup
+		level4Groups []tsm1.PlannedCompactionGroup
+		level5Groups []tsm1.PlannedCompactionGroup
+	}{
+		{
+			blockCounts: []int{
+				tsdb.DefaultAggressiveMaxPointsPerBlock,
+				tsdb.DefaultMaxPointsPerBlock,
+				tsdb.DefaultMaxPointsPerBlock,
+				tsdb.DefaultMaxPointsPerBlock,
+			},
+			level5Groups: []tsm1.PlannedCompactionGroup{
+				{
+					tsm1.CompactionGroup{"01-05.tsm", "02-05.tsm", "03-05.tsm", "04-04.tsm"},
+					tsdb.DefaultAggressiveMaxPointsPerBlock,
+				},
+			},
+		},
+		{
+			blockCounts: []int{
+				tsdb.DefaultAggressiveMaxPointsPerBlock,
+				tsdb.DefaultMaxPointsPerBlock,
+				tsdb.DefaultMaxPointsPerBlock,
+				tsdb.DefaultMaxPointsPerBlock,
+			},
+			level5Groups: []tsm1.PlannedCompactionGroup{
+				{
+					tsm1.CompactionGroup{"01-05.tsm", "02-05.tsm", "03-05.tsm", "04-05.tsm"},
+					tsdb.DefaultAggressiveMaxPointsPerBlock,
+				},
+			},
+		},
+	}
+
+	e, err := NewEngine(tsdb.InmemIndexName)
+	require.NoError(t, err, "create engine")
+	e.SetEnabled(false)
+	require.NoError(t, e.Open(), "open engine")
+	defer func() { require.NoError(t, e.Close(), "close engine") }()
+	e.Compactor = tsm1.NewCompactor()
+	defer e.Compactor.Close()
+
+	for i := range testFileSets {
+		ffs := &fakeFileStore{
+			PathsFn: func() []tsm1.FileStat {
+				return testFileSets[i]
+			},
+		}
+		cp := tsm1.NewDefaultPlanner(ffs, tsdb.DefaultCompactFullWriteColdDuration)
+		require.NoError(t, ffs.SetBlockCounts(testBlockCountsAndResults[i].blockCounts), "failed setting block counts")
+		e.MaxPointsPerBlock = tsdb.DefaultMaxPointsPerBlock
+		e.CompactionPlan = cp
+		e.Compactor.FileStore = ffs
+
+		level1Groups, level2Groups, Level3Groups, Level4Groups, Level5Groups := e.PlanCompactions()
+		compareLevelGroups(t, testBlockCountsAndResults[i].level1Groups, level1Groups, "unexpected level 1 Group")
+		compareLevelGroups(t, testBlockCountsAndResults[i].level2Groups, level2Groups, "unexpected level 2 Group")
+		compareLevelGroups(t, testBlockCountsAndResults[i].level3Groups, Level3Groups, "unexpected level 3 Group")
+		compareLevelGroups(t, testBlockCountsAndResults[i].level4Groups, Level4Groups, "unexpected level 4 Group")
+		compareLevelGroups(t, testBlockCountsAndResults[i].level5Groups, Level5Groups, "unexpected level 5 Group")
+	}
+}
+
+func compareLevelGroups(t *testing.T, exp, got []tsm1.PlannedCompactionGroup, message string) {
+	require.Lenf(t, got, len(exp), "%s %s", message, " collection length mismatch")
+	for i, group := range exp {
+		require.Equal(t, group.Group, got[i].Group, message)
+		require.Equal(t, group.PointsPerBlock, got[i].PointsPerBlock, message)
+	}
 }
 
 func assertValueEqual(t *testing.T, a, b tsm1.Value) {

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -55,6 +55,12 @@ func init() {
 }
 
 var (
+	ErrCompactionLimited         = errors.New("reached concurrent compaction limit")
+	ErrNoCompactionStrategy      = errors.New("no compaction strategy")
+	ErrOptimizeCompactionLimited = errors.New("reached concurrent optimized compaction limit")
+)
+
+var (
 	// Ensure Engine implements the interface.
 	_ tsdb.Engine = &Engine{}
 	// Static objects to prevent small allocs.
@@ -94,6 +100,18 @@ const (
 
 	// DoNotCompactFile is the name of the file that disables compactions.
 	DoNotCompactFile = "do_not_compact"
+
+	// LevelCompactionCount is the number of level compactions (e.g. 1, 2, 3).
+	LevelCompactionCount = 3
+
+	// FullCompactionLevel is the compaction level for full compactions.
+	FullCompactionLevel = 4
+
+	// OptimizeCompactionLevel is the compaction level for optimized compactions.
+	OptimizeCompactionLevel = 5
+
+	// TotalCompactionLevels is the overall number of compaction levels.
+	TotalCompactionLevels = 5
 )
 
 // Statistics gathered by the engine.
@@ -196,6 +214,9 @@ type Engine struct {
 	// Limiter for concurrent compactions.
 	compactionLimiter limiter.Fixed
 
+	// Limiter for concurrent optimized compactions.
+	optimizedCompactionLimiter limiter.Fixed
+
 	scheduler *scheduler
 
 	// provides access to the total set of series IDs
@@ -262,6 +283,7 @@ func NewEngine(id uint64, idx tsdb.Index, path string, walPath string, sfile *ts
 		formatFileName:                DefaultFormatFileName,
 		stats:                         stats,
 		compactionLimiter:             opt.CompactionLimiter,
+		optimizedCompactionLimiter:    opt.OptimizedCompactionLimiter,
 		scheduler:                     newScheduler(stats, opt.CompactionLimiter.Capacity()),
 		seriesIDSets:                  opt.SeriesIDSets,
 	}
@@ -662,11 +684,11 @@ type EngineStatistics struct {
 	CacheCompactionErrors   int64 // Counter of cache compactions that have failed due to error.
 	CacheCompactionDuration int64 // Counter of number of wall nanoseconds spent in cache compactions.
 
-	TSMCompactions        [3]int64 // Counter of TSM compactions (by level) that have ever run.
-	TSMCompactionsActive  [3]int64 // Gauge of TSM compactions (by level) currently running.
-	TSMCompactionErrors   [3]int64 // Counter of TSM compcations (by level) that have failed due to error.
-	TSMCompactionDuration [3]int64 // Counter of number of wall nanoseconds spent in TSM compactions (by level).
-	TSMCompactionsQueue   [3]int64 // Gauge of TSM compactions queues (by level).
+	TSMCompactions        [LevelCompactionCount]int64 // Counter of TSM compactions (by level) that have ever run.
+	TSMCompactionsActive  [LevelCompactionCount]int64 // Gauge of TSM compactions (by level) currently running.
+	TSMCompactionErrors   [LevelCompactionCount]int64 // Counter of TSM compcations (by level) that have failed due to error.
+	TSMCompactionDuration [LevelCompactionCount]int64 // Counter of number of wall nanoseconds spent in TSM compactions (by level).
+	TSMCompactionsQueue   [LevelCompactionCount]int64 // Gauge of TSM compactions queues (by level).
 
 	TSMOptimizeCompactions        int64 // Counter of optimize compactions that have ever run.
 	TSMOptimizeCompactionsActive  int64 // Gauge of optimize compactions currently running.
@@ -2096,10 +2118,37 @@ func (e *Engine) ShouldCompactCache(t time.Time) bool {
 	return t.Sub(e.Cache.LastWriteTime()) > e.CacheFlushWriteColdDuration
 }
 
+// isFileOptimized returns true if a TSM file appears to have already been previously optimized.
+// If file appears previously optimized, a description of the heuristic used to determine this is also returned.
+func (e *Engine) isFileOptimized(f string) (bool, string) {
+	if tsmPointsPerBlock := e.Compactor.FileStore.BlockCount(f, 1); tsmPointsPerBlock >= e.CompactionPlan.GetAggressiveCompactionPointsPerBlock() {
+		return true, fmt.Sprintf("first block of file contains aggressive points per block (%d >= %d)", tsmPointsPerBlock, e.CompactionPlan.GetAggressiveCompactionPointsPerBlock())
+	} else {
+		return false, ""
+	}
+}
+
+// IsGroupOptimized returns true if any file in a compaction group appears to be have been previously optimized.
+// The name of the first optimized file found along with the heuristic used to determine this is returned.
+func (e *Engine) IsGroupOptimized(group CompactionGroup) (optimized bool, file string, heuristic string) {
+	for _, f := range group {
+		if isOpt, heur := e.isFileOptimized(f); isOpt {
+			return true, f, heur
+		}
+	}
+	return false, "", ""
+}
+
+const waitForOptimization = time.Hour
+const tickPeriod = time.Second
+
+var waitMessage = fmt.Sprintf("waiting %s before optimizing compaction", waitForOptimization.String())
+
 func (e *Engine) compact(wg *sync.WaitGroup) {
-	t := time.NewTicker(time.Second)
+	t := time.NewTicker(tickPeriod)
 	defer t.Stop()
 
+	startTime := time.Now()
 	var nextDisabledMsg time.Time
 
 	for {
@@ -2124,31 +2173,15 @@ func (e *Engine) compact(wg *sync.WaitGroup) {
 				continue
 			}
 
-			// Find our compaction plans
-			level1Groups, len1 := e.CompactionPlan.PlanLevel(1)
-			level2Groups, len2 := e.CompactionPlan.PlanLevel(2)
-			level3Groups, len3 := e.CompactionPlan.PlanLevel(3)
-			level4Groups, len4 := e.CompactionPlan.Plan(e.LastModified())
-			atomic.StoreInt64(&e.stats.TSMOptimizeCompactionsQueue, len4)
-
-			// If no full compactions are need, see if an optimize is needed
-			var genLen int64
-			if len(level4Groups) == 0 {
-				level4Groups, len4, genLen = e.CompactionPlan.PlanOptimize(e.LastModified())
-				if len(level4Groups) > 0 {
-					for _, group := range level4Groups {
-						e.logger.Info("TSM scheduled for optimized compaction", zap.Strings("files", group))
-					}
+			skipOptimize := func() (bool, string) {
+				if time.Since(startTime) < waitForOptimization {
+					return true, waitMessage
+				} else {
+					return false, ""
 				}
-				atomic.StoreInt64(&e.stats.TSMOptimizeCompactionsQueue, len4)
 			}
 
-			// Update the level plan queue stats
-			// For stats, use the length needed, even if the lock was
-			// not acquired
-			atomic.StoreInt64(&e.stats.TSMCompactionsQueue[0], len1)
-			atomic.StoreInt64(&e.stats.TSMCompactionsQueue[1], len2)
-			atomic.StoreInt64(&e.stats.TSMCompactionsQueue[2], len3)
+			level1Groups, level2Groups, level3Groups, level4Groups, level5Groups := e.PlanCompactions()
 
 			// Set the queue depths on the scheduler
 			// Use the real queue depth, dependent on acquiring
@@ -2157,62 +2190,224 @@ func (e *Engine) compact(wg *sync.WaitGroup) {
 			e.scheduler.setDepth(2, len(level2Groups))
 			e.scheduler.setDepth(3, len(level3Groups))
 			e.scheduler.setDepth(4, len(level4Groups))
+			e.scheduler.setDepth(5, len(level5Groups))
 
 			// Find the next compaction that can run and try to kick it off
 			if level, runnable := e.scheduler.next(); runnable {
 				switch level {
 				case 1:
-					if e.compactHiPriorityLevel(level1Groups[0], 1, false, tsdb.DefaultMaxPointsPerBlock, wg) {
+					if e.compactHiPriorityLevel(level1Groups[0].Group, 1, false, wg) {
 						level1Groups = level1Groups[1:]
 					}
 				case 2:
-					if e.compactHiPriorityLevel(level2Groups[0], 2, false, tsdb.DefaultMaxPointsPerBlock, wg) {
+					if e.compactHiPriorityLevel(level2Groups[0].Group, 2, false, wg) {
 						level2Groups = level2Groups[1:]
 					}
 				case 3:
-					if e.compactLoPriorityLevel(level3Groups[0], 3, true, tsdb.DefaultMaxPointsPerBlock, wg) {
+					if e.compactLoPriorityLevel(level3Groups[0].Group, 3, true, wg) {
 						level3Groups = level3Groups[1:]
 					}
 				case 4:
-					var pointsPerBlock int
-					// This is a heuristic. The 10_000 points per block default is suitable for when we have a
-					// single generation with multiple files at max block size under 2 GB.
-					if genLen == 1 {
-						// Log TSM files that will have an increased points per block count.
-						for _, f := range level4Groups[0] {
-							e.logger.Info("TSM optimized compaction on single generation running, increasing total points per block.", zap.String("path", f), zap.Int("points-per-block", e.CompactionPlan.GetAggressiveCompactionPointsPerBlock()))
-						}
-						pointsPerBlock = e.CompactionPlan.GetAggressiveCompactionPointsPerBlock()
-					} else {
-						pointsPerBlock = tsdb.DefaultMaxPointsPerBlock
-						for _, group := range level4Groups {
-							for _, f := range group {
-								if tsmPointsPerBlock := e.Compactor.FileStore.BlockCount(f, 1); tsmPointsPerBlock >= e.CompactionPlan.GetAggressiveCompactionPointsPerBlock() {
-									pointsPerBlock = e.CompactionPlan.GetAggressiveCompactionPointsPerBlock()
-									e.logger.Info("TSM compaction on shard with increased points per block.", zap.String("path", f), zap.Int("points-per-block", e.CompactionPlan.GetAggressiveCompactionPointsPerBlock()))
-									break
-								}
-							}
-						}
-					}
-					if e.compactFull(level4Groups[0], pointsPerBlock, wg) {
+					if e.compactFull(level4Groups[0].Group, wg) {
 						level4Groups = level4Groups[1:]
+					}
+				case 5:
+					theGroup := level5Groups[0].Group
+					pointsPerBlock := level5Groups[0].PointsPerBlock
+					log := e.logger.With(zap.Strings("files", theGroup))
+
+					log = log.With(zap.Bool("aggressive", true))
+					if skip, reason := skipOptimize(); skip {
+						log.Info("Skipping optimized level 5 compaction group", zap.String("reason", reason))
+					} else {
+						log.Info("Running optimized compaction for level 5 group")
+						if err := e.compactOptimize(theGroup, pointsPerBlock, wg); err != nil {
+							if errors.Is(err, ErrOptimizeCompactionLimited) {
+								// We've reached the limit of optimized compactions. Let's not schedule anything else this schedule cycle
+								// in an effort to avoid starving level compactions.
+								log.Info("Reached limit for optimized compactions. Ending optimized compaction scheduling for this scheduling cycle")
+							} else if errors.Is(err, ErrCompactionLimited) {
+								// We've reached the maximum amount of total concurrent compactions. Again, don't schedule any more optimized
+								// compactions this cycle to prevent starving level compactions.
+								log.Info("Reached limit for concurrent compactions while attempting optimized compaction. Ending optimized compaction scheduling for this scheduling cycle")
+							} else {
+								log.Error("Error during compactOptimize", zap.Error(err))
+							}
+						} else {
+							level5Groups = level5Groups[1:]
+						}
 					}
 				}
 			}
 
 			// Release all the plans we didn't start.
-			e.CompactionPlan.Release(level1Groups)
-			e.CompactionPlan.Release(level2Groups)
-			e.CompactionPlan.Release(level3Groups)
-			e.CompactionPlan.Release(level4Groups)
+			e.releaseCompactionPlans(level1Groups, level2Groups, level3Groups, level4Groups, level5Groups)
 		}
 	}
 }
 
+func (e *Engine) releaseCompactionPlans(
+	level1Groups []PlannedCompactionGroup,
+	level2Groups []PlannedCompactionGroup,
+	level3Groups []PlannedCompactionGroup,
+	level4Groups []PlannedCompactionGroup,
+	level5Groups []PlannedCompactionGroup) {
+	for _, compactGroup := range level1Groups {
+		e.CompactionPlan.Release([]CompactionGroup{
+			compactGroup.Group,
+		})
+	}
+
+	for _, compactGroup := range level2Groups {
+		e.CompactionPlan.Release([]CompactionGroup{
+			compactGroup.Group,
+		})
+	}
+
+	for _, compactGroup := range level3Groups {
+		e.CompactionPlan.Release([]CompactionGroup{
+			compactGroup.Group,
+		})
+	}
+
+	for _, compactGroup := range level4Groups {
+		e.CompactionPlan.Release([]CompactionGroup{
+			compactGroup.Group,
+		})
+	}
+
+	for _, compactGroup := range level5Groups {
+		e.CompactionPlan.Release([]CompactionGroup{
+			compactGroup.Group,
+		})
+	}
+}
+
+// During compaction planning we need to indicate whether or
+// not the points per block has changed. PlannedCompactionGroup
+// is an abstraction on top of CompactionGroup that includes
+// PointsPerBlock for compaction processing. Without this we
+// may unroll a compacted TSM file that is above our max points per block
+// and rewrite it in its entirety at max points per block.
+type PlannedCompactionGroup struct {
+	Group          CompactionGroup
+	PointsPerBlock int
+}
+
+func (e *Engine) PlanCompactions() (
+	level1Groups []PlannedCompactionGroup,
+	level2Groups []PlannedCompactionGroup,
+	level3Groups []PlannedCompactionGroup,
+	level4Groups []PlannedCompactionGroup,
+	level5Groups []PlannedCompactionGroup) {
+	// Find our compaction plans
+	l1Groups, len1 := e.CompactionPlan.PlanLevel(1)
+	l2Groups, len2 := e.CompactionPlan.PlanLevel(2)
+	l3Groups, len3 := e.CompactionPlan.PlanLevel(3)
+	initialLevellevel4Groups, _ := e.CompactionPlan.Plan(e.LastModified())
+
+	for _, group := range l1Groups {
+		level1Groups = append(level1Groups, PlannedCompactionGroup{
+			Group:          group,
+			PointsPerBlock: tsdb.DefaultMaxPointsPerBlock,
+		})
+	}
+
+	for _, group := range l2Groups {
+		level2Groups = append(level2Groups, PlannedCompactionGroup{
+			Group:          group,
+			PointsPerBlock: tsdb.DefaultMaxPointsPerBlock,
+		})
+	}
+
+	for _, group := range l3Groups {
+		level3Groups = append(level3Groups, PlannedCompactionGroup{
+			Group:          group,
+			PointsPerBlock: tsdb.DefaultMaxPointsPerBlock,
+		})
+	}
+
+	// Some groups in level 4 may contain already optimized files. In these cases, we want
+	// to maintain optimization for the entire group to avoid "going backwards" on the
+	// optimization level. For instance, if an optimized cold shard had back-fill data
+	// added to it, we should maintain the optimization to avoid unoptimizing the bulk of
+	// the shards only to need to reoptimize them later.
+	// In an ideal world, CompactionPlan.Plan and CompactionPlan.PlanOptimize might handle this.
+	level4Groups = make([]PlannedCompactionGroup, 0, len(initialLevellevel4Groups))
+	level5Groups = make([]PlannedCompactionGroup, 0, len(initialLevellevel4Groups))
+	for _, group := range initialLevellevel4Groups {
+		if isOpt, filename, heur := e.IsGroupOptimized(group); isOpt {
+			e.logger.Info("Promoting full compaction level 4 group to optimized level 5 compaction group because it contains an already optimized TSM file",
+				zap.String("optimized_file", filename), zap.String("heuristic", heur), zap.Strings("files", group))
+
+			// Should set this compaction group to aggressive. IsGroupOptimized will check the
+			// block count and return true if there is a file at aggressivePointsPerBlock.
+			// We will need to run aggressive compaction on this group if that's the case.
+			level5Groups = append(level5Groups, PlannedCompactionGroup{
+				Group:          group,
+				PointsPerBlock: e.CompactionPlan.GetAggressiveCompactionPointsPerBlock(),
+			})
+		} else {
+			level4Groups = append(level4Groups, PlannedCompactionGroup{
+				Group:          group,
+				PointsPerBlock: tsdb.DefaultMaxPointsPerBlock,
+			})
+		}
+	}
+
+	if len(level4Groups) == 0 {
+		plannedLevel5Groups, _, genCount := e.CompactionPlan.PlanOptimize(e.LastModified())
+
+		for _, group := range plannedLevel5Groups {
+			// If a level5 optimized compaction group is a single generation. We will need to rewrite
+			// the files at a higher points per block count in order to fully compact them in to a single TSM file.
+			if genCount == 1 {
+				e.logger.Info("Planned optimized level 5 compactions belong to single generation. All groups will use aggressive points per block.")
+				level5Groups = append(level5Groups, PlannedCompactionGroup{
+					Group:          group,
+					PointsPerBlock: e.CompactionPlan.GetAggressiveCompactionPointsPerBlock(),
+				})
+			} else {
+				if isOpt, filename, heur := e.IsGroupOptimized(group); isOpt {
+					e.logger.Info("Planning optimized level 5 compaction Group at aggressive points per block.",
+						zap.String("optimized_file", filename), zap.String("heuristic", heur), zap.Strings("files", group))
+					// Should set this compaction group to aggressive. IsGroupOptimized will check the
+					// block count and return true if there is a file at aggressivePointsPerBlock.
+					// We will need to run aggressive compaction on this group if that's the case.
+					level5Groups = append(level5Groups, PlannedCompactionGroup{
+						Group:          group,
+						PointsPerBlock: e.CompactionPlan.GetAggressiveCompactionPointsPerBlock(),
+					})
+				} else {
+					e.logger.Info("Planning optimized level 5 compaction Group", zap.Strings("files", group))
+					level5Groups = append(level5Groups, PlannedCompactionGroup{
+						Group:          group,
+						PointsPerBlock: tsdb.DefaultMaxPointsPerBlock,
+					})
+
+				}
+
+			}
+		}
+	}
+
+	len4 := int64(len(level4Groups))
+	len5 := int64(len(level5Groups))
+
+	// Update the level plan queue stats
+	// For stats, use the length needed, even if the lock was
+	// not acquired
+	atomic.StoreInt64(&e.stats.TSMCompactionsQueue[0], len1)
+	atomic.StoreInt64(&e.stats.TSMCompactionsQueue[1], len2)
+	atomic.StoreInt64(&e.stats.TSMCompactionsQueue[2], len3)
+	atomic.StoreInt64(&e.stats.TSMFullCompactionsQueue, len4)
+	atomic.StoreInt64(&e.stats.TSMOptimizeCompactionsQueue, len5)
+	return level1Groups, level2Groups, level3Groups, level4Groups, level5Groups
+}
+
 // compactHiPriorityLevel kicks off compactions using the high priority policy. It returns
-// true if the compaction was started
-func (e *Engine) compactHiPriorityLevel(grp CompactionGroup, level int, fast bool, pointsPerBlock int, wg *sync.WaitGroup) bool {
+// true if the compaction was started.
+func (e *Engine) compactHiPriorityLevel(grp CompactionGroup, level int, fast bool, wg *sync.WaitGroup) bool {
 	s := e.levelCompactionStrategy(grp, fast, level)
 	if s == nil {
 		return false
@@ -2228,7 +2423,7 @@ func (e *Engine) compactHiPriorityLevel(grp CompactionGroup, level int, fast boo
 			defer atomic.AddInt64(&e.stats.TSMCompactionsActive[level-1], -1)
 
 			defer e.compactionLimiter.Release()
-			s.Apply(pointsPerBlock)
+			s.Apply()
 			// Release the files in the compaction plan
 			e.CompactionPlan.Release([]CompactionGroup{s.group})
 		}()
@@ -2241,7 +2436,7 @@ func (e *Engine) compactHiPriorityLevel(grp CompactionGroup, level int, fast boo
 
 // compactLoPriorityLevel kicks off compactions using the lo priority policy. It returns
 // the plans that were not able to be started
-func (e *Engine) compactLoPriorityLevel(grp CompactionGroup, level int, fast bool, pointsPerBlock int, wg *sync.WaitGroup) bool {
+func (e *Engine) compactLoPriorityLevel(grp CompactionGroup, level int, fast bool, wg *sync.WaitGroup) bool {
 	s := e.levelCompactionStrategy(grp, fast, level)
 	if s == nil {
 		return false
@@ -2255,7 +2450,7 @@ func (e *Engine) compactLoPriorityLevel(grp CompactionGroup, level int, fast boo
 			defer wg.Done()
 			defer atomic.AddInt64(&e.stats.TSMCompactionsActive[level-1], -1)
 			defer e.compactionLimiter.Release()
-			s.Apply(pointsPerBlock)
+			s.Apply()
 			// Release the files in the compaction plan
 			e.CompactionPlan.Release([]CompactionGroup{s.group})
 		}()
@@ -2266,8 +2461,8 @@ func (e *Engine) compactLoPriorityLevel(grp CompactionGroup, level int, fast boo
 
 // compactFull kicks off full and optimize compactions using the lo priority policy. It returns
 // the plans that were not able to be started.
-func (e *Engine) compactFull(grp CompactionGroup, pointsPerBlock int, wg *sync.WaitGroup) bool {
-	s := e.fullCompactionStrategy(grp, false)
+func (e *Engine) compactFull(grp CompactionGroup, wg *sync.WaitGroup) bool {
+	s := e.fullCompactionStrategy(grp)
 	if s == nil {
 		return false
 	}
@@ -2280,7 +2475,7 @@ func (e *Engine) compactFull(grp CompactionGroup, pointsPerBlock int, wg *sync.W
 			defer wg.Done()
 			defer atomic.AddInt64(&e.stats.TSMFullCompactionsActive, -1)
 			defer e.compactionLimiter.Release()
-			s.Apply(pointsPerBlock)
+			s.Apply()
 			// Release the files in the compaction plan
 			e.CompactionPlan.Release([]CompactionGroup{s.group})
 		}()
@@ -2289,12 +2484,50 @@ func (e *Engine) compactFull(grp CompactionGroup, pointsPerBlock int, wg *sync.W
 	return false
 }
 
+// compactOptimize kicks off an optimize compaction using the lo priority policy.
+// On success, it returns no error. It returns an ErrOptimizeCompactionLimited if
+// the optimized compaction limiter has no available slots. Other errors are returned as appropriate.
+func (e *Engine) compactOptimize(grp CompactionGroup, pointsPerBlock int, wg *sync.WaitGroup) error {
+	s := e.optimizeCompactionStrategy(grp, pointsPerBlock)
+	if s == nil {
+		return ErrNoCompactionStrategy
+	}
+
+	// Try the lo priority limiter, otherwise steal a little from the high priority if we can.
+	// Ordering for taking and releasing limiters:
+	// 1. Take compactionLimiter
+	// 2. Take optimizedCompactionLimiter
+	// 3. Release optimizedCompactionLimiter
+	// 4/ Release compactionLimiter
+	if e.compactionLimiter.TryTake() {
+		if !e.optimizedCompactionLimiter.TryTake() {
+			e.compactionLimiter.Release()
+			return ErrOptimizeCompactionLimited
+		}
+		atomic.AddInt64(&e.stats.TSMOptimizeCompactionsActive, 1)
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			defer atomic.AddInt64(&e.stats.TSMOptimizeCompactionsActive, -1)
+			defer e.compactionLimiter.Release()          // Happens second
+			defer e.optimizedCompactionLimiter.Release() // Happens first
+			s.Apply()
+			// Release the files in the compaction plan
+			e.CompactionPlan.Release([]CompactionGroup{s.group})
+		}()
+		return nil
+	} else {
+		return ErrCompactionLimited
+	}
+}
+
 // compactionStrategy holds the details of what to do in a compaction.
 type compactionStrategy struct {
 	group CompactionGroup
 
-	fast  bool
-	level int
+	fast           bool
+	level          int
+	pointsPerBlock int
 
 	durationStat *int64
 	activeStat   *int64
@@ -2309,17 +2542,22 @@ type compactionStrategy struct {
 }
 
 // Apply concurrently compacts all the groups in a compaction strategy.
-func (s *compactionStrategy) Apply(pointsPerBlock int) {
+func (s *compactionStrategy) Apply() {
 	start := time.Now()
-	s.compactGroup(pointsPerBlock)
+	s.compactGroup()
 	atomic.AddInt64(s.durationStat, time.Since(start).Nanoseconds())
 }
 
 // compactGroup executes the compaction strategy against a single CompactionGroup.
-func (s *compactionStrategy) compactGroup(pointsPerBlock int) {
+func (s *compactionStrategy) compactGroup() {
 	group := s.group
 	log, logEnd := logger.NewOperation(s.logger, "TSM compaction", "tsm1_compact_group", logger.Shard(s.engine.id))
 	defer logEnd()
+
+	pointsPerBlock := s.pointsPerBlock
+	if pointsPerBlock <= 0 {
+		pointsPerBlock = tsdb.DefaultMaxPointsPerBlock
+	}
 
 	log.Info("Beginning compaction", zap.Int("tsm1_files_n", len(group)))
 	for i, f := range group {
@@ -2398,16 +2636,16 @@ func MoveTsmOnReadErr(err error, log *zap.Logger, replaceFn func([]string, []str
 }
 
 // levelCompactionStrategy returns a compactionStrategy for the given level.
-// It returns nil if there are no TSM files to compact.
 func (e *Engine) levelCompactionStrategy(group CompactionGroup, fast bool, level int) *compactionStrategy {
 	return &compactionStrategy{
-		group:     group,
-		logger:    e.logger.With(zap.Int("tsm1_level", level), zap.String("tsm1_strategy", "level")),
-		fileStore: e.FileStore,
-		compactor: e.Compactor,
-		fast:      fast,
-		engine:    e,
-		level:     level,
+		group:          group,
+		logger:         e.logger.With(zap.Int("tsm1_level", level), zap.String("tsm1_strategy", "level")),
+		fileStore:      e.FileStore,
+		compactor:      e.Compactor,
+		pointsPerBlock: tsdb.DefaultMaxPointsPerBlock,
+		fast:           fast,
+		engine:         e,
+		level:          level,
 
 		activeStat:   &e.stats.TSMCompactionsActive[level-1],
 		successStat:  &e.stats.TSMCompactions[level-1],
@@ -2417,29 +2655,44 @@ func (e *Engine) levelCompactionStrategy(group CompactionGroup, fast bool, level
 }
 
 // fullCompactionStrategy returns a compactionStrategy for higher level generations of TSM files.
-// It returns nil if there are no TSM files to compact.
-func (e *Engine) fullCompactionStrategy(group CompactionGroup, optimize bool) *compactionStrategy {
+func (e *Engine) fullCompactionStrategy(group CompactionGroup) *compactionStrategy {
+	pointsPerBlock := tsdb.DefaultMaxPointsPerBlock
 	s := &compactionStrategy{
-		group:     group,
-		logger:    e.logger.With(zap.String("tsm1_strategy", "full"), zap.Bool("tsm1_optimize", optimize)),
-		fileStore: e.FileStore,
-		compactor: e.Compactor,
-		fast:      optimize,
-		engine:    e,
-		level:     4,
+		group:          group,
+		logger:         e.logger.With(zap.String("tsm1_strategy", "full"), zap.Int("points-per-block", pointsPerBlock)),
+		fileStore:      e.FileStore,
+		compactor:      e.Compactor,
+		pointsPerBlock: pointsPerBlock,
+		fast:           false,
+		engine:         e,
+		level:          FullCompactionLevel,
 	}
 
-	if optimize {
-		s.activeStat = &e.stats.TSMOptimizeCompactionsActive
-		s.successStat = &e.stats.TSMOptimizeCompactions
-		s.errorStat = &e.stats.TSMOptimizeCompactionErrors
-		s.durationStat = &e.stats.TSMOptimizeCompactionDuration
-	} else {
-		s.activeStat = &e.stats.TSMFullCompactionsActive
-		s.successStat = &e.stats.TSMFullCompactions
-		s.errorStat = &e.stats.TSMFullCompactionErrors
-		s.durationStat = &e.stats.TSMFullCompactionDuration
+	s.activeStat = &e.stats.TSMFullCompactionsActive
+	s.successStat = &e.stats.TSMFullCompactions
+	s.errorStat = &e.stats.TSMFullCompactionErrors
+	s.durationStat = &e.stats.TSMFullCompactionDuration
+
+	return s
+}
+
+// optimizeCompactionStrategy returns a compactionStrategy for optimized compaction of TSM files.
+func (e *Engine) optimizeCompactionStrategy(group CompactionGroup, pointsPerBlock int) *compactionStrategy {
+	s := &compactionStrategy{
+		group:          group,
+		logger:         e.logger.With(zap.String("tsm1_strategy", "optimize"), zap.Bool("aggressive", pointsPerBlock >= e.CompactionPlan.GetAggressiveCompactionPointsPerBlock()), zap.Int("points-per-block", pointsPerBlock)),
+		fileStore:      e.FileStore,
+		compactor:      e.Compactor,
+		pointsPerBlock: pointsPerBlock,
+		fast:           false,
+		engine:         e,
+		level:          OptimizeCompactionLevel,
 	}
+
+	s.activeStat = &e.stats.TSMOptimizeCompactionsActive
+	s.successStat = &e.stats.TSMOptimizeCompactions
+	s.errorStat = &e.stats.TSMOptimizeCompactionErrors
+	s.durationStat = &e.stats.TSMOptimizeCompactionDuration
 
 	return s
 }

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -507,6 +507,19 @@ func (s *Store) loadShards() error {
 
 	s.EngineOptions.CompactionLimiter = limiter.NewFixed(lim)
 
+	// Setup optimized limiter.
+	optLim := s.EngineOptions.Config.MaxConcurrentOptimizedCompactions
+	if optLim <= 0 {
+		optLim = 1
+	}
+
+	// Don't allow more optimized compactions to run than overall compactions.
+	if optLim > lim {
+		optLim = lim
+	}
+
+	s.EngineOptions.OptimizedCompactionLimiter = limiter.NewFixed(optLim)
+
 	compactionSettings := []zapcore.Field{zap.Int("max_concurrent_compactions", lim)}
 	throughput := int(s.EngineOptions.Config.CompactThroughput)
 	throughputBurst := int(s.EngineOptions.Config.CompactThroughputBurst)


### PR DESCRIPTION
Limit number of concurrent optimized compactions so that level compactions do not get starved. Starved level compactions result in a sudden increase in disk usage.

Add [data] max-concurrent-optimized-compactions for configuring maximum number of concurrent optimized compactions. Default value is 1.

Co-authored-by: davidby-influx <dbyrne@influxdata.com>
Co-authored-by: devanbenz <devandbenz@gmail.com>
Closes: #26315
(cherry picked from commit 66f4dbe)Closes #

Describe your proposed changes here.

- [ ] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb/blob/main/README.md).
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
