### PR TITLE
WIP: refactor to use iox_http_util

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,16 +19,16 @@ checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
 name = "ahash"
-version = "0.8.11"
+version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
  "const-random",
- "getrandom",
+ "getrandom 0.3.3",
  "once_cell",
  "version_check",
- "zerocopy",
+ "zerocopy 0.8.25",
 ]
 
 [[package]]
@@ -123,19 +123,20 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.6"
+version = "3.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
+checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
 dependencies = [
  "anstyle",
+ "once_cell",
  "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.95"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "arrayref"
@@ -195,7 +196,7 @@ dependencies = [
  "chrono",
  "chrono-tz",
  "half",
- "hashbrown 0.15.2",
+ "hashbrown 0.15.3",
  "num",
 ]
 
@@ -311,7 +312,7 @@ dependencies = [
  "arrow-schema",
  "chrono",
  "half",
- "indexmap 2.7.0",
+ "indexmap 2.9.0",
  "lexical-core",
  "num",
  "serde",
@@ -382,7 +383,7 @@ dependencies = [
 [[package]]
 name = "arrow_util"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f#26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=d5e075085bba8e08916a442e9eb8bf91675268ac#d5e075085bba8e08916a442e9eb8bf91675268ac"
 dependencies = [
  "ahash",
  "arrow",
@@ -411,9 +412,9 @@ dependencies = [
 
 [[package]]
 name = "assert_cmd"
-version = "2.0.16"
+version = "2.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1835b7f27878de8525dc71410b5a31cdcc5f230aed5ba5df968e09c201b23d"
+checksum = "2bd389a4b2970a01282ee455294913c0a43724daedcd1a24c3eb0ec1c1320b66"
 dependencies = [
  "anstyle",
  "bstr",
@@ -433,14 +434,13 @@ checksum = "9b34d609dfbaf33d6889b2b7106d3ca345eacad44200913df5ba02bfd31d2ba9"
 
 [[package]]
 name = "async-compression"
-version = "0.4.18"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df895a515f70646414f4b45c0b79082783b80552b373a68283012928df56f522"
+checksum = "06575e6a9673580f52661c92107baabffbf41e2141373441cbcdc47cb733003c"
 dependencies = [
  "bzip2",
  "flate2",
  "futures-core",
- "futures-io",
  "memchr",
  "pin-project-lite",
  "tokio",
@@ -468,18 +468,18 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.85"
+version = "0.1.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f934833b4b7233644e5848f235df3f57ed8c80f1528a26c3dfa13d2147fa056"
+checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -500,7 +500,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 [[package]]
 name = "authz"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f#26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=d5e075085bba8e08916a442e9eb8bf91675268ac#d5e075085bba8e08916a442e9eb8bf91675268ac"
 dependencies = [
  "async-trait",
  "backoff",
@@ -511,7 +511,6 @@ dependencies = [
  "metric",
  "observability_deps",
  "snafu",
- "tonic 0.11.0",
  "workspace-hack",
 ]
 
@@ -569,10 +568,10 @@ dependencies = [
 [[package]]
 name = "backoff"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f#26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=d5e075085bba8e08916a442e9eb8bf91675268ac#d5e075085bba8e08916a442e9eb8bf91675268ac"
 dependencies = [
  "observability_deps",
- "rand",
+ "rand 0.9.1",
  "snafu",
  "tokio",
  "workspace-hack",
@@ -580,9 +579,9 @@ dependencies = [
 
 [[package]]
 name = "backtrace"
-version = "0.3.74"
+version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
+checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
 dependencies = [
  "addr2line",
  "cfg-if",
@@ -607,9 +606,22 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "base64ct"
-version = "1.6.0"
+version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
+
+[[package]]
+name = "bigdecimal"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a22f228ab7a1b23027ccc6c350b72868017af7ea8356fbdf19f8d991c690013"
+dependencies = [
+ "autocfg",
+ "libm",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "bimap"
@@ -618,25 +630,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
 
 [[package]]
-name = "bit-set"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
-dependencies = [
- "bit-vec",
-]
-
-[[package]]
-name = "bit-vec"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
-
-[[package]]
 name = "bitcode"
-version = "0.6.3"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee1bce7608560cd4bf0296a4262d0dbf13e6bcec5ff2105724c8ab88cc7fc784"
+checksum = "cf300f4aa6e66f3bdff11f1236a88c622fe47ea814524792240b4d554d9858ee"
 dependencies = [
  "arrayvec",
  "bitcode_derive",
@@ -647,13 +644,13 @@ dependencies = [
 
 [[package]]
 name = "bitcode_derive"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a539389a13af092cd345a2b47ae7dec12deb306d660b2223d25cd3419b253ebe"
+checksum = "42b6b4cb608b8282dc3b53d0f4c9ab404655d562674c682db7e6c0458cc83c23"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -664,9 +661,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.6.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 dependencies = [
  "serde",
 ]
@@ -682,9 +679,9 @@ dependencies = [
 
 [[package]]
 name = "blake3"
-version = "1.5.5"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8ee0c1824c4dea5b5f81736aff91bae041d2c07ee1192bec91054e10e3e601e"
+checksum = "3888aaa89e4b2a40fca9848e400f6a658a5a3978de7be858e209cafa8be9a4a0"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -707,9 +704,6 @@ name = "bloom2"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92ca28db4dacf55b7a764e73c12fc191ccbc0707a3804fc2e5da72fe22b14b47"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "brotli"
@@ -724,9 +718,9 @@ dependencies = [
 
 [[package]]
 name = "brotli-decompressor"
-version = "4.0.1"
+version = "4.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a45bd2e4095a8b518033b128020dd4a55aab1c0a381ba4404a472630f4bc362"
+checksum = "a334ef7c9e23abf0ce748e8cd309037da93e606ad52eb372e4ce327a0dcfbdfd"
 dependencies = [
  "alloc-no-stdlib",
  "alloc-stdlib",
@@ -734,9 +728,9 @@ dependencies = [
 
 [[package]]
 name = "bstr"
-version = "1.11.3"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "531a9155a481e2ee699d4f98f43c0ca4ff8ee1bfd55c31e9e98fb29d2b176fe0"
+checksum = "234113d19d0d7d613b40e86fb654acf958910802bcceab913a4f9e7cda03b1a4"
 dependencies = [
  "memchr",
  "regex-automata 0.4.9",
@@ -745,15 +739,15 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.16.0"
+version = "3.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "bytemuck"
-version = "1.21.0"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef657dfab802224e671f5818e9a4935f9b1957ed18e58292690cc39e7a4092a3"
+checksum = "9134a6ef01ce4b366b50689c94f82c14bc72bc5d0386829828a2e2752ef7958c"
 
 [[package]]
 name = "byteorder"
@@ -763,28 +757,26 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.9.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "bzip2"
-version = "0.4.4"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
+checksum = "49ecfb22d906f800d4fe833b6282cf4dc1c298f5057ca0b5445e5c209735ca47"
 dependencies = [
  "bzip2-sys",
- "libc",
 ]
 
 [[package]]
 name = "bzip2-sys"
-version = "0.1.11+1.0.8"
+version = "0.1.13+1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
 dependencies = [
  "cc",
- "libc",
  "pkg-config",
 ]
 
@@ -795,30 +787,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
-name = "catalog_cache"
-version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f#26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f"
-dependencies = [
- "bytes",
- "dashmap",
- "futures",
- "generated_types",
- "hyper 0.14.32",
- "metric",
- "observability_deps",
- "reqwest 0.11.27",
- "snafu",
- "tokio",
- "tokio-util",
- "url",
- "workspace-hack",
-]
-
-[[package]]
 name = "cc"
-version = "1.2.16"
+version = "1.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
+checksum = "5f4ac86a9e5bc1e2b3449ab9d7d3a6a405e3d1bb28d7b9be8614f55846ae3766"
 dependencies = [
  "jobserver",
  "libc",
@@ -854,9 +826,9 @@ dependencies = [
 
 [[package]]
 name = "chrono-tz"
-version = "0.10.0"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd6dd8046d00723a59a2f8c5f295c515b9bb9a331ee4f8f3d4dd49e428acd3b6"
+checksum = "efdce149c370f133a071ca8ef6ea340b7b88748ab0810097a9e2976eaa34b4f3"
 dependencies = [
  "chrono",
  "chrono-tz-build",
@@ -865,9 +837,9 @@ dependencies = [
 
 [[package]]
 name = "chrono-tz-build"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e94fea34d77a245229e7746bd2beb786cd2a896f306ff491fb8cecb3074b10a7"
+checksum = "8f10f8c9340e31fc120ff885fcdb54a0b48e474bbd77cab557f0c30a3e569402"
 dependencies = [
  "parse-zoneinfo",
  "phf_codegen",
@@ -902,9 +874,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.23"
+version = "4.5.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3135e7ec2ef7b10c6ed8950f0f792ed96ee093fa088608f1c76e569722700c84"
+checksum = "ed93b9805f8ba930df42c2590f05453d5ec36cbb85d018868a5b24d31f6ac000"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -912,9 +884,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.23"
+version = "4.5.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30582fc632330df2bd26877bde0c1f4470d57c582bbc070376afcd04d8cb4838"
+checksum = "379026ff283facf611b0ea629334361c4211d1b12ee01024eec1591133b04120"
 dependencies = [
  "anstream",
  "anstyle",
@@ -924,14 +896,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.18"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
+checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -943,13 +915,13 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 [[package]]
 name = "client_util"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f#26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=d5e075085bba8e08916a442e9eb8bf91675268ac#d5e075085bba8e08916a442e9eb8bf91675268ac"
 dependencies = [
  "http 0.2.12",
  "reqwest 0.11.27",
- "thiserror 2.0.9",
+ "thiserror 2.0.12",
  "tonic 0.11.0",
- "tower 0.4.13",
+ "tower 0.5.2",
  "workspace-hack",
 ]
 
@@ -961,12 +933,11 @@ checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "comfy-table"
-version = "7.1.3"
+version = "7.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24f165e7b643266ea80cb858aed492ad9280e3e05ce24d4a99d7d7b889b6a4d9"
+checksum = "4a65ebfec4fb190b6f90e944a817d60499ee0744e582530e2c9900a22e591d9a"
 dependencies = [
- "strum",
- "strum_macros",
+ "unicode-segmentation",
  "unicode-width",
 ]
 
@@ -981,9 +952,9 @@ dependencies = [
 
 [[package]]
 name = "console"
-version = "0.15.10"
+version = "0.15.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea3c6ecd8059b57859df5c69830340ed3c41d30e3da0c1cbed90a96ac853041b"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
 dependencies = [
  "encode_unicode",
  "libc",
@@ -1049,7 +1020,7 @@ version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9d839f2a20b0aee515dc581a6172f2321f96cab76c1a38a4c584a194955390e"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.16",
  "once_cell",
  "tiny-keccak",
 ]
@@ -1088,18 +1059,18 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "crc"
-version = "3.2.1"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69e6e4d7b33a94f0991c26729976b10ebde1d34c3ee82408fb536164fa10d636"
+checksum = "9710d3b3739c2e349eb44fe848ad0b7c8cb1e42bd87ee49371df2f7acaf3e675"
 dependencies = [
  "crc-catalog",
 ]
@@ -1157,18 +1128,18 @@ dependencies = [
 
 [[package]]
 name = "croaring"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4db0840d5e5da1b31604dd5479b5330dc6b8261d23715938c7dd607002149c"
+checksum = "1583a0c6ed2e2fe1a948e23d62ca42e0f2f3b45c59276c884a947c0dab47a20d"
 dependencies = [
  "croaring-sys",
 ]
 
 [[package]]
 name = "croaring-sys"
-version = "4.2.1"
+version = "4.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bc4dd5c267e5305b86d68109e1041605903232cd0f447183ed8f1b7f3d10628"
+checksum = "3124cf04e54f50ecc5f53874e1b1e3a803e35523221bd2864851977b48ba7d00"
 dependencies = [
  "cc",
 ]
@@ -1229,9 +1200,9 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+checksum = "43da5946c66ffcc7745f48db692ffbb10a83bfe0afd96235c5c2a4fb23994929"
 
 [[package]]
 name = "crypto-common"
@@ -1257,18 +1228,18 @@ dependencies = [
 
 [[package]]
 name = "csv-core"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5efa2b3d7902f4b634a20cae3c9c4e6209dc4779feb6863329607560143efa70"
+checksum = "7d02f3b0da4c6504f86e9cd789d8dbafab48c2321be74e9987593de5a894d93d"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "darling"
-version = "0.20.10"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -1276,27 +1247,27 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.20.10"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
 dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.95",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.20.10"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1316,7 +1287,7 @@ dependencies = [
 [[package]]
 name = "data_types"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f#26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=d5e075085bba8e08916a442e9eb8bf91675268ac#d5e075085bba8e08916a442e9eb8bf91675268ac"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -1328,26 +1299,25 @@ dependencies = [
  "iox_time",
  "murmur3",
  "observability_deps",
- "ordered-float 4.6.0",
+ "ordered-float 5.0.0",
  "percent-encoding",
  "prost 0.12.6",
  "schema",
  "serde_json",
  "sha2",
- "siphasher 1.0.1",
+ "siphasher",
  "snafu",
  "sqlx",
- "thiserror 2.0.9",
+ "thiserror 2.0.12",
  "uuid",
  "workspace-hack",
 ]
 
 [[package]]
 name = "datafusion"
-version = "42.1.0"
-source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=ae0a57b05895ccf4d2febb9c91bbb0956cf7e863#ae0a57b05895ccf4d2febb9c91bbb0956cf7e863"
+version = "44.0.0"
+source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=1c10b8b635831e87cb043a1e3fa8eb89be430d54#1c10b8b635831e87cb043a1e3fa8eb89be430d54"
 dependencies = [
- "ahash",
  "arrow",
  "arrow-array",
  "arrow-ipc",
@@ -1366,6 +1336,7 @@ dependencies = [
  "datafusion-functions",
  "datafusion-functions-aggregate",
  "datafusion-functions-nested",
+ "datafusion-functions-table",
  "datafusion-functions-window",
  "datafusion-optimizer",
  "datafusion-physical-expr",
@@ -1376,18 +1347,13 @@ dependencies = [
  "flate2",
  "futures",
  "glob",
- "half",
- "hashbrown 0.14.5",
- "indexmap 2.7.0",
  "itertools 0.13.0",
  "log",
- "num_cpus",
  "object_store",
  "parking_lot",
  "parquet",
- "paste",
- "pin-project-lite",
- "rand",
+ "rand 0.8.5",
+ "regex",
  "sqlparser",
  "tempfile",
  "tokio",
@@ -1400,8 +1366,8 @@ dependencies = [
 
 [[package]]
 name = "datafusion-catalog"
-version = "42.1.0"
-source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=ae0a57b05895ccf4d2febb9c91bbb0956cf7e863#ae0a57b05895ccf4d2febb9c91bbb0956cf7e863"
+version = "44.0.0"
+source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=1c10b8b635831e87cb043a1e3fa8eb89be430d54#1c10b8b635831e87cb043a1e3fa8eb89be430d54"
 dependencies = [
  "arrow-schema",
  "async-trait",
@@ -1414,95 +1380,94 @@ dependencies = [
 
 [[package]]
 name = "datafusion-common"
-version = "42.1.0"
-source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=ae0a57b05895ccf4d2febb9c91bbb0956cf7e863#ae0a57b05895ccf4d2febb9c91bbb0956cf7e863"
+version = "44.0.0"
+source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=1c10b8b635831e87cb043a1e3fa8eb89be430d54#1c10b8b635831e87cb043a1e3fa8eb89be430d54"
 dependencies = [
  "ahash",
  "arrow",
  "arrow-array",
  "arrow-buffer",
  "arrow-schema",
- "chrono",
  "half",
  "hashbrown 0.14.5",
- "indexmap 2.7.0",
- "instant",
+ "indexmap 2.9.0",
  "libc",
- "num_cpus",
+ "log",
  "object_store",
  "parquet",
  "paste",
+ "recursive",
  "sqlparser",
  "tokio",
+ "web-time",
 ]
 
 [[package]]
 name = "datafusion-common-runtime"
-version = "42.1.0"
-source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=ae0a57b05895ccf4d2febb9c91bbb0956cf7e863#ae0a57b05895ccf4d2febb9c91bbb0956cf7e863"
+version = "44.0.0"
+source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=1c10b8b635831e87cb043a1e3fa8eb89be430d54#1c10b8b635831e87cb043a1e3fa8eb89be430d54"
 dependencies = [
  "log",
  "tokio",
 ]
 
 [[package]]
+name = "datafusion-doc"
+version = "44.0.0"
+source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=1c10b8b635831e87cb043a1e3fa8eb89be430d54#1c10b8b635831e87cb043a1e3fa8eb89be430d54"
+
+[[package]]
 name = "datafusion-execution"
-version = "42.1.0"
-source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=ae0a57b05895ccf4d2febb9c91bbb0956cf7e863#ae0a57b05895ccf4d2febb9c91bbb0956cf7e863"
+version = "44.0.0"
+source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=1c10b8b635831e87cb043a1e3fa8eb89be430d54#1c10b8b635831e87cb043a1e3fa8eb89be430d54"
 dependencies = [
  "arrow",
- "chrono",
  "dashmap",
  "datafusion-common",
  "datafusion-expr",
  "futures",
- "hashbrown 0.14.5",
  "log",
  "object_store",
  "parking_lot",
- "rand",
+ "rand 0.8.5",
  "tempfile",
  "url",
 ]
 
 [[package]]
 name = "datafusion-expr"
-version = "42.1.0"
-source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=ae0a57b05895ccf4d2febb9c91bbb0956cf7e863#ae0a57b05895ccf4d2febb9c91bbb0956cf7e863"
+version = "44.0.0"
+source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=1c10b8b635831e87cb043a1e3fa8eb89be430d54#1c10b8b635831e87cb043a1e3fa8eb89be430d54"
 dependencies = [
- "ahash",
  "arrow",
- "arrow-array",
- "arrow-buffer",
  "chrono",
  "datafusion-common",
+ "datafusion-doc",
  "datafusion-expr-common",
  "datafusion-functions-aggregate-common",
  "datafusion-functions-window-common",
  "datafusion-physical-expr-common",
- "indexmap 2.7.0",
+ "indexmap 2.9.0",
  "paste",
+ "recursive",
  "serde_json",
  "sqlparser",
- "strum",
- "strum_macros",
 ]
 
 [[package]]
 name = "datafusion-expr-common"
-version = "42.1.0"
-source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=ae0a57b05895ccf4d2febb9c91bbb0956cf7e863#ae0a57b05895ccf4d2febb9c91bbb0956cf7e863"
+version = "44.0.0"
+source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=1c10b8b635831e87cb043a1e3fa8eb89be430d54#1c10b8b635831e87cb043a1e3fa8eb89be430d54"
 dependencies = [
  "arrow",
  "datafusion-common",
  "itertools 0.13.0",
- "paste",
 ]
 
 [[package]]
 name = "datafusion-functions"
-version = "42.1.0"
-source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=ae0a57b05895ccf4d2febb9c91bbb0956cf7e863#ae0a57b05895ccf4d2febb9c91bbb0956cf7e863"
+version = "44.0.0"
+source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=1c10b8b635831e87cb043a1e3fa8eb89be430d54#1c10b8b635831e87cb043a1e3fa8eb89be430d54"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -1511,14 +1476,17 @@ dependencies = [
  "blake3",
  "chrono",
  "datafusion-common",
+ "datafusion-doc",
  "datafusion-execution",
  "datafusion-expr",
+ "datafusion-expr-common",
+ "datafusion-macros",
  "hashbrown 0.14.5",
  "hex",
  "itertools 0.13.0",
  "log",
  "md-5",
- "rand",
+ "rand 0.8.5",
  "regex",
  "sha2",
  "unicode-segmentation",
@@ -1527,41 +1495,41 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-aggregate"
-version = "42.1.0"
-source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=ae0a57b05895ccf4d2febb9c91bbb0956cf7e863#ae0a57b05895ccf4d2febb9c91bbb0956cf7e863"
+version = "44.0.0"
+source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=1c10b8b635831e87cb043a1e3fa8eb89be430d54#1c10b8b635831e87cb043a1e3fa8eb89be430d54"
 dependencies = [
  "ahash",
  "arrow",
  "arrow-schema",
  "datafusion-common",
+ "datafusion-doc",
  "datafusion-execution",
  "datafusion-expr",
  "datafusion-functions-aggregate-common",
+ "datafusion-macros",
  "datafusion-physical-expr",
  "datafusion-physical-expr-common",
  "half",
- "indexmap 2.7.0",
  "log",
  "paste",
 ]
 
 [[package]]
 name = "datafusion-functions-aggregate-common"
-version = "42.1.0"
-source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=ae0a57b05895ccf4d2febb9c91bbb0956cf7e863#ae0a57b05895ccf4d2febb9c91bbb0956cf7e863"
+version = "44.0.0"
+source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=1c10b8b635831e87cb043a1e3fa8eb89be430d54#1c10b8b635831e87cb043a1e3fa8eb89be430d54"
 dependencies = [
  "ahash",
  "arrow",
  "datafusion-common",
  "datafusion-expr-common",
  "datafusion-physical-expr-common",
- "rand",
 ]
 
 [[package]]
 name = "datafusion-functions-nested"
-version = "42.1.0"
-source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=ae0a57b05895ccf4d2febb9c91bbb0956cf7e863#ae0a57b05895ccf4d2febb9c91bbb0956cf7e863"
+version = "44.0.0"
+source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=1c10b8b635831e87cb043a1e3fa8eb89be430d54#1c10b8b635831e87cb043a1e3fa8eb89be430d54"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -1577,17 +1545,33 @@ dependencies = [
  "itertools 0.13.0",
  "log",
  "paste",
- "rand",
+]
+
+[[package]]
+name = "datafusion-functions-table"
+version = "44.0.0"
+source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=1c10b8b635831e87cb043a1e3fa8eb89be430d54#1c10b8b635831e87cb043a1e3fa8eb89be430d54"
+dependencies = [
+ "arrow",
+ "async-trait",
+ "datafusion-catalog",
+ "datafusion-common",
+ "datafusion-expr",
+ "datafusion-physical-plan",
+ "parking_lot",
+ "paste",
 ]
 
 [[package]]
 name = "datafusion-functions-window"
-version = "42.1.0"
-source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=ae0a57b05895ccf4d2febb9c91bbb0956cf7e863#ae0a57b05895ccf4d2febb9c91bbb0956cf7e863"
+version = "44.0.0"
+source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=1c10b8b635831e87cb043a1e3fa8eb89be430d54#1c10b8b635831e87cb043a1e3fa8eb89be430d54"
 dependencies = [
  "datafusion-common",
+ "datafusion-doc",
  "datafusion-expr",
  "datafusion-functions-window-common",
+ "datafusion-macros",
  "datafusion-physical-expr",
  "datafusion-physical-expr-common",
  "log",
@@ -1596,45 +1580,50 @@ dependencies = [
 
 [[package]]
 name = "datafusion-functions-window-common"
-version = "42.1.0"
-source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=ae0a57b05895ccf4d2febb9c91bbb0956cf7e863#ae0a57b05895ccf4d2febb9c91bbb0956cf7e863"
+version = "44.0.0"
+source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=1c10b8b635831e87cb043a1e3fa8eb89be430d54#1c10b8b635831e87cb043a1e3fa8eb89be430d54"
 dependencies = [
  "datafusion-common",
  "datafusion-physical-expr-common",
 ]
 
 [[package]]
+name = "datafusion-macros"
+version = "44.0.0"
+source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=1c10b8b635831e87cb043a1e3fa8eb89be430d54#1c10b8b635831e87cb043a1e3fa8eb89be430d54"
+dependencies = [
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
 name = "datafusion-optimizer"
-version = "42.1.0"
-source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=ae0a57b05895ccf4d2febb9c91bbb0956cf7e863#ae0a57b05895ccf4d2febb9c91bbb0956cf7e863"
+version = "44.0.0"
+source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=1c10b8b635831e87cb043a1e3fa8eb89be430d54#1c10b8b635831e87cb043a1e3fa8eb89be430d54"
 dependencies = [
  "arrow",
- "async-trait",
  "chrono",
  "datafusion-common",
  "datafusion-expr",
  "datafusion-physical-expr",
- "hashbrown 0.14.5",
- "indexmap 2.7.0",
+ "indexmap 2.9.0",
  "itertools 0.13.0",
  "log",
- "paste",
+ "recursive",
+ "regex",
  "regex-syntax 0.8.5",
 ]
 
 [[package]]
 name = "datafusion-physical-expr"
-version = "42.1.0"
-source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=ae0a57b05895ccf4d2febb9c91bbb0956cf7e863#ae0a57b05895ccf4d2febb9c91bbb0956cf7e863"
+version = "44.0.0"
+source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=1c10b8b635831e87cb043a1e3fa8eb89be430d54#1c10b8b635831e87cb043a1e3fa8eb89be430d54"
 dependencies = [
  "ahash",
  "arrow",
  "arrow-array",
  "arrow-buffer",
- "arrow-ord",
  "arrow-schema",
- "arrow-string",
- "chrono",
  "datafusion-common",
  "datafusion-expr",
  "datafusion-expr-common",
@@ -1642,7 +1631,7 @@ dependencies = [
  "datafusion-physical-expr-common",
  "half",
  "hashbrown 0.14.5",
- "indexmap 2.7.0",
+ "indexmap 2.9.0",
  "itertools 0.13.0",
  "log",
  "paste",
@@ -1651,36 +1640,37 @@ dependencies = [
 
 [[package]]
 name = "datafusion-physical-expr-common"
-version = "42.1.0"
-source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=ae0a57b05895ccf4d2febb9c91bbb0956cf7e863#ae0a57b05895ccf4d2febb9c91bbb0956cf7e863"
+version = "44.0.0"
+source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=1c10b8b635831e87cb043a1e3fa8eb89be430d54#1c10b8b635831e87cb043a1e3fa8eb89be430d54"
 dependencies = [
  "ahash",
  "arrow",
  "datafusion-common",
  "datafusion-expr-common",
  "hashbrown 0.14.5",
- "rand",
+ "itertools 0.13.0",
 ]
 
 [[package]]
 name = "datafusion-physical-optimizer"
-version = "42.1.0"
-source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=ae0a57b05895ccf4d2febb9c91bbb0956cf7e863#ae0a57b05895ccf4d2febb9c91bbb0956cf7e863"
+version = "44.0.0"
+source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=1c10b8b635831e87cb043a1e3fa8eb89be430d54#1c10b8b635831e87cb043a1e3fa8eb89be430d54"
 dependencies = [
  "arrow",
- "arrow-schema",
  "datafusion-common",
  "datafusion-execution",
  "datafusion-expr-common",
  "datafusion-physical-expr",
  "datafusion-physical-plan",
  "itertools 0.13.0",
+ "log",
+ "recursive",
 ]
 
 [[package]]
 name = "datafusion-physical-plan"
-version = "42.1.0"
-source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=ae0a57b05895ccf4d2febb9c91bbb0956cf7e863#ae0a57b05895ccf4d2febb9c91bbb0956cf7e863"
+version = "44.0.0"
+source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=1c10b8b635831e87cb043a1e3fa8eb89be430d54#1c10b8b635831e87cb043a1e3fa8eb89be430d54"
 dependencies = [
  "ahash",
  "arrow",
@@ -1694,44 +1684,42 @@ dependencies = [
  "datafusion-common-runtime",
  "datafusion-execution",
  "datafusion-expr",
- "datafusion-functions-aggregate-common",
  "datafusion-functions-window-common",
  "datafusion-physical-expr",
  "datafusion-physical-expr-common",
  "futures",
  "half",
  "hashbrown 0.14.5",
- "indexmap 2.7.0",
+ "indexmap 2.9.0",
  "itertools 0.13.0",
  "log",
- "once_cell",
  "parking_lot",
  "pin-project-lite",
- "rand",
  "tokio",
 ]
 
 [[package]]
 name = "datafusion-sql"
-version = "42.1.0"
-source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=ae0a57b05895ccf4d2febb9c91bbb0956cf7e863#ae0a57b05895ccf4d2febb9c91bbb0956cf7e863"
+version = "44.0.0"
+source = "git+https://github.com/influxdata/arrow-datafusion.git?rev=1c10b8b635831e87cb043a1e3fa8eb89be430d54#1c10b8b635831e87cb043a1e3fa8eb89be430d54"
 dependencies = [
  "arrow",
  "arrow-array",
  "arrow-schema",
+ "bigdecimal",
  "datafusion-common",
  "datafusion-expr",
- "indexmap 2.7.0",
+ "indexmap 2.9.0",
  "log",
+ "recursive",
  "regex",
  "sqlparser",
- "strum",
 ]
 
 [[package]]
 name = "datafusion_util"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f#26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=d5e075085bba8e08916a442e9eb8bf91675268ac#d5e075085bba8e08916a442e9eb8bf91675268ac"
 dependencies = [
  "async-trait",
  "datafusion",
@@ -1759,9 +1747,9 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid",
  "pem-rfc7468",
@@ -1770,9 +1758,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.3.11"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+checksum = "9c9e6a11ca8224451684bc0d7d5a7adbf8f2fd6887261a1cfc3c0432f9d4068e"
 dependencies = [
  "powerfmt",
  "serde",
@@ -1810,7 +1798,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -1833,9 +1821,9 @@ checksum = "1435fa1053d8b2fbbe9be7e97eca7f33d37b28409959813daefc1446a14247f1"
 
 [[package]]
 name = "either"
-version = "1.13.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 dependencies = [
  "serde",
 ]
@@ -1866,9 +1854,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.6"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcaee3d8e3cfc3fd92428d477bc97fc29ec8716d180c0d74c643bb26166660e0"
+checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1878,15 +1866,15 @@ dependencies = [
 
 [[package]]
 name = "equivalent"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.10"
+version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
@@ -1895,7 +1883,7 @@ dependencies = [
 [[package]]
 name = "error_reporting"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f#26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=d5e075085bba8e08916a442e9eb8bf91675268ac#d5e075085bba8e08916a442e9eb8bf91675268ac"
 dependencies = [
  "workspace-hack",
 ]
@@ -1913,9 +1901,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.3.1"
+version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba"
+checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
 dependencies = [
  "concurrent-queue",
  "parking",
@@ -1925,7 +1913,7 @@ dependencies = [
 [[package]]
 name = "executor"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f#26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=d5e075085bba8e08916a442e9eb8bf91675268ac#d5e075085bba8e08916a442e9eb8bf91675268ac"
 dependencies = [
  "futures",
  "metric",
@@ -1962,9 +1950,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.35"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
+checksum = "7ced92e76e966ca2fd84c8f7aa01a4aea65b0eb6648d72f7c8f3e2764a67fece"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -1973,7 +1961,7 @@ dependencies = [
 [[package]]
 name = "flightsql"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f#26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=d5e075085bba8e08916a442e9eb8bf91675268ac#d5e075085bba8e08916a442e9eb8bf91675268ac"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -1987,7 +1975,6 @@ dependencies = [
  "observability_deps",
  "prost 0.12.6",
  "snafu",
- "tonic 0.11.0",
  "workspace-hack",
 ]
 
@@ -2010,9 +1997,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "form_urlencoded"
@@ -2025,9 +2012,9 @@ dependencies = [
 
 [[package]]
 name = "fragile"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c2141d6d6c8512188a7891b4b01590a45f6dac67afb4f255c4124dbb86d4eaa"
+checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
 
 [[package]]
 name = "futures"
@@ -2096,7 +2083,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -2132,7 +2119,7 @@ dependencies = [
 [[package]]
 name = "generated_types"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f#26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=d5e075085bba8e08916a442e9eb8bf91675268ac#d5e075085bba8e08916a442e9eb8bf91675268ac"
 dependencies = [
  "observability_deps",
  "pbjson",
@@ -2156,19 +2143,32 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
- "zeroize",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
  "wasm-bindgen",
 ]
 
@@ -2180,9 +2180,9 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "glam"
-version = "0.29.2"
+version = "0.30.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc46dd3ec48fdd8e693a98d2b8bafae273a2d54c1de02a2a7e3d57d501f39677"
+checksum = "6b46b9ca4690308844c644e7c634d68792467260e051c8543e0c7871662b3ba7"
 
 [[package]]
 name = "glob"
@@ -2202,7 +2202,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http 0.2.12",
- "indexmap 2.7.0",
+ "indexmap 2.9.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2211,17 +2211,17 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.7"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccae279728d634d083c00f6099cb58f01cc99c145b84b8be2f6c74618d79922e"
+checksum = "a9421a676d1b147b16b82c9225157dc629087ef8ec4d5e2960f9437a90dac0a5"
 dependencies = [
  "atomic-waker",
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.2.0",
- "indexmap 2.7.0",
+ "http 1.3.1",
+ "indexmap 2.9.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2230,9 +2230,9 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "2.4.1"
+version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
+checksum = "459196ed295495a68f7d7fe1d84f6c4b7ff0e21fe3017b2f283c6fac3ad803c9"
 dependencies = [
  "cfg-if",
  "crunchy",
@@ -2257,9 +2257,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.2"
+version = "0.15.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -2285,7 +2285,7 @@ dependencies = [
  "base64 0.21.7",
  "byteorder",
  "flate2",
- "nom",
+ "nom 7.1.3",
  "num-traits",
 ]
 
@@ -2309,9 +2309,9 @@ checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hermit-abi"
-version = "0.4.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
+checksum = "f154ce46856750ed433c8649605bf7ed2de3bc35fd9d2a9f30cddd873c80cb08"
 
 [[package]]
 name = "hex"
@@ -2359,9 +2359,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.2.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f16ca2af56261c99fba8bac40a10251ce8188205a4c448fbb745a2e4daa76fea"
+checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
 dependencies = [
  "bytes",
  "fnv",
@@ -2386,27 +2386,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.2.0",
+ "http 1.3.1",
 ]
 
 [[package]]
 name = "http-body-util"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
- "futures-util",
- "http 1.2.0",
+ "futures-core",
+ "http 1.3.1",
  "http-body 1.0.1",
  "pin-project-lite",
 ]
 
 [[package]]
 name = "httparse"
-version = "1.9.5"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "httpdate"
@@ -2416,9 +2416,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "humantime"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
 
 [[package]]
 name = "hyper"
@@ -2446,15 +2446,15 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.5.2"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "256fb8d4bd6413123cc9d91832d78325c48ff41677595be797d90f42969beae0"
+checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
 dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.7",
- "http 1.2.0",
+ "h2 0.4.10",
+ "http 1.3.1",
  "http-body 1.0.1",
  "httparse",
  "httpdate",
@@ -2503,16 +2503,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
 dependencies = [
  "futures-util",
- "http 1.2.0",
- "hyper 1.5.2",
+ "http 1.3.1",
+ "hyper 1.6.0",
  "hyper-util",
- "rustls 0.23.20",
+ "rustls 0.23.27",
  "rustls-native-certs 0.8.1",
  "rustls-pki-types",
  "tokio",
- "tokio-rustls 0.26.1",
+ "tokio-rustls 0.26.2",
  "tower-service",
- "webpki-roots 0.26.7",
 ]
 
 [[package]]
@@ -2529,16 +2528,17 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
+checksum = "497bbc33a26fdd4af9ed9c70d63f61cf56a938375fbb32df34db9b1cd6d643f2"
 dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.2.0",
+ "http 1.3.1",
  "http-body 1.0.1",
- "hyper 1.5.2",
+ "hyper 1.6.0",
+ "libc",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -2548,16 +2548,17 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.61"
+version = "0.1.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
+checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
+ "log",
  "wasm-bindgen",
- "windows-core 0.52.0",
+ "windows-core 0.61.1",
 ]
 
 [[package]]
@@ -2571,21 +2572,22 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
+checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
 dependencies = [
  "displaydoc",
+ "potential_utf",
  "yoke",
  "zerofrom",
  "zerovec",
 ]
 
 [[package]]
-name = "icu_locid"
-version = "1.5.0"
+name = "icu_locale_core"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -2595,30 +2597,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_locid_transform"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_locid_transform_data",
- "icu_provider",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid_transform_data"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
-
-[[package]]
 name = "icu_normalizer"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
 dependencies = [
  "displaydoc",
  "icu_collections",
@@ -2626,65 +2608,52 @@ dependencies = [
  "icu_properties",
  "icu_provider",
  "smallvec",
- "utf16_iter",
- "utf8_iter",
- "write16",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_normalizer_data"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
+checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
 
 [[package]]
 name = "icu_properties"
-version = "1.5.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+checksum = "2549ca8c7241c82f59c80ba2a6f415d931c5b58d24fb8412caa1a1f02c49139a"
 dependencies = [
  "displaydoc",
  "icu_collections",
- "icu_locid_transform",
+ "icu_locale_core",
  "icu_properties_data",
  "icu_provider",
- "tinystr",
+ "potential_utf",
+ "zerotrie",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_properties_data"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
+checksum = "8197e866e47b68f8f7d95249e172903bec06004b18b2937f1095d40a0c57de04"
 
 [[package]]
 name = "icu_provider"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
 dependencies = [
  "displaydoc",
- "icu_locid",
- "icu_provider_macros",
+ "icu_locale_core",
  "stable_deref_trait",
  "tinystr",
  "writeable",
  "yoke",
  "zerofrom",
+ "zerotrie",
  "zerovec",
-]
-
-[[package]]
-name = "icu_provider_macros"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.95",
 ]
 
 [[package]]
@@ -2706,9 +2675,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -2727,29 +2696,29 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.7.0"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.2",
+ "hashbrown 0.15.3",
  "serde",
 ]
 
 [[package]]
 name = "indoc"
-version = "2.0.5"
+version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
+checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
 
 [[package]]
 name = "influxdb-line-protocol"
 version = "1.0.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f#26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=d5e075085bba8e08916a442e9eb8bf91675268ac#d5e075085bba8e08916a442e9eb8bf91675268ac"
 dependencies = [
  "bytes",
  "log",
- "nom",
+ "nom 8.0.0",
  "smallvec",
  "snafu",
 ]
@@ -2772,7 +2741,7 @@ dependencies = [
  "datafusion_util",
  "dotenvy",
  "futures",
- "hashbrown 0.15.2",
+ "hashbrown 0.15.3",
  "hex",
  "humantime",
  "hyper 0.14.32",
@@ -2806,7 +2775,7 @@ dependencies = [
  "parking_lot",
  "parquet_file",
  "pretty_assertions",
- "rand",
+ "rand 0.8.5",
  "rcgen",
  "regex",
  "reqwest 0.11.27",
@@ -2839,7 +2808,7 @@ version = "3.1.0-nightly"
 dependencies = [
  "async-trait",
  "authz",
- "hashbrown 0.15.2",
+ "hashbrown 0.15.3",
  "influxdb3_id",
  "iox_time",
  "observability_deps",
@@ -2865,7 +2834,7 @@ dependencies = [
  "data_types",
  "datafusion",
  "futures",
- "indexmap 2.7.0",
+ "indexmap 2.9.0",
  "influxdb3_catalog",
  "influxdb3_id",
  "influxdb3_test_helpers",
@@ -2901,10 +2870,10 @@ dependencies = [
  "crc32fast",
  "cron",
  "futures",
- "hashbrown 0.15.2",
+ "hashbrown 0.15.3",
  "hex",
  "humantime",
- "indexmap 2.7.0",
+ "indexmap 2.9.0",
  "influxdb-line-protocol",
  "influxdb3_authz",
  "influxdb3_id",
@@ -2920,7 +2889,7 @@ dependencies = [
  "observability_deps",
  "parking_lot",
  "pretty_assertions",
- "rand",
+ "rand 0.8.5",
  "schema",
  "serde",
  "serde_json",
@@ -2943,9 +2912,8 @@ dependencies = [
  "datafusion",
  "futures",
  "http 0.2.12",
- "http 1.2.0",
+ "http 1.3.1",
  "humantime",
- "iox_catalog",
  "iox_query",
  "iox_time",
  "itertools 0.13.0",
@@ -2971,7 +2939,7 @@ name = "influxdb3_client"
 version = "3.1.0-nightly"
 dependencies = [
  "bytes",
- "hashbrown 0.15.2",
+ "hashbrown 0.15.3",
  "influxdb3_catalog",
  "influxdb3_types",
  "influxdb3_wal",
@@ -2990,7 +2958,7 @@ dependencies = [
 name = "influxdb3_id"
 version = "3.1.0-nightly"
 dependencies = [
- "indexmap 2.7.0",
+ "indexmap 2.9.0",
  "serde",
  "serde_json",
 ]
@@ -3028,7 +2996,7 @@ dependencies = [
  "influxdb3_types",
  "observability_deps",
  "parking_lot",
- "rand",
+ "rand 0.8.5",
  "secrecy",
  "serde",
  "serde_json",
@@ -3064,7 +3032,7 @@ dependencies = [
  "data_types",
  "datafusion_util",
  "futures-util",
- "hashbrown 0.15.2",
+ "hashbrown 0.15.3",
  "humantime",
  "hyper 0.14.32",
  "influxdb3_cache",
@@ -3103,7 +3071,7 @@ dependencies = [
  "bytes",
  "chrono",
  "futures",
- "hashbrown 0.15.2",
+ "hashbrown 0.15.3",
  "humantime",
  "influxdb3_catalog",
  "influxdb3_id",
@@ -3142,7 +3110,7 @@ dependencies = [
  "datafusion_util",
  "flate2",
  "futures",
- "hashbrown 0.15.2",
+ "hashbrown 0.15.3",
  "hex",
  "http 0.2.12",
  "humantime",
@@ -3165,7 +3133,6 @@ dependencies = [
  "influxdb3_wal",
  "influxdb3_write",
  "influxdb_influxql_parser",
- "iox_catalog",
  "iox_http",
  "iox_query",
  "iox_query_influxql",
@@ -3238,7 +3205,7 @@ dependencies = [
  "iox_time",
  "observability_deps",
  "proptest",
- "rand",
+ "rand 0.8.5",
  "test-log",
 ]
 
@@ -3270,7 +3237,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures",
- "hashbrown 0.15.2",
+ "hashbrown 0.15.3",
  "object_store",
  "parking_lot",
  "tokio",
@@ -3282,7 +3249,7 @@ version = "3.1.0-nightly"
 dependencies = [
  "anyhow",
  "chrono",
- "hashbrown 0.15.2",
+ "hashbrown 0.15.3",
  "hex",
  "hyper 0.14.32",
  "influxdb3_authz",
@@ -3307,9 +3274,9 @@ dependencies = [
  "crc32fast",
  "data_types",
  "futures-util",
- "hashbrown 0.15.2",
+ "hashbrown 0.15.3",
  "humantime",
- "indexmap 2.7.0",
+ "indexmap 2.9.0",
  "influxdb-line-protocol",
  "influxdb3_id",
  "influxdb3_shutdown",
@@ -3346,9 +3313,9 @@ dependencies = [
  "executor",
  "futures",
  "futures-util",
- "hashbrown 0.15.2",
+ "hashbrown 0.15.3",
  "hex",
- "indexmap 2.7.0",
+ "indexmap 2.9.0",
  "influxdb-line-protocol",
  "influxdb3_cache",
  "influxdb3_catalog",
@@ -3362,7 +3329,6 @@ dependencies = [
  "influxdb3_types",
  "influxdb3_wal",
  "insta",
- "iox_catalog",
  "iox_http",
  "iox_query",
  "iox_time",
@@ -3392,22 +3358,22 @@ dependencies = [
 [[package]]
 name = "influxdb_influxql_parser"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f#26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=d5e075085bba8e08916a442e9eb8bf91675268ac#d5e075085bba8e08916a442e9eb8bf91675268ac"
 dependencies = [
  "chrono",
  "chrono-tz",
  "iox_query_params",
- "nom",
+ "nom 8.0.0",
  "num-integer",
  "num-traits",
- "thiserror 2.0.9",
+ "thiserror 2.0.12",
  "workspace-hack",
 ]
 
 [[package]]
 name = "influxdb_iox_client"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f#26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=d5e075085bba8e08916a442e9eb8bf91675268ac#d5e075085bba8e08916a442e9eb8bf91675268ac"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -3421,42 +3387,28 @@ dependencies = [
  "influxdb-line-protocol",
  "iox_query_params",
  "prost 0.12.6",
- "rand",
+ "rand 0.9.1",
  "reqwest 0.11.27",
  "schema",
  "serde_json",
- "thiserror 2.0.9",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-stream",
- "tonic 0.11.0",
  "tonic-reflection",
 ]
 
 [[package]]
 name = "insta"
-version = "1.42.0"
+version = "1.43.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6513e4067e16e69ed1db5ab56048ed65db32d10ba5fc1217f5393f8f17d8b5a5"
+checksum = "154934ea70c58054b556dd430b99a98c2a7ff5309ac9891597e339b5c28f4371"
 dependencies = [
  "console",
- "linked-hash-map",
  "once_cell",
  "pest",
  "pest_derive",
  "serde",
  "similar",
-]
-
-[[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if",
- "js-sys",
- "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
@@ -3466,83 +3418,58 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
-name = "iox_catalog"
-version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f#26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f"
-dependencies = [
- "async-trait",
- "backoff",
- "base64 0.22.1",
- "catalog_cache",
- "client_util",
- "dashmap",
- "data_types",
- "error_reporting",
- "futures",
- "generated_types",
- "hashbrown 0.14.5",
- "http 0.2.12",
- "iox_time",
- "log",
- "metric",
- "observability_deps",
- "parking_lot",
- "paste",
- "ring",
- "serde",
- "siphasher 1.0.1",
- "snafu",
- "sqlx",
- "sqlx-hotswap-pool",
- "thiserror 2.0.9",
- "tokio",
- "tonic 0.11.0",
- "trace",
- "trace_http",
- "uuid",
- "workspace-hack",
-]
-
-[[package]]
 name = "iox_http"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f#26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=d5e075085bba8e08916a442e9eb8bf91675268ac#d5e075085bba8e08916a442e9eb8bf91675268ac"
 dependencies = [
  "async-trait",
  "authz",
  "data_types",
  "hyper 0.14.32",
+ "iox_http_util",
  "parking_lot",
  "serde",
  "serde_urlencoded",
- "thiserror 2.0.9",
+ "thiserror 2.0.12",
+ "workspace-hack",
+]
+
+[[package]]
+name = "iox_http_util"
+version = "0.1.0"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=d5e075085bba8e08916a442e9eb8bf91675268ac#d5e075085bba8e08916a442e9eb8bf91675268ac"
+dependencies = [
+ "futures",
+ "http 0.2.12",
+ "hyper 0.14.32",
  "workspace-hack",
 ]
 
 [[package]]
 name = "iox_query"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f#26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=d5e075085bba8e08916a442e9eb8bf91675268ac#d5e075085bba8e08916a442e9eb8bf91675268ac"
 dependencies = [
  "arrow",
  "arrow_util",
  "async-trait",
  "bytes",
  "chrono",
- "dashmap",
  "data_types",
  "datafusion",
  "datafusion_util",
  "executor",
  "futures",
  "hashbrown 0.14.5",
- "indexmap 2.7.0",
+ "indexmap 2.9.0",
  "iox_query_params",
  "iox_time",
  "itertools 0.13.0",
+ "jemalloc_stats",
  "meta_data_cache",
  "metric",
  "object_store",
+ "object_store_size_hinting",
  "observability_deps",
  "parking_lot",
  "parquet_file",
@@ -3560,7 +3487,7 @@ dependencies = [
 [[package]]
 name = "iox_query_influxql"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f#26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=d5e075085bba8e08916a442e9eb8bf91675268ac#d5e075085bba8e08916a442e9eb8bf91675268ac"
 dependencies = [
  "arrow",
  "assert_matches",
@@ -3578,7 +3505,7 @@ dependencies = [
  "regex",
  "schema",
  "serde_json",
- "thiserror 2.0.9",
+ "thiserror 2.0.12",
  "workspace-hack",
 ]
 
@@ -3593,7 +3520,7 @@ dependencies = [
 [[package]]
 name = "iox_query_params"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f#26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=d5e075085bba8e08916a442e9eb8bf91675268ac#d5e075085bba8e08916a442e9eb8bf91675268ac"
 dependencies = [
  "arrow",
  "datafusion",
@@ -3601,14 +3528,14 @@ dependencies = [
  "observability_deps",
  "serde",
  "serde_json",
- "thiserror 2.0.9",
+ "thiserror 2.0.12",
  "workspace-hack",
 ]
 
 [[package]]
 name = "iox_system_tables"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f#26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=d5e075085bba8e08916a442e9eb8bf91675268ac#d5e075085bba8e08916a442e9eb8bf91675268ac"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3620,7 +3547,7 @@ dependencies = [
 [[package]]
 name = "iox_time"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f#26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=d5e075085bba8e08916a442e9eb8bf91675268ac#d5e075085bba8e08916a442e9eb8bf91675268ac"
 dependencies = [
  "chrono",
  "parking_lot",
@@ -3630,19 +3557,19 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.10.1"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.13"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
+checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
- "hermit-abi 0.4.0",
+ "hermit-abi 0.5.1",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3689,24 +3616,36 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
+name = "jemalloc_stats"
+version = "0.1.0"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=d5e075085bba8e08916a442e9eb8bf91675268ac#d5e075085bba8e08916a442e9eb8bf91675268ac"
+dependencies = [
+ "snafu",
+ "tikv-jemalloc-ctl",
+ "tokio",
+ "workspace-hack",
+]
 
 [[package]]
 name = "jobserver"
-version = "0.1.32"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
+checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
 dependencies = [
+ "getrandom 0.3.3",
  "libc",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.76"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6717b6b5b077764fb5966237269cb3c64edddde4b14ce42647430a78ced9e7b7"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -3787,15 +3726,15 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libm"
-version = "0.2.11"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
+checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libsqlite3-sys"
@@ -3809,22 +3748,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "linked-hash-map"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
-
-[[package]]
 name = "linux-raw-sys"
-version = "0.4.14"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "litemap"
-version = "0.7.4"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
+checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "lock_api"
@@ -3839,20 +3772,27 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "logfmt"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f#26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=d5e075085bba8e08916a442e9eb8bf91675268ac#d5e075085bba8e08916a442e9eb8bf91675268ac"
 dependencies = [
  "humantime",
  "observability_deps",
  "tracing-subscriber",
+ "unicode-segmentation",
  "workspace-hack",
 ]
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lz4_flex"
@@ -3917,7 +3857,7 @@ dependencies = [
 [[package]]
 name = "meta_data_cache"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f#26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=d5e075085bba8e08916a442e9eb8bf91675268ac#d5e075085bba8e08916a442e9eb8bf91675268ac"
 dependencies = [
  "arrow",
  "data_types",
@@ -3933,7 +3873,7 @@ dependencies = [
 [[package]]
 name = "metric"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f#26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=d5e075085bba8e08916a442e9eb8bf91675268ac#d5e075085bba8e08916a442e9eb8bf91675268ac"
 dependencies = [
  "parking_lot",
  "workspace-hack",
@@ -3942,11 +3882,12 @@ dependencies = [
 [[package]]
 name = "metric_exporters"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f#26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=d5e075085bba8e08916a442e9eb8bf91675268ac#d5e075085bba8e08916a442e9eb8bf91675268ac"
 dependencies = [
  "metric",
  "observability_deps",
  "prometheus",
+ "reqwest 0.11.27",
  "workspace-hack",
 ]
 
@@ -3957,16 +3898,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
-name = "mime_guess"
-version = "2.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
-dependencies = [
- "mime",
- "unicase",
-]
-
-[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3974,9 +3905,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.2"
+version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ffbe83022cedc1d264172192511ae958937694cd57ce297164951b8b3568394"
+checksum = "3be647b768db090acb35d5ec5db2b0e1f1de11133ca123b9eacf5137868f892a"
 dependencies = [
  "adler2",
 ]
@@ -3988,7 +3919,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
 
@@ -4015,25 +3946,25 @@ dependencies = [
  "cfg-if",
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "mockito"
-version = "1.6.1"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "652cd6d169a36eaf9d1e6bce1a221130439a966d7f27858af66a33a66e9c4ee2"
+checksum = "7760e0e418d9b7e5777c0374009ca4c93861b9066f18cb334a20ce50ab63aa48"
 dependencies = [
  "assert-json-diff",
  "bytes",
  "futures-util",
- "http 1.2.0",
+ "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.5.2",
+ "hyper 1.6.0",
  "hyper-util",
  "log",
- "rand",
+ "rand 0.9.1",
  "regex",
  "serde_json",
  "serde_urlencoded",
@@ -4043,28 +3974,15 @@ dependencies = [
 
 [[package]]
 name = "multimap"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "defc4c55412d89136f966bbb339008b474350e5e6e78d2714439c386b3137a03"
+checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
 
 [[package]]
 name = "murmur3"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9252111cf132ba0929b6f8e030cac2a24b507f3a4d6db6fb2896f27b354c714b"
-
-[[package]]
-name = "nix"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
-dependencies = [
- "bitflags 2.6.0",
- "cfg-if",
- "cfg_aliases",
- "libc",
- "memoffset",
-]
 
 [[package]]
 name = "nom"
@@ -4077,10 +3995,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "non-empty-string"
-version = "0.2.5"
+name = "nom"
+version = "8.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7c6b5dd693859a717623d1d11279f64ef97c27c423d8c5ba1703e0466df211b"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "non-empty-string"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "260010741d90def3ca7c4b5ec0bbe28c26d0c775d3c7d291b38642514136677a"
 dependencies = [
  "delegate",
 ]
@@ -4126,7 +4053,6 @@ checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
- "serde",
 ]
 
 [[package]]
@@ -4141,7 +4067,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "smallvec",
  "zeroize",
 ]
@@ -4213,6 +4139,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-core-foundation"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c10c2894a6fed806ade6027bcd50662746363a9589d3ec9d9bef30a4e4bc166"
+dependencies = [
+ "bitflags 2.9.1",
+]
+
+[[package]]
+name = "objc2-io-kit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71c1c64d6120e51cd86033f67176b1cb66780c2efe34dec55176f77befd93c0a"
+dependencies = [
+ "libc",
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4224,8 +4169,7 @@ dependencies = [
 [[package]]
 name = "object_store"
 version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cfccb68961a56facde1163f9319e0d15743352344e7808a11795fb99698dcaf"
+source = "git+https://github.com/influxdata/arrow-rs.git?rev=c946cd81fa12e6588a3be33be08e3d8e9a2770e7#c946cd81fa12e6588a3be33be08e3d8e9a2770e7"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -4234,14 +4178,14 @@ dependencies = [
  "futures",
  "httparse",
  "humantime",
- "hyper 1.5.2",
+ "hyper 1.6.0",
  "itertools 0.13.0",
  "md-5",
  "parking_lot",
  "percent-encoding",
  "quick-xml",
- "rand",
- "reqwest 0.12.12",
+ "rand 0.8.5",
+ "reqwest 0.12.15",
  "ring",
  "rustls-pemfile 2.2.0",
  "serde",
@@ -4256,17 +4200,20 @@ dependencies = [
 [[package]]
 name = "object_store_mem_cache"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f#26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=d5e075085bba8e08916a442e9eb8bf91675268ac#d5e075085bba8e08916a442e9eb8bf91675268ac"
 dependencies = [
  "async-trait",
  "bytes",
  "dashmap",
  "data_types",
  "futures",
- "indexmap 2.7.0",
+ "indexmap 2.9.0",
  "iox_time",
  "metric",
  "object_store",
+ "object_store_metrics",
+ "object_store_mock",
+ "object_store_size_hinting",
  "observability_deps",
  "tokio",
  "tracker",
@@ -4276,23 +4223,51 @@ dependencies = [
 [[package]]
 name = "object_store_metrics"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f#26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=d5e075085bba8e08916a442e9eb8bf91675268ac#d5e075085bba8e08916a442e9eb8bf91675268ac"
 dependencies = [
  "async-trait",
+ "bloom2",
  "bytes",
  "futures",
  "iox_time",
  "metric",
  "object_store",
+ "observability_deps",
  "pin-project",
  "tokio",
+ "tracker",
+ "workspace-hack",
+]
+
+[[package]]
+name = "object_store_mock"
+version = "0.1.0"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=d5e075085bba8e08916a442e9eb8bf91675268ac#d5e075085bba8e08916a442e9eb8bf91675268ac"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures",
+ "object_store",
+ "tokio",
+ "workspace-hack",
+]
+
+[[package]]
+name = "object_store_size_hinting"
+version = "0.1.0"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=d5e075085bba8e08916a442e9eb8bf91675268ac#d5e075085bba8e08916a442e9eb8bf91675268ac"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures",
+ "object_store",
  "workspace-hack",
 ]
 
 [[package]]
 name = "observability_deps"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f#26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=d5e075085bba8e08916a442e9eb8bf91675268ac#d5e075085bba8e08916a442e9eb8bf91675268ac"
 dependencies = [
  "tracing",
  "workspace-hack",
@@ -4300,21 +4275,21 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.2"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "oorandom"
-version = "11.1.4"
+version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
+checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "ordered-float"
@@ -4327,9 +4302,9 @@ dependencies = [
 
 [[package]]
 name = "ordered-float"
-version = "4.6.0"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+checksum = "e2c1f9f56e534ac6a9b8a4600bdf0f530fb393b5f393e7b4d03489c3cf0c3f01"
 dependencies = [
  "num-traits",
 ]
@@ -4342,14 +4317,14 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "owo-colors"
-version = "4.2.0"
+version = "4.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1036865bb9422d3300cf723f657c2851d0e9ab12567854b1f4eba3d77decf564"
+checksum = "26995317201fa17f3656c36716aed4a7c81743a9634ac4c99c0eeda495db0cec"
 
 [[package]]
 name = "panic_logging"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f#26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=d5e075085bba8e08916a442e9eb8bf91675268ac#d5e075085bba8e08916a442e9eb8bf91675268ac"
 dependencies = [
  "metric",
  "observability_deps",
@@ -4405,7 +4380,7 @@ dependencies = [
  "flate2",
  "futures",
  "half",
- "hashbrown 0.15.2",
+ "hashbrown 0.15.3",
  "lz4_flex",
  "num",
  "num-bigint",
@@ -4423,7 +4398,7 @@ dependencies = [
 [[package]]
 name = "parquet_file"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f#26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=d5e075085bba8e08916a442e9eb8bf91675268ac#d5e075085bba8e08916a442e9eb8bf91675268ac"
 dependencies = [
  "arrow",
  "arrow_util",
@@ -4443,7 +4418,7 @@ dependencies = [
  "prost 0.12.6",
  "schema",
  "snafu",
- "thiserror 2.0.9",
+ "thiserror 2.0.12",
  "thrift",
  "tokio",
  "uuid",
@@ -4530,20 +4505,20 @@ checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "pest"
-version = "2.7.15"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b7cafe60d6cf8e62e1b9b2ea516a089c008945bb5a275416789e7db0bc199dc"
+checksum = "198db74531d58c70a361c42201efde7e2591e976d518caf7662a47dc5720e7b6"
 dependencies = [
  "memchr",
- "thiserror 2.0.9",
+ "thiserror 2.0.12",
  "ucd-trie",
 ]
 
 [[package]]
 name = "pest_derive"
-version = "2.7.15"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "816518421cfc6887a0d62bf441b6ffb4536fcc926395a69e1a85852d4363f57e"
+checksum = "d725d9cfd79e87dccc9341a2ef39d1b6f6353d68c4b33c177febbe1a402c97c5"
 dependencies = [
  "pest",
  "pest_generator",
@@ -4551,22 +4526,22 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.15"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d1396fd3a870fc7838768d171b4616d5c91f6cc25e377b673d714567d99377b"
+checksum = "db7d01726be8ab66ab32f9df467ae8b1148906685bbe75c82d1e65d7f5b3f841"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.7.15"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e58089ea25d717bfd31fb534e4f3afcc2cc569c70de3e239778991ea3b7dea"
+checksum = "7f9f832470494906d1fca5329f8ab5791cc60beb230c74815dff541cbd2b5ca0"
 dependencies = [
  "once_cell",
  "pest",
@@ -4580,23 +4555,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap 2.7.0",
+ "indexmap 2.9.0",
 ]
 
 [[package]]
 name = "phf"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
  "phf_shared",
 ]
 
 [[package]]
 name = "phf_codegen"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8d39688d359e6b34654d328e262234662d16cc0f60ec8dcbe5e718709342a5a"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
 dependencies = [
  "phf_generator",
  "phf_shared",
@@ -4604,41 +4579,41 @@ dependencies = [
 
 [[package]]
 name = "phf_generator"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared",
- "rand",
+ "rand 0.8.5",
 ]
 
 [[package]]
 name = "phf_shared"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
 dependencies = [
- "siphasher 0.3.11",
+ "siphasher",
 ]
 
 [[package]]
 name = "pin-project"
-version = "1.1.8"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e2ec53ad785f4d35dac0adea7f7dc6f1bb277ad84a680c7afefeae05d1f5916"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.8"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d56a66c0c55993aa927429d0f8a0abfd74f084e4d9c192cffed01e418d83eefb"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4676,9 +4651,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plotters"
@@ -4710,9 +4685,18 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
+checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
+
+[[package]]
+name = "potential_utf"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
+dependencies = [
+ "zerovec",
+]
 
 [[package]]
 name = "powerfmt"
@@ -4722,17 +4706,17 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy",
+ "zerocopy 0.8.25",
 ]
 
 [[package]]
 name = "predicate"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f#26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=d5e075085bba8e08916a442e9eb8bf91675268ac#d5e075085bba8e08916a442e9eb8bf91675268ac"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4786,35 +4770,35 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.27"
+version = "0.2.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "483f8c21f64f3ea09fe0f30f5d48c3e8eefe5dac9129f0075f76593b4c1da705"
+checksum = "664ec5419c51e34154eec046ebcba56312d5a2fc3b09a06da188e1ad21afadf6"
 dependencies = [
  "proc-macro2",
- "syn 2.0.95",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.92"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "prometheus"
-version = "0.13.4"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d33c28a30771f7f96db69893f78b857f7450d7e0237e9c8fc6427a81bae7ed1"
+checksum = "3ca5326d8d0b950a9acd87e6a3f94745394f62e4dae1b1ee22b2bc0c394af43a"
 dependencies = [
  "cfg-if",
  "fnv",
  "lazy_static",
  "memchr",
  "parking_lot",
- "thiserror 1.0.69",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -4835,17 +4819,13 @@ version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14cae93065090804185d3b75f0bf93b8eeda30c7a9b4a33d3bdb3988d6229e50"
 dependencies = [
- "bit-set",
- "bit-vec",
- "bitflags 2.6.0",
+ "bitflags 2.9.1",
  "lazy_static",
  "num-traits",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "rand_xorshift",
  "regex-syntax 0.8.5",
- "rusty-fork",
- "tempfile",
  "unarray",
 ]
 
@@ -4870,16 +4850,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prost"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c0fef6c4230e4ccf618a35c59d7ede15dea37de8427500f50aff708806e42ec"
-dependencies = [
- "bytes",
- "prost-derive 0.13.4",
-]
-
-[[package]]
 name = "prost-build"
 version = "0.12.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4887,7 +4857,7 @@ checksum = "22505a5c94da8e3b7c2996394d1c933236c4d743e81a410bcca4e6989fc066a4"
 dependencies = [
  "bytes",
  "heck 0.5.0",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "log",
  "multimap",
  "once_cell",
@@ -4896,7 +4866,7 @@ dependencies = [
  "prost 0.12.6",
  "prost-types 0.12.6",
  "regex",
- "syn 2.0.95",
+ "syn 2.0.101",
  "tempfile",
 ]
 
@@ -4920,23 +4890,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
 dependencies = [
  "anyhow",
- "itertools 0.10.5",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.95",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "157c5a9d7ea5c2ed2d9fb8f495b64759f7816c7eaea54ba3978f0d63000162e3"
-dependencies = [
- "anyhow",
- "itertools 0.10.5",
- "proc-macro2",
- "quote",
- "syn 2.0.95",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -4958,10 +4915,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "pyo3"
-version = "0.24.1"
+name = "psm"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17da310086b068fbdcefbba30aeb3721d5bb9af8db4987d6735b2183ca567229"
+checksum = "6e944464ec8536cd1beb0bbfd96987eb5e3b72f2ecdafdc5c769a37f1fa2ae1f"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "pyo3"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5203598f366b11a02b13aa20cab591229ff0a89fd121a308a5df751d5fc9219"
 dependencies = [
  "cfg-if",
  "indoc",
@@ -4977,9 +4943,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e27165889bd793000a098bb966adc4300c312497ea25cf7a690a9f0ac5aa5fc1"
+checksum = "99636d423fa2ca130fa5acde3059308006d46f98caac629418e53f7ebb1e9999"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -4987,9 +4953,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05280526e1dbf6b420062f3ef228b78c0c54ba94e157f5cb724a609d0f2faabc"
+checksum = "78f9cf92ba9c409279bc3305b5409d90db2d2c22392d443a87df3a1adad59e33"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -4997,33 +4963,33 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c3ce5686aa4d3f63359a5100c62a127c9f15e8398e5fdeb5deef1fed5cd5f44"
+checksum = "0b999cb1a6ce21f9a6b147dcf1be9ffedf02e0043aec74dc390f3007047cecd9"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.24.1"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4cf6faa0cbfb0ed08e89beb8103ae9724eb4750e3a78084ba4017cbe94f3855"
+checksum = "822ece1c7e1012745607d5cf0bcb2874769f0f7cb34c4cde03b9358eb9ef911a"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "pyo3-build-config",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "query_functions"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f#26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=d5e075085bba8e08916a442e9eb8bf91675268ac#d5e075085bba8e08916a442e9eb8bf91675268ac"
 dependencies = [
  "arrow",
  "chrono",
@@ -5036,16 +5002,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "quick-error"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
-
-[[package]]
 name = "quick-xml"
-version = "0.37.2"
+version = "0.37.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "165859e9e55f79d67b96c5d96f4e88b6f2695a1972849c15a6a3f5c59fc2c003"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
 dependencies = [
  "memchr",
  "serde",
@@ -5053,37 +5013,40 @@ dependencies = [
 
 [[package]]
 name = "quinn"
-version = "0.11.6"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62e96808277ec6f97351a2380e6c25114bc9e67037775464979f3037c92d05ef"
+checksum = "626214629cda6781b6dc1d316ba307189c85ba657213ce642d9c77670f8202c8"
 dependencies = [
  "bytes",
+ "cfg_aliases",
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
  "rustc-hash",
- "rustls 0.23.20",
+ "rustls 0.23.27",
  "socket2",
- "thiserror 2.0.9",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
+ "web-time",
 ]
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.9"
+version = "0.11.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2fe5ef3495d7d2e377ff17b1a8ce2ee2ec2a18cde8b6ad6619d65d0701c135d"
+checksum = "49df843a9161c85bb8aae55f101bc0bac8bcafd637a620d9122fd7e0b2f7422e"
 dependencies = [
  "bytes",
- "getrandom",
- "rand",
+ "getrandom 0.3.3",
+ "lru-slab",
+ "rand 0.9.1",
  "ring",
  "rustc-hash",
- "rustls 0.23.20",
+ "rustls 0.23.27",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.9",
+ "thiserror 2.0.12",
  "tinyvec",
  "tracing",
  "web-time",
@@ -5091,9 +5054,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.9"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c40286217b4ba3a71d644d752e6a0b71f13f1b6a2c5311acfcbe0c2418ed904"
+checksum = "ee4e529991f949c5e25755532370b8af5d114acae52326361d68d47af64aa842"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -5105,12 +5068,18 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "rand"
@@ -5119,8 +5088,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -5130,7 +5109,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -5139,7 +5128,16 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.16",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.3",
 ]
 
 [[package]]
@@ -5148,7 +5146,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -5185,12 +5183,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.5.8"
+name = "recursive"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
+checksum = "0786a43debb760f491b1bc0269fe5e84155353c67482b9e60d0cfb596054b43e"
 dependencies = [
- "bitflags 2.6.0",
+ "recursive-proc-macro-impl",
+ "stacker",
+]
+
+[[package]]
+name = "recursive-proc-macro-impl"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76009fbe0614077fc1a2ce255e3a1881a2e3a3527097d5dc6d8212c585e7e38b"
+dependencies = [
+ "quote",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
+dependencies = [
+ "bitflags 2.9.1",
 ]
 
 [[package]]
@@ -5283,32 +5301,30 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.12"
+version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da"
+checksum = "d19c46a6fdd48bc4dab94b6103fccc55d34c67cc0ad04653aad4ea2a07cd7bbb"
 dependencies = [
- "async-compression",
  "base64 0.22.1",
  "bytes",
  "futures-core",
  "futures-util",
- "h2 0.4.7",
- "http 1.2.0",
+ "h2 0.4.10",
+ "http 1.3.1",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.5.2",
+ "hyper 1.6.0",
  "hyper-rustls 0.27.5",
  "hyper-util",
  "ipnet",
  "js-sys",
  "log",
  "mime",
- "mime_guess",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.20",
+ "rustls 0.23.27",
  "rustls-native-certs 0.8.1",
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
@@ -5317,7 +5333,7 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper 1.0.2",
  "tokio",
- "tokio-rustls 0.26.1",
+ "tokio-rustls 0.26.2",
  "tokio-util",
  "tower 0.5.2",
  "tower-service",
@@ -5326,19 +5342,18 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "webpki-roots 0.26.7",
  "windows-registry",
 ]
 
 [[package]]
 name = "ring"
-version = "0.17.13"
+version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ac5d832aa16abd7d1def883a8545280c20a60f523a370aa3a9617c2b8550ee"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.16",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -5346,9 +5361,9 @@ dependencies = [
 
 [[package]]
 name = "rsa"
-version = "0.9.7"
+version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47c75d7c5c6b673e58bf54d8544a9f432e3a925b0e80f7cd3602ab5c50c55519"
+checksum = "78928ac1ed176a5ca1d17e578a1825f3d81ca54cf41053a592584b020cfd691b"
 dependencies = [
  "const-oid",
  "digest",
@@ -5357,7 +5372,7 @@ dependencies = [
  "num-traits",
  "pkcs1",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "signature",
  "spki",
  "subtle",
@@ -5372,9 +5387,9 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7fb8039b3032c191086b10f11f319a6e99e1e82889c5cc6046f515c9db1d497"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustc_version"
@@ -5387,11 +5402,11 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.42"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93dc38ecbab2eb790ff964bb77fa94faf256fd3e73285fd7ba0903b76bedb85"
+checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -5426,15 +5441,14 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.20"
+version = "0.23.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5065c3f250cbd332cd894be57c40fa52387247659b14a2d6041d121547903b1b"
+checksum = "730944ca083c1c233a75c09f199e973ca499344a2b7ba9e755c457e86fb4a321"
 dependencies = [
- "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.102.8",
+ "rustls-webpki 0.103.3",
  "subtle",
  "zeroize",
 ]
@@ -5473,7 +5487,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework 3.1.0",
+ "security-framework 3.2.0",
 ]
 
 [[package]]
@@ -5496,11 +5510,12 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.10.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2bf47e6ff922db3825eb750c4e2ff784c6ff8fb9e13046ef6a1d1c5401b0b37"
+checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
 dependencies = [
  "web-time",
+ "zeroize",
 ]
 
 [[package]]
@@ -5525,28 +5540,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustversion"
-version = "1.0.19"
+name = "rustls-webpki"
+version = "0.103.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
-
-[[package]]
-name = "rusty-fork"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
+checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
 dependencies = [
- "fnv",
- "quick-error",
- "tempfile",
- "wait-timeout",
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
 ]
 
 [[package]]
-name = "ryu"
-version = "1.0.18"
+name = "rustversion"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+
+[[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "same-file"
@@ -5569,11 +5583,11 @@ dependencies = [
 [[package]]
 name = "schema"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f#26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=d5e075085bba8e08916a442e9eb8bf91675268ac#d5e075085bba8e08916a442e9eb8bf91675268ac"
 dependencies = [
  "arrow",
  "hashbrown 0.14.5",
- "indexmap 2.7.0",
+ "indexmap 2.9.0",
  "observability_deps",
  "snafu",
  "workspace-hack",
@@ -5610,7 +5624,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.1",
  "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
@@ -5619,11 +5633,11 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81d3f8c9bfcc3cbb6b0179eb57042d75b1582bdc65c3cb95f3fa999509c03cbc"
+checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags 2.9.1",
  "core-foundation 0.10.0",
  "core-foundation-sys",
  "libc",
@@ -5632,9 +5646,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1863fd3768cd83c56a7f60faa4dc0d403f1b6df0a38c3c25f44b7894e45370d5"
+checksum = "49db231d56a190491cb4aeda9527f1ad45345af50b0851622a7adb8c03b01c32"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -5642,41 +5656,41 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.24"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cb6eb87a131f756572d7fb904f6e7b68633f09cca868c5df1c4b8d1a694bbba"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
 name = "seq-macro"
-version = "0.3.5"
+version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3f0bf26fd526d2a95683cd0f87bf103b8539e2ca1ef48ce002d67aad59aa0b4"
+checksum = "1bc711410fbe7399f390ca1c3b60ad0f53f80e95c5eb935e52268a0e2cd49acc"
 
 [[package]]
 name = "serde"
-version = "1.0.217"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.217"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.134"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d00f4175c42ee48b15416f6193a959ba3a0d67fc699a0db9ad12df9f83991c7d"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "itoa",
  "memchr",
@@ -5706,7 +5720,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.7.0",
+ "indexmap 2.9.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -5723,13 +5737,13 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "service_common"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f#26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=d5e075085bba8e08916a442e9eb8bf91675268ac#d5e075085bba8e08916a442e9eb8bf91675268ac"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -5743,7 +5757,7 @@ dependencies = [
 [[package]]
 name = "service_grpc_flight"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f#26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=d5e075085bba8e08916a442e9eb8bf91675268ac#d5e075085bba8e08916a442e9eb8bf91675268ac"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -5765,7 +5779,6 @@ dependencies = [
  "service_common",
  "snafu",
  "tokio",
- "tonic 0.11.0",
  "tower_trailer",
  "trace",
  "trace_http",
@@ -5785,9 +5798,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -5811,9 +5824,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.2"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
 dependencies = [
  "libc",
 ]
@@ -5825,20 +5838,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
 name = "similar"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1de1d4f81173b03af4c0cbed3c898f6bff5b870e4a7f5d6f4057d62a7a4b686e"
-
-[[package]]
-name = "siphasher"
-version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "siphasher"
@@ -5857,9 +5864,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 dependencies = [
  "serde",
 ]
@@ -5870,8 +5877,6 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "223891c85e2a29c3fe8fb900c1fae5e69c2e42415e3177752e8718475efa5019"
 dependencies = [
- "futures-core",
- "pin-project",
  "snafu-derive",
 ]
 
@@ -5884,7 +5889,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -5895,9 +5900,9 @@ checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
 
 [[package]]
 name = "socket2"
-version = "0.5.8"
+version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c970269d99b64e60ec3bd6ad27270092a5394c4e309314b18ae3fe575695fbe8"
+checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -5928,15 +5933,15 @@ version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7bba3a93db0cc4f7bdece8bb09e77e2e785c20bfebf79eb8340ed80708048790"
 dependencies = [
- "nom",
+ "nom 7.1.3",
  "unicode_categories",
 ]
 
 [[package]]
 name = "sqlparser"
-version = "0.51.0"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fe11944a61da0da3f592e19a45ebe5ab92dc14a779907ff1f08fbb797bfefc7"
+checksum = "05a528114c392209b3264855ad491fcce534b94a38771b0a0b97a79379275ce8"
 dependencies = [
  "log",
  "sqlparser_derive",
@@ -5944,13 +5949,13 @@ dependencies = [
 
 [[package]]
 name = "sqlparser_derive"
-version = "0.2.2"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01b2e185515564f15375f593fb966b5718bc624ba77fe49fa4616ad619690554"
+checksum = "da5fc6819faabb412da764b99d3b713bb55083c11e7e0c00144d386cd6a1939c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -5987,13 +5992,13 @@ dependencies = [
  "hashbrown 0.14.5",
  "hashlink",
  "hex",
- "indexmap 2.7.0",
+ "indexmap 2.9.0",
  "log",
  "memchr",
  "once_cell",
  "paste",
  "percent-encoding",
- "rustls 0.23.20",
+ "rustls 0.23.27",
  "rustls-pemfile 2.2.0",
  "serde",
  "serde_json",
@@ -6006,18 +6011,7 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
- "webpki-roots 0.26.7",
-]
-
-[[package]]
-name = "sqlx-hotswap-pool"
-version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f#26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f"
-dependencies = [
- "either",
- "futures",
- "sqlx",
- "workspace-hack",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -6030,7 +6024,7 @@ dependencies = [
  "quote",
  "sqlx-core",
  "sqlx-macros-core",
- "syn 2.0.95",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -6053,7 +6047,7 @@ dependencies = [
  "sqlx-mysql",
  "sqlx-postgres",
  "sqlx-sqlite",
- "syn 2.0.95",
+ "syn 2.0.101",
  "tempfile",
  "tokio",
  "url",
@@ -6067,7 +6061,7 @@ checksum = "64bb4714269afa44aef2755150a0fc19d756fb580a67db8885608cf02f47d06a"
 dependencies = [
  "atoi",
  "base64 0.22.1",
- "bitflags 2.6.0",
+ "bitflags 2.9.1",
  "byteorder",
  "bytes",
  "crc",
@@ -6088,7 +6082,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rand",
+ "rand 0.8.5",
  "rsa",
  "serde",
  "sha1",
@@ -6110,7 +6104,7 @@ checksum = "6fa91a732d854c5d7726349bb4bb879bb9478993ceb764247660aee25f67c2f8"
 dependencies = [
  "atoi",
  "base64 0.22.1",
- "bitflags 2.6.0",
+ "bitflags 2.9.1",
  "byteorder",
  "crc",
  "dotenvy",
@@ -6128,7 +6122,7 @@ dependencies = [
  "md-5",
  "memchr",
  "once_cell",
- "rand",
+ "rand 0.8.5",
  "serde",
  "serde_json",
  "sha2",
@@ -6172,6 +6166,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
+name = "stacker"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cddb07e32ddb770749da91081d8d0ac3a16f1a569a18b20348cd371f5dead06b"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "psm",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "static_assertions"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6195,28 +6202,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
-name = "strum"
-version = "0.26.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
-dependencies = [
- "strum_macros",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
-dependencies = [
- "heck 0.5.0",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 2.0.95",
-]
-
-[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6235,9 +6220,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.95"
+version = "2.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46f71c0377baf4ef1cc3e3402ded576dccc315800fbc62dfc7fe04b009773b4a"
+checksum = "8ce2b7fc941b3a24138a0a7cf8e858bfc6a992e7978a068a5c760deb0ed43caf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6261,13 +6246,13 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -6287,16 +6272,16 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.33.1"
+version = "0.35.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fc858248ea01b66f19d8e8a6d55f41deaf91e9d495246fd01368d99935c6c01"
+checksum = "79251336d17c72d9762b8b54be4befe38d2db56fbbc0241396d70f173c39d47a"
 dependencies = [
- "core-foundation-sys",
  "libc",
  "memchr",
  "ntapi",
- "rayon",
- "windows 0.57.0",
+ "objc2-core-foundation",
+ "objc2-io-kit",
+ "windows 0.61.1",
 ]
 
 [[package]]
@@ -6328,13 +6313,12 @@ checksum = "e502f78cdbb8ba4718f566c418c52bc729126ffd16baee5baa718cf25dd5a69a"
 
 [[package]]
 name = "tempfile"
-version = "3.15.0"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8a559c81686f576e8cd0290cd2a24a2a9ad80c98b3478856500fcbd7acd704"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
 dependencies = [
- "cfg-if",
  "fastrand",
- "getrandom",
+ "getrandom 0.3.3",
  "once_cell",
  "rustix",
  "windows-sys 0.59.0",
@@ -6348,9 +6332,9 @@ checksum = "8f50febec83f5ee1df3015341d8bd429f2d1cc62bcba7ea2076759d315084683"
 
 [[package]]
 name = "test-log"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dffced63c2b5c7be278154d76b479f9f9920ed34e7574201407f0b14e2bbb93"
+checksum = "e7f46083d221181166e5b6f6b1e5f1d499f3a76888826e6cb1d057554157cd0f"
 dependencies = [
  "env_logger",
  "test-log-macros",
@@ -6359,29 +6343,30 @@ dependencies = [
 
 [[package]]
 name = "test-log-macros"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5999e24eaa32083191ba4e425deb75cdf25efefabe5aaccb7446dd0d4122a3f5"
+checksum = "888d0c3c6db53c0fdab160d2ed5e12ba745383d3e85813f2ea0f2b1475ab553f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "test_helpers"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f#26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=d5e075085bba8e08916a442e9eb8bf91675268ac#d5e075085bba8e08916a442e9eb8bf91675268ac"
 dependencies = [
  "async-trait",
  "dotenvy",
  "observability_deps",
- "ordered-float 4.6.0",
+ "ordered-float 5.0.0",
  "parking_lot",
  "prometheus-parse",
  "reqwest 0.11.27",
+ "serde",
  "tempfile",
- "thiserror 2.0.9",
+ "thiserror 2.0.12",
  "tokio",
  "tracing-log",
  "tracing-subscriber",
@@ -6399,11 +6384,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.9"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f072643fd0190df67a8bab670c20ef5d8737177d6ac6b2e9a236cb096206b2cc"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl 2.0.9",
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -6414,18 +6399,18 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.9"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b50fa271071aae2e6ee85f842e2e28ba8cd2c5fb67f11fcb1fd70b276f9e7d4"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -6493,9 +6478,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.37"
+version = "0.3.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
+checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
 dependencies = [
  "deranged",
  "itoa",
@@ -6508,15 +6493,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.2"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+checksum = "c9e9a38711f559d9e3ce1cdb06dd7c5b8ea546bc90052da6d06bb76da74bb07c"
 
 [[package]]
 name = "time-macros"
-version = "0.2.19"
+version = "0.2.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
+checksum = "3526739392ec93fd8b359c8e98514cb3e8e021beb4e5f597b00a0221f8ed8a49"
 dependencies = [
  "num-conv",
  "time-core",
@@ -6533,9 +6518,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.7.6"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -6553,9 +6538,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "022db8904dfa342efe721985167e9fcd16c29b226db4397ed752a761cfce81e8"
+checksum = "09b3661f17e86524eccd4371ab0429194e0d7c008abb45f7a7495b1719463c71"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -6568,9 +6553,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.44.2"
+version = "1.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6b88822cbe49de4185e3a4cbf8321dd487cf5fe0c5c65695fef6346371e9c48"
+checksum = "2513ca694ef9ede0fb23fe71a4ee4107cb102b9dc1930f6d0fd77aae068ae165"
 dependencies = [
  "backtrace",
  "bytes",
@@ -6603,19 +6588,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
-]
-
-[[package]]
-name = "tokio-metrics"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb2bb07a8451c4c6fa8b3497ad198510d8b8dffa5df5cfb97a64102a58b113c8"
-dependencies = [
- "futures-util",
- "pin-project-lite",
- "tokio",
- "tokio-stream",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -6641,11 +6614,11 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37"
+checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
- "rustls 0.23.20",
+ "rustls 0.23.27",
  "tokio",
 ]
 
@@ -6662,16 +6635,16 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.13"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078"
+checksum = "66a539a9ad6d5d281510d5bd368c973d636c02dbf8a67300bfb6b950696ad7df"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-io",
  "futures-sink",
  "futures-util",
- "hashbrown 0.14.5",
+ "hashbrown 0.15.3",
  "pin-project-lite",
  "tokio",
 ]
@@ -6679,7 +6652,7 @@ dependencies = [
 [[package]]
 name = "tokio_metrics_bridge"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f#26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=d5e075085bba8e08916a442e9eb8bf91675268ac#d5e075085bba8e08916a442e9eb8bf91675268ac"
 dependencies = [
  "metric",
  "parking_lot",
@@ -6690,7 +6663,7 @@ dependencies = [
 [[package]]
 name = "tokio_watchdog"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f#26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=d5e075085bba8e08916a442e9eb8bf91675268ac#d5e075085bba8e08916a442e9eb8bf91675268ac"
 dependencies = [
  "metric",
  "observability_deps",
@@ -6767,7 +6740,7 @@ dependencies = [
  "proc-macro2",
  "prost-build",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -6794,7 +6767,7 @@ dependencies = [
  "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
- "rand",
+ "rand 0.8.5",
  "slab",
  "tokio",
  "tokio-util",
@@ -6833,33 +6806,33 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 [[package]]
 name = "tower_trailer"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f#26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=d5e075085bba8e08916a442e9eb8bf91675268ac#d5e075085bba8e08916a442e9eb8bf91675268ac"
 dependencies = [
  "futures",
  "http 0.2.12",
  "http-body 0.4.6",
  "parking_lot",
  "pin-project",
- "tower 0.4.13",
+ "tower 0.5.2",
  "workspace-hack",
 ]
 
 [[package]]
 name = "trace"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f#26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=d5e075085bba8e08916a442e9eb8bf91675268ac#d5e075085bba8e08916a442e9eb8bf91675268ac"
 dependencies = [
  "chrono",
  "observability_deps",
  "parking_lot",
- "rand",
+ "rand 0.9.1",
  "workspace-hack",
 ]
 
 [[package]]
 name = "trace_exporters"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f#26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=d5e075085bba8e08916a442e9eb8bf91675268ac#d5e075085bba8e08916a442e9eb8bf91675268ac"
 dependencies = [
  "async-trait",
  "clap",
@@ -6877,7 +6850,7 @@ dependencies = [
 [[package]]
 name = "trace_http"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f#26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=d5e075085bba8e08916a442e9eb8bf91675268ac#d5e075085bba8e08916a442e9eb8bf91675268ac"
 dependencies = [
  "bytes",
  "futures",
@@ -6890,7 +6863,7 @@ dependencies = [
  "parking_lot",
  "pin-project",
  "snafu",
- "tower 0.4.13",
+ "tower 0.5.2",
  "trace",
  "workspace-hack",
 ]
@@ -6915,7 +6888,7 @@ checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.101",
 ]
 
 [[package]]
@@ -6974,7 +6947,7 @@ dependencies = [
 [[package]]
 name = "tracker"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f#26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=d5e075085bba8e08916a442e9eb8bf91675268ac#d5e075085bba8e08916a442e9eb8bf91675268ac"
 dependencies = [
  "futures",
  "hashbrown 0.14.5",
@@ -6984,7 +6957,7 @@ dependencies = [
  "observability_deps",
  "parking_lot",
  "pin-project",
- "sysinfo 0.33.1",
+ "sysinfo 0.35.1",
  "tokio",
  "tokio-util",
  "trace",
@@ -6994,12 +6967,12 @@ dependencies = [
 [[package]]
 name = "trogging"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f#26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=d5e075085bba8e08916a442e9eb8bf91675268ac#d5e075085bba8e08916a442e9eb8bf91675268ac"
 dependencies = [
  "clap",
  "logfmt",
  "observability_deps",
- "thiserror 2.0.9",
+ "thiserror 2.0.12",
  "tracing-log",
  "tracing-subscriber",
 ]
@@ -7022,9 +6995,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "ucd-trie"
@@ -7039,12 +7012,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
-name = "unicase"
-version = "2.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
-
-[[package]]
 name = "unicode-bidi"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7052,9 +7019,9 @@ checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.14"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "unicode-normalization"
@@ -7091,9 +7058,9 @@ checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
 name = "unindent"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7de7d73e1754487cb58364ee906a499937a0dfabd86bcb980fa99ec8c8fa2ce"
+checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "untrusted"
@@ -7119,12 +7086,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a1f0175e03a0973cf4afd476bef05c26e228520400eb1fd473ad417b1c00ffb"
 
 [[package]]
-name = "utf16_iter"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
-
-[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7138,19 +7099,21 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.11.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
+checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.3",
+ "js-sys",
  "serde",
+ "wasm-bindgen",
 ]
 
 [[package]]
 name = "valuable"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"
@@ -7166,9 +7129,9 @@ checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wait-timeout"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
 dependencies = [
  "libc",
 ]
@@ -7199,6 +7162,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
 name = "wasite"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7206,34 +7178,35 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a474f6281d1d70c17ae7aa6a613c87fce69a127e2624002df63dcb39d6cf6396"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
  "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f89bb38646b4f81674e8f5c3fb81b562be1fd936d84320f3264486418519c79"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.101",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.49"
+version = "0.4.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38176d9b44ea84e9184eff0bc34cc167ed044f816accfe5922e54d84cf48eca2"
+checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -7244,9 +7217,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cc6181fd9a7492eef6fef1f33961e3695e4579b9872a6f7c83aee556666d4fe"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -7254,22 +7227,25 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d7a95b763d3c45903ed6c81f156801839e5ee968bb07e534c44df0fcd330c2"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.101",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.99"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "943aab3fdaaa029a6e0271b35ea10b72b943135afe9bffca82384098ad0e06a6"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "wasm-streams"
@@ -7286,9 +7262,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.76"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dd7223427d52553d3702c004d3b2fe07c148165faa56313cb00211e31c12bc"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -7312,18 +7288,27 @@ checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "webpki-roots"
-version = "0.26.7"
+version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d642ff16b7e79272ae451b7322067cdc17cadf68c23264be9d94a32319efe7e"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.0",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2853738d1cc4f2da3a225c18ec6c3721abb31961096e9dbf5ab35fa88b19cfdb"
 dependencies = [
  "rustls-pki-types",
 ]
 
 [[package]]
 name = "whoami"
-version = "1.5.2"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "372d5b87f58ec45c384ba03563b03544dc5fadc3983e434b286913f5b4a9bb6d"
+checksum = "6994d13118ab492c3c80c1f81928718159254c53c472bf9ce36f8dae4add02a7"
 dependencies = [
  "redox_syscall",
  "wasite",
@@ -7372,12 +7357,24 @@ dependencies = [
 
 [[package]]
 name = "windows"
-version = "0.57.0"
+version = "0.61.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12342cb4d8e3b046f3d80effd474a7a02447231330ef77d71daa6fbc40681143"
+checksum = "c5ee8f3d025738cb02bad7868bbb5f8a6327501e870bf51f1b455b0a2454a419"
 dependencies = [
- "windows-core 0.57.0",
- "windows-targets 0.52.6",
+ "windows-collections",
+ "windows-core 0.61.1",
+ "windows-future",
+ "windows-link",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core 0.61.1",
 ]
 
 [[package]]
@@ -7391,75 +7388,102 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.57.0"
+version = "0.61.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2ed2439a290666cd67ecce2b0ffaad89c2a56b976b736e6ece670297897832d"
+checksum = "46ec44dc15085cea82cf9c78f85a9114c463a369786585ad2882d1ff0b0acf40"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-result 0.1.2",
- "windows-targets 0.52.6",
+ "windows-link",
+ "windows-result",
+ "windows-strings 0.4.1",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+dependencies = [
+ "windows-core 0.61.1",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
 name = "windows-implement"
-version = "0.57.0"
+version = "0.60.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "windows-interface"
-version = "0.57.0"
+version = "0.59.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
+
+[[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core 0.61.1",
+ "windows-link",
 ]
 
 [[package]]
 name = "windows-registry"
-version = "0.2.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
+checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
 dependencies = [
- "windows-result 0.2.0",
- "windows-strings",
- "windows-targets 0.52.6",
+ "windows-result",
+ "windows-strings 0.3.1",
+ "windows-targets 0.53.0",
 ]
 
 [[package]]
 name = "windows-result"
-version = "0.1.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+checksum = "4b895b5356fc36103d0f64dd1e94dfa7ac5633f1c9dd6e80fe9ec4adef69e09d"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
-dependencies = [
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.1.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
 dependencies = [
- "windows-result 0.2.0",
- "windows-targets 0.52.6",
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a7ab927b2637c19b3dbe0965e75d8f2d30bdd697a1516191cad2ec4df8fb28a"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -7513,11 +7537,36 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
+dependencies = [
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -7533,6 +7582,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7543,6 +7598,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -7557,10 +7618,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -7575,6 +7648,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7585,6 +7664,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -7599,6 +7684,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7611,10 +7702,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "winnow"
-version = "0.6.24"
+name = "windows_x86_64_msvc"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8d71a593cc5c42ad7876e2c1fda56f314f3754c084128833e64f1345ff8a03a"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "winnow"
+version = "0.6.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e90edd2ac1aa278a5c4599b1d89cf03074b610800f866d4026dc199d7929a28"
 dependencies = [
  "memchr",
 ]
@@ -7630,31 +7727,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags 2.9.1",
+]
+
+[[package]]
 name = "workspace-hack"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f#26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=d5e075085bba8e08916a442e9eb8bf91675268ac#d5e075085bba8e08916a442e9eb8bf91675268ac"
 dependencies = [
  "ahash",
  "arrayvec",
  "arrow",
  "arrow-ipc",
- "async-compression",
  "base64 0.22.1",
- "bitflags 2.6.0",
- "bloom2",
+ "bitflags 2.9.1",
  "byteorder",
  "bytes",
  "cc",
  "chrono",
  "clap",
  "clap_builder",
- "crossbeam-epoch",
  "crossbeam-utils",
  "crypto-common",
  "digest",
  "either",
- "fixedbitset",
- "flatbuffers",
+ "fastrand",
  "flate2",
  "form_urlencoded",
  "futures-channel",
@@ -7664,49 +7766,37 @@ dependencies = [
  "futures-sink",
  "futures-task",
  "futures-util",
- "generic-array",
- "getrandom",
+ "getrandom 0.2.16",
+ "getrandom 0.3.3",
  "hashbrown 0.14.5",
+ "httparse",
  "hyper 0.14.32",
- "hyper 1.5.2",
- "hyper-rustls 0.27.5",
+ "hyper 1.6.0",
  "hyper-util",
  "idna",
- "indexmap 2.7.0",
+ "indexmap 2.9.0",
  "itertools 0.12.1",
  "libc",
- "lock_api",
  "log",
- "lzma-sys",
  "md-5",
  "memchr",
- "nix",
- "nom",
- "num-bigint",
- "num-integer",
  "num-traits",
- "object_store",
- "parking_lot",
  "percent-encoding",
  "petgraph",
  "phf_shared",
- "proptest",
  "prost 0.12.6",
- "prost 0.13.4",
  "prost-types 0.12.6",
- "rand",
- "rand_core",
+ "rand 0.8.5",
+ "rand_core 0.6.4",
  "regex",
  "regex-automata 0.4.9",
  "regex-syntax 0.8.5",
  "reqwest 0.11.27",
- "reqwest 0.12.12",
  "ring",
- "rustls 0.23.20",
+ "rustls-pemfile 2.2.0",
  "serde",
  "serde_json",
  "sha2",
- "signature",
  "similar",
  "smallvec",
  "snafu",
@@ -7718,16 +7808,12 @@ dependencies = [
  "sqlx-macros-core",
  "sqlx-postgres",
  "sqlx-sqlite",
- "strum",
- "subtle",
- "syn 2.0.95",
+ "syn 2.0.101",
  "thrift",
+ "tikv-jemalloc-sys",
  "tokio",
- "tokio-metrics",
- "tokio-rustls 0.26.1",
  "tokio-stream",
  "tokio-util",
- "tower 0.4.13",
  "tracing",
  "tracing-core",
  "tracing-log",
@@ -7738,25 +7824,14 @@ dependencies = [
  "windows-sys 0.48.0",
  "windows-sys 0.52.0",
  "windows-sys 0.59.0",
- "xz2",
- "zerocopy",
- "zeroize",
- "zstd",
- "zstd-safe",
- "zstd-sys",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
-name = "write16"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
-
-[[package]]
 name = "writeable"
-version = "0.5.5"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
 
 [[package]]
 name = "xz2"
@@ -7784,9 +7859,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.7.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
+checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -7796,13 +7871,13 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.7.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
+checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.101",
  "synstructure",
 ]
 
@@ -7813,7 +7888,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "byteorder",
- "zerocopy-derive",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
+dependencies = [
+ "zerocopy-derive 0.8.25",
 ]
 
 [[package]]
@@ -7824,27 +7908,38 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.101",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "zerofrom"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.101",
  "synstructure",
 ]
 
@@ -7853,26 +7948,23 @@ name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
-dependencies = [
- "zeroize_derive",
-]
 
 [[package]]
-name = "zeroize_derive"
-version = "1.4.2"
+name = "zerotrie"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.95",
+ "displaydoc",
+ "yoke",
+ "zerofrom",
 ]
 
 [[package]]
 name = "zerovec"
-version = "0.10.4"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
+checksum = "4a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -7881,20 +7973,20 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.10.3"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
+checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.95",
+ "syn 2.0.101",
 ]
 
 [[package]]
 name = "zstd"
-version = "0.13.2"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcf2b778a664581e31e389454a7072dab1647606d44f7feea22cd5abb9c9f3f9"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
 dependencies = [
  "zstd-safe",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3134,6 +3134,7 @@ dependencies = [
  "influxdb3_write",
  "influxdb_influxql_parser",
  "iox_http",
+ "iox_http_util",
  "iox_query",
  "iox_query_influxql",
  "iox_query_influxql_rewrite",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3045,6 +3045,7 @@ dependencies = [
  "influxdb3_types",
  "influxdb3_wal",
  "influxdb3_write",
+ "iox_http_util",
  "iox_query",
  "iox_time",
  "metric",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3113,6 +3113,7 @@ dependencies = [
  "hashbrown 0.15.3",
  "hex",
  "http 0.2.12",
+ "http-body 0.4.6",
  "humantime",
  "hyper 0.14.32",
  "hyper-rustls 0.25.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,8 +79,8 @@ crossbeam-channel = "0.5.11"
 csv = "1.3.0"
 # Use DataFusion fork
 # See https://github.com/influxdata/arrow-datafusion/pull/49 for contents
-datafusion = { git = "https://github.com/influxdata/arrow-datafusion.git", rev = "ae0a57b05895ccf4d2febb9c91bbb0956cf7e863" }
-datafusion-proto = { git = "https://github.com/influxdata/arrow-datafusion.git", rev = "ae0a57b05895ccf4d2febb9c91bbb0956cf7e863" }
+datafusion = { git = "https://github.com/influxdata/arrow-datafusion.git", rev = "1c10b8b635831e87cb043a1e3fa8eb89be430d54" }
+datafusion-proto = { git = "https://github.com/influxdata/arrow-datafusion.git", rev = "1c10b8b635831e87cb043a1e3fa8eb89be430d54" }
 dashmap = "6.1.0"
 dotenvy = "0.15.7"
 flate2 = "1.0.27"
@@ -136,7 +136,7 @@ sysinfo = "0.30.8"
 tempfile = "3.14.0"
 test-log = { version = "0.2.16", features = ["trace"] }
 thiserror = "1.0"
-tokio = { version = "1.43.1", features = ["full"] }
+tokio = { version = "1.45", features = ["full"] }
 tokio-util = { version = "0.7.13", features = ["rt"] }
 tonic = { version = "0.11.0", features = ["tls", "tls-roots"] }
 tonic-build = "0.11.0"
@@ -147,41 +147,40 @@ twox-hash = "2.1.0"
 unicode-segmentation = "1.11.0"
 url = "2.5.0"
 urlencoding = "1.1"
-uuid = { version = "1", features = ["v4"] }
+uuid = { version = "1", features = ["v4", "serde"] }
 num = { version = "0.4.3" }
 
 # Core.git crates we depend on
-arrow_util = { git = "https://github.com/influxdata/influxdb3_core", rev = "26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f" }
-authz = { git = "https://github.com/influxdata/influxdb3_core", rev = "26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f" }
-data_types = { git = "https://github.com/influxdata/influxdb3_core", rev = "26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f" }
-datafusion_util = { git = "https://github.com/influxdata/influxdb3_core", rev = "26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f" }
-executor = { git = "https://github.com/influxdata/influxdb3_core", rev = "26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f" }
-influxdb-line-protocol = { git = "https://github.com/influxdata/influxdb3_core", rev = "26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f", features = ["v3"]}
-influxdb_influxql_parser = { git = "https://github.com/influxdata/influxdb3_core", rev = "26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f" }
-influxdb_iox_client = { git = "https://github.com/influxdata/influxdb3_core", rev = "26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f" }
-iox_catalog = { git = "https://github.com/influxdata/influxdb3_core", rev = "26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f" }
-iox_http = { git = "https://github.com/influxdata/influxdb3_core", rev = "26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f" }
-iox_query = { git = "https://github.com/influxdata/influxdb3_core", rev = "26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f" }
-iox_query_params = { git = "https://github.com/influxdata/influxdb3_core", rev = "26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f" }
-iox_query_influxql = { git = "https://github.com/influxdata/influxdb3_core", rev = "26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f" }
-iox_system_tables = { git = "https://github.com/influxdata/influxdb3_core", rev = "26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f" }
-iox_time = { git = "https://github.com/influxdata/influxdb3_core", rev = "26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f" }
-metric = { git = "https://github.com/influxdata/influxdb3_core", rev = "26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f" }
-metric_exporters = { git = "https://github.com/influxdata/influxdb3_core", rev = "26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f" }
-object_store_metrics = { git = "https://github.com/influxdata/influxdb3_core", rev = "26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f" }
-observability_deps = { git = "https://github.com/influxdata/influxdb3_core", rev = "26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f" }
-panic_logging = { git = "https://github.com/influxdata/influxdb3_core", rev = "26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f" }
-parquet_file = { git = "https://github.com/influxdata/influxdb3_core", rev = "26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f" }
-schema = { git = "https://github.com/influxdata/influxdb3_core", rev = "26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f", features = ["v3"]}
-service_common = { git = "https://github.com/influxdata/influxdb3_core", rev = "26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f" }
-service_grpc_flight = { git = "https://github.com/influxdata/influxdb3_core", rev = "26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f" }
-test_helpers = { git = "https://github.com/influxdata/influxdb3_core", rev = "26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f" }
-tokio_metrics_bridge = { git = "https://github.com/influxdata/influxdb3_core", rev = "26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f" }
-trace = { git = "https://github.com/influxdata/influxdb3_core", rev = "26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f" }
-trace_exporters = { git = "https://github.com/influxdata/influxdb3_core", rev = "26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f" }
-trace_http = { git = "https://github.com/influxdata/influxdb3_core", rev = "26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f" }
-tracker = { git = "https://github.com/influxdata/influxdb3_core", rev = "26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f" }
-trogging = { git = "https://github.com/influxdata/influxdb3_core", rev = "26a30bf8d6e2b6b3f1dd905c4ec27e3db6e20d5f", features = ["clap"] }
+arrow_util = { git = "https://github.com/influxdata/influxdb3_core", rev = "d5e075085bba8e08916a442e9eb8bf91675268ac" }
+authz = { git = "https://github.com/influxdata/influxdb3_core", rev = "d5e075085bba8e08916a442e9eb8bf91675268ac" }
+data_types = { git = "https://github.com/influxdata/influxdb3_core", rev = "d5e075085bba8e08916a442e9eb8bf91675268ac" }
+datafusion_util = { git = "https://github.com/influxdata/influxdb3_core", rev = "d5e075085bba8e08916a442e9eb8bf91675268ac" }
+executor = { git = "https://github.com/influxdata/influxdb3_core", rev = "d5e075085bba8e08916a442e9eb8bf91675268ac" }
+influxdb-line-protocol = { git = "https://github.com/influxdata/influxdb3_core", rev = "d5e075085bba8e08916a442e9eb8bf91675268ac", features = ["v3"]}
+influxdb_influxql_parser = { git = "https://github.com/influxdata/influxdb3_core", rev = "d5e075085bba8e08916a442e9eb8bf91675268ac" }
+influxdb_iox_client = { git = "https://github.com/influxdata/influxdb3_core", rev = "d5e075085bba8e08916a442e9eb8bf91675268ac" }
+iox_http = { git = "https://github.com/influxdata/influxdb3_core", rev = "d5e075085bba8e08916a442e9eb8bf91675268ac" }
+iox_query = { git = "https://github.com/influxdata/influxdb3_core", rev = "d5e075085bba8e08916a442e9eb8bf91675268ac" }
+iox_query_params = { git = "https://github.com/influxdata/influxdb3_core", rev = "d5e075085bba8e08916a442e9eb8bf91675268ac" }
+iox_query_influxql = { git = "https://github.com/influxdata/influxdb3_core", rev = "d5e075085bba8e08916a442e9eb8bf91675268ac" }
+iox_system_tables = { git = "https://github.com/influxdata/influxdb3_core", rev = "d5e075085bba8e08916a442e9eb8bf91675268ac" }
+iox_time = { git = "https://github.com/influxdata/influxdb3_core", rev = "d5e075085bba8e08916a442e9eb8bf91675268ac" }
+metric = { git = "https://github.com/influxdata/influxdb3_core", rev = "d5e075085bba8e08916a442e9eb8bf91675268ac" }
+metric_exporters = { git = "https://github.com/influxdata/influxdb3_core", rev = "d5e075085bba8e08916a442e9eb8bf91675268ac" }
+object_store_metrics = { git = "https://github.com/influxdata/influxdb3_core", rev = "d5e075085bba8e08916a442e9eb8bf91675268ac" }
+observability_deps = { git = "https://github.com/influxdata/influxdb3_core", rev = "d5e075085bba8e08916a442e9eb8bf91675268ac" }
+panic_logging = { git = "https://github.com/influxdata/influxdb3_core", rev = "d5e075085bba8e08916a442e9eb8bf91675268ac" }
+parquet_file = { git = "https://github.com/influxdata/influxdb3_core", rev = "d5e075085bba8e08916a442e9eb8bf91675268ac" }
+schema = { git = "https://github.com/influxdata/influxdb3_core", rev = "d5e075085bba8e08916a442e9eb8bf91675268ac", features = ["v3"]}
+service_common = { git = "https://github.com/influxdata/influxdb3_core", rev = "d5e075085bba8e08916a442e9eb8bf91675268ac" }
+service_grpc_flight = { git = "https://github.com/influxdata/influxdb3_core", rev = "d5e075085bba8e08916a442e9eb8bf91675268ac" }
+test_helpers = { git = "https://github.com/influxdata/influxdb3_core", rev = "d5e075085bba8e08916a442e9eb8bf91675268ac" }
+tokio_metrics_bridge = { git = "https://github.com/influxdata/influxdb3_core", rev = "d5e075085bba8e08916a442e9eb8bf91675268ac" }
+trace = { git = "https://github.com/influxdata/influxdb3_core", rev = "d5e075085bba8e08916a442e9eb8bf91675268ac" }
+trace_exporters = { git = "https://github.com/influxdata/influxdb3_core", rev = "d5e075085bba8e08916a442e9eb8bf91675268ac" }
+trace_http = { git = "https://github.com/influxdata/influxdb3_core", rev = "d5e075085bba8e08916a442e9eb8bf91675268ac" }
+tracker = { git = "https://github.com/influxdata/influxdb3_core", rev = "d5e075085bba8e08916a442e9eb8bf91675268ac" }
+trogging = { git = "https://github.com/influxdata/influxdb3_core", rev = "d5e075085bba8e08916a442e9eb8bf91675268ac", features = ["clap"] }
 
 [workspace.lints.rust]
 missing_copy_implementations = "deny"
@@ -267,3 +266,4 @@ arrow-string = { git = "https://github.com/influxdata/arrow-rs.git", rev = "eae1
 arrow-ord = { git = "https://github.com/influxdata/arrow-rs.git", rev = "eae176c21b1ef915227294e8a8a201b6f266031a" }
 arrow-flight = { git = "https://github.com/influxdata/arrow-rs.git", rev = "eae176c21b1ef915227294e8a8a201b6f266031a" }
 parquet = { git = "https://github.com/influxdata/arrow-rs.git", rev = "eae176c21b1ef915227294e8a8a201b6f266031a" }
+object_store = { git = "https://github.com/influxdata/arrow-rs.git", rev = "c946cd81fa12e6588a3be33be08e3d8e9a2770e7" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -160,6 +160,7 @@ influxdb-line-protocol = { git = "https://github.com/influxdata/influxdb3_core",
 influxdb_influxql_parser = { git = "https://github.com/influxdata/influxdb3_core", rev = "d5e075085bba8e08916a442e9eb8bf91675268ac" }
 influxdb_iox_client = { git = "https://github.com/influxdata/influxdb3_core", rev = "d5e075085bba8e08916a442e9eb8bf91675268ac" }
 iox_http = { git = "https://github.com/influxdata/influxdb3_core", rev = "d5e075085bba8e08916a442e9eb8bf91675268ac" }
+iox_http_util = { git = "https://github.com/influxdata/influxdb3_core", rev = "d5e075085bba8e08916a442e9eb8bf91675268ac" }
 iox_query = { git = "https://github.com/influxdata/influxdb3_core", rev = "d5e075085bba8e08916a442e9eb8bf91675268ac" }
 iox_query_params = { git = "https://github.com/influxdata/influxdb3_core", rev = "d5e075085bba8e08916a442e9eb8bf91675268ac" }
 iox_query_influxql = { git = "https://github.com/influxdata/influxdb3_core", rev = "d5e075085bba8e08916a442e9eb8bf91675268ac" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,7 @@ futures-util = "0.3.31"
 hashbrown = { version = "0.15.1", features = ["serde"] }
 hex = "0.4.3"
 http = "0.2.9"
+http-body = "0.4.6"
 humantime = "2.1.0"
 hyper = "0.14"
 hyper-rustls = { version = "0.25", features = ["http1", "http2", "ring", "rustls-native-certs"] }

--- a/influxdb3/tests/server/mod.rs
+++ b/influxdb3/tests/server/mod.rs
@@ -276,7 +276,7 @@ impl TestServer {
         //
         // The file is deleted when it goes out of scope (the end of this method) by the TempDir type.
         let tmp_dir = TempDir::new().unwrap();
-        let tmp_dir_path = tmp_dir.into_path();
+        let tmp_dir_path = tmp_dir.keep();
         let tcp_addr_file = tmp_dir_path.join("tcp-listener");
         let mut command = Command::cargo_bin("influxdb3").expect("create the influxdb3 command");
         let command = command

--- a/influxdb3_cache/src/distinct_cache/table_function.rs
+++ b/influxdb3_cache/src/distinct_cache/table_function.rs
@@ -3,9 +3,9 @@ use std::{any::Any, sync::Arc};
 use arrow::{array::RecordBatch, datatypes::SchemaRef};
 use async_trait::async_trait;
 use datafusion::{
-    catalog::{Session, TableProvider},
+    catalog::{Session, TableFunctionImpl, TableProvider},
     common::{DFSchema, Result, internal_err, plan_err},
-    datasource::{TableType, function::TableFunctionImpl},
+    datasource::TableType,
     execution::context::ExecutionProps,
     logical_expr::TableProviderFilterPushDown,
     physical_expr::{

--- a/influxdb3_cache/src/last_cache/table_function.rs
+++ b/influxdb3_cache/src/last_cache/table_function.rs
@@ -3,9 +3,9 @@ use std::{any::Any, sync::Arc};
 use arrow::{array::RecordBatch, datatypes::SchemaRef};
 use async_trait::async_trait;
 use datafusion::{
-    catalog::{Session, TableProvider},
+    catalog::{Session, TableFunctionImpl, TableProvider},
     common::{DFSchema, internal_err, plan_err},
-    datasource::{TableType, function::TableFunctionImpl},
+    datasource::TableType,
     error::DataFusionError,
     execution::context::ExecutionProps,
     logical_expr::TableProviderFilterPushDown,

--- a/influxdb3_clap_blocks/Cargo.toml
+++ b/influxdb3_clap_blocks/Cargo.toml
@@ -18,7 +18,6 @@ http.workspace = true
 # object store crate uses the new version of the http crate
 http_1 = { version = "1.1", package = "http" }
 humantime.workspace = true
-iox_catalog.workspace = true
 iox_time.workspace = true
 itertools.workspace = true
 libc.workspace = true

--- a/influxdb3_clap_blocks/src/tokio.rs
+++ b/influxdb3_clap_blocks/src/tokio.rs
@@ -169,7 +169,7 @@ macro_rules! tokio_rt_config {
                         TokioRuntimeType::MultiThreadAlt => {
                             #[cfg(tokio_unstable)]
                             {
-                                tokio::runtime::Builder::new_multi_thread_alt()
+                                tokio::runtime::Builder::new_multi_thread()
                             }
                             #[cfg(not(tokio_unstable))]
                             {

--- a/influxdb3_processing_engine/Cargo.toml
+++ b/influxdb3_processing_engine/Cargo.toml
@@ -16,6 +16,7 @@ futures-util.workspace = true
 humantime.workspace = true
 hashbrown.workspace = true
 hyper.workspace = true
+iox_http_util.workspace = true
 iox_time.workspace = true
 influxdb3_catalog = { path = "../influxdb3_catalog" }
 influxdb3_client = { path = "../influxdb3_client" }

--- a/influxdb3_processing_engine/src/lib.rs
+++ b/influxdb3_processing_engine/src/lib.rs
@@ -6,7 +6,6 @@ use crate::plugins::{PluginError, ProcessingEngineEnvironmentManager};
 use anyhow::Context;
 use bytes::Bytes;
 use hashbrown::HashMap;
-use hyper::{Body, Response};
 use influxdb3_catalog::CatalogError;
 use influxdb3_catalog::catalog::Catalog;
 use influxdb3_catalog::channel::CatalogUpdateReceiver;
@@ -23,6 +22,7 @@ use influxdb3_types::http::{
 };
 use influxdb3_wal::{SnapshotDetails, WalContents, WalFileNotifier};
 use influxdb3_write::WriteBuffer;
+use iox_http_util::Response;
 use iox_time::TimeProvider;
 use observability_deps::tracing::{debug, error, warn};
 use parking_lot::Mutex;
@@ -587,7 +587,7 @@ impl ProcessingEngineManagerImpl {
         query_params: HashMap<String, String>,
         request_headers: HashMap<String, String>,
         request_body: Bytes,
-    ) -> Result<Response<Body>, ProcessingEngineError> {
+    ) -> Result<Response, ProcessingEngineError> {
         // oneshot channel for the response
         let (tx, rx) = oneshot::channel();
         let request = Request {
@@ -663,7 +663,7 @@ pub(crate) struct Request {
     pub query_params: HashMap<String, String>,
     pub headers: HashMap<String, String>,
     pub body: Bytes,
-    pub response_tx: oneshot::Sender<Response<Body>>,
+    pub response_tx: oneshot::Sender<Response>,
 }
 
 fn background_catalog_update(

--- a/influxdb3_processing_engine/src/lib.rs
+++ b/influxdb3_processing_engine/src/lib.rs
@@ -760,7 +760,9 @@ mod tests {
     use influxdb3_write::persister::Persister;
     use influxdb3_write::write_buffer::{WriteBufferImpl, WriteBufferImplArgs};
     use influxdb3_write::{Precision, WriteBuffer};
-    use iox_query::exec::{DedicatedExecutor, Executor, ExecutorConfig, IOxSessionContext};
+    use iox_query::exec::{
+        DedicatedExecutor, Executor, ExecutorConfig, IOxSessionContext, PerQueryMemoryPoolConfig,
+    };
     use iox_time::{MockProvider, Time, TimeProvider};
     use metric::Registry;
     use object_store::ObjectStore;
@@ -1065,6 +1067,8 @@ def process_writes(influxdb3_local, table_batches, args=None):
                 metric_registry: Arc::clone(&metrics),
                 // Default to 1gb
                 mem_pool_size: 1024 * 1024 * 1024, // 1024 (b/kb) * 1024 (kb/mb) * 1024 (mb/gb)
+                heap_memory_limit: None,
+                per_query_mem_pool_config: PerQueryMemoryPoolConfig::Disabled,
             },
             DedicatedExecutor::new_testing(),
         ))

--- a/influxdb3_processing_engine/src/plugins.rs
+++ b/influxdb3_processing_engine/src/plugins.rs
@@ -193,8 +193,8 @@ mod python_plugin {
     use futures_util::StreamExt;
     use futures_util::stream::FuturesUnordered;
     use humantime::{format_duration, parse_duration};
+    use hyper::StatusCode;
     use hyper::http::HeaderValue;
-    use hyper::{Body, StatusCode};
     use influxdb3_catalog::catalog::DatabaseSchema;
     use influxdb3_catalog::log::ErrorBehavior;
     use influxdb3_py_api::logging::LogLevel;
@@ -204,7 +204,7 @@ mod python_plugin {
     };
     use influxdb3_wal::{WalContents, WalOp};
     use influxdb3_write::Precision;
-    use iox_http_util::ResponseBuilder;
+    use iox_http_util::{ResponseBuilder, bytes_to_response_body};
     use iox_time::Time;
     use observability_deps::tracing::{info, warn};
     use std::str::FromStr;
@@ -514,7 +514,7 @@ mod python_plugin {
                                 }
 
                                 response
-                                    .body(Body::from(response_body))
+                                    .body(bytes_to_response_body(response_body))
                                     .context("building response")?
                             }
                             Err(e) => {
@@ -527,7 +527,7 @@ mod python_plugin {
                                 let body = serde_json::json!({"error": e.to_string()}).to_string();
                                 ResponseBuilder::new()
                                     .status(StatusCode::INTERNAL_SERVER_ERROR)
-                                    .body(Body::from(body))
+                                    .body(bytes_to_response_body(body))
                                     .context("building response")?
                             }
                         };

--- a/influxdb3_processing_engine/src/plugins.rs
+++ b/influxdb3_processing_engine/src/plugins.rs
@@ -194,7 +194,7 @@ mod python_plugin {
     use futures_util::stream::FuturesUnordered;
     use humantime::{format_duration, parse_duration};
     use hyper::http::HeaderValue;
-    use hyper::{Body, Response, StatusCode};
+    use hyper::{Body, StatusCode};
     use influxdb3_catalog::catalog::DatabaseSchema;
     use influxdb3_catalog::log::ErrorBehavior;
     use influxdb3_py_api::logging::LogLevel;
@@ -204,6 +204,7 @@ mod python_plugin {
     };
     use influxdb3_wal::{WalContents, WalOp};
     use influxdb3_write::Precision;
+    use iox_http_util::ResponseBuilder;
     use iox_time::Time;
     use observability_deps::tracing::{info, warn};
     use std::str::FromStr;
@@ -502,7 +503,7 @@ mod python_plugin {
 
                                 let response_status = StatusCode::from_u16(response_code)
                                     .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
-                                let mut response = Response::builder().status(response_status);
+                                let mut response = ResponseBuilder::new().status(response_status);
 
                                 for (key, value) in response_headers {
                                     response = response.header(
@@ -524,7 +525,7 @@ mod python_plugin {
                                 );
                                 error!(?self.trigger_definition, "error running request plugin: {}", e);
                                 let body = serde_json::json!({"error": e.to_string()}).to_string();
-                                Response::builder()
+                                ResponseBuilder::new()
                                     .status(StatusCode::INTERNAL_SERVER_ERROR)
                                     .body(Body::from(body))
                                     .context("building response")?

--- a/influxdb3_server/Cargo.toml
+++ b/influxdb3_server/Cargo.toml
@@ -15,7 +15,6 @@ data_types.workspace = true
 datafusion_util.workspace = true
 influxdb-line-protocol.workspace = true
 influxdb_influxql_parser.workspace = true
-iox_catalog.workspace = true
 iox_http.workspace = true
 iox_query.workspace = true
 iox_query_params.workspace = true

--- a/influxdb3_server/Cargo.toml
+++ b/influxdb3_server/Cargo.toml
@@ -16,6 +16,7 @@ datafusion_util.workspace = true
 influxdb-line-protocol.workspace = true
 influxdb_influxql_parser.workspace = true
 iox_http.workspace = true
+iox_http_util.workspace = true
 iox_query.workspace = true
 iox_query_params.workspace = true
 iox_query_influxql.workspace = true

--- a/influxdb3_server/Cargo.toml
+++ b/influxdb3_server/Cargo.toml
@@ -70,6 +70,7 @@ futures.workspace = true
 hashbrown.workspace = true
 hex.workspace = true
 http.workspace = true
+http-body.workspace = true
 hyper.workspace = true
 hyper-rustls.workspace = true
 humantime.workspace = true

--- a/influxdb3_server/src/http.rs
+++ b/influxdb3_server/src/http.rs
@@ -1432,7 +1432,7 @@ fn token_part_as_bytes(token: &str) -> Result<Vec<u8>, AuthenticationError> {
 impl From<authz::Error> for AuthenticationError {
     fn from(auth_error: authz::Error) -> Self {
         match auth_error {
-            authz::Error::Forbidden => Self::Forbidden,
+            authz::Error::Forbidden { .. } => Self::Forbidden,
             _ => Self::Unauthenticated,
         }
     }

--- a/influxdb3_server/src/http.rs
+++ b/influxdb3_server/src/http.rs
@@ -20,7 +20,7 @@ use hyper::header::AUTHORIZATION;
 use hyper::header::CONTENT_ENCODING;
 use hyper::header::CONTENT_TYPE;
 use hyper::http::HeaderValue;
-use hyper::{Body, Method, Request, Response, StatusCode};
+use hyper::{Body, Method, Response, StatusCode};
 use influxdb_influxql_parser::select::GroupByClause;
 use influxdb_influxql_parser::statement::Statement;
 use influxdb3_authz::{AuthProvider, NoAuthAuthenticator};
@@ -41,6 +41,7 @@ use influxdb3_write::write_buffer::Error as WriteBufferError;
 use iox_http::write::single_tenant::SingleTenantRequestUnifier;
 use iox_http::write::v1::V1_NAMESPACE_RP_SEPARATOR;
 use iox_http::write::{WriteParseError, WriteRequestUnifier};
+use iox_http_util::Request;
 use iox_query_influxql_rewrite as rewrite;
 use iox_query_params::StatementParams;
 use iox_time::TimeProvider;
@@ -548,7 +549,7 @@ impl HttpApi {
 }
 
 impl HttpApi {
-    async fn write_lp(&self, req: Request<Body>) -> Result<Response<Body>> {
+    async fn write_lp(&self, req: Request) -> Result<Response<Body>> {
         let query = req.uri().query().ok_or(Error::MissingWriteParams)?;
         let params: WriteParams = serde_urlencoded::from_str(query)?;
         self.write_lp_inner(params, req, false).await
@@ -557,7 +558,7 @@ impl HttpApi {
     async fn write_lp_inner(
         &self,
         params: WriteParams,
-        req: Request<Body>,
+        req: Request,
         accept_rp: bool,
     ) -> Result<Response<Body>> {
         validate_db_name(&params.db, accept_rp)?;
@@ -596,10 +597,7 @@ impl HttpApi {
         }
     }
 
-    pub(crate) async fn create_admin_token(
-        &self,
-        _req: Request<Body>,
-    ) -> Result<Response<Body>, Error> {
+    pub(crate) async fn create_admin_token(&self, _req: Request) -> Result<Response<Body>, Error> {
         let catalog = self.write_buffer.catalog();
         let (token_info, token) = catalog.create_admin_token(false).await?;
 
@@ -616,7 +614,7 @@ impl HttpApi {
 
     pub(crate) async fn regenerate_admin_token(
         &self,
-        _req: Request<Body>,
+        _req: Request,
     ) -> Result<Response<Body>, Error> {
         let catalog = self.write_buffer.catalog();
         let (token_info, token) = catalog.create_admin_token(true).await?;
@@ -632,7 +630,7 @@ impl HttpApi {
         Ok(body?)
     }
 
-    async fn query_sql(&self, req: Request<Body>) -> Result<Response<Body>> {
+    async fn query_sql(&self, req: Request) -> Result<Response<Body>> {
         let QueryRequest {
             database,
             query_str,
@@ -658,7 +656,7 @@ impl HttpApi {
             .map_err(Into::into)
     }
 
-    async fn query_influxql(&self, req: Request<Body>) -> Result<Response<Body>> {
+    async fn query_influxql(&self, req: Request) -> Result<Response<Body>> {
         let QueryRequest {
             database,
             query_str,
@@ -703,7 +701,7 @@ impl HttpApi {
 
     /// Parse the request's body into raw bytes, applying the configured size
     /// limits and decoding any content encoding.
-    async fn read_body(&self, req: hyper::Request<Body>) -> Result<Bytes> {
+    async fn read_body(&self, req: Request) -> Result<Bytes> {
         let encoding = req
             .headers()
             .get(&CONTENT_ENCODING)
@@ -758,10 +756,7 @@ impl HttpApi {
         Ok(decoded_data.into())
     }
 
-    async fn authenticate_request(
-        &self,
-        req: &mut Request<Body>,
-    ) -> Result<(), AuthenticationError> {
+    async fn authenticate_request(&self, req: &mut Request) -> Result<(), AuthenticationError> {
         // Extend the request with the authorization token; this is used downstream in some
         // APIs, such as write, that need the full header value to authorize a request.
         let auth_header = req.headers().get(AUTHORIZATION).cloned();
@@ -798,7 +793,7 @@ impl HttpApi {
 
     async fn extract_query_request<D: DeserializeOwned>(
         &self,
-        req: Request<Body>,
+        req: Request,
     ) -> Result<QueryRequest<D, QueryFormat, StatementParams>> {
         let header_format = QueryFormat::try_from_headers(req.headers())?;
         let request = match *req.method() {
@@ -896,7 +891,7 @@ impl HttpApi {
     /// If the result is to create a cache that already exists, with the same configuration, this
     /// will respond with a 204 NOT CREATED. If an existing cache would be overwritten with a
     /// different configuration, that is a 400 BAD REQUEST
-    async fn configure_distinct_cache_create(&self, req: Request<Body>) -> Result<Response<Body>> {
+    async fn configure_distinct_cache_create(&self, req: Request) -> Result<Response<Body>> {
         let args = self.read_body_json(req).await?;
         info!(?args, "create distinct value cache request");
         let DistinctCacheCreateRequest {
@@ -931,7 +926,7 @@ impl HttpApi {
     /// Delete a distinct value cache entry with the given [`DistinctCacheDeleteRequest`] parameters
     ///
     /// The parameters must be passed in either the query string or the body of the request as JSON.
-    async fn configure_distinct_cache_delete(&self, req: Request<Body>) -> Result<Response<Body>> {
+    async fn configure_distinct_cache_delete(&self, req: Request) -> Result<Response<Body>> {
         let DistinctCacheDeleteRequest { db, table, name } = if let Some(query) = req.uri().query()
         {
             serde_urlencoded::from_str(query)?
@@ -950,7 +945,7 @@ impl HttpApi {
             .map_err(Into::into)
     }
 
-    async fn configure_last_cache_create(&self, req: Request<Body>) -> Result<Response<Body>> {
+    async fn configure_last_cache_create(&self, req: Request) -> Result<Response<Body>> {
         let LastCacheCreateRequest {
             db,
             table,
@@ -986,7 +981,7 @@ impl HttpApi {
     ///
     /// This will first attempt to parse the parameters from the URI query string, if a query string
     /// is provided, but if not, will attempt to parse them from the request body as JSON.
-    async fn configure_last_cache_delete(&self, req: Request<Body>) -> Result<Response<Body>> {
+    async fn configure_last_cache_delete(&self, req: Request) -> Result<Response<Body>> {
         let LastCacheDeleteRequest { db, table, name } = if let Some(query) = req.uri().query() {
             serde_urlencoded::from_str(query)?
         } else {
@@ -1004,10 +999,7 @@ impl HttpApi {
             .map_err(Into::into)
     }
 
-    async fn configure_processing_engine_trigger(
-        &self,
-        req: Request<Body>,
-    ) -> Result<Response<Body>> {
+    async fn configure_processing_engine_trigger(&self, req: Request) -> Result<Response<Body>> {
         let ProcessingEngineTriggerCreateRequest {
             db,
             plugin_filename,
@@ -1044,7 +1036,7 @@ impl HttpApi {
             .body(Body::empty())?)
     }
 
-    async fn delete_processing_engine_trigger(&self, req: Request<Body>) -> Result<Response<Body>> {
+    async fn delete_processing_engine_trigger(&self, req: Request) -> Result<Response<Body>> {
         let ProcessingEngineTriggerDeleteRequest {
             db,
             trigger_name,
@@ -1063,10 +1055,7 @@ impl HttpApi {
             .body(Body::empty())?)
     }
 
-    async fn disable_processing_engine_trigger(
-        &self,
-        req: Request<Body>,
-    ) -> Result<Response<Body>> {
+    async fn disable_processing_engine_trigger(&self, req: Request) -> Result<Response<Body>> {
         let query = req.uri().query().unwrap_or("");
         let ProcessingEngineTriggerIdentifier { db, trigger_name } =
             serde_urlencoded::from_str(query)?;
@@ -1083,7 +1072,7 @@ impl HttpApi {
         }
     }
 
-    async fn enable_processing_engine_trigger(&self, req: Request<Body>) -> Result<Response<Body>> {
+    async fn enable_processing_engine_trigger(&self, req: Request) -> Result<Response<Body>> {
         let query = req.uri().query().unwrap_or("");
         let ProcessingEngineTriggerIdentifier { db, trigger_name } =
             serde_urlencoded::from_str(query)?;
@@ -1100,10 +1089,7 @@ impl HttpApi {
         }
     }
 
-    async fn install_plugin_environment_packages(
-        &self,
-        req: Request<Body>,
-    ) -> Result<Response<Body>> {
+    async fn install_plugin_environment_packages(&self, req: Request) -> Result<Response<Body>> {
         let ProcessingEngineInstallPackagesRequest { packages } =
             if let Some(query) = req.uri().query() {
                 serde_urlencoded::from_str(query)?
@@ -1122,7 +1108,7 @@ impl HttpApi {
 
     async fn install_plugin_environment_requirements(
         &self,
-        req: Request<Body>,
+        req: Request,
     ) -> Result<Response<Body>> {
         let ProcessingEngineInstallRequirementsRequest {
             requirements_location,
@@ -1145,7 +1131,7 @@ impl HttpApi {
             .body(Body::empty())?)
     }
 
-    async fn show_databases(&self, req: Request<Body>) -> Result<Response<Body>> {
+    async fn show_databases(&self, req: Request) -> Result<Response<Body>> {
         let query = req.uri().query().unwrap_or("");
         let ShowDatabasesRequest {
             format,
@@ -1159,7 +1145,7 @@ impl HttpApi {
             .map_err(Into::into)
     }
 
-    async fn create_database(&self, req: Request<Body>) -> Result<Response<Body>> {
+    async fn create_database(&self, req: Request) -> Result<Response<Body>> {
         let CreateDatabaseRequest { db } = self.read_body_json(req).await?;
         self.write_buffer.catalog().create_database(&db).await?;
         Ok(Response::builder()
@@ -1169,10 +1155,7 @@ impl HttpApi {
     }
 
     /// Endpoint for testing a plugin that will be trigger on WAL writes.
-    async fn test_processing_engine_wal_plugin(
-        &self,
-        req: Request<Body>,
-    ) -> Result<Response<Body>> {
+    async fn test_processing_engine_wal_plugin(&self, req: Request) -> Result<Response<Body>> {
         let request: influxdb3_types::http::WalPluginTestRequest = self.read_body_json(req).await?;
 
         let output = self
@@ -1186,10 +1169,7 @@ impl HttpApi {
             .body(Body::from(body))?)
     }
 
-    async fn test_processing_engine_schedule_plugin(
-        &self,
-        req: Request<Body>,
-    ) -> Result<Response<Body>> {
+    async fn test_processing_engine_schedule_plugin(&self, req: Request) -> Result<Response<Body>> {
         let request: influxdb3_types::http::SchedulePluginTestRequest =
             self.read_body_json(req).await?;
 
@@ -1207,7 +1187,7 @@ impl HttpApi {
     async fn processing_engine_request_plugin(
         &self,
         trigger_path: &str,
-        req: Request<Body>,
+        req: Request,
     ) -> Result<Response<Body>> {
         use hashbrown::HashMap;
 
@@ -1249,7 +1229,7 @@ impl HttpApi {
         }
     }
 
-    async fn delete_database(&self, req: Request<Body>) -> Result<Response<Body>> {
+    async fn delete_database(&self, req: Request) -> Result<Response<Body>> {
         let query = req.uri().query().unwrap_or("");
         let delete_req = serde_urlencoded::from_str::<DeleteDatabaseRequest>(query)?;
         self.write_buffer
@@ -1262,7 +1242,7 @@ impl HttpApi {
             .unwrap())
     }
 
-    async fn create_table(&self, req: Request<Body>) -> Result<Response<Body>> {
+    async fn create_table(&self, req: Request) -> Result<Response<Body>> {
         let CreateTableRequest {
             db,
             table,
@@ -1287,7 +1267,7 @@ impl HttpApi {
             .unwrap())
     }
 
-    async fn delete_table(&self, req: Request<Body>) -> Result<Response<Body>> {
+    async fn delete_table(&self, req: Request) -> Result<Response<Body>> {
         let query = req.uri().query().unwrap_or("");
         let delete_req = serde_urlencoded::from_str::<DeleteTableRequest>(query)?;
         self.write_buffer
@@ -1300,7 +1280,7 @@ impl HttpApi {
             .unwrap())
     }
 
-    async fn delete_token(&self, req: Request<Body>) -> Result<Response<Body>> {
+    async fn delete_token(&self, req: Request) -> Result<Response<Body>> {
         let query = req.uri().query().unwrap_or("");
         let delete_req = serde_urlencoded::from_str::<TokenDeleteRequest>(query)?;
         self.write_buffer
@@ -1313,10 +1293,7 @@ impl HttpApi {
             .unwrap())
     }
 
-    async fn read_body_json<ReqBody: DeserializeOwned>(
-        &self,
-        req: hyper::Request<Body>,
-    ) -> Result<ReqBody> {
+    async fn read_body_json<ReqBody: DeserializeOwned>(&self, req: Request) -> Result<ReqBody> {
         if !json_content_type(req.headers()) {
             return Err(Error::InvalidContentType {
                 expected: mime::APPLICATION_JSON,
@@ -1361,7 +1338,7 @@ struct V1AuthParameters {
 
 /// Extract the authentication token for v1 API requests, which may use the `p` query
 /// parameter to pass the authentication token.
-fn extract_v1_auth_token(req: &mut Request<Body>) -> Option<Vec<u8>> {
+fn extract_v1_auth_token(req: &mut Request) -> Option<Vec<u8>> {
     req.uri()
         .path_and_query()
         .and_then(|pq| match pq.path() {
@@ -1710,7 +1687,7 @@ async fn record_batch_stream_to_body(
 
 pub(crate) async fn route_request(
     http_server: Arc<HttpApi>,
-    mut req: Request<Body>,
+    mut req: Request,
     started_without_auth: bool,
     paths_without_authz: &'static Vec<&'static str>,
 ) -> Result<Response<Body>, Infallible> {
@@ -1880,7 +1857,7 @@ pub(crate) async fn route_request(
 
 async fn authenticate(
     http_server: &Arc<HttpApi>,
-    req: &mut Request<Body>,
+    req: &mut Request,
 ) -> Option<std::result::Result<Response<Body>, Infallible>> {
     if let Err(e) = http_server.authenticate_request(req).await {
         match e {

--- a/influxdb3_server/src/http.rs
+++ b/influxdb3_server/src/http.rs
@@ -1924,7 +1924,7 @@ mod tests {
     use arrow_array::{Int32Array, RecordBatch, record_batch};
     use datafusion::execution::SendableRecordBatchStream;
     use datafusion::physical_plan::stream::RecordBatchStreamAdapter;
-    use hyper::body::to_bytes;
+    use iox_http_util::read_body_bytes_for_tests;
     use pretty_assertions::assert_eq;
     use std::str;
     use std::sync::Arc;
@@ -1973,13 +1973,12 @@ mod tests {
     async fn test_json_output_empty() {
         // Turn RecordBatches into a Body and then collect into Bytes to assert
         // their validity
-        let bytes = to_bytes(
+        let bytes = read_body_bytes_for_tests(
             record_batch_stream_to_body(make_record_stream(None), QueryFormat::Json)
                 .await
                 .unwrap(),
         )
-        .await
-        .unwrap();
+        .await;
         assert_eq!(str::from_utf8(bytes.as_ref()).unwrap(), "[]");
     }
 
@@ -1987,19 +1986,18 @@ mod tests {
     async fn test_json_output_one_record() {
         // Turn RecordBatches into a Body and then collect into Bytes to assert
         // their validity
-        let bytes = to_bytes(
+        let bytes = read_body_bytes_for_tests(
             record_batch_stream_to_body(make_record_stream(Some(1)), QueryFormat::Json)
                 .await
                 .unwrap(),
         )
-        .await
-        .unwrap();
+        .await;
         assert_eq!(str::from_utf8(bytes.as_ref()).unwrap(), "[{\"a\":1}]");
     }
 
     #[tokio::test]
     async fn test_json_output_all_empties() {
-        let bytes = to_bytes(
+        let bytes = read_body_bytes_for_tests(
             record_batch_stream_to_body(
                 make_record_stream_with_sizes(vec![0, 0, 0]),
                 QueryFormat::Json,
@@ -2007,14 +2005,13 @@ mod tests {
             .await
             .unwrap(),
         )
-        .await
-        .unwrap();
+        .await;
         assert_eq!(str::from_utf8(bytes.as_ref()).unwrap(), "[]");
     }
 
     #[tokio::test]
     async fn test_empty_present_mixture() {
-        let bytes = to_bytes(
+        let bytes = read_body_bytes_for_tests(
             record_batch_stream_to_body(
                 make_record_stream_with_sizes(vec![0, 0, 1, 1, 0, 1, 0]),
                 QueryFormat::Json,
@@ -2022,8 +2019,7 @@ mod tests {
             .await
             .unwrap(),
         )
-        .await
-        .unwrap();
+        .await;
         assert_eq!(
             str::from_utf8(bytes.as_ref()).unwrap(),
             "[{\"a\":1},{\"a\":1},{\"a\":1}]"
@@ -2033,13 +2029,12 @@ mod tests {
     async fn test_json_output_three_records() {
         // Turn RecordBatches into a Body and then collect into Bytes to assert
         // their validity
-        let bytes = to_bytes(
+        let bytes = read_body_bytes_for_tests(
             record_batch_stream_to_body(make_record_stream(Some(3)), QueryFormat::Json)
                 .await
                 .unwrap(),
         )
-        .await
-        .unwrap();
+        .await;
         assert_eq!(
             str::from_utf8(bytes.as_ref()).unwrap(),
             "[{\"a\":1},{\"a\":1},{\"a\":1}]"
@@ -2049,13 +2044,12 @@ mod tests {
     async fn test_json_output_five_records() {
         // Turn RecordBatches into a Body and then collect into Bytes to assert
         // their validity
-        let bytes = to_bytes(
+        let bytes = read_body_bytes_for_tests(
             record_batch_stream_to_body(make_record_stream(Some(5)), QueryFormat::Json)
                 .await
                 .unwrap(),
         )
-        .await
-        .unwrap();
+        .await;
         assert_eq!(
             str::from_utf8(bytes.as_ref()).unwrap(),
             "[{\"a\":1},{\"a\":1},{\"a\":1},{\"a\":1},{\"a\":1}]"
@@ -2066,13 +2060,12 @@ mod tests {
     async fn test_jsonl_output_empty() {
         // Turn RecordBatches into a Body and then collect into Bytes to assert
         // their validity
-        let bytes = to_bytes(
+        let bytes = read_body_bytes_for_tests(
             record_batch_stream_to_body(make_record_stream(None), QueryFormat::JsonLines)
                 .await
                 .unwrap(),
         )
-        .await
-        .unwrap();
+        .await;
         assert_eq!(str::from_utf8(bytes.as_ref()).unwrap(), "");
     }
 
@@ -2080,26 +2073,24 @@ mod tests {
     async fn test_jsonl_output_one_record() {
         // Turn RecordBatches into a Body and then collect into Bytes to assert
         // their validity
-        let bytes = to_bytes(
+        let bytes = read_body_bytes_for_tests(
             record_batch_stream_to_body(make_record_stream(Some(1)), QueryFormat::JsonLines)
                 .await
                 .unwrap(),
         )
-        .await
-        .unwrap();
+        .await;
         assert_eq!(str::from_utf8(bytes.as_ref()).unwrap(), "{\"a\":1}\n");
     }
     #[tokio::test]
     async fn test_jsonl_output_three_records() {
         // Turn RecordBatches into a Body and then collect into Bytes to assert
         // their validity
-        let bytes = to_bytes(
+        let bytes = read_body_bytes_for_tests(
             record_batch_stream_to_body(make_record_stream(Some(3)), QueryFormat::JsonLines)
                 .await
                 .unwrap(),
         )
-        .await
-        .unwrap();
+        .await;
         assert_eq!(
             str::from_utf8(bytes.as_ref()).unwrap(),
             "{\"a\":1}\n{\"a\":1}\n{\"a\":1}\n"
@@ -2109,13 +2100,12 @@ mod tests {
     async fn test_jsonl_output_five_records() {
         // Turn RecordBatches into a Body and then collect into Bytes to assert
         // their validity
-        let bytes = to_bytes(
+        let bytes = read_body_bytes_for_tests(
             record_batch_stream_to_body(make_record_stream(Some(5)), QueryFormat::JsonLines)
                 .await
                 .unwrap(),
         )
-        .await
-        .unwrap();
+        .await;
         assert_eq!(
             str::from_utf8(bytes.as_ref()).unwrap(),
             "{\"a\":1}\n{\"a\":1}\n{\"a\":1}\n{\"a\":1}\n{\"a\":1}\n"
@@ -2125,13 +2115,12 @@ mod tests {
     async fn test_csv_output_empty() {
         // Turn RecordBatches into a Body and then collect into Bytes to assert
         // their validity
-        let bytes = to_bytes(
+        let bytes = read_body_bytes_for_tests(
             record_batch_stream_to_body(make_record_stream(None), QueryFormat::Csv)
                 .await
                 .unwrap(),
         )
-        .await
-        .unwrap();
+        .await;
         assert_eq!(str::from_utf8(bytes.as_ref()).unwrap(), "");
     }
 
@@ -2139,39 +2128,36 @@ mod tests {
     async fn test_csv_output_one_record() {
         // Turn RecordBatches into a Body and then collect into Bytes to assert
         // their validity
-        let bytes = to_bytes(
+        let bytes = read_body_bytes_for_tests(
             record_batch_stream_to_body(make_record_stream(Some(1)), QueryFormat::Csv)
                 .await
                 .unwrap(),
         )
-        .await
-        .unwrap();
+        .await;
         assert_eq!(str::from_utf8(bytes.as_ref()).unwrap(), "a\n1\n");
     }
     #[tokio::test]
     async fn test_csv_output_three_records() {
         // Turn RecordBatches into a Body and then collect into Bytes to assert
         // their validity
-        let bytes = to_bytes(
+        let bytes = read_body_bytes_for_tests(
             record_batch_stream_to_body(make_record_stream(Some(3)), QueryFormat::Csv)
                 .await
                 .unwrap(),
         )
-        .await
-        .unwrap();
+        .await;
         assert_eq!(str::from_utf8(bytes.as_ref()).unwrap(), "a\n1\n1\n1\n");
     }
     #[tokio::test]
     async fn test_csv_output_five_records() {
         // Turn RecordBatches into a Body and then collect into Bytes to assert
         // their validity
-        let bytes = to_bytes(
+        let bytes = read_body_bytes_for_tests(
             record_batch_stream_to_body(make_record_stream(Some(5)), QueryFormat::Csv)
                 .await
                 .unwrap(),
         )
-        .await
-        .unwrap();
+        .await;
         assert_eq!(
             str::from_utf8(bytes.as_ref()).unwrap(),
             "a\n1\n1\n1\n1\n1\n"

--- a/influxdb3_server/src/http.rs
+++ b/influxdb3_server/src/http.rs
@@ -20,7 +20,7 @@ use hyper::header::AUTHORIZATION;
 use hyper::header::CONTENT_ENCODING;
 use hyper::header::CONTENT_TYPE;
 use hyper::http::HeaderValue;
-use hyper::{Body, Method, StatusCode};
+use hyper::{Method, StatusCode};
 use influxdb_influxql_parser::select::GroupByClause;
 use influxdb_influxql_parser::statement::Statement;
 use influxdb3_authz::{AuthProvider, NoAuthAuthenticator};
@@ -43,6 +43,7 @@ use iox_http::write::v1::V1_NAMESPACE_RP_SEPARATOR;
 use iox_http::write::{WriteParseError, WriteRequestUnifier};
 use iox_http_util::{
     Request, Response, ResponseBody, ResponseBuilder, bytes_to_response_body, empty_response_body,
+    stream_results_to_response_body,
 };
 use iox_query_influxql_rewrite as rewrite;
 use iox_query_params::StatementParams;
@@ -1561,9 +1562,9 @@ async fn record_batch_stream_to_body(
                 first_poll: true,
                 stream,
             };
-            Ok(Body::wrap_stream(futures::stream::poll_fn(move |ctx| {
-                future.poll_unpin(ctx)
-            })))
+            Ok(stream_results_to_response_body(futures::stream::poll_fn(
+                move |ctx| future.poll_unpin(ctx),
+            )))
         }
         QueryFormat::Json => {
             struct JsonFuture {
@@ -1658,9 +1659,9 @@ async fn record_batch_stream_to_body(
                 state: State::FirstPoll,
                 stream,
             };
-            Ok(Body::wrap_stream(futures::stream::poll_fn(move |ctx| {
-                future.poll_unpin(ctx)
-            })))
+            Ok(stream_results_to_response_body(futures::stream::poll_fn(
+                move |ctx| future.poll_unpin(ctx),
+            )))
         }
         QueryFormat::JsonLines => {
             let stream = futures::stream::poll_fn(move |ctx| match stream.poll_next_unpin(ctx) {
@@ -1682,7 +1683,7 @@ async fn record_batch_stream_to_body(
                 Poll::Ready(None) => Poll::Ready(None),
                 Poll::Pending => Poll::Pending,
             });
-            Ok(Body::wrap_stream(stream))
+            Ok(stream_results_to_response_body(stream))
         }
     }
 }

--- a/influxdb3_server/src/http.rs
+++ b/influxdb3_server/src/http.rs
@@ -20,7 +20,7 @@ use hyper::header::AUTHORIZATION;
 use hyper::header::CONTENT_ENCODING;
 use hyper::header::CONTENT_TYPE;
 use hyper::http::HeaderValue;
-use hyper::{Body, Method, Response, StatusCode};
+use hyper::{Body, Method, StatusCode};
 use influxdb_influxql_parser::select::GroupByClause;
 use influxdb_influxql_parser::statement::Statement;
 use influxdb3_authz::{AuthProvider, NoAuthAuthenticator};
@@ -41,7 +41,7 @@ use influxdb3_write::write_buffer::Error as WriteBufferError;
 use iox_http::write::single_tenant::SingleTenantRequestUnifier;
 use iox_http::write::v1::V1_NAMESPACE_RP_SEPARATOR;
 use iox_http::write::{WriteParseError, WriteRequestUnifier};
-use iox_http_util::Request;
+use iox_http_util::{Request, Response};
 use iox_query_influxql_rewrite as rewrite;
 use iox_query_params::StatementParams;
 use iox_time::TimeProvider;
@@ -259,11 +259,11 @@ struct ErrorMessage<T: Serialize> {
 }
 
 trait IntoResponse {
-    fn into_response(self) -> Response<Body>;
+    fn into_response(self) -> Response;
 }
 
 impl IntoResponse for CatalogError {
-    fn into_response(self) -> Response<Body> {
+    fn into_response(self) -> Response {
         match self {
             Self::NotFound => Response::builder()
                 .status(StatusCode::NOT_FOUND)
@@ -308,7 +308,7 @@ impl IntoResponse for CatalogError {
 
 impl IntoResponse for Error {
     /// Convert this error into an HTTP [`Response`]
-    fn into_response(self) -> Response<Body> {
+    fn into_response(self) -> Response {
         debug!(error = ?self, "API error");
         match self {
             Self::Catalog(err @ CatalogError::CannotDeleteOperatorToken) => Response::builder()
@@ -549,7 +549,7 @@ impl HttpApi {
 }
 
 impl HttpApi {
-    async fn write_lp(&self, req: Request) -> Result<Response<Body>> {
+    async fn write_lp(&self, req: Request) -> Result<Response> {
         let query = req.uri().query().ok_or(Error::MissingWriteParams)?;
         let params: WriteParams = serde_urlencoded::from_str(query)?;
         self.write_lp_inner(params, req, false).await
@@ -560,7 +560,7 @@ impl HttpApi {
         params: WriteParams,
         req: Request,
         accept_rp: bool,
-    ) -> Result<Response<Body>> {
+    ) -> Result<Response> {
         validate_db_name(&params.db, accept_rp)?;
         let body = self.read_body(req).await?;
         let body = std::str::from_utf8(&body).map_err(Error::NonUtf8Body)?;
@@ -597,7 +597,7 @@ impl HttpApi {
         }
     }
 
-    pub(crate) async fn create_admin_token(&self, _req: Request) -> Result<Response<Body>, Error> {
+    pub(crate) async fn create_admin_token(&self, _req: Request) -> Result<Response, Error> {
         let catalog = self.write_buffer.catalog();
         let (token_info, token) = catalog.create_admin_token(false).await?;
 
@@ -612,10 +612,7 @@ impl HttpApi {
         Ok(body?)
     }
 
-    pub(crate) async fn regenerate_admin_token(
-        &self,
-        _req: Request,
-    ) -> Result<Response<Body>, Error> {
+    pub(crate) async fn regenerate_admin_token(&self, _req: Request) -> Result<Response, Error> {
         let catalog = self.write_buffer.catalog();
         let (token_info, token) = catalog.create_admin_token(true).await?;
 
@@ -630,7 +627,7 @@ impl HttpApi {
         Ok(body?)
     }
 
-    async fn query_sql(&self, req: Request) -> Result<Response<Body>> {
+    async fn query_sql(&self, req: Request) -> Result<Response> {
         let QueryRequest {
             database,
             query_str,
@@ -656,7 +653,7 @@ impl HttpApi {
             .map_err(Into::into)
     }
 
-    async fn query_influxql(&self, req: Request) -> Result<Response<Body>> {
+    async fn query_influxql(&self, req: Request) -> Result<Response> {
         let QueryRequest {
             database,
             query_str,
@@ -676,12 +673,12 @@ impl HttpApi {
             .map_err(Into::into)
     }
 
-    fn health(&self) -> Result<Response<Body>> {
+    fn health(&self) -> Result<Response> {
         let response_body = "OK";
         Ok(Response::new(Body::from(response_body.to_string())))
     }
 
-    fn ping(&self) -> Result<Response<Body>> {
+    fn ping(&self) -> Result<Response> {
         let body = serde_json::to_string(&PingResponse {
             version: INFLUXDB3_VERSION.to_string(),
             revision: INFLUXDB3_GIT_HASH_SHORT.to_string(),
@@ -691,7 +688,7 @@ impl HttpApi {
         Ok(Response::new(Body::from(body)))
     }
 
-    fn handle_metrics(&self) -> Result<Response<Body>> {
+    fn handle_metrics(&self) -> Result<Response> {
         let mut body: Vec<u8> = Default::default();
         let mut reporter = metric_exporters::PrometheusTextEncoder::new(&mut body);
         self.common_state.metrics.report(&mut reporter);
@@ -891,7 +888,7 @@ impl HttpApi {
     /// If the result is to create a cache that already exists, with the same configuration, this
     /// will respond with a 204 NOT CREATED. If an existing cache would be overwritten with a
     /// different configuration, that is a 400 BAD REQUEST
-    async fn configure_distinct_cache_create(&self, req: Request) -> Result<Response<Body>> {
+    async fn configure_distinct_cache_create(&self, req: Request) -> Result<Response> {
         let args = self.read_body_json(req).await?;
         info!(?args, "create distinct value cache request");
         let DistinctCacheCreateRequest {
@@ -926,7 +923,7 @@ impl HttpApi {
     /// Delete a distinct value cache entry with the given [`DistinctCacheDeleteRequest`] parameters
     ///
     /// The parameters must be passed in either the query string or the body of the request as JSON.
-    async fn configure_distinct_cache_delete(&self, req: Request) -> Result<Response<Body>> {
+    async fn configure_distinct_cache_delete(&self, req: Request) -> Result<Response> {
         let DistinctCacheDeleteRequest { db, table, name } = if let Some(query) = req.uri().query()
         {
             serde_urlencoded::from_str(query)?
@@ -945,7 +942,7 @@ impl HttpApi {
             .map_err(Into::into)
     }
 
-    async fn configure_last_cache_create(&self, req: Request) -> Result<Response<Body>> {
+    async fn configure_last_cache_create(&self, req: Request) -> Result<Response> {
         let LastCacheCreateRequest {
             db,
             table,
@@ -981,7 +978,7 @@ impl HttpApi {
     ///
     /// This will first attempt to parse the parameters from the URI query string, if a query string
     /// is provided, but if not, will attempt to parse them from the request body as JSON.
-    async fn configure_last_cache_delete(&self, req: Request) -> Result<Response<Body>> {
+    async fn configure_last_cache_delete(&self, req: Request) -> Result<Response> {
         let LastCacheDeleteRequest { db, table, name } = if let Some(query) = req.uri().query() {
             serde_urlencoded::from_str(query)?
         } else {
@@ -999,7 +996,7 @@ impl HttpApi {
             .map_err(Into::into)
     }
 
-    async fn configure_processing_engine_trigger(&self, req: Request) -> Result<Response<Body>> {
+    async fn configure_processing_engine_trigger(&self, req: Request) -> Result<Response> {
         let ProcessingEngineTriggerCreateRequest {
             db,
             plugin_filename,
@@ -1036,7 +1033,7 @@ impl HttpApi {
             .body(Body::empty())?)
     }
 
-    async fn delete_processing_engine_trigger(&self, req: Request) -> Result<Response<Body>> {
+    async fn delete_processing_engine_trigger(&self, req: Request) -> Result<Response> {
         let ProcessingEngineTriggerDeleteRequest {
             db,
             trigger_name,
@@ -1055,7 +1052,7 @@ impl HttpApi {
             .body(Body::empty())?)
     }
 
-    async fn disable_processing_engine_trigger(&self, req: Request) -> Result<Response<Body>> {
+    async fn disable_processing_engine_trigger(&self, req: Request) -> Result<Response> {
         let query = req.uri().query().unwrap_or("");
         let ProcessingEngineTriggerIdentifier { db, trigger_name } =
             serde_urlencoded::from_str(query)?;
@@ -1072,7 +1069,7 @@ impl HttpApi {
         }
     }
 
-    async fn enable_processing_engine_trigger(&self, req: Request) -> Result<Response<Body>> {
+    async fn enable_processing_engine_trigger(&self, req: Request) -> Result<Response> {
         let query = req.uri().query().unwrap_or("");
         let ProcessingEngineTriggerIdentifier { db, trigger_name } =
             serde_urlencoded::from_str(query)?;
@@ -1089,7 +1086,7 @@ impl HttpApi {
         }
     }
 
-    async fn install_plugin_environment_packages(&self, req: Request) -> Result<Response<Body>> {
+    async fn install_plugin_environment_packages(&self, req: Request) -> Result<Response> {
         let ProcessingEngineInstallPackagesRequest { packages } =
             if let Some(query) = req.uri().query() {
                 serde_urlencoded::from_str(query)?
@@ -1106,10 +1103,7 @@ impl HttpApi {
             .body(Body::empty())?)
     }
 
-    async fn install_plugin_environment_requirements(
-        &self,
-        req: Request,
-    ) -> Result<Response<Body>> {
+    async fn install_plugin_environment_requirements(&self, req: Request) -> Result<Response> {
         let ProcessingEngineInstallRequirementsRequest {
             requirements_location,
         } = if let Some(query) = req.uri().query() {
@@ -1131,7 +1125,7 @@ impl HttpApi {
             .body(Body::empty())?)
     }
 
-    async fn show_databases(&self, req: Request) -> Result<Response<Body>> {
+    async fn show_databases(&self, req: Request) -> Result<Response> {
         let query = req.uri().query().unwrap_or("");
         let ShowDatabasesRequest {
             format,
@@ -1145,7 +1139,7 @@ impl HttpApi {
             .map_err(Into::into)
     }
 
-    async fn create_database(&self, req: Request) -> Result<Response<Body>> {
+    async fn create_database(&self, req: Request) -> Result<Response> {
         let CreateDatabaseRequest { db } = self.read_body_json(req).await?;
         self.write_buffer.catalog().create_database(&db).await?;
         Ok(Response::builder()
@@ -1155,7 +1149,7 @@ impl HttpApi {
     }
 
     /// Endpoint for testing a plugin that will be trigger on WAL writes.
-    async fn test_processing_engine_wal_plugin(&self, req: Request) -> Result<Response<Body>> {
+    async fn test_processing_engine_wal_plugin(&self, req: Request) -> Result<Response> {
         let request: influxdb3_types::http::WalPluginTestRequest = self.read_body_json(req).await?;
 
         let output = self
@@ -1169,7 +1163,7 @@ impl HttpApi {
             .body(Body::from(body))?)
     }
 
-    async fn test_processing_engine_schedule_plugin(&self, req: Request) -> Result<Response<Body>> {
+    async fn test_processing_engine_schedule_plugin(&self, req: Request) -> Result<Response> {
         let request: influxdb3_types::http::SchedulePluginTestRequest =
             self.read_body_json(req).await?;
 
@@ -1188,7 +1182,7 @@ impl HttpApi {
         &self,
         trigger_path: &str,
         req: Request,
-    ) -> Result<Response<Body>> {
+    ) -> Result<Response> {
         use hashbrown::HashMap;
 
         // pull out the query params into a hashmap
@@ -1229,7 +1223,7 @@ impl HttpApi {
         }
     }
 
-    async fn delete_database(&self, req: Request) -> Result<Response<Body>> {
+    async fn delete_database(&self, req: Request) -> Result<Response> {
         let query = req.uri().query().unwrap_or("");
         let delete_req = serde_urlencoded::from_str::<DeleteDatabaseRequest>(query)?;
         self.write_buffer
@@ -1242,7 +1236,7 @@ impl HttpApi {
             .unwrap())
     }
 
-    async fn create_table(&self, req: Request) -> Result<Response<Body>> {
+    async fn create_table(&self, req: Request) -> Result<Response> {
         let CreateTableRequest {
             db,
             table,
@@ -1267,7 +1261,7 @@ impl HttpApi {
             .unwrap())
     }
 
-    async fn delete_table(&self, req: Request) -> Result<Response<Body>> {
+    async fn delete_table(&self, req: Request) -> Result<Response> {
         let query = req.uri().query().unwrap_or("");
         let delete_req = serde_urlencoded::from_str::<DeleteTableRequest>(query)?;
         self.write_buffer
@@ -1280,7 +1274,7 @@ impl HttpApi {
             .unwrap())
     }
 
-    async fn delete_token(&self, req: Request) -> Result<Response<Body>> {
+    async fn delete_token(&self, req: Request) -> Result<Response> {
         let query = req.uri().query().unwrap_or("");
         let delete_req = serde_urlencoded::from_str::<TokenDeleteRequest>(query)?;
         self.write_buffer
@@ -1690,7 +1684,7 @@ pub(crate) async fn route_request(
     mut req: Request,
     started_without_auth: bool,
     paths_without_authz: &'static Vec<&'static str>,
-) -> Result<Response<Body>, Infallible> {
+) -> Result<Response, Infallible> {
     let method = req.method().clone();
     let uri = req.uri().clone();
 
@@ -1858,7 +1852,7 @@ pub(crate) async fn route_request(
 async fn authenticate(
     http_server: &Arc<HttpApi>,
     req: &mut Request,
-) -> Option<std::result::Result<Response<Body>, Infallible>> {
+) -> Option<std::result::Result<Response, Infallible>> {
     if let Err(e) = http_server.authenticate_request(req).await {
         match e {
             AuthenticationError::Unauthenticated => {
@@ -1892,7 +1886,7 @@ async fn authenticate(
     None
 }
 
-fn legacy_write_error_to_response(e: WriteParseError) -> Response<Body> {
+fn legacy_write_error_to_response(e: WriteParseError) -> Response {
     let err: ErrorMessage<()> = ErrorMessage {
         error: e.to_string(),
         data: None,

--- a/influxdb3_server/src/http.rs
+++ b/influxdb3_server/src/http.rs
@@ -41,7 +41,7 @@ use influxdb3_write::write_buffer::Error as WriteBufferError;
 use iox_http::write::single_tenant::SingleTenantRequestUnifier;
 use iox_http::write::v1::V1_NAMESPACE_RP_SEPARATOR;
 use iox_http::write::{WriteParseError, WriteRequestUnifier};
-use iox_http_util::{Request, Response};
+use iox_http_util::{Request, Response, ResponseBuilder};
 use iox_query_influxql_rewrite as rewrite;
 use iox_query_params::StatementParams;
 use iox_time::TimeProvider;
@@ -265,18 +265,18 @@ trait IntoResponse {
 impl IntoResponse for CatalogError {
     fn into_response(self) -> Response {
         match self {
-            Self::NotFound => Response::builder()
+            Self::NotFound => ResponseBuilder::new()
                 .status(StatusCode::NOT_FOUND)
                 .body(Body::from(self.to_string()))
                 .unwrap(),
-            Self::AlreadyExists | Self::AlreadyDeleted => Response::builder()
+            Self::AlreadyExists | Self::AlreadyDeleted => ResponseBuilder::new()
                 .status(StatusCode::CONFLICT)
                 .body(Body::from(self.to_string()))
                 .unwrap(),
             Self::InvalidConfiguration { .. }
             | Self::InvalidDistinctCacheColumnType
             | Self::InvalidLastCacheKeyColumnType
-            | Self::InvalidColumnType { .. } => Response::builder()
+            | Self::InvalidColumnType { .. } => ResponseBuilder::new()
                 .status(StatusCode::BAD_REQUEST)
                 .body(Body::from(self.to_string()))
                 .unwrap(),
@@ -290,14 +290,14 @@ impl IntoResponse for CatalogError {
                 };
                 let serialized = serde_json::to_string(&err).unwrap();
                 let body = Body::from(serialized);
-                Response::builder()
+                ResponseBuilder::new()
                     .status(StatusCode::UNPROCESSABLE_ENTITY)
                     .body(body)
                     .unwrap()
             }
             _ => {
                 let body = Body::from(self.to_string());
-                Response::builder()
+                ResponseBuilder::new()
                     .status(StatusCode::INTERNAL_SERVER_ERROR)
                     .body(body)
                     .unwrap()
@@ -311,23 +311,27 @@ impl IntoResponse for Error {
     fn into_response(self) -> Response {
         debug!(error = ?self, "API error");
         match self {
-            Self::Catalog(err @ CatalogError::CannotDeleteOperatorToken) => Response::builder()
+            Self::Catalog(err @ CatalogError::CannotDeleteOperatorToken) => ResponseBuilder::new()
                 .status(StatusCode::METHOD_NOT_ALLOWED)
                 .body(Body::from(err.to_string()))
                 .unwrap(),
-            Self::Catalog(err @ CatalogError::TokenNameAlreadyExists { .. }) => Response::builder()
-                .status(StatusCode::CONFLICT)
-                .body(Body::from(err.to_string()))
-                .unwrap(),
+            Self::Catalog(err @ CatalogError::TokenNameAlreadyExists { .. }) => {
+                ResponseBuilder::new()
+                    .status(StatusCode::CONFLICT)
+                    .body(Body::from(err.to_string()))
+                    .unwrap()
+            }
             Self::Catalog(err) | Self::WriteBuffer(WriteBufferError::CatalogUpdateError(err)) => {
                 err.into_response()
             }
-            Self::Query(err @ QueryExecutorError::MethodNotImplemented(_)) => Response::builder()
-                .status(StatusCode::METHOD_NOT_ALLOWED)
-                .body(Body::from(err.to_string()))
-                .unwrap(),
+            Self::Query(err @ QueryExecutorError::MethodNotImplemented(_)) => {
+                ResponseBuilder::new()
+                    .status(StatusCode::METHOD_NOT_ALLOWED)
+                    .body(Body::from(err.to_string()))
+                    .unwrap()
+            }
             Self::WriteBuffer(err @ WriteBufferError::DatabaseNotFound { db_name: _ }) => {
-                Response::builder()
+                ResponseBuilder::new()
                     .status(StatusCode::NOT_FOUND)
                     .body(Body::from(err.to_string()))
                     .unwrap()
@@ -337,11 +341,11 @@ impl IntoResponse for Error {
                     db_name: _,
                     table_name: _,
                 },
-            ) => Response::builder()
+            ) => ResponseBuilder::new()
                 .status(StatusCode::NOT_FOUND)
                 .body(Body::from(err.to_string()))
                 .unwrap(),
-            Self::WriteBuffer(err @ WriteBufferError::DatabaseExists(_)) => Response::builder()
+            Self::WriteBuffer(err @ WriteBufferError::DatabaseExists(_)) => ResponseBuilder::new()
                 .status(StatusCode::BAD_REQUEST)
                 .body(Body::from(err.to_string()))
                 .unwrap(),
@@ -352,12 +356,12 @@ impl IntoResponse for Error {
                 };
                 let serialized = serde_json::to_string(&err).unwrap();
                 let body = Body::from(serialized);
-                Response::builder()
+                ResponseBuilder::new()
                     .status(StatusCode::BAD_REQUEST)
                     .body(body)
                     .unwrap()
             }
-            Self::WriteBuffer(err @ WriteBufferError::EmptyWrite) => Response::builder()
+            Self::WriteBuffer(err @ WriteBufferError::EmptyWrite) => ResponseBuilder::new()
                 .status(StatusCode::BAD_REQUEST)
                 .body(Body::from(err.to_string()))
                 .unwrap(),
@@ -368,7 +372,7 @@ impl IntoResponse for Error {
                 };
                 let serialized = serde_json::to_string(&err).unwrap();
                 let body = Body::from(serialized);
-                Response::builder()
+                ResponseBuilder::new()
                     .status(StatusCode::BAD_REQUEST)
                     .body(body)
                     .unwrap()
@@ -381,11 +385,11 @@ impl IntoResponse for Error {
                 | last_cache::Error::KeyColumnDoesNotExist { .. }
                 | last_cache::Error::KeyColumnDoesNotExistByName { .. }
                 | last_cache::Error::InvalidKeyColumn { .. }
-                | last_cache::Error::ValueColumnDoesNotExist { .. } => Response::builder()
+                | last_cache::Error::ValueColumnDoesNotExist { .. } => ResponseBuilder::new()
                     .status(StatusCode::BAD_REQUEST)
                     .body(Body::from(lc_err.to_string()))
                     .unwrap(),
-                last_cache::Error::CacheDoesNotExist => Response::builder()
+                last_cache::Error::CacheDoesNotExist => ResponseBuilder::new()
                     .status(StatusCode::NOT_FOUND)
                     .body(Body::from(self.to_string()))
                     .unwrap(),
@@ -395,21 +399,21 @@ impl IntoResponse for Error {
                     distinct_cache::CacheError::EmptyColumnSet
                     | distinct_cache::CacheError::NonTagOrStringColumn { .. }
                     | distinct_cache::CacheError::ConfigurationMismatch { .. } => {
-                        Response::builder()
+                        ResponseBuilder::new()
                             .status(StatusCode::BAD_REQUEST)
                             .body(Body::from(mc_err.to_string()))
                             .unwrap()
                     }
-                    distinct_cache::CacheError::Unexpected(_) => Response::builder()
+                    distinct_cache::CacheError::Unexpected(_) => ResponseBuilder::new()
                         .status(StatusCode::INTERNAL_SERVER_ERROR)
                         .body(Body::from(mc_err.to_string()))
                         .unwrap(),
                 },
-                distinct_cache::ProviderError::CacheNotFound => Response::builder()
+                distinct_cache::ProviderError::CacheNotFound => ResponseBuilder::new()
                     .status(StatusCode::NOT_FOUND)
                     .body(Body::from(mc_err.to_string()))
                     .unwrap(),
-                distinct_cache::ProviderError::Unexpected(_) => Response::builder()
+                distinct_cache::ProviderError::Unexpected(_) => ResponseBuilder::new()
                     .status(StatusCode::INTERNAL_SERVER_ERROR)
                     .body(Body::from(mc_err.to_string()))
                     .unwrap(),
@@ -421,7 +425,7 @@ impl IntoResponse for Error {
                 };
                 let serialized = serde_json::to_string(&err).unwrap();
                 let body = Body::from(serialized);
-                Response::builder()
+                ResponseBuilder::new()
                     .status(StatusCode::BAD_REQUEST)
                     .body(body)
                     .unwrap()
@@ -440,7 +444,7 @@ impl IntoResponse for Error {
                 };
                 let serialized = serde_json::to_string(&err).unwrap();
                 let body = Body::from(serialized);
-                Response::builder()
+                ResponseBuilder::new()
                     .status(if limit_hit {
                         StatusCode::UNPROCESSABLE_ENTITY
                     } else {
@@ -456,7 +460,7 @@ impl IntoResponse for Error {
                 };
                 let serialized = serde_json::to_string(&err).unwrap();
                 let body = Body::from(serialized);
-                Response::builder()
+                ResponseBuilder::new()
                     .status(StatusCode::METHOD_NOT_ALLOWED)
                     .body(body)
                     .unwrap()
@@ -468,37 +472,37 @@ impl IntoResponse for Error {
                 };
                 let serialized = serde_json::to_string(&err).unwrap();
                 let body = Body::from(serialized);
-                Response::builder()
+                ResponseBuilder::new()
                     .status(StatusCode::NOT_FOUND)
                     .body(body)
                     .unwrap()
             }
-            Self::SerdeJson(_) => Response::builder()
+            Self::SerdeJson(_) => ResponseBuilder::new()
                 .status(StatusCode::BAD_REQUEST)
                 .body(Body::from(self.to_string()))
                 .unwrap(),
-            Self::InvalidContentEncoding(_) => Response::builder()
+            Self::InvalidContentEncoding(_) => ResponseBuilder::new()
                 .status(StatusCode::BAD_REQUEST)
                 .body(Body::from(self.to_string()))
                 .unwrap(),
-            Self::InvalidContentType { .. } => Response::builder()
+            Self::InvalidContentType { .. } => ResponseBuilder::new()
                 .status(StatusCode::UNSUPPORTED_MEDIA_TYPE)
                 .body(Body::from(self.to_string()))
                 .unwrap(),
-            Self::SerdeUrlDecoding(_) => Response::builder()
+            Self::SerdeUrlDecoding(_) => ResponseBuilder::new()
                 .status(StatusCode::BAD_REQUEST)
                 .body(Body::from(self.to_string()))
                 .unwrap(),
             Self::MissingQueryParams
             | Self::MissingQueryV1Params
             | Self::MissingWriteParams
-            | Self::MissingDeleteDatabaseParams => Response::builder()
+            | Self::MissingDeleteDatabaseParams => ResponseBuilder::new()
                 .status(StatusCode::BAD_REQUEST)
                 .body(Body::from(self.to_string()))
                 .unwrap(),
             _ => {
                 let body = Body::from(self.to_string());
-                Response::builder()
+                ResponseBuilder::new()
                     .status(StatusCode::INTERNAL_SERVER_ERROR)
                     .body(body)
                     .unwrap()
@@ -588,7 +592,7 @@ impl HttpApi {
             .add_write_metrics(num_lines, payload_size);
 
         if result.invalid_lines.is_empty() {
-            Response::builder()
+            ResponseBuilder::new()
                 .status(StatusCode::NO_CONTENT)
                 .body(Body::empty())
                 .map_err(Into::into)
@@ -604,7 +608,7 @@ impl HttpApi {
         let response = CreateTokenWithPermissionsResponse::from_token_info(token_info, token);
         let body = serde_json::to_vec(&response)?;
 
-        let body = Response::builder()
+        let body = ResponseBuilder::new()
             .status(StatusCode::CREATED)
             .header(CONTENT_TYPE, "json")
             .body(Body::from(body));
@@ -619,7 +623,7 @@ impl HttpApi {
         let response = CreateTokenWithPermissionsResponse::from_token_info(token_info, token);
         let body = serde_json::to_vec(&response)?;
 
-        let body = Response::builder()
+        let body = ResponseBuilder::new()
             .status(StatusCode::CREATED)
             .header(CONTENT_TYPE, "json")
             .body(Body::from(body));
@@ -646,7 +650,7 @@ impl HttpApi {
             .query_sql(&database, &query_str, params, span_ctx, None)
             .await?;
 
-        Response::builder()
+        ResponseBuilder::new()
             .status(StatusCode::OK)
             .header(CONTENT_TYPE, format.as_content_type())
             .body(record_batch_stream_to_body(stream, format).await?)
@@ -666,7 +670,7 @@ impl HttpApi {
             .query_influxql_inner(database, &query_str, params)
             .await?;
 
-        Response::builder()
+        ResponseBuilder::new()
             .status(StatusCode::OK)
             .header(CONTENT_TYPE, format.as_content_type())
             .body(record_batch_stream_to_body(stream, format).await?)
@@ -912,7 +916,7 @@ impl HttpApi {
             )
             .await
         {
-            Ok(batch) => Response::builder()
+            Ok(batch) => ResponseBuilder::new()
                 .status(StatusCode::CREATED)
                 .body(Body::from(serde_json::to_vec(&batch)?))
                 .map_err(Into::into),
@@ -936,7 +940,7 @@ impl HttpApi {
             .delete_distinct_cache(&db, &table, &name)
             .await?;
 
-        Response::builder()
+        ResponseBuilder::new()
             .status(StatusCode::OK)
             .body(Body::empty())
             .map_err(Into::into)
@@ -966,7 +970,7 @@ impl HttpApi {
             )
             .await
         {
-            Ok(batch) => Response::builder()
+            Ok(batch) => ResponseBuilder::new()
                 .status(StatusCode::CREATED)
                 .body(Body::from(serde_json::to_vec(&batch)?))
                 .map_err(Into::into),
@@ -990,7 +994,7 @@ impl HttpApi {
             .delete_last_cache(&db, &table, &name)
             .await?;
 
-        Response::builder()
+        ResponseBuilder::new()
             .status(StatusCode::OK)
             .body(Body::empty())
             .map_err(Into::into)
@@ -1028,7 +1032,7 @@ impl HttpApi {
                 disabled,
             )
             .await?;
-        Ok(Response::builder()
+        Ok(ResponseBuilder::new()
             .status(StatusCode::OK)
             .body(Body::empty())?)
     }
@@ -1047,7 +1051,7 @@ impl HttpApi {
             .catalog()
             .delete_processing_engine_trigger(&db, &trigger_name, force)
             .await?;
-        Ok(Response::builder()
+        Ok(ResponseBuilder::new()
             .status(StatusCode::OK)
             .body(Body::empty())?)
     }
@@ -1062,7 +1066,7 @@ impl HttpApi {
             .disable_processing_engine_trigger(&db, &trigger_name)
             .await
         {
-            Ok(_) | Err(CatalogError::TriggerAlreadyDisabled) => Ok(Response::builder()
+            Ok(_) | Err(CatalogError::TriggerAlreadyDisabled) => Ok(ResponseBuilder::new()
                 .status(StatusCode::OK)
                 .body(Body::empty())?),
             Err(error) => Err(error.into()),
@@ -1079,7 +1083,7 @@ impl HttpApi {
             .enable_processing_engine_trigger(&db, &trigger_name)
             .await
         {
-            Ok(_) | Err(CatalogError::TriggerAlreadyEnabled) => Ok(Response::builder()
+            Ok(_) | Err(CatalogError::TriggerAlreadyEnabled) => Ok(ResponseBuilder::new()
                 .status(StatusCode::OK)
                 .body(Body::empty())?),
             Err(error) => Err(error.into()),
@@ -1098,7 +1102,7 @@ impl HttpApi {
             .install_packages(packages)
             .map_err(ProcessingEngineError::from)?;
 
-        Ok(Response::builder()
+        Ok(ResponseBuilder::new()
             .status(StatusCode::OK)
             .body(Body::empty())?)
     }
@@ -1120,7 +1124,7 @@ impl HttpApi {
             .install_requirements(requirements_location)
             .map_err(ProcessingEngineError::from)?;
 
-        Ok(Response::builder()
+        Ok(ResponseBuilder::new()
             .status(StatusCode::OK)
             .body(Body::empty())?)
     }
@@ -1132,7 +1136,7 @@ impl HttpApi {
             show_deleted,
         } = serde_urlencoded::from_str(query)?;
         let stream = self.query_executor.show_databases(show_deleted)?;
-        Response::builder()
+        ResponseBuilder::new()
             .status(StatusCode::OK)
             .header(CONTENT_TYPE, format.as_content_type())
             .body(record_batch_stream_to_body(stream, format).await?)
@@ -1142,7 +1146,7 @@ impl HttpApi {
     async fn create_database(&self, req: Request) -> Result<Response> {
         let CreateDatabaseRequest { db } = self.read_body_json(req).await?;
         self.write_buffer.catalog().create_database(&db).await?;
-        Ok(Response::builder()
+        Ok(ResponseBuilder::new()
             .status(StatusCode::OK)
             .body(Body::empty())
             .unwrap())
@@ -1158,7 +1162,7 @@ impl HttpApi {
             .await?;
         let body = serde_json::to_string(&output)?;
 
-        Ok(Response::builder()
+        Ok(ResponseBuilder::new()
             .status(StatusCode::OK)
             .body(Body::from(body))?)
     }
@@ -1173,7 +1177,7 @@ impl HttpApi {
             .await?;
         let body = serde_json::to_string(&output)?;
 
-        Ok(Response::builder()
+        Ok(ResponseBuilder::new()
             .status(StatusCode::OK)
             .body(Body::from(body))?)
     }
@@ -1215,7 +1219,7 @@ impl HttpApi {
                 influxdb3_processing_engine::manager::ProcessingEngineError::RequestTriggerNotFound,
             ) => {
                 let body = "{error: \"not found\"}";
-                Ok(Response::builder()
+                Ok(ResponseBuilder::new()
                     .status(StatusCode::NOT_FOUND)
                     .body(Body::from(body))?)
             }
@@ -1230,7 +1234,7 @@ impl HttpApi {
             .catalog()
             .soft_delete_database(&delete_req.db)
             .await?;
-        Ok(Response::builder()
+        Ok(ResponseBuilder::new()
             .status(StatusCode::OK)
             .body(Body::empty())
             .unwrap())
@@ -1255,7 +1259,7 @@ impl HttpApi {
                     .collect::<Vec<(String, FieldDataType)>>(),
             )
             .await?;
-        Ok(Response::builder()
+        Ok(ResponseBuilder::new()
             .status(StatusCode::OK)
             .body(Body::empty())
             .unwrap())
@@ -1268,7 +1272,7 @@ impl HttpApi {
             .catalog()
             .soft_delete_table(&delete_req.db, &delete_req.table)
             .await?;
-        Ok(Response::builder()
+        Ok(ResponseBuilder::new()
             .status(StatusCode::OK)
             .body(Body::empty())
             .unwrap())
@@ -1281,7 +1285,7 @@ impl HttpApi {
             .catalog()
             .delete_token(&delete_req.token_name)
             .await?;
-        Ok(Response::builder()
+        Ok(ResponseBuilder::new()
             .status(StatusCode::OK)
             .body(Body::empty())
             .unwrap())
@@ -1697,7 +1701,7 @@ pub(crate) async fn route_request(
     // the browser will not send a request with an auth header for CORS.
     if let Method::OPTIONS = method {
         info!(?uri, "preflight request");
-        return Ok(Response::builder()
+        return Ok(ResponseBuilder::new()
             .header("Access-Control-Allow-Origin", "*")
             .header("Access-Control-Allow-Methods", "*")
             .header("Access-Control-Allow-Headers", "*")
@@ -1708,7 +1712,7 @@ pub(crate) async fn route_request(
     }
 
     if started_without_auth && uri.path().starts_with(all_paths::API_V3_CONFIGURE_TOKEN) {
-        return Ok(Response::builder()
+        return Ok(ResponseBuilder::new()
             .status(StatusCode::METHOD_NOT_ALLOWED)
             .body("endpoint disabled, started without auth".into())
             .unwrap());
@@ -1826,7 +1830,7 @@ pub(crate) async fn route_request(
         }
         _ => {
             let body = Body::from("not found");
-            Ok(Response::builder()
+            Ok(ResponseBuilder::new()
                 .status(StatusCode::NOT_FOUND)
                 .body(body)
                 .unwrap())
@@ -1856,19 +1860,19 @@ async fn authenticate(
     if let Err(e) = http_server.authenticate_request(req).await {
         match e {
             AuthenticationError::Unauthenticated => {
-                return Some(Ok(Response::builder()
+                return Some(Ok(ResponseBuilder::new()
                     .status(StatusCode::UNAUTHORIZED)
                     .body(Body::empty())
                     .unwrap()));
             }
             AuthenticationError::MalformedRequest => {
-                return Some(Ok(Response::builder()
+                return Some(Ok(ResponseBuilder::new()
                     .status(StatusCode::BAD_REQUEST)
                     .body(Body::from(format!(r#"{{"error": "{e}"}}"#)))
                     .unwrap()));
             }
             AuthenticationError::Forbidden => {
-                return Some(Ok(Response::builder()
+                return Some(Ok(ResponseBuilder::new()
                     .status(StatusCode::FORBIDDEN)
                     .body(Body::empty())
                     .unwrap()));
@@ -1876,7 +1880,7 @@ async fn authenticate(
             // We don't expect this to happen, but if the header is messed up
             // better to handle it then not at all
             AuthenticationError::ToStr(_) => {
-                return Some(Ok(Response::builder()
+                return Some(Ok(ResponseBuilder::new()
                     .status(StatusCode::INTERNAL_SERVER_ERROR)
                     .body(Body::empty())
                     .unwrap()));
@@ -1898,7 +1902,7 @@ fn legacy_write_error_to_response(e: WriteParseError) -> Response {
         WriteParseError::SingleTenantError(e) => StatusCode::from(&e),
         WriteParseError::MultiTenantError(e) => StatusCode::from(&e),
     };
-    Response::builder().status(status).body(body).unwrap()
+    ResponseBuilder::new().status(status).body(body).unwrap()
 }
 
 #[cfg(test)]

--- a/influxdb3_server/src/http.rs
+++ b/influxdb3_server/src/http.rs
@@ -41,7 +41,9 @@ use influxdb3_write::write_buffer::Error as WriteBufferError;
 use iox_http::write::single_tenant::SingleTenantRequestUnifier;
 use iox_http::write::v1::V1_NAMESPACE_RP_SEPARATOR;
 use iox_http::write::{WriteParseError, WriteRequestUnifier};
-use iox_http_util::{Request, Response, ResponseBuilder, empty_response_body};
+use iox_http_util::{
+    Request, Response, ResponseBody, ResponseBuilder, bytes_to_response_body, empty_response_body,
+};
 use iox_query_influxql_rewrite as rewrite;
 use iox_query_params::StatementParams;
 use iox_time::TimeProvider;
@@ -267,18 +269,18 @@ impl IntoResponse for CatalogError {
         match self {
             Self::NotFound => ResponseBuilder::new()
                 .status(StatusCode::NOT_FOUND)
-                .body(Body::from(self.to_string()))
+                .body(bytes_to_response_body(self.to_string()))
                 .unwrap(),
             Self::AlreadyExists | Self::AlreadyDeleted => ResponseBuilder::new()
                 .status(StatusCode::CONFLICT)
-                .body(Body::from(self.to_string()))
+                .body(bytes_to_response_body(self.to_string()))
                 .unwrap(),
             Self::InvalidConfiguration { .. }
             | Self::InvalidDistinctCacheColumnType
             | Self::InvalidLastCacheKeyColumnType
             | Self::InvalidColumnType { .. } => ResponseBuilder::new()
                 .status(StatusCode::BAD_REQUEST)
-                .body(Body::from(self.to_string()))
+                .body(bytes_to_response_body(self.to_string()))
                 .unwrap(),
             Self::TooManyColumns(_)
             | Self::TooManyTables(_)
@@ -289,14 +291,14 @@ impl IntoResponse for CatalogError {
                     data: None,
                 };
                 let serialized = serde_json::to_string(&err).unwrap();
-                let body = Body::from(serialized);
+                let body = bytes_to_response_body(serialized);
                 ResponseBuilder::new()
                     .status(StatusCode::UNPROCESSABLE_ENTITY)
                     .body(body)
                     .unwrap()
             }
             _ => {
-                let body = Body::from(self.to_string());
+                let body = bytes_to_response_body(self.to_string());
                 ResponseBuilder::new()
                     .status(StatusCode::INTERNAL_SERVER_ERROR)
                     .body(body)
@@ -313,12 +315,12 @@ impl IntoResponse for Error {
         match self {
             Self::Catalog(err @ CatalogError::CannotDeleteOperatorToken) => ResponseBuilder::new()
                 .status(StatusCode::METHOD_NOT_ALLOWED)
-                .body(Body::from(err.to_string()))
+                .body(bytes_to_response_body(err.to_string()))
                 .unwrap(),
             Self::Catalog(err @ CatalogError::TokenNameAlreadyExists { .. }) => {
                 ResponseBuilder::new()
                     .status(StatusCode::CONFLICT)
-                    .body(Body::from(err.to_string()))
+                    .body(bytes_to_response_body(err.to_string()))
                     .unwrap()
             }
             Self::Catalog(err) | Self::WriteBuffer(WriteBufferError::CatalogUpdateError(err)) => {
@@ -327,13 +329,13 @@ impl IntoResponse for Error {
             Self::Query(err @ QueryExecutorError::MethodNotImplemented(_)) => {
                 ResponseBuilder::new()
                     .status(StatusCode::METHOD_NOT_ALLOWED)
-                    .body(Body::from(err.to_string()))
+                    .body(bytes_to_response_body(err.to_string()))
                     .unwrap()
             }
             Self::WriteBuffer(err @ WriteBufferError::DatabaseNotFound { db_name: _ }) => {
                 ResponseBuilder::new()
                     .status(StatusCode::NOT_FOUND)
-                    .body(Body::from(err.to_string()))
+                    .body(bytes_to_response_body(err.to_string()))
                     .unwrap()
             }
             Self::WriteBuffer(
@@ -343,11 +345,11 @@ impl IntoResponse for Error {
                 },
             ) => ResponseBuilder::new()
                 .status(StatusCode::NOT_FOUND)
-                .body(Body::from(err.to_string()))
+                .body(bytes_to_response_body(err.to_string()))
                 .unwrap(),
             Self::WriteBuffer(err @ WriteBufferError::DatabaseExists(_)) => ResponseBuilder::new()
                 .status(StatusCode::BAD_REQUEST)
-                .body(Body::from(err.to_string()))
+                .body(bytes_to_response_body(err.to_string()))
                 .unwrap(),
             Self::WriteBuffer(WriteBufferError::ParseError(err)) => {
                 let err = ErrorMessage {
@@ -355,7 +357,7 @@ impl IntoResponse for Error {
                     data: Some(err),
                 };
                 let serialized = serde_json::to_string(&err).unwrap();
-                let body = Body::from(serialized);
+                let body = bytes_to_response_body(serialized);
                 ResponseBuilder::new()
                     .status(StatusCode::BAD_REQUEST)
                     .body(body)
@@ -363,7 +365,7 @@ impl IntoResponse for Error {
             }
             Self::WriteBuffer(err @ WriteBufferError::EmptyWrite) => ResponseBuilder::new()
                 .status(StatusCode::BAD_REQUEST)
-                .body(Body::from(err.to_string()))
+                .body(bytes_to_response_body(err.to_string()))
                 .unwrap(),
             Self::WriteBuffer(err @ WriteBufferError::ColumnDoesNotExist(_)) => {
                 let err: ErrorMessage<()> = ErrorMessage {
@@ -371,7 +373,7 @@ impl IntoResponse for Error {
                     data: None,
                 };
                 let serialized = serde_json::to_string(&err).unwrap();
-                let body = Body::from(serialized);
+                let body = bytes_to_response_body(serialized);
                 ResponseBuilder::new()
                     .status(StatusCode::BAD_REQUEST)
                     .body(body)
@@ -387,11 +389,11 @@ impl IntoResponse for Error {
                 | last_cache::Error::InvalidKeyColumn { .. }
                 | last_cache::Error::ValueColumnDoesNotExist { .. } => ResponseBuilder::new()
                     .status(StatusCode::BAD_REQUEST)
-                    .body(Body::from(lc_err.to_string()))
+                    .body(bytes_to_response_body(lc_err.to_string()))
                     .unwrap(),
                 last_cache::Error::CacheDoesNotExist => ResponseBuilder::new()
                     .status(StatusCode::NOT_FOUND)
-                    .body(Body::from(self.to_string()))
+                    .body(bytes_to_response_body(self.to_string()))
                     .unwrap(),
             },
             Self::WriteBuffer(WriteBufferError::DistinctCacheError(ref mc_err)) => match mc_err {
@@ -401,21 +403,21 @@ impl IntoResponse for Error {
                     | distinct_cache::CacheError::ConfigurationMismatch { .. } => {
                         ResponseBuilder::new()
                             .status(StatusCode::BAD_REQUEST)
-                            .body(Body::from(mc_err.to_string()))
+                            .body(bytes_to_response_body(mc_err.to_string()))
                             .unwrap()
                     }
                     distinct_cache::CacheError::Unexpected(_) => ResponseBuilder::new()
                         .status(StatusCode::INTERNAL_SERVER_ERROR)
-                        .body(Body::from(mc_err.to_string()))
+                        .body(bytes_to_response_body(mc_err.to_string()))
                         .unwrap(),
                 },
                 distinct_cache::ProviderError::CacheNotFound => ResponseBuilder::new()
                     .status(StatusCode::NOT_FOUND)
-                    .body(Body::from(mc_err.to_string()))
+                    .body(bytes_to_response_body(mc_err.to_string()))
                     .unwrap(),
                 distinct_cache::ProviderError::Unexpected(_) => ResponseBuilder::new()
                     .status(StatusCode::INTERNAL_SERVER_ERROR)
-                    .body(Body::from(mc_err.to_string()))
+                    .body(bytes_to_response_body(mc_err.to_string()))
                     .unwrap(),
             },
             Self::DbName(e) => {
@@ -424,7 +426,7 @@ impl IntoResponse for Error {
                     data: None,
                 };
                 let serialized = serde_json::to_string(&err).unwrap();
-                let body = Body::from(serialized);
+                let body = bytes_to_response_body(serialized);
                 ResponseBuilder::new()
                     .status(StatusCode::BAD_REQUEST)
                     .body(body)
@@ -443,7 +445,7 @@ impl IntoResponse for Error {
                     data: Some(data.invalid_lines),
                 };
                 let serialized = serde_json::to_string(&err).unwrap();
-                let body = Body::from(serialized);
+                let body = bytes_to_response_body(serialized);
                 ResponseBuilder::new()
                     .status(if limit_hit {
                         StatusCode::UNPROCESSABLE_ENTITY
@@ -459,7 +461,7 @@ impl IntoResponse for Error {
                     data: None,
                 };
                 let serialized = serde_json::to_string(&err).unwrap();
-                let body = Body::from(serialized);
+                let body = bytes_to_response_body(serialized);
                 ResponseBuilder::new()
                     .status(StatusCode::METHOD_NOT_ALLOWED)
                     .body(body)
@@ -471,7 +473,7 @@ impl IntoResponse for Error {
                     data: None,
                 };
                 let serialized = serde_json::to_string(&err).unwrap();
-                let body = Body::from(serialized);
+                let body = bytes_to_response_body(serialized);
                 ResponseBuilder::new()
                     .status(StatusCode::NOT_FOUND)
                     .body(body)
@@ -479,29 +481,29 @@ impl IntoResponse for Error {
             }
             Self::SerdeJson(_) => ResponseBuilder::new()
                 .status(StatusCode::BAD_REQUEST)
-                .body(Body::from(self.to_string()))
+                .body(bytes_to_response_body(self.to_string()))
                 .unwrap(),
             Self::InvalidContentEncoding(_) => ResponseBuilder::new()
                 .status(StatusCode::BAD_REQUEST)
-                .body(Body::from(self.to_string()))
+                .body(bytes_to_response_body(self.to_string()))
                 .unwrap(),
             Self::InvalidContentType { .. } => ResponseBuilder::new()
                 .status(StatusCode::UNSUPPORTED_MEDIA_TYPE)
-                .body(Body::from(self.to_string()))
+                .body(bytes_to_response_body(self.to_string()))
                 .unwrap(),
             Self::SerdeUrlDecoding(_) => ResponseBuilder::new()
                 .status(StatusCode::BAD_REQUEST)
-                .body(Body::from(self.to_string()))
+                .body(bytes_to_response_body(self.to_string()))
                 .unwrap(),
             Self::MissingQueryParams
             | Self::MissingQueryV1Params
             | Self::MissingWriteParams
             | Self::MissingDeleteDatabaseParams => ResponseBuilder::new()
                 .status(StatusCode::BAD_REQUEST)
-                .body(Body::from(self.to_string()))
+                .body(bytes_to_response_body(self.to_string()))
                 .unwrap(),
             _ => {
-                let body = Body::from(self.to_string());
+                let body = bytes_to_response_body(self.to_string());
                 ResponseBuilder::new()
                     .status(StatusCode::INTERNAL_SERVER_ERROR)
                     .body(body)
@@ -611,7 +613,7 @@ impl HttpApi {
         let body = ResponseBuilder::new()
             .status(StatusCode::CREATED)
             .header(CONTENT_TYPE, "json")
-            .body(Body::from(body));
+            .body(bytes_to_response_body(body));
 
         Ok(body?)
     }
@@ -626,7 +628,7 @@ impl HttpApi {
         let body = ResponseBuilder::new()
             .status(StatusCode::CREATED)
             .header(CONTENT_TYPE, "json")
-            .body(Body::from(body));
+            .body(bytes_to_response_body(body));
 
         Ok(body?)
     }
@@ -679,7 +681,9 @@ impl HttpApi {
 
     fn health(&self) -> Result<Response> {
         let response_body = "OK";
-        Ok(Response::new(Body::from(response_body.to_string())))
+        Ok(Response::new(bytes_to_response_body(
+            response_body.to_string(),
+        )))
     }
 
     fn ping(&self) -> Result<Response> {
@@ -689,7 +693,7 @@ impl HttpApi {
             process_id: *PROCESS_UUID,
         })?;
 
-        Ok(Response::new(Body::from(body)))
+        Ok(Response::new(bytes_to_response_body(body)))
     }
 
     fn handle_metrics(&self) -> Result<Response> {
@@ -697,7 +701,7 @@ impl HttpApi {
         let mut reporter = metric_exporters::PrometheusTextEncoder::new(&mut body);
         self.common_state.metrics.report(&mut reporter);
 
-        Ok(Response::new(Body::from(body)))
+        Ok(Response::new(bytes_to_response_body(body)))
     }
 
     /// Parse the request's body into raw bytes, applying the configured size
@@ -918,7 +922,7 @@ impl HttpApi {
         {
             Ok(batch) => ResponseBuilder::new()
                 .status(StatusCode::CREATED)
-                .body(Body::from(serde_json::to_vec(&batch)?))
+                .body(bytes_to_response_body(serde_json::to_vec(&batch)?))
                 .map_err(Into::into),
             Err(error) => Err(error.into()),
         }
@@ -972,7 +976,7 @@ impl HttpApi {
         {
             Ok(batch) => ResponseBuilder::new()
                 .status(StatusCode::CREATED)
-                .body(Body::from(serde_json::to_vec(&batch)?))
+                .body(bytes_to_response_body(serde_json::to_vec(&batch)?))
                 .map_err(Into::into),
             Err(error) => Err(error.into()),
         }
@@ -1164,7 +1168,7 @@ impl HttpApi {
 
         Ok(ResponseBuilder::new()
             .status(StatusCode::OK)
-            .body(Body::from(body))?)
+            .body(bytes_to_response_body(body))?)
     }
 
     async fn test_processing_engine_schedule_plugin(&self, req: Request) -> Result<Response> {
@@ -1179,7 +1183,7 @@ impl HttpApi {
 
         Ok(ResponseBuilder::new()
             .status(StatusCode::OK)
-            .body(Body::from(body))?)
+            .body(bytes_to_response_body(body))?)
     }
 
     async fn processing_engine_request_plugin(
@@ -1221,7 +1225,7 @@ impl HttpApi {
                 let body = "{error: \"not found\"}";
                 Ok(ResponseBuilder::new()
                     .status(StatusCode::NOT_FOUND)
-                    .body(Body::from(body))?)
+                    .body(bytes_to_response_body(body))?)
             }
             Err(e) => Err(e.into()),
         }
@@ -1486,11 +1490,11 @@ pub enum ValidateDbNameError {
 async fn record_batch_stream_to_body(
     mut stream: Pin<Box<dyn RecordBatchStream + Send>>,
     format: QueryFormat,
-) -> Result<Body, Error> {
+) -> Result<ResponseBody, Error> {
     match format {
         QueryFormat::Pretty => {
             let batches = stream.try_collect::<Vec<RecordBatch>>().await?;
-            Ok(Body::from(Bytes::from(format!(
+            Ok(bytes_to_response_body(Bytes::from(format!(
                 "{}",
                 pretty::pretty_format_batches(&batches)?
             ))))
@@ -1512,7 +1516,7 @@ async fn record_batch_stream_to_body(
                 writer.write(batch)?;
             }
             writer.close()?;
-            Ok(Body::from(Bytes::from(bytes)))
+            Ok(bytes_to_response_body(Bytes::from(bytes)))
         }
         QueryFormat::Csv => {
             struct CsvFuture {
@@ -1829,7 +1833,7 @@ pub(crate) async fn route_request(
                 .await
         }
         _ => {
-            let body = Body::from("not found");
+            let body = bytes_to_response_body("not found");
             Ok(ResponseBuilder::new()
                 .status(StatusCode::NOT_FOUND)
                 .body(body)
@@ -1868,7 +1872,7 @@ async fn authenticate(
             AuthenticationError::MalformedRequest => {
                 return Some(Ok(ResponseBuilder::new()
                     .status(StatusCode::BAD_REQUEST)
-                    .body(Body::from(format!(r#"{{"error": "{e}"}}"#)))
+                    .body(bytes_to_response_body(format!(r#"{{"error": "{e}"}}"#)))
                     .unwrap()));
             }
             AuthenticationError::Forbidden => {
@@ -1896,7 +1900,7 @@ fn legacy_write_error_to_response(e: WriteParseError) -> Response {
         data: None,
     };
     let serialized = serde_json::to_string(&err).unwrap();
-    let body = Body::from(serialized);
+    let body = bytes_to_response_body(serialized);
     let status = match e {
         WriteParseError::NotImplemented => StatusCode::NOT_FOUND,
         WriteParseError::SingleTenantError(e) => StatusCode::from(&e),

--- a/influxdb3_server/src/http.rs
+++ b/influxdb3_server/src/http.rs
@@ -41,7 +41,7 @@ use influxdb3_write::write_buffer::Error as WriteBufferError;
 use iox_http::write::single_tenant::SingleTenantRequestUnifier;
 use iox_http::write::v1::V1_NAMESPACE_RP_SEPARATOR;
 use iox_http::write::{WriteParseError, WriteRequestUnifier};
-use iox_http_util::{Request, Response, ResponseBuilder};
+use iox_http_util::{Request, Response, ResponseBuilder, empty_response_body};
 use iox_query_influxql_rewrite as rewrite;
 use iox_query_params::StatementParams;
 use iox_time::TimeProvider;
@@ -594,7 +594,7 @@ impl HttpApi {
         if result.invalid_lines.is_empty() {
             ResponseBuilder::new()
                 .status(StatusCode::NO_CONTENT)
-                .body(Body::empty())
+                .body(empty_response_body())
                 .map_err(Into::into)
         } else {
             Err(Error::PartialLpWrite(result))
@@ -942,7 +942,7 @@ impl HttpApi {
 
         ResponseBuilder::new()
             .status(StatusCode::OK)
-            .body(Body::empty())
+            .body(empty_response_body())
             .map_err(Into::into)
     }
 
@@ -996,7 +996,7 @@ impl HttpApi {
 
         ResponseBuilder::new()
             .status(StatusCode::OK)
-            .body(Body::empty())
+            .body(empty_response_body())
             .map_err(Into::into)
     }
 
@@ -1034,7 +1034,7 @@ impl HttpApi {
             .await?;
         Ok(ResponseBuilder::new()
             .status(StatusCode::OK)
-            .body(Body::empty())?)
+            .body(empty_response_body())?)
     }
 
     async fn delete_processing_engine_trigger(&self, req: Request) -> Result<Response> {
@@ -1053,7 +1053,7 @@ impl HttpApi {
             .await?;
         Ok(ResponseBuilder::new()
             .status(StatusCode::OK)
-            .body(Body::empty())?)
+            .body(empty_response_body())?)
     }
 
     async fn disable_processing_engine_trigger(&self, req: Request) -> Result<Response> {
@@ -1068,7 +1068,7 @@ impl HttpApi {
         {
             Ok(_) | Err(CatalogError::TriggerAlreadyDisabled) => Ok(ResponseBuilder::new()
                 .status(StatusCode::OK)
-                .body(Body::empty())?),
+                .body(empty_response_body())?),
             Err(error) => Err(error.into()),
         }
     }
@@ -1085,7 +1085,7 @@ impl HttpApi {
         {
             Ok(_) | Err(CatalogError::TriggerAlreadyEnabled) => Ok(ResponseBuilder::new()
                 .status(StatusCode::OK)
-                .body(Body::empty())?),
+                .body(empty_response_body())?),
             Err(error) => Err(error.into()),
         }
     }
@@ -1104,7 +1104,7 @@ impl HttpApi {
 
         Ok(ResponseBuilder::new()
             .status(StatusCode::OK)
-            .body(Body::empty())?)
+            .body(empty_response_body())?)
     }
 
     async fn install_plugin_environment_requirements(&self, req: Request) -> Result<Response> {
@@ -1126,7 +1126,7 @@ impl HttpApi {
 
         Ok(ResponseBuilder::new()
             .status(StatusCode::OK)
-            .body(Body::empty())?)
+            .body(empty_response_body())?)
     }
 
     async fn show_databases(&self, req: Request) -> Result<Response> {
@@ -1148,7 +1148,7 @@ impl HttpApi {
         self.write_buffer.catalog().create_database(&db).await?;
         Ok(ResponseBuilder::new()
             .status(StatusCode::OK)
-            .body(Body::empty())
+            .body(empty_response_body())
             .unwrap())
     }
 
@@ -1236,7 +1236,7 @@ impl HttpApi {
             .await?;
         Ok(ResponseBuilder::new()
             .status(StatusCode::OK)
-            .body(Body::empty())
+            .body(empty_response_body())
             .unwrap())
     }
 
@@ -1261,7 +1261,7 @@ impl HttpApi {
             .await?;
         Ok(ResponseBuilder::new()
             .status(StatusCode::OK)
-            .body(Body::empty())
+            .body(empty_response_body())
             .unwrap())
     }
 
@@ -1274,7 +1274,7 @@ impl HttpApi {
             .await?;
         Ok(ResponseBuilder::new()
             .status(StatusCode::OK)
-            .body(Body::empty())
+            .body(empty_response_body())
             .unwrap())
     }
 
@@ -1287,7 +1287,7 @@ impl HttpApi {
             .await?;
         Ok(ResponseBuilder::new()
             .status(StatusCode::OK)
-            .body(Body::empty())
+            .body(empty_response_body())
             .unwrap())
     }
 
@@ -1498,7 +1498,7 @@ async fn record_batch_stream_to_body(
         QueryFormat::Parquet => {
             // Grab the first batch so that we can get the schema
             let Some(batch) = stream.next().await.transpose()? else {
-                return Ok(Body::empty());
+                return Ok(empty_response_body());
             };
             let schema = batch.schema();
 
@@ -1707,7 +1707,7 @@ pub(crate) async fn route_request(
             .header("Access-Control-Allow-Headers", "*")
             .header("Access-Control-Max-Age", "86400")
             .status(204)
-            .body(Body::empty())
+            .body(empty_response_body())
             .expect("Able to always create a valid response type for CORS"));
     }
 
@@ -1862,7 +1862,7 @@ async fn authenticate(
             AuthenticationError::Unauthenticated => {
                 return Some(Ok(ResponseBuilder::new()
                     .status(StatusCode::UNAUTHORIZED)
-                    .body(Body::empty())
+                    .body(empty_response_body())
                     .unwrap()));
             }
             AuthenticationError::MalformedRequest => {
@@ -1874,7 +1874,7 @@ async fn authenticate(
             AuthenticationError::Forbidden => {
                 return Some(Ok(ResponseBuilder::new()
                     .status(StatusCode::FORBIDDEN)
-                    .body(Body::empty())
+                    .body(empty_response_body())
                     .unwrap()));
             }
             // We don't expect this to happen, but if the header is messed up
@@ -1882,7 +1882,7 @@ async fn authenticate(
             AuthenticationError::ToStr(_) => {
                 return Some(Ok(ResponseBuilder::new()
                     .status(StatusCode::INTERNAL_SERVER_ERROR)
-                    .body(Body::empty())
+                    .body(empty_response_body())
                     .unwrap()));
             }
         }

--- a/influxdb3_server/src/http/v1.rs
+++ b/influxdb3_server/src/http/v1.rs
@@ -24,9 +24,9 @@ use chrono::{DateTime, format::SecondsFormat};
 use datafusion::physical_plan::SendableRecordBatchStream;
 use futures::{Stream, StreamExt, ready, stream::Fuse};
 use hyper::http::HeaderValue;
-use hyper::{Body, Response, StatusCode, header::ACCEPT, header::CONTENT_TYPE};
+use hyper::{Body, StatusCode, header::ACCEPT, header::CONTENT_TYPE};
 use influxdb_influxql_parser::select::{Dimension, GroupByClause};
-use iox_http_util::Request;
+use iox_http_util::{Request, Response};
 use observability_deps::tracing::info;
 use regex::Regex;
 use schema::{INFLUXQL_MEASUREMENT_COLUMN_NAME, InfluxColumnType, TIME_COLUMN_NAME};
@@ -45,7 +45,7 @@ impl HttpApi {
     /// response stream will be chunked into chunks of size `chunk_size`, if provided,
     /// or 10,000. For InfluxQL queries that select from multiple measurements, chunks
     /// will be split on the `chunk_size`, or series, whichever comes first.
-    pub(super) async fn v1_query(&self, req: Request) -> Result<Response<Body>> {
+    pub(super) async fn v1_query(&self, req: Request) -> Result<Response> {
         // extract params first from URI:
         let uri_params = QueryParams::from_request_uri(&req)?;
         // determine the format from the request headers now because we need to consume req to get

--- a/influxdb3_server/src/http/v1.rs
+++ b/influxdb3_server/src/http/v1.rs
@@ -24,8 +24,9 @@ use chrono::{DateTime, format::SecondsFormat};
 use datafusion::physical_plan::SendableRecordBatchStream;
 use futures::{Stream, StreamExt, ready, stream::Fuse};
 use hyper::http::HeaderValue;
-use hyper::{Body, Request, Response, StatusCode, header::ACCEPT, header::CONTENT_TYPE};
+use hyper::{Body, Response, StatusCode, header::ACCEPT, header::CONTENT_TYPE};
 use influxdb_influxql_parser::select::{Dimension, GroupByClause};
+use iox_http_util::Request;
 use observability_deps::tracing::info;
 use regex::Regex;
 use schema::{INFLUXQL_MEASUREMENT_COLUMN_NAME, InfluxColumnType, TIME_COLUMN_NAME};
@@ -44,7 +45,7 @@ impl HttpApi {
     /// response stream will be chunked into chunks of size `chunk_size`, if provided,
     /// or 10,000. For InfluxQL queries that select from multiple measurements, chunks
     /// will be split on the `chunk_size`, or series, whichever comes first.
-    pub(super) async fn v1_query(&self, req: Request<Body>) -> Result<Response<Body>> {
+    pub(super) async fn v1_query(&self, req: Request) -> Result<Response<Body>> {
         // extract params first from URI:
         let uri_params = QueryParams::from_request_uri(&req)?;
         // determine the format from the request headers now because we need to consume req to get
@@ -120,7 +121,7 @@ struct QueryParams {
 
 impl QueryParams {
     /// Extract [`QueryParams`] from an HTTP [`Request`]
-    fn from_request_uri(req: &Request<Body>) -> Result<Self> {
+    fn from_request_uri(req: &Request) -> Result<Self> {
         let query = req.uri().query().unwrap_or_default();
         serde_urlencoded::from_str(query).map_err(Into::into)
     }
@@ -204,7 +205,7 @@ impl QueryFormat {
     /// The function inspects the `Accept` header of the request to determine the
     /// format, defaulting to JSON if no specific format is requested. If the format
     /// is invalid or non-UTF8, an error is returned.
-    fn from_request(req: &Request<Body>) -> Result<Self> {
+    fn from_request(req: &Request) -> Result<Self> {
         let mime_type = req.headers().get(ACCEPT).map(HeaderValue::as_bytes);
         match mime_type {
             Some(b"application/csv" | b"text/csv") => Ok(Self::Csv),

--- a/influxdb3_server/src/http/v1.rs
+++ b/influxdb3_server/src/http/v1.rs
@@ -17,7 +17,6 @@ use arrow::{
     },
     record_batch::RecordBatch,
 };
-
 use arrow_schema::{Field, SchemaRef};
 use bytes::Bytes;
 use chrono::{DateTime, format::SecondsFormat};
@@ -26,7 +25,7 @@ use futures::{Stream, StreamExt, ready, stream::Fuse};
 use hyper::http::HeaderValue;
 use hyper::{Body, StatusCode, header::ACCEPT, header::CONTENT_TYPE};
 use influxdb_influxql_parser::select::{Dimension, GroupByClause};
-use iox_http_util::{Request, Response};
+use iox_http_util::{Request, Response, ResponseBuilder};
 use observability_deps::tracing::info;
 use regex::Regex;
 use schema::{INFLUXQL_MEASUREMENT_COLUMN_NAME, InfluxColumnType, TIME_COLUMN_NAME};
@@ -79,7 +78,7 @@ impl HttpApi {
             .map_err(QueryError)?;
         let body = Body::wrap_stream(stream);
 
-        Ok(Response::builder()
+        Ok(ResponseBuilder::new()
             .status(StatusCode::OK)
             .header(CONTENT_TYPE, format.as_content_type())
             .body(body)

--- a/influxdb3_server/src/http/v1.rs
+++ b/influxdb3_server/src/http/v1.rs
@@ -21,11 +21,11 @@ use arrow_schema::{Field, SchemaRef};
 use bytes::Bytes;
 use chrono::{DateTime, format::SecondsFormat};
 use datafusion::physical_plan::SendableRecordBatchStream;
-use futures::{Stream, StreamExt, ready, stream::Fuse};
+use futures::{Stream, StreamExt, TryStreamExt, ready, stream::Fuse};
 use hyper::http::HeaderValue;
-use hyper::{Body, StatusCode, header::ACCEPT, header::CONTENT_TYPE};
+use hyper::{StatusCode, header::ACCEPT, header::CONTENT_TYPE};
 use influxdb_influxql_parser::select::{Dimension, GroupByClause};
-use iox_http_util::{Request, Response, ResponseBuilder};
+use iox_http_util::{Request, Response, ResponseBuilder, stream_results_to_response_body};
 use observability_deps::tracing::info;
 use regex::Regex;
 use schema::{INFLUXQL_MEASUREMENT_COLUMN_NAME, InfluxColumnType, TIME_COLUMN_NAME};
@@ -76,7 +76,7 @@ impl HttpApi {
         let (stream, group_by) = self.query_influxql_inner(database, &query, None).await?;
         let stream = QueryResponseStream::new(0, stream, chunk_size, format, epoch, group_by)
             .map_err(QueryError)?;
-        let body = Body::wrap_stream(stream);
+        let body = stream_results_to_response_body(stream.map_err(QueryError));
 
         Ok(ResponseBuilder::new()
             .status(StatusCode::OK)
@@ -263,7 +263,7 @@ struct QueryResponse {
     format: QueryFormat,
 }
 
-/// Convert `QueryResponse` to [`Bytes`] for `hyper`'s [`Body::wrap_stream`] method
+/// Convert `QueryResponse` to [`Bytes`] for `the` [`stream_results_to_response_body`] method
 impl From<QueryResponse> for Bytes {
     fn from(s: QueryResponse) -> Self {
         /// Convert a [`QueryResponse`] to a JSON byte vector.

--- a/influxdb3_server/src/lib.rs
+++ b/influxdb3_server/src/lib.rs
@@ -286,7 +286,7 @@ mod tests {
     use crate::query_executor::{CreateQueryExecutorArgs, QueryExecutorImpl};
     use crate::serve;
     use datafusion::parquet::data_type::AsBytes;
-    use hyper::{Body, Client, Response, StatusCode, body};
+    use hyper::{Client, StatusCode, body};
     use influxdb3_authz::NoAuthAuthenticator;
     use influxdb3_cache::distinct_cache::DistinctCacheProvider;
     use influxdb3_cache::last_cache::LastCacheProvider;
@@ -302,7 +302,7 @@ mod tests {
     use influxdb3_write::persister::Persister;
     use influxdb3_write::write_buffer::persisted_files::PersistedFiles;
     use influxdb3_write::{Bufferer, WriteBuffer};
-    use iox_http_util::{RequestBuilder, bytes_to_request_body, empty_request_body};
+    use iox_http_util::{RequestBuilder, Response, bytes_to_request_body, empty_request_body};
     use iox_query::exec::{DedicatedExecutor, Executor, ExecutorConfig, PerQueryMemoryPoolConfig};
     use iox_time::{MockProvider, Time};
     use object_store::DynObjectStore;
@@ -984,7 +984,7 @@ mod tests {
         authorization: Option<&str>,
         accept_partial: bool,
         precision: impl Into<String> + Send,
-    ) -> Response<Body> {
+    ) -> Response {
         let server = server.into();
         let client = Client::new();
         let url = format!(
@@ -1015,7 +1015,7 @@ mod tests {
         query: impl Into<String> + Send,
         format: impl Into<String> + Send,
         authorization: Option<&str>,
-    ) -> Response<Body> {
+    ) -> Response {
         let client = Client::new();
         // query escaped for uri
         let query = urlencoding::encode(&query.into());

--- a/influxdb3_server/src/lib.rs
+++ b/influxdb3_server/src/lib.rs
@@ -302,7 +302,7 @@ mod tests {
     use influxdb3_write::persister::Persister;
     use influxdb3_write::write_buffer::persisted_files::PersistedFiles;
     use influxdb3_write::{Bufferer, WriteBuffer};
-    use iox_http_util::{RequestBuilder, empty_request_body};
+    use iox_http_util::{RequestBuilder, bytes_to_request_body, empty_request_body};
     use iox_query::exec::{DedicatedExecutor, Executor, ExecutorConfig, PerQueryMemoryPoolConfig};
     use iox_time::{MockProvider, Time};
     use object_store::DynObjectStore;
@@ -1000,7 +1000,7 @@ mod tests {
             builder = builder.header(hyper::header::AUTHORIZATION, authorization);
         };
         let request = builder
-            .body(Body::from(lp.into()))
+            .body(bytes_to_request_body(lp.into()))
             .expect("failed to construct HTTP request");
 
         client

--- a/influxdb3_server/src/lib.rs
+++ b/influxdb3_server/src/lib.rs
@@ -286,7 +286,7 @@ mod tests {
     use crate::query_executor::{CreateQueryExecutorArgs, QueryExecutorImpl};
     use crate::serve;
     use datafusion::parquet::data_type::AsBytes;
-    use hyper::{Body, Client, Request, Response, StatusCode, body};
+    use hyper::{Body, Client, Response, StatusCode, body};
     use influxdb3_authz::NoAuthAuthenticator;
     use influxdb3_cache::distinct_cache::DistinctCacheProvider;
     use influxdb3_cache::last_cache::LastCacheProvider;
@@ -302,6 +302,7 @@ mod tests {
     use influxdb3_write::persister::Persister;
     use influxdb3_write::write_buffer::persisted_files::PersistedFiles;
     use influxdb3_write::{Bufferer, WriteBuffer};
+    use iox_http_util::RequestBuilder;
     use iox_query::exec::{DedicatedExecutor, Executor, ExecutorConfig, PerQueryMemoryPoolConfig};
     use iox_time::{MockProvider, Time};
     use object_store::DynObjectStore;
@@ -994,7 +995,7 @@ mod tests {
         );
         println!("{}", url);
 
-        let mut builder = Request::builder().uri(url).method("POST");
+        let mut builder = RequestBuilder::new().uri(url).method("POST");
         if let Some(authorization) = authorization {
             builder = builder.header(hyper::header::AUTHORIZATION, authorization);
         };
@@ -1027,7 +1028,7 @@ mod tests {
         );
 
         println!("query url: {}", url);
-        let mut builder = Request::builder().uri(url).method("GET");
+        let mut builder = RequestBuilder::new().uri(url).method("GET");
         if let Some(authorization) = authorization {
             builder = builder.header(hyper::header::AUTHORIZATION, authorization);
         };

--- a/influxdb3_server/src/lib.rs
+++ b/influxdb3_server/src/lib.rs
@@ -302,7 +302,7 @@ mod tests {
     use influxdb3_write::persister::Persister;
     use influxdb3_write::write_buffer::persisted_files::PersistedFiles;
     use influxdb3_write::{Bufferer, WriteBuffer};
-    use iox_http_util::RequestBuilder;
+    use iox_http_util::{RequestBuilder, empty_request_body};
     use iox_query::exec::{DedicatedExecutor, Executor, ExecutorConfig, PerQueryMemoryPoolConfig};
     use iox_time::{MockProvider, Time};
     use object_store::DynObjectStore;
@@ -1033,7 +1033,7 @@ mod tests {
             builder = builder.header(hyper::header::AUTHORIZATION, authorization);
         };
         let request = builder
-            .body(Body::empty())
+            .body(empty_request_body())
             .expect("failed to construct HTTP request");
 
         client

--- a/influxdb3_server/src/query_executor/mod.rs
+++ b/influxdb3_server/src/query_executor/mod.rs
@@ -35,6 +35,7 @@ use iox_query::query_log::StateReceived;
 use iox_query::query_log::{QueryCompletedToken, QueryLogEntries};
 use iox_query::{QueryChunk, QueryNamespace};
 use iox_query_params::StatementParams;
+use iox_time::TimeProvider;
 use metric::Registry;
 use observability_deps::tracing::{debug, info};
 use std::any::Any;
@@ -70,6 +71,7 @@ pub struct CreateQueryExecutorArgs {
     pub write_buffer: Arc<dyn WriteBuffer>,
     pub exec: Arc<Executor>,
     pub metrics: Arc<Registry>,
+    pub time_provider: Arc<dyn TimeProvider>,
     pub datafusion_config: Arc<HashMap<String, String>>,
     pub query_log_size: usize,
     pub telemetry_store: Arc<TelemetryStore>,
@@ -89,6 +91,7 @@ impl QueryExecutorImpl {
             telemetry_store,
             sys_events_store,
             started_with_auth,
+            time_provider,
         }: CreateQueryExecutorArgs,
     ) -> Self {
         let semaphore_metrics = Arc::new(AsyncSemaphoreMetrics::new(
@@ -97,10 +100,7 @@ impl QueryExecutorImpl {
         ));
         let query_execution_semaphore =
             Arc::new(semaphore_metrics.new_semaphore(Semaphore::MAX_PERMITS));
-        let query_log = Arc::new(QueryLog::new(
-            query_log_size,
-            Arc::new(iox_time::SystemProvider::new()),
-        ));
+        let query_log = Arc::new(QueryLog::new(query_log_size, time_provider, &metrics));
         Self {
             catalog,
             write_buffer,
@@ -271,6 +271,8 @@ async fn query_database_sql(
         "sql",
         Box::new(query.to_string()),
         params.clone(),
+        // NB: do we need to provide an auth ID?
+        None,
     );
 
     // NOTE - we use the default query configuration on the IOxSessionContext here:
@@ -325,6 +327,8 @@ async fn query_database_influxql(
         "influxql",
         Box::new(query_str.to_string()),
         params.clone(),
+        // NB: do we need to provide an auth ID?
+        None,
     );
 
     let ctx = db.new_query_context(span_ctx, Default::default());
@@ -556,6 +560,7 @@ impl QueryNamespace for Database {
         query_type: &'static str,
         query_text: QueryText,
         query_params: StatementParams,
+        auth_id: Option<String>,
     ) -> QueryCompletedToken<StateReceived> {
         let trace_id = span_ctx.map(|ctx| ctx.trace_id);
         let namespace_name: Arc<str> = Arc::from("influxdb3 oss");
@@ -565,6 +570,7 @@ impl QueryNamespace for Database {
             query_type,
             query_text,
             query_params,
+            auth_id,
             trace_id,
         )
     }
@@ -767,7 +773,7 @@ mod tests {
         persister::Persister,
         write_buffer::{WriteBufferImpl, WriteBufferImplArgs, persisted_files::PersistedFiles},
     };
-    use iox_query::exec::{DedicatedExecutor, Executor, ExecutorConfig};
+    use iox_query::exec::{DedicatedExecutor, Executor, ExecutorConfig, PerQueryMemoryPoolConfig};
     use iox_time::{MockProvider, Time};
     use metric::Registry;
     use object_store::{ObjectStore, local::LocalFileSystem};
@@ -793,6 +799,8 @@ mod tests {
                 metric_registry: Arc::clone(&metrics),
                 // Default to 1gb
                 mem_pool_size: 1024 * 1024 * 1024, // 1024 (b/kb) * 1024 (kb/mb) * 1024 (mb/gb)
+                per_query_mem_pool_config: PerQueryMemoryPoolConfig::Disabled,
+                heap_memory_limit: None,
             },
             DedicatedExecutor::new_testing(),
         ))
@@ -886,6 +894,7 @@ mod tests {
             telemetry_store,
             sys_events_store: Arc::clone(&sys_events_store),
             started_with_auth,
+            time_provider: Arc::clone(&time_provider) as _,
         });
 
         (

--- a/influxdb3_server/src/query_planner.rs
+++ b/influxdb3_server/src/query_planner.rs
@@ -93,18 +93,24 @@ impl SchemaExec {
         }
     }
 
-    /// This function creates the cache object that stores the plan properties such as equivalence properties, partitioning, ordering, etc.
+    /// This function creates the cache object that stores the plan properties such as equivalence
+    /// properties, partitioning, ordering, etc.
     fn compute_properties(input: &Arc<dyn ExecutionPlan>, schema: SchemaRef) -> PlanProperties {
         let eq_properties = match input.properties().output_ordering() {
             None => EquivalenceProperties::new(schema),
             Some(output_odering) => {
-                EquivalenceProperties::new_with_orderings(schema, &[output_odering.to_vec()])
+                EquivalenceProperties::new_with_orderings(schema, &[output_odering.clone()])
             }
         };
 
         let output_partitioning = input.output_partitioning().clone();
 
-        PlanProperties::new(eq_properties, output_partitioning, input.execution_mode())
+        PlanProperties::new(
+            eq_properties,
+            output_partitioning,
+            input.pipeline_behavior(),
+            input.boundedness(),
+        )
     }
 }
 

--- a/influxdb3_server/src/service.rs
+++ b/influxdb3_server/src/service.rs
@@ -18,7 +18,8 @@ use std::task::{Context, Poll};
 
 use futures::Future;
 use hyper::HeaderMap;
-use hyper::{Body, Request, Response, body::HttpBody};
+use hyper::{Response, body::HttpBody};
+use iox_http_util::Request;
 use pin_project_lite::pin_project;
 use tower::Service;
 
@@ -99,10 +100,10 @@ pub(crate) struct HybridService<Rest, Grpc> {
     grpc: Grpc,
 }
 
-impl<Rest, Grpc, RestBody, GrpcBody> Service<Request<Body>> for HybridService<Rest, Grpc>
+impl<Rest, Grpc, RestBody, GrpcBody> Service<Request> for HybridService<Rest, Grpc>
 where
-    Rest: Service<Request<Body>, Response = Response<RestBody>>,
-    Grpc: Service<Request<Body>, Response = Response<GrpcBody>>,
+    Rest: Service<Request, Response = Response<RestBody>>,
+    Grpc: Service<Request, Response = Response<GrpcBody>>,
     Rest::Error: Into<BoxError>,
     Grpc::Error: Into<BoxError>,
 {
@@ -125,7 +126,7 @@ where
     /// When calling the service, gRPC is served if the HTTP request version is HTTP/2
     /// and if the Content-Type is "application/grpc"; otherwise, the request is served
     /// as a REST request
-    fn call(&mut self, req: Request<Body>) -> Self::Future {
+    fn call(&mut self, req: Request) -> Self::Future {
         match (
             req.version(),
             req.headers().get(hyper::header::CONTENT_TYPE),

--- a/influxdb3_server/src/service.rs
+++ b/influxdb3_server/src/service.rs
@@ -17,8 +17,9 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 
 use futures::Future;
+use http::Response;
+use http_body::Body as HttpBody;
 use hyper::HeaderMap;
-use hyper::{Response, body::HttpBody};
 use iox_http_util::Request;
 use pin_project_lite::pin_project;
 use tower::Service;

--- a/influxdb3_write/Cargo.toml
+++ b/influxdb3_write/Cargo.toml
@@ -14,7 +14,6 @@ data_types.workspace = true
 datafusion_util.workspace = true
 executor.workspace = true
 influxdb-line-protocol.workspace = true
-iox_catalog.workspace = true
 iox_http.workspace = true
 iox_query.workspace = true
 iox_time.workspace = true

--- a/influxdb3_write/src/write_buffer/mod.rs
+++ b/influxdb3_write/src/write_buffer/mod.rs
@@ -674,7 +674,7 @@ mod tests {
     use influxdb3_test_helpers::object_store::RequestCountedObjectStore;
     use influxdb3_types::http::LastCacheSize;
     use influxdb3_wal::{Gen1Duration, SnapshotSequenceNumber, WalFileSequenceNumber};
-    use iox_query::exec::{Executor, ExecutorConfig, IOxSessionContext};
+    use iox_query::exec::{Executor, ExecutorConfig, IOxSessionContext, PerQueryMemoryPoolConfig};
     use iox_time::{MockProvider, Time};
     use metric::{Attributes, Metric, U64Counter};
     use metrics::{
@@ -3278,6 +3278,8 @@ mod tests {
                 metric_registry: Arc::clone(&metrics),
                 // Default to 1gb
                 mem_pool_size: 1024 * 1024 * 1024, // 1024 (b/kb) * 1024 (kb/mb) * 1024 (mb/gb)
+                per_query_mem_pool_config: PerQueryMemoryPoolConfig::Disabled,
+                heap_memory_limit: None,
             },
             DedicatedExecutor::new_testing(),
         ))

--- a/influxdb3_write/src/write_buffer/queryable_buffer.rs
+++ b/influxdb3_write/src/write_buffer/queryable_buffer.rs
@@ -614,7 +614,7 @@ mod tests {
     use datafusion_util::config::register_iox_object_store;
     use executor::{DedicatedExecutor, register_current_runtime_for_io};
     use influxdb3_wal::{Gen1Duration, SnapshotSequenceNumber, WalFileSequenceNumber};
-    use iox_query::exec::ExecutorConfig;
+    use iox_query::exec::{ExecutorConfig, PerQueryMemoryPoolConfig};
     use iox_time::{MockProvider, Time, TimeProvider};
     use object_store::ObjectStore;
     use object_store::memory::InMemory;
@@ -638,6 +638,8 @@ mod tests {
                 metric_registry: Arc::clone(&metrics),
                 // Default to 1gb
                 mem_pool_size: 1024 * 1024 * 1024, // 1024 (b/kb) * 1024 (kb/mb) * 1024 (mb/gb)
+                per_query_mem_pool_config: PerQueryMemoryPoolConfig::Disabled,
+                heap_memory_limit: None,
             },
             DedicatedExecutor::new_testing(),
         ));


### PR DESCRIPTION
This builds on https://github.com/influxdata/influxdb/pull/26429. I'm happy to wait until that is merged in and then I'll rebase!

That PR makes `iox_http_util` available, which is a crate I made in IOx to extract common HTTP types and functions so that when we upgrade to hyper 1, those definitions only need to be updated in `iox_http_util` (mostly), not everywhere.