### PR TITLE
feat: add shard creation to precreator service

### DIFF
--- a/cmd/influxd/run/server.go
+++ b/cmd/influxd/run/server.go
@@ -393,6 +393,7 @@ func (s *Server) appendPrecreatorService(c precreator.Config) error {
 	}
 	srv := precreator.NewService(c)
 	srv.MetaClient = s.MetaClient
+	srv.Store = s.TSDBStore
 	s.Services = append(s.Services, srv)
 	return nil
 }

--- a/internal/meta_client.go
+++ b/internal/meta_client.go
@@ -32,7 +32,7 @@ type MetaClientMock struct {
 
 	OpenFn func() error
 
-	PrecreateShardGroupsFn func(from, to time.Time) error
+	PrecreateShardGroupsFn func(from, to time.Time) ([]meta.ShardGroupFullInfo, error)
 	PruneShardGroupsFn     func() error
 
 	RetentionPolicyFn func(database, name string) (rpi *meta.RetentionPolicyInfo, err error)
@@ -173,7 +173,7 @@ func (c *MetaClientMock) Open() error                { return c.OpenFn() }
 func (c *MetaClientMock) Data() meta.Data            { return c.DataFn() }
 func (c *MetaClientMock) SetData(d *meta.Data) error { return c.SetDataFn(d) }
 
-func (c *MetaClientMock) PrecreateShardGroups(from, to time.Time) error {
+func (c *MetaClientMock) PrecreateShardGroups(from, to time.Time) ([]meta.ShardGroupFullInfo, error) {
 	return c.PrecreateShardGroupsFn(from, to)
 }
 func (c *MetaClientMock) PruneShardGroups() error { return c.PruneShardGroupsFn() }

--- a/services/meta/client.go
+++ b/services/meta/client.go
@@ -775,7 +775,8 @@ func (c *Client) PrecreateShardGroups(from, to time.Time) ([]ShardGroupFullInfo,
 	data := c.cacheData.Clone()
 	var changed bool
 
-	newShardGroups := make([]ShardGroupFullInfo, 0)
+	// return nil if no shard groups are created
+	var newShardGroups []ShardGroupFullInfo = nil
 	for _, di := range data.Databases {
 		for _, rp := range di.RetentionPolicies {
 			if len(rp.ShardGroups) == 0 {
@@ -816,11 +817,10 @@ func (c *Client) PrecreateShardGroups(from, to time.Time) ([]ShardGroupFullInfo,
 
 	if changed {
 		if err := c.commit(data); err != nil {
-			return newShardGroups, err
+			return nil, err
 		}
 	}
-
-	return nil, nil
+	return newShardGroups, nil
 }
 
 // ShardOwner returns the owning shard group info for a specific shard.

--- a/services/meta/client_test.go
+++ b/services/meta/client_test.go
@@ -956,10 +956,10 @@ func TestMetaClient_Shards(t *testing.T) {
 	// Test pre-creating shard groups.
 	dur := sg.EndTime.Sub(sg.StartTime) + time.Nanosecond
 	tmax := tmin.Add(dur)
-	if err := c.PrecreateShardGroups(tmin, tmax); err != nil {
+	if err, _ := c.PrecreateShardGroups(tmin, tmax); err != nil {
 		t.Fatal(err)
 	}
-
+	// TODO(DSB): check shard directories are created here
 	// Test finding shard groups by time range.
 	groups, err := c.ShardGroupsByTimeRange("db0", "autogen", tmin, tmax)
 	if err != nil {
@@ -1029,14 +1029,16 @@ func TestMetaClient_CreateShardGroupIdempotent(t *testing.T) {
 	// Test pre-creating shard groups.
 	dur := sg.EndTime.Sub(sg.StartTime) + time.Nanosecond
 	tmax := tmin.Add(dur)
-	if err := c.PrecreateShardGroups(tmin, tmax); err != nil {
+	if err, _ := c.PrecreateShardGroups(tmin, tmax); err != nil {
 		t.Fatal(err)
 	}
+	// TODO(DSB): check shard groups created
 	i = c.Data().Index
 	t.Log("index: ", i)
-	if err := c.PrecreateShardGroups(tmin, tmax); err != nil {
+	if err, _ := c.PrecreateShardGroups(tmin, tmax); err != nil {
 		t.Fatal(err)
 	}
+	// TODO(DSB): Test no shard groups created
 	t.Log("index: ", i)
 	if got, exp := c.Data().Index, i; got != exp {
 		t.Fatalf("PrecreateShardGroups failed: invalid index, got %d, exp %d", got, exp)

--- a/services/meta/client_test.go
+++ b/services/meta/client_test.go
@@ -956,10 +956,11 @@ func TestMetaClient_Shards(t *testing.T) {
 	// Test pre-creating shard groups.
 	dur := sg.EndTime.Sub(sg.StartTime) + time.Nanosecond
 	tmax := tmin.Add(dur)
-	if err, _ := c.PrecreateShardGroups(tmin, tmax); err != nil {
+	if newShardGroups, err := c.PrecreateShardGroups(tmin, tmax); err != nil {
 		t.Fatal(err)
+	} else if len(newShardGroups) != 1 {
+		t.Fatalf("wrong number of shard groups: %d", len(newShardGroups))
 	}
-	// TODO(DSB): check shard directories are created here
 	// Test finding shard groups by time range.
 	groups, err := c.ShardGroupsByTimeRange("db0", "autogen", tmin, tmax)
 	if err != nil {
@@ -1029,16 +1030,18 @@ func TestMetaClient_CreateShardGroupIdempotent(t *testing.T) {
 	// Test pre-creating shard groups.
 	dur := sg.EndTime.Sub(sg.StartTime) + time.Nanosecond
 	tmax := tmin.Add(dur)
-	if err, _ := c.PrecreateShardGroups(tmin, tmax); err != nil {
+	if newShardGroups, err := c.PrecreateShardGroups(tmin, tmax); err != nil {
 		t.Fatal(err)
+	} else if len(newShardGroups) != 1 {
+		t.Fatalf("wrong number of shard groups: %d", len(newShardGroups))
 	}
-	// TODO(DSB): check shard groups created
 	i = c.Data().Index
 	t.Log("index: ", i)
-	if err, _ := c.PrecreateShardGroups(tmin, tmax); err != nil {
+	if newShardGroups, err := c.PrecreateShardGroups(tmin, tmax); err != nil {
 		t.Fatal(err)
+	} else if len(newShardGroups) != 0 {
+		t.Fatalf("wrong number of shard groups: %d", len(newShardGroups))
 	}
-	// TODO(DSB): Test no shard groups created
 	t.Log("index: ", i)
 	if got, exp := c.Data().Index, i; got != exp {
 		t.Fatalf("PrecreateShardGroups failed: invalid index, got %d, exp %d", got, exp)

--- a/services/precreator/service.go
+++ b/services/precreator/service.go
@@ -4,11 +4,11 @@ package precreator // import "github.com/influxdata/influxdb/services/precreator
 import (
 	"errors"
 	"fmt"
-	"github.com/influxdata/influxdb/services/meta"
 	"sync"
 	"time"
 
 	"github.com/influxdata/influxdb/logger"
+	"github.com/influxdata/influxdb/services/meta"
 	"go.uber.org/zap"
 )
 

--- a/services/precreator/service_test.go
+++ b/services/precreator/service_test.go
@@ -1,6 +1,7 @@
 package precreator_test
 
 import (
+	"github.com/influxdata/influxdb/services/meta"
 	"os"
 	"testing"
 	"time"
@@ -16,12 +17,12 @@ func TestShardPrecreation(t *testing.T) {
 	precreate := false
 
 	var mc internal.MetaClientMock
-	mc.PrecreateShardGroupsFn = func(now, cutoff time.Time) error {
+	mc.PrecreateShardGroupsFn = func(now, cutoff time.Time) ([]meta.ShardGroupFullInfo, error) {
 		if !precreate {
 			close(done)
 			precreate = true
 		}
-		return nil
+		return nil, nil
 	}
 
 	s := NewTestService()


### PR DESCRIPTION
The shard precreator service only creates metadata for shards 
before their start time. Add a call to tsdb.Store.CreateShard() 
for each shard group precreated to create on-disk shard 
representation

closes https://github.com/influxdata/influxdb/issues/26359

