### PR TITLE
feat: Install awscli per circle ci docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -560,6 +560,10 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp/workspace
+      - run:
+          name: Install AWS CLI
+          command: |
+            pip install awscli
       - aws-s3/sync:
           arguments:             --acl public-read
           aws-region:            RELEASE_AWS_REGION


### PR DESCRIPTION
see: https://circleci.com/docs/deploy-to-aws/#deploy-awscli
This will install `awscli` to the CI machine while running s3 sync
