### PR TITLE
feat: support `Basic $TOKEN` for all apis

### DIFF
--- a/influxdb3/tests/server/auth.rs
+++ b/influxdb3/tests/server/auth.rs
@@ -125,6 +125,69 @@ async fn auth_http() {
     );
 }
 
+#[tokio::test]
+async fn http_v1_write_basic_auth() {
+    let server = TestServer::configure().with_auth().spawn().await;
+    let token = server
+        .auth_token
+        .clone()
+        .expect("admin token to have been present");
+
+    let client = server.http_client();
+    let base = server.client_addr();
+    let write_lp_url = format!("{base}/write");
+    let write_lp_params = [("db", "foo")];
+    let write_lp_params_with_user_and_password = [("db", "foo"), ("u", "ignored"), ("p", &token)];
+    assert_eq!(
+        client
+            .post(&write_lp_url)
+            .query(&write_lp_params)
+            .body("cpu,host=a val=1i 2998574937")
+            .send()
+            .await
+            .unwrap()
+            .status(),
+        StatusCode::UNAUTHORIZED
+    );
+    assert_eq!(
+        client
+            .post(&write_lp_url)
+            .query(&write_lp_params)
+            .body("cpu,host=a val=1i 2998574937")
+            .basic_auth("username", Some(token.clone()))
+            .send()
+            .await
+            .unwrap()
+            .status(),
+        StatusCode::NO_CONTENT
+    );
+    // Note: this test does not use Authorization header
+    assert_eq!(
+        client
+            .post(&write_lp_url)
+            .query(&write_lp_params_with_user_and_password)
+            .body("cpu,host=a val=1i 2998574937")
+            .send()
+            .await
+            .unwrap()
+            .status(),
+        StatusCode::NO_CONTENT
+    );
+    // Malformed Header Tests
+    // Test that there is an extra string after the token foo
+    assert_eq!(
+        client
+            .get(&write_lp_url)
+            .query(&write_lp_params)
+            .header("Authorization", format!("Basic {token} whee"))
+            .send()
+            .await
+            .unwrap()
+            .status(),
+        StatusCode::BAD_REQUEST
+    );
+}
+
 #[test_log::test(tokio::test)]
 async fn auth_grpc() {
     let server = TestServer::configure().with_auth().spawn().await;

--- a/influxdb3_server/src/http.rs
+++ b/influxdb3_server/src/http.rs
@@ -242,7 +242,7 @@ pub(crate) enum AuthenticationError {
     #[error("the request was not authenticated")]
     Unauthenticated,
     #[error(
-        "the request was not in the form of 'Authorization: <auth-scheme> <token>', supported auth-schemes are Bearer, Token and Basic"
+        "Authorization header was malformed, the request was not in the form of 'Authorization: <auth-scheme> <token>', supported auth-schemes are Bearer, Token and Basic"
     )]
     MalformedRequest,
     #[error("requestor is forbidden from requested resource")]
