### PR TITLE
fix: defer calls that return a closure need to be called (#25951)

### DIFF
--- a/cmd/influxd/inspect/type_conflicts/schema.go
+++ b/cmd/influxd/inspect/type_conflicts/schema.go
@@ -125,7 +125,7 @@ func (s Schema) WriteConflictsFile(filename string) error {
 
 func (s Schema) encodeSchema(filename string) (rErr error) {
 	schemaFile, err := os.Create(filename)
-	defer errors2.Capture(&rErr, schemaFile.Close)
+	defer errors2.Capture(&rErr, schemaFile.Close)()
 	if err != nil {
 		return fmt.Errorf("unable to create schema file: %w", err)
 	}

--- a/sqlite/sqlite.go
+++ b/sqlite/sqlite.go
@@ -138,7 +138,8 @@ func (s *SqlStore) BackupSqlStore(ctx context.Context, w io.Writer) (rErr error)
 	if err != nil {
 		return err
 	}
-	defer errors2.Capture(&rErr, dest.Close)
+
+	defer errors2.Capture(&rErr, dest.Close)() // close the backup sqlite store
 
 	if err := backup(ctx, dest, s); err != nil {
 		return err
@@ -227,16 +228,19 @@ func (s *SqlStore) RestoreSqlStore(ctx context.Context, r io.Reader) (rErr error
 	if err != nil {
 		return err
 	}
-	defer errors2.Capture(&rErr, f.Close)
+	copySyncClose := func(f *os.File, r io.Reader) (innerErr error) {
+		defer errors2.Capture(&innerErr, f.Close)() // close the temp file
 
-	// Copy the contents of r to the temporary file
-	if _, err := io.Copy(f, r); err != nil {
-		return err
+		// Copy the contents of r to the temporary file
+		if _, err := io.Copy(f, r); err != nil {
+			return err
+		}
+		if err := f.Sync(); err != nil {
+			return err
+		}
+		return nil
 	}
-	if err := f.Sync(); err != nil {
-		return err
-	}
-	if err := f.Close(); err != nil {
+	if err := copySyncClose(f, r); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
* fix: defer calls that return a closure need to be called

* fixes #25950

* chore: avoid a double close

* chore: call defer

(cherry picked from commit de12b6d07efe4c638ef3e325db3cf466df114b84)
