### PR TITLE
fix: do not allow operator token from being deleted (#26418)

### DIFF
--- a/influxdb3/Cargo.toml
+++ b/influxdb3/Cargo.toml
@@ -53,6 +53,7 @@ libc.workspace = true
 num_cpus.workspace = true
 parking_lot.workspace = true
 rand.workspace = true
+reqwest.workspace = true
 rustls.workspace = true
 secrecy.workspace = true
 serde.workspace = true

--- a/influxdb3/src/commands/delete.rs
+++ b/influxdb3/src/commands/delete.rs
@@ -293,6 +293,13 @@ pub async fn command(config: Config) -> Result<(), Box<dyn Error>> {
             println!("Trigger {} deleted successfully", trigger_name);
         }
         SubCommand::Token(TokenConfig { token_name, .. }) => {
+            if token_name == "_admin" {
+                println!(
+                    "The operator token \"_admin\" is required and cannot be deleted. To regenerate an operator token, use: influxdb3 create token --admin --regenerate --token [TOKEN]"
+                );
+                return Ok(());
+            }
+
             println!(
                 "Are you sure you want to delete {:?}? Enter 'yes' to confirm",
                 token_name
@@ -303,7 +310,6 @@ pub async fn command(config: Config) -> Result<(), Box<dyn Error>> {
                 println!("Cannot delete token without confirmation");
             } else {
                 client.api_v3_configure_token_delete(&token_name).await?;
-
                 println!("Token {:?} deleted successfully", &token_name);
             }
         }

--- a/influxdb3/tests/server/configure.rs
+++ b/influxdb3/tests/server/configure.rs
@@ -1,5 +1,4 @@
 use hyper::StatusCode;
-use influxdb3_types::http::CreateTokenWithPermissionsResponse;
 use observability_deps::tracing::{debug, info};
 use pretty_assertions::assert_eq;
 use serde_json::{Value, json};
@@ -1365,7 +1364,6 @@ async fn api_v3_configure_token_delete() {
     let delete_url = format!("{base}/api/v3/configure/token", base = server.client_addr());
 
     let admin_token = server.token().expect("admin token to be present");
-
     let delete_result = client
         .delete(&delete_url)
         .bearer_auth(admin_token)
@@ -1374,32 +1372,12 @@ async fn api_v3_configure_token_delete() {
         .await
         .unwrap();
     info!(?delete_result, "test: result running the token delete");
+    assert_eq!(delete_result.status(), StatusCode::METHOD_NOT_ALLOWED);
 
-    // create admin token again
+    // create admin token again - this will fail as operator token already exists
     let result = client.post(&create_url).send().await.unwrap();
     info!(?result, "test: result running the create token");
-    assert_eq!(result.status(), StatusCode::CREATED);
-    let json: CreateTokenWithPermissionsResponse = result.json().await.unwrap();
-    info!(?json, "test: result running the token delete");
-    assert_eq!(json.id, 1);
-
-    // delete again
-    let delete_result = client
-        .delete(&delete_url)
-        .bearer_auth(&json.token)
-        .query(&[("token_name", token_name)])
-        .send()
-        .await
-        .unwrap();
-    info!(?delete_result, "test: result running the token delete");
-
-    // create admin token once again
-    let result = client.post(&create_url).send().await.unwrap();
-    info!(?result, "test: result running the create token");
-    assert_eq!(result.status(), StatusCode::CREATED);
-    let json: CreateTokenWithPermissionsResponse = result.json().await.unwrap();
-    info!(?json, "test: result running the token delete");
-    assert_eq!(json.id, 2);
+    assert_eq!(result.status(), StatusCode::CONFLICT);
 }
 
 #[test_log::test(tokio::test)]

--- a/influxdb3_catalog/src/catalog.rs
+++ b/influxdb3_catalog/src/catalog.rs
@@ -64,7 +64,7 @@ pub const TIME_COLUMN_NAME: &str = "time";
 
 pub const INTERNAL_DB_NAME: &str = "_internal";
 
-const DEFAULT_ADMIN_TOKEN_NAME: &str = "_admin";
+const DEFAULT_OPERATOR_TOKEN_NAME: &str = "_admin";
 
 /// Limit for the number of tag columns on a table
 pub(crate) const NUM_TAG_COLUMNS_LIMIT: usize = 250;
@@ -458,7 +458,7 @@ impl Catalog {
                     .read()
                     .tokens
                     .repo()
-                    .get_by_name(DEFAULT_ADMIN_TOKEN_NAME);
+                    .get_by_name(DEFAULT_OPERATOR_TOKEN_NAME);
 
                 if default_admin_token.is_none() {
                     return Err(CatalogError::MissingAdminTokenToUpdate);
@@ -482,10 +482,10 @@ impl Catalog {
                     .read()
                     .tokens
                     .repo()
-                    .contains_name(DEFAULT_ADMIN_TOKEN_NAME)
+                    .contains_name(DEFAULT_OPERATOR_TOKEN_NAME)
                 {
                     return Err(CatalogError::TokenNameAlreadyExists(
-                        DEFAULT_ADMIN_TOKEN_NAME.to_owned(),
+                        DEFAULT_OPERATOR_TOKEN_NAME.to_owned(),
                     ));
                 }
 
@@ -501,7 +501,7 @@ impl Catalog {
                     time_ns: created_at,
                     ops: vec![TokenCatalogOp::CreateAdminToken(CreateAdminTokenDetails {
                         token_id,
-                        name: Arc::from(DEFAULT_ADMIN_TOKEN_NAME),
+                        name: Arc::from(DEFAULT_OPERATOR_TOKEN_NAME),
                         hash: hash.clone(),
                         created_at,
                         updated_at: None,
@@ -517,7 +517,7 @@ impl Catalog {
                 .read()
                 .tokens
                 .repo()
-                .get_by_name(DEFAULT_ADMIN_TOKEN_NAME)
+                .get_by_name(DEFAULT_OPERATOR_TOKEN_NAME)
                 .expect("token info must be present after token creation by name")
         };
 

--- a/influxdb3_catalog/src/catalog/update.rs
+++ b/influxdb3_catalog/src/catalog/update.rs
@@ -13,7 +13,7 @@ use super::{
 };
 use crate::{
     CatalogError, Result,
-    catalog::NUM_TAG_COLUMNS_LIMIT,
+    catalog::{DEFAULT_OPERATOR_TOKEN_NAME, NUM_TAG_COLUMNS_LIMIT},
     log::{
         AddFieldsLog, CatalogBatch, CreateDatabaseLog, CreateTableLog, DatabaseCatalogOp,
         DeleteDistinctCacheLog, DeleteLastCacheLog, DeleteTokenDetails, DeleteTriggerLog,
@@ -681,6 +681,11 @@ impl Catalog {
 
     pub async fn delete_token(&self, token_name: &str) -> Result<OrderedCatalogBatch> {
         info!(token_name, "delete token");
+
+        if token_name == DEFAULT_OPERATOR_TOKEN_NAME {
+            return Err(CatalogError::CannotDeleteOperatorToken);
+        }
+
         self.catalog_update_with_retry(|| {
             if !self.inner.read().tokens.repo().contains_name(token_name) {
                 // maybe deleted by another node or genuinely not present

--- a/influxdb3_catalog/src/error.rs
+++ b/influxdb3_catalog/src/error.rs
@@ -175,6 +175,9 @@ pub enum CatalogError {
 
     #[error("tried to stop a node ({node_id}) that is already stopped")]
     NodeAlreadyStopped { node_id: Arc<str> },
+
+    #[error("cannot delete operator token")]
+    CannotDeleteOperatorToken,
 }
 
 impl CatalogError {

--- a/influxdb3_server/src/http.rs
+++ b/influxdb3_server/src/http.rs
@@ -306,6 +306,14 @@ impl IntoResponse for Error {
     fn into_response(self) -> Response<Body> {
         debug!(error = ?self, "API error");
         match self {
+            Self::Catalog(err @ CatalogError::CannotDeleteOperatorToken) => Response::builder()
+                .status(StatusCode::METHOD_NOT_ALLOWED)
+                .body(Body::from(err.to_string()))
+                .unwrap(),
+            Self::Catalog(err @ CatalogError::TokenNameAlreadyExists { .. }) => Response::builder()
+                .status(StatusCode::CONFLICT)
+                .body(Body::from(err.to_string()))
+                .unwrap(),
             Self::Catalog(err) | Self::WriteBuffer(WriteBufferError::CatalogUpdateError(err)) => {
                 err.into_response()
             }


### PR DESCRIPTION
* fix: do not allow operator token from being deleted

closes: https://github.com/influxdata/influxdb_pro/issues/819

* refactor: address PR feedback

* fix: add a word and clarifying colon

* fix: failing test

---------

Co-authored-by: Peter Barnett <peter.barnett03@gmail.com>

commit hash in main: b404e8475c3088c1ae71cb4d5c53134298ebd8d9