### PR TITLE
feat: `/ping` API contains versioning headers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -789,6 +789,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "camino"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.9",
+]
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3043,6 +3075,7 @@ dependencies = [
 name = "influxdb3_process"
 version = "3.1.0-nightly"
 dependencies = [
+ "cargo_metadata",
  "iox_time",
  "metric",
  "tikv-jemalloc-ctl",
@@ -3209,6 +3242,7 @@ dependencies = [
  "unicode-segmentation",
  "url",
  "urlencoding",
+ "uuid",
 ]
 
 [[package]]
@@ -4887,7 +4921,7 @@ checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes",
  "heck 0.5.0",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "once_cell",
@@ -4920,7 +4954,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
  "syn 2.0.95",
@@ -4933,7 +4967,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "157c5a9d7ea5c2ed2d9fb8f495b64759f7816c7eaea54ba3978f0d63000162e3"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "syn 2.0.95",
@@ -5645,6 +5679,9 @@ name = "semver"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cb6eb87a131f756572d7fb904f6e7b68633f09cca868c5df1c4b8d1a694bbba"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "seq-macro"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ bimap = "0.6.3"
 bitcode = { version = "0.6.3", features = ["serde"] }
 byteorder = "1.3.4"
 bytes = "1.9"
+cargo_metadata = "0.19.2"
 chrono = "0.4"
 cron = "0.15"
 clap = { version = "4", features = ["derive", "env", "string"] }

--- a/influxdb3/tests/server/ping.rs
+++ b/influxdb3/tests/server/ping.rs
@@ -1,4 +1,5 @@
 use hyper::Method;
+use influxdb3_process::{INFLUXDB3_BUILD, INFLUXDB3_VERSION};
 use serde_json::Value;
 
 use crate::server::TestServer;
@@ -32,6 +33,27 @@ async fn test_ping() {
             .send()
             .await
             .unwrap();
+        // Verify we have a request id
+        assert!(resp.headers().contains_key("Request-Id"));
+        assert!(resp.headers().contains_key("X-Request-Id"));
+
+        assert_eq!(
+            resp.headers()
+                .get("X-Influxdb-Version")
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            &INFLUXDB3_VERSION[..]
+        );
+        assert_eq!(
+            resp.headers()
+                .get("X-Influxdb-Build")
+                .unwrap()
+                .to_str()
+                .unwrap(),
+            &INFLUXDB3_BUILD[..]
+        );
+
         let json = resp.json::<Value>().await.unwrap();
         println!("Method: {}, URL: {}", t.method, t.url);
         println!("{json:#}");

--- a/influxdb3_process/Cargo.toml
+++ b/influxdb3_process/Cargo.toml
@@ -21,7 +21,7 @@ tokio.workspace = true
 uuid.workspace = true
 
 [build-dependencies]
-cargo_metadata = "0.19.2"
+cargo_metadata.workspace = true
 
 # Optional Dependencies
 [target.'cfg(not(target_env = "msvc"))'.dependencies]

--- a/influxdb3_process/Cargo.toml
+++ b/influxdb3_process/Cargo.toml
@@ -5,6 +5,9 @@ authors.workspace = true
 edition.workspace = true
 license.workspace = true
 
+[package.metadata.influxdb3]
+build = "Core"
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -16,6 +19,9 @@ tokio_metrics_bridge.workspace = true
 # Crates.io dependencies
 tokio.workspace = true
 uuid.workspace = true
+
+[build-dependencies]
+cargo_metadata = "0.19.2"
 
 # Optional Dependencies
 [target.'cfg(not(target_env = "msvc"))'.dependencies]

--- a/influxdb3_process/src/lib.rs
+++ b/influxdb3_process/src/lib.rs
@@ -36,7 +36,7 @@ pub static INFLUXDB3_VERSION: LazyLock<&'static str> =
 
 /// Build information.
 pub static INFLUXDB3_BUILD: LazyLock<&'static str> =
-    LazyLock::new(|| option_env!("INFLUXDB3_BUILD_VERSION").unwrap());
+    LazyLock::new(|| env!("INFLUXDB3_BUILD_VERSION"));
 
 /// Build-time GIT revision hash.
 pub static INFLUXDB3_GIT_HASH: &str = env!(

--- a/influxdb3_process/src/lib.rs
+++ b/influxdb3_process/src/lib.rs
@@ -34,6 +34,10 @@ pub fn build_malloc_conf() -> String {
 pub static INFLUXDB3_VERSION: LazyLock<&'static str> =
     LazyLock::new(|| option_env!("CARGO_PKG_VERSION").unwrap_or("UNKNOWN"));
 
+/// Build information.
+pub static INFLUXDB3_BUILD: LazyLock<&'static str> =
+    LazyLock::new(|| option_env!("INFLUXDB3_BUILD_VERSION").unwrap_or("Core"));
+
 /// Build-time GIT revision hash.
 pub static INFLUXDB3_GIT_HASH: &str = env!(
     "GIT_HASH",

--- a/influxdb3_process/src/lib.rs
+++ b/influxdb3_process/src/lib.rs
@@ -36,7 +36,7 @@ pub static INFLUXDB3_VERSION: LazyLock<&'static str> =
 
 /// Build information.
 pub static INFLUXDB3_BUILD: LazyLock<&'static str> =
-    LazyLock::new(|| option_env!("INFLUXDB3_BUILD_VERSION").unwrap_or("Core"));
+    LazyLock::new(|| option_env!("INFLUXDB3_BUILD_VERSION").unwrap());
 
 /// Build-time GIT revision hash.
 pub static INFLUXDB3_GIT_HASH: &str = env!(

--- a/influxdb3_server/Cargo.toml
+++ b/influxdb3_server/Cargo.toml
@@ -93,6 +93,7 @@ tonic.workspace = true
 tower.workspace = true
 unicode-segmentation.workspace = true
 url.workspace = true
+uuid.workspace = true
 
 [dev-dependencies]
 # Core Crates


### PR DESCRIPTION
Further, the product version can be modified by updating the metadata in the `influxdb3_process` `Cargo.toml`.

Closes #26138

Adds additional headers to the `/ping` response per the requirements outlined in #26138

## Example response

```sh
❯ curl -i $"($env.INFLUXDB3_HOST_URL)/ping"
```
```http
HTTP/1.1 200 OK
content-type: application/json
request-id: 0196e6d7-5ae5-7650-8f73-e81033bd8197
x-influxdb-build: Core
x-influxdb-version: 3.1.0-nightly
x-request-id: 0196e6d7-5ae5-7650-8f73-e81033bd8197
access-control-allow-origin: *
transfer-encoding: chunked
date: Mon, 19 May 2025 04:39:55 GMT

{"version":"3.1.0-nightly","revision":"a967e23171","process_id":"836df3ab-4cab-4c10-90cc-fadf9c92731e"}
```

> [!NOTE]
>
> The HTTP stack in Rust is normalising the header field names to lowercase, which is fine. Per [Section 4.2](https://www.rfc-editor.org/rfc/rfc2616#section-4.2) of RFC 2616 (HTTP/1.1 spec), it explicitly notes that field names are to be treated as case-insensitive.
>
> > Field names are case-insensitive.