@@ -1877,11 +1877,9 @@ async fn authenticate(
             }
             AuthenticationError::MalformedRequest => {
                 return Some(Ok(Response::builder()
-                        .status(StatusCode::BAD_REQUEST)
-                        .body(Body::from("{\"error\":\
-                            \"Authorization header was malformed and should be in the form 'Authorization: Bearer <token>'\"\
-                        }"))
-                        .unwrap()));
+                    .status(StatusCode::BAD_REQUEST)
+                    .body(Body::from(format!(r#"{{"error": "{e}"}}"#)))
+                    .unwrap()));
             }
             AuthenticationError::Forbidden => {
                 return Some(Ok(Response::builder()


### PR DESCRIPTION
closes: https://github.com/influxdata/influxdb/issues/25833

### Tests

The tokens below are base64 encoded built from `export BASIC=$(echo -n "username:$TOKEN" | base64 -w 0)`

- Before this change
```
❯ curl -H "Authorization: Basic dXNlcm5hbWU6YXBpdjNfSmthbHYtSVBLcUpSMlA3UVQwbjI4Z0ZwZjFpRXdLLWVaN3E2aFhxeXpySnUwa0VQQi1WRTg4ZUdYVFR6OUdLaHdLbTM4LTZxa3lrS1BkaE5lZHVTOWc=" -H "Content-type: application/text" http://localhost:8181/write\?db=foo -X POST --data-binary "mymeas,mytag1=sometag value=0.56 $(date +%s%N)" -vv
Note: Unnecessary use of -X or --request, POST is already inferred.
12:03:01.635872 [0-0] * Host localhost:8181 was resolved.
12:03:01.635910 [0-0] * IPv6: ::1
12:03:01.635921 [0-0] * IPv4: 127.0.0.1
12:03:01.635933 [0-0] * [SETUP] added
12:03:01.635963 [0-0] *   Trying [::1]:8181...
12:03:01.636040 [0-0] * [SETUP] Curl_conn_connect(block=0) -> 0, done=0
12:03:01.636106 [0-0] * connect to ::1 port 8181 from ::1 port 59476 failed: Connection refused
12:03:01.636135 [0-0] *   Trying 127.0.0.1:8181...
12:03:01.636214 [0-0] * [SETUP] Curl_conn_connect(block=0) -> 0, done=0
12:03:01.636230 [0-0] * [SETUP] Curl_conn_connect(block=0) -> 0, done=1
12:03:01.636241 [0-0] * Connected to localhost (127.0.0.1) port 8181
12:03:01.636249 [0-0] * using HTTP/1.x
12:03:01.636315 [0-0] > POST /write?db=foo HTTP/1.1
12:03:01.636315 [0-0] > Host: localhost:8181
12:03:01.636315 [0-0] > User-Agent: curl/8.13.0
12:03:01.636315 [0-0] > Accept: */*
12:03:01.636315 [0-0] > Authorization: Basic apiv3_Jkalv-IPKqJR2P7QT0n28gFpf1iEwK-eZ7q6hXqyzrJu0kEPB-VE88eGXTTz9GKhwKm38-6qkykKPdhNeduS9g
12:03:01.636315 [0-0] > Content-type: application/text
12:03:01.636315 [0-0] > Content-Length: 52
12:03:01.636315 [0-0] >
12:03:01.636451 [0-0] * upload completely sent off: 52 bytes
12:03:01.638113 [0-0] < HTTP/1.1 400 Bad Request
12:03:01.638138 [0-0] < transfer-encoding: chunked
12:03:01.638149 [0-0] < date: Wed, 07 May 2025 11:03:01 GMT
12:03:01.638160 [0-0] <
12:03:01.638178 [0-0] * Connection #0 to host localhost left intact
{"error":"Authorization header was malformed and should be in the form 'Authorization: Bearer <token>'"}

```

- After this change
```
❯ curl -H "Authorization: Basic dXNlcm5hbWU6YXBpdjNfSmthbHYtSVBLcUpSMlA3UVQwbjI4Z0ZwZjFpRXdLLWVaN3E2aFhxeXpySnUwa0VQQi1WRTg4ZUdYVFR6OUdLaHdLbTM4LTZxa3lrS1BkaE5lZHVTOWc=" -H "Content-type: application/text" http://localhost:8181/write\?db=foo -X POST --data-binary "mymeas,mytag1=sometag value=0.56 $(date +%s%N)" -vv
Note: Unnecessary use of -X or --request, POST is already inferred.
16:40:57.187560 [0-0] * Host localhost:8181 was resolved.
16:40:57.187595 [0-0] * IPv6: ::1
16:40:57.187608 [0-0] * IPv4: 127.0.0.1
16:40:57.187622 [0-0] * [SETUP] added
16:40:57.187652 [0-0] *   Trying [::1]:8181...
16:40:57.187721 [0-0] * [SETUP] Curl_conn_connect(block=0) -> 0, done=0
16:40:57.187782 [0-0] * connect to ::1 port 8181 from ::1 port 44456 failed: Connection refused
16:40:57.187807 [0-0] *   Trying 127.0.0.1:8181...
16:40:57.187888 [0-0] * [SETUP] Curl_conn_connect(block=0) -> 0, done=0
16:40:57.187904 [0-0] * [SETUP] Curl_conn_connect(block=0) -> 0, done=1
16:40:57.187915 [0-0] * Connected to localhost (127.0.0.1) port 8181
16:40:57.187923 [0-0] * using HTTP/1.x
16:40:57.187995 [0-0] > POST /write?db=foo HTTP/1.1
16:40:57.187995 [0-0] > Host: localhost:8181
16:40:57.187995 [0-0] > User-Agent: curl/8.13.0
16:40:57.187995 [0-0] > Accept: */*
16:40:57.187995 [0-0] > Authorization: Basic dXNlcm5hbWU6YXBpdjNfSmthbHYtSVBLcUpSMlA3UVQwbjI4Z0ZwZjFpRXdLLWVaN3E2aFhxeXpySnUwa0VQQi1WRTg4ZUdYVFR6OUdLaHdLbTM4LTZxa3lrS1BkaE5lZHVTOWc=
16:40:57.187995 [0-0] > Content-type: application/text
16:40:57.187995 [0-0] > Content-Length: 52
16:40:57.187995 [0-0] >
16:40:57.188127 [0-0] * upload completely sent off: 52 bytes
16:40:57.801599 [0-0] < HTTP/1.1 204 No Content
16:40:57.801648 [0-0] < access-control-allow-origin: *
16:40:57.801673 [0-0] < date: Wed, 07 May 2025 15:40:57 GMT
16:40:57.801717 [0-0] <
16:40:57.801765 [0-0] * Connection #0 to host localhost left intact

```

- Malformed auth header

```
❯ curl -H "Authorization: Basic YXBpdjNfSmthbHYtSVBLcUpSMlA3UVQwbjI4Z0ZwZjFpRXdLLWVaN3E2aFhxeXpySnUwa0VQQi1WRTg4ZUdYVFR6OUdLaHdLbTM4LTZxa3lrS1BkaE5lZHVTOWc=" -H "Content-type: application/text" http://localhost:8181/write\?db=foo -X POST --data-binary "mymeas,mytag1=sometag value=0.56 $(date +%s%N)" -vv
Note: Unnecessary use of -X or --request, POST is already inferred.
17:34:11.247631 [0-0] * Host localhost:8181 was resolved.
17:34:11.247666 [0-0] * IPv6: ::1
17:34:11.247685 [0-0] * IPv4: 127.0.0.1
17:34:11.247711 [0-0] * [SETUP] added
17:34:11.247737 [0-0] *   Trying [::1]:8181...
17:34:11.247821 [0-0] * [SETUP] Curl_conn_connect(block=0) -> 0, done=0
17:34:11.247896 [0-0] * connect to ::1 port 8181 from ::1 port 46610 failed: Connection refused
17:34:11.247930 [0-0] *   Trying 127.0.0.1:8181...
17:34:11.248021 [0-0] * [SETUP] Curl_conn_connect(block=0) -> 0, done=0
17:34:11.248041 [0-0] * [SETUP] Curl_conn_connect(block=0) -> 0, done=1
17:34:11.248052 [0-0] * Connected to localhost (127.0.0.1) port 8181
17:34:11.248060 [0-0] * using HTTP/1.x
17:34:11.248139 [0-0] > POST /write?db=foo HTTP/1.1
17:34:11.248139 [0-0] > Host: localhost:8181
17:34:11.248139 [0-0] > User-Agent: curl/8.13.0
17:34:11.248139 [0-0] > Accept: */*
17:34:11.248139 [0-0] > Authorization: Basic YXBpdjNfSmthbHYtSVBLcUpSMlA3UVQwbjI4Z0ZwZjFpRXdLLWVaN3E2aFhxeXpySnUwa0VQQi1WRTg4ZUdYVFR6OUdLaHdLbTM4LTZxa3lrS1BkaE5lZHVTOWc=
17:34:11.248139 [0-0] > Content-type: application/text
17:34:11.248139 [0-0] > Content-Length: 52
17:34:11.248139 [0-0] >
17:34:11.248277 [0-0] * upload completely sent off: 52 bytes
17:34:11.249261 [0-0] < HTTP/1.1 400 Bad Request
17:34:11.249296 [0-0] < transfer-encoding: chunked
17:34:11.249319 [0-0] < date: Fri, 09 May 2025 16:34:11 GMT
17:34:11.249338 [0-0] <
17:34:11.249398 [0-0] * Connection #0 to host localhost left intact
{"error": "Authorization header was malformed, the request was not in the form of 'Authorization: <auth-scheme> <token>', supported auth-schemes are Bearer, Token and Basic"}⏎

```