### PR TITLE
fix: add key variant back to wal to fix bitcode deserialization

### DIFF
--- a/influxdb3_cache/src/distinct_cache/cache.rs
+++ b/influxdb3_cache/src/distinct_cache/cache.rs
@@ -469,6 +469,7 @@ impl From<&FieldData> for Value {
             | FieldData::UInteger(_)
             | FieldData::Float(_)
             | FieldData::Boolean(_) => panic!("unexpected field type for distinct value cache"),
+            FieldData::Key(_) => unreachable!("key type should never be constructed"),
         }
     }
 }

--- a/influxdb3_cache/src/last_cache/cache.rs
+++ b/influxdb3_cache/src/last_cache/cache.rs
@@ -679,6 +679,7 @@ impl From<&FieldData> for KeyValue {
             FieldData::Boolean(b) => Self::Bool(*b),
             FieldData::Timestamp(_) => panic!("unexpected time stamp as key value"),
             FieldData::Float(_) => panic!("unexpected float as key value"),
+            FieldData::Key(_) => unreachable!("key type should never be constructed"),
         }
     }
 }
@@ -1140,5 +1141,6 @@ fn data_type_from_buffer_field(field: &Field) -> InfluxColumnType {
         FieldData::UInteger(_) => InfluxColumnType::Field(InfluxFieldType::UInteger),
         FieldData::Float(_) => InfluxColumnType::Field(InfluxFieldType::Float),
         FieldData::Boolean(_) => InfluxColumnType::Field(InfluxFieldType::Boolean),
+        FieldData::Key(_) => unreachable!("key type should never be constructed"),
     }
 }

--- a/influxdb3_py_api/src/system_py.rs
+++ b/influxdb3_py_api/src/system_py.rs
@@ -565,6 +565,9 @@ pub fn execute_python_with_batch(
                                     .set_item(field_name.as_ref(), t)
                                     .context("failed to set timestamp")?;
                             }
+                            FieldData::Key(_) => {
+                                unreachable!("key type should never be constructed")
+                            }
                         };
                     }
 

--- a/influxdb3_wal/src/lib.rs
+++ b/influxdb3_wal/src/lib.rs
@@ -387,6 +387,7 @@ pub struct Row {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum FieldData {
     Timestamp(i64),
+    Key(String),
     Tag(String),
     String(String),
     Integer(i64),

--- a/influxdb3_write/src/write_buffer/table_buffer.rs
+++ b/influxdb3_write/src/write_buffer/table_buffer.rs
@@ -331,6 +331,7 @@ impl MutableTableChunk {
                             panic!("unexpected field type");
                         }
                     }
+                    FieldData::Key(_) => unreachable!("key type should never be constructed"),
                 }
             }
 


### PR DESCRIPTION
Addresses #26452

Re-introduce the `Key` variant to the `FieldData` type in the WAL to fix WAL file deserialization of WAL files created before https://github.com/influxdata/influxdb/pull/26443