### PR TITLE
test: reproduce problem with NULL backfill of omitted tag cols

### DIFF
--- a/influxdb3_write/src/write_buffer/mod.rs
+++ b/influxdb3_write/src/write_buffer/mod.rs
@@ -3121,10 +3121,8 @@ mod tests {
                 .unwrap()
                 .as_dictionary::<Int32Type>();
             let tag_vals = tag_col.values().as_string::<i32>();
-            for val in tag_vals {
-                if let Some(s) = val {
-                    assert!(!s.is_empty(), "there should not be any empty strings");
-                }
+            for s in tag_vals.iter().flatten() {
+                assert!(!s.is_empty(), "there should not be any empty strings");
             }
         }
     }

--- a/influxdb3_write/src/write_buffer/table_buffer.rs
+++ b/influxdb3_write/src/write_buffer/table_buffer.rs
@@ -386,24 +386,6 @@ impl MutableTableChunk {
             cols.push(col);
         }
 
-        // ensure that every series key column is present in the batch
-        for col_id in &table_def.series_key {
-            if !cols_in_batch.contains(col_id) {
-                let col_name = table_def
-                    .column_id_to_name(col_id)
-                    .expect("valid column id");
-                schema_builder.influx_column(col_name.as_ref(), InfluxColumnType::Tag);
-                let mut tag_builder: StringDictionaryBuilder<Int32Type> =
-                    StringDictionaryBuilder::new();
-                for _ in 0..self.row_count {
-                    tag_builder.append_value("");
-                }
-
-                cols.push(Arc::new(tag_builder.finish()));
-                cols_in_batch.insert(*col_id);
-            }
-        }
-
         // ensure that every field column is present in the batch
         for (col_id, col_def) in table_def.columns.iter() {
             if !cols_in_batch.contains(col_id) {


### PR DESCRIPTION
Part of #26441 

I found a place where empty string was being used to fill in missing tags, instead of `NULL`. This is when persisting parquet. If a tag column has not been written, e.g., since the last snapshot, and therefore is absent in the buffer, then tags were being filled in with `""` instead of nulls (see [here](https://github.com/influxdata/influxdb/blob/56df158afd593e0f90590a658e36476158cd47f8/influxdb3_write/src/write_buffer/table_buffer.rs#L399)).

A reproducer was added for this scenario, which can be seen failing originally [in CI](https://app.circleci.com/pipelines/github/influxdata/influxdb/45990/workflows/a7bad554-a490-415e-924b-19135f394b42/jobs/437126?invite=true#step-110-96428_41) for 62cca91745cdc1aa342205d80d9b772f91dc3a8f

The issue is fixed in 61c09060d11375ee946d0594164d96ebfcd85e05