### PR TITLE
feat: Add error join for file writing in snapshots (#26004) (#26005)

### DIFF
--- a/tsdb/engine/tsm1/compact.go
+++ b/tsdb/engine/tsm1/compact.go
@@ -876,12 +876,12 @@ func (c *Compactor) WriteSnapshot(cache *Cache, logger *zap.Logger) ([]string, e
 		}(splits[i])
 	}
 
-	var err error
+	var errs []error
 	files := make([]string, 0, concurrency)
 	for i := 0; i < concurrency; i++ {
 		result := <-resC
 		if result.err != nil {
-			err = result.err
+			errs = append(errs, result.err)
 		}
 		files = append(files, result.files...)
 	}
@@ -900,7 +900,7 @@ func (c *Compactor) WriteSnapshot(cache *Cache, logger *zap.Logger) ([]string, e
 		return nil, errSnapshotsDisabled
 	}
 
-	return files, err
+	return files, errors.Join(errs...)
 }
 
 // compact writes multiple smaller TSM files into 1 or more larger files.


### PR DESCRIPTION
This PR adds an error join to help with handling multiple errors from snapshot file writers.

(cherry picked from commit 4ad5e2aba7d6d725e4ba81ed15a2b96fb2869ec2) (cherry picked from commit 982ae57f22c3b772747f7621c1cf78834698f463)
