### PR TITLE
chore: update go to 1.23.9 (#26405)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ orbs:
 parameters:
   cross-container-tag:
     type: string
-    default: go1.23.8-latest
+    default: go1.23.9-latest
 
   workflow:
     type: string

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/influxdata/influxdb/v2
 
 go 1.23.0
 
-toolchain go1.23.8
+toolchain go1.23.9
 
 require (
 	github.com/BurntSushi/toml v1.2.1


### PR DESCRIPTION
Fixes CVE-2025-22871.

Fixes #26404.


(cherry picked from commit ec9dcde5d6f0e1c4d15ff2332127987a42ca30fc)

