### PR TITLE
chore: update to go 1.23.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ orbs:
 parameters:
   cross-container-tag:
     type: string
-    default: go1.23.5-latest
+    default: go1.23.8-latest
 
   workflow:
     type: string

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/influxdata/influxdb/v2
 
 go 1.23.0
 
-toolchain go1.23.5
+toolchain go1.23.8
 
 require (
 	github.com/BurntSushi/toml v1.2.1


### PR DESCRIPTION
Clean cherry-pick of #26291 to 2.7 branch.

(cherry picked from commit dc86dcb55ee417d6041f0902733fede7fa7d0497)
