### PR TITLE
fix: use associated constant to ensure correct file ID is always used for serialization

### DIFF
--- a/influxdb3_catalog/src/catalog.rs
+++ b/influxdb3_catalog/src/catalog.rs
@@ -2137,7 +2137,7 @@ mod tests {
     use crate::{
         log::{FieldDataType, LastCacheSize, LastCacheTtl, MaxAge, MaxCardinality, create},
         object_store::CatalogFilePath,
-        serialize::{serialize_catalog_snapshot, verify_and_deserialize_catalog_checkpoint_file},
+        serialize::{serialize_catalog_file, verify_and_deserialize_catalog_checkpoint_file},
     };
 
     use super::*;
@@ -2192,7 +2192,7 @@ mod tests {
                     ".catalog_uuid" => "[uuid]"
                 });
                 // Serialize/deserialize to ensure roundtrip
-                let serialized = serialize_catalog_snapshot(&snapshot).unwrap();
+                let serialized = serialize_catalog_file(&snapshot).unwrap();
                 let snapshot = verify_and_deserialize_catalog_checkpoint_file(serialized).unwrap() ;
                 insta::assert_json_snapshot!(snapshot, {
                     ".catalog_uuid" => "[uuid]"
@@ -2322,7 +2322,7 @@ mod tests {
                     ".catalog_uuid" => "[uuid]"
                 });
                 // Serialize/deserialize to ensure roundtrip
-                let serialized = serialize_catalog_snapshot(&snapshot).unwrap();
+                let serialized = serialize_catalog_file(&snapshot).unwrap();
                 let snapshot = verify_and_deserialize_catalog_checkpoint_file(serialized).unwrap() ;
                 insta::assert_json_snapshot!(snapshot, {
                     ".catalog_uuid" => "[uuid]"
@@ -2369,7 +2369,7 @@ mod tests {
                     ".catalog_uuid" => "[uuid]"
                 });
                 // Serialize/deserialize to ensure roundtrip
-                let serialized = serialize_catalog_snapshot(&snapshot).unwrap();
+                let serialized = serialize_catalog_file(&snapshot).unwrap();
                 let snapshot = verify_and_deserialize_catalog_checkpoint_file(serialized).unwrap() ;
                 insta::assert_json_snapshot!(snapshot, {
                     ".catalog_uuid" => "[uuid]"
@@ -2415,7 +2415,7 @@ mod tests {
                     ".catalog_uuid" => "[uuid]"
                 });
                 // Serialize/deserialize to ensure roundtrip
-                let serialized = serialize_catalog_snapshot(&snapshot).unwrap();
+                let serialized = serialize_catalog_file(&snapshot).unwrap();
                 let snapshot = verify_and_deserialize_catalog_checkpoint_file(serialized).unwrap() ;
                 insta::assert_json_snapshot!(snapshot, {
                     ".catalog_uuid" => "[uuid]"

--- a/influxdb3_catalog/src/log/versions/v1.rs
+++ b/influxdb3_catalog/src/log/versions/v1.rs
@@ -25,7 +25,7 @@ use hashbrown::HashMap;
 use influxdb3_id::{ColumnId, DbId, DistinctCacheId, LastCacheId, NodeId, TableId, TriggerId};
 use serde::{Deserialize, Serialize};
 
-use crate::{CatalogError, Result, catalog::CatalogSequenceNumber};
+use crate::{CatalogError, Result, catalog::CatalogSequenceNumber, serialize::VersionedFileType};
 
 mod conversion;
 
@@ -56,6 +56,10 @@ pub(crate) struct DatabaseBatch {
 pub(crate) struct OrderedCatalogBatch {
     pub(crate) catalog_batch: CatalogBatch,
     pub(crate) sequence_number: CatalogSequenceNumber,
+}
+
+impl VersionedFileType for OrderedCatalogBatch {
+    const VERSION_ID: [u8; 10] = *b"idb3.001.l";
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]

--- a/influxdb3_catalog/src/log/versions/v2.rs
+++ b/influxdb3_catalog/src/log/versions/v2.rs
@@ -21,7 +21,7 @@ use schema::{InfluxColumnType, InfluxFieldType};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::{CatalogError, Result, catalog::CatalogSequenceNumber};
+use crate::{CatalogError, Result, catalog::CatalogSequenceNumber, serialize::VersionedFileType};
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub enum CatalogBatch {
@@ -134,6 +134,10 @@ impl OrderedCatalogBatch {
     pub fn into_batch(self) -> CatalogBatch {
         self.catalog_batch
     }
+}
+
+impl VersionedFileType for OrderedCatalogBatch {
+    const VERSION_ID: [u8; 10] = *b"idb3.002.l";
 }
 
 impl PartialOrd for OrderedCatalogBatch {

--- a/influxdb3_catalog/src/log/versions/v3.rs
+++ b/influxdb3_catalog/src/log/versions/v3.rs
@@ -22,7 +22,7 @@ use schema::{InfluxColumnType, InfluxFieldType};
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
-use crate::{CatalogError, Result, catalog::CatalogSequenceNumber};
+use crate::{CatalogError, Result, catalog::CatalogSequenceNumber, serialize::VersionedFileType};
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
 pub enum CatalogBatch {
@@ -135,6 +135,10 @@ impl OrderedCatalogBatch {
     pub fn into_batch(self) -> CatalogBatch {
         self.catalog_batch
     }
+}
+
+impl VersionedFileType for OrderedCatalogBatch {
+    const VERSION_ID: [u8; 10] = *b"idb3.003.l";
 }
 
 impl PartialOrd for OrderedCatalogBatch {

--- a/influxdb3_catalog/src/object_store.rs
+++ b/influxdb3_catalog/src/object_store.rs
@@ -16,9 +16,7 @@ use crate::snapshot::versions::Snapshot;
 use crate::{
     catalog::CatalogSequenceNumber,
     log::OrderedCatalogBatch,
-    serialize::{
-        serialize_catalog_log, serialize_catalog_snapshot, verify_and_deserialize_catalog_file,
-    },
+    serialize::{serialize_catalog_file, verify_and_deserialize_catalog_file},
 };
 
 #[derive(Debug, thiserror::Error)]
@@ -211,7 +209,7 @@ impl ObjectStoreCatalog {
     ) -> Result<PersistCatalogResult> {
         let catalog_path = CatalogFilePath::log(&self.prefix, batch.sequence_number());
 
-        let content = serialize_catalog_log(batch).context("failed to serialize catalog batch")?;
+        let content = serialize_catalog_file(batch).context("failed to serialize catalog batch")?;
 
         self.catalog_update_if_not_exists(catalog_path, content)
             .await
@@ -228,7 +226,7 @@ impl ObjectStoreCatalog {
         let catalog_path = CatalogFilePath::checkpoint(&self.prefix);
 
         let content =
-            serialize_catalog_snapshot(snapshot).context("failed to serialize catalog snapshot")?;
+            serialize_catalog_file(snapshot).context("failed to serialize catalog snapshot")?;
 
         // NOTE: not sure if this should be done in a loop, i.e., what error variants from
         // the object store would warrant a retry.
@@ -270,7 +268,7 @@ impl ObjectStoreCatalog {
         let catalog_path = CatalogFilePath::checkpoint(&self.prefix);
 
         let content =
-            serialize_catalog_snapshot(snapshot).context("failed to serialize catalog snapshot")?;
+            serialize_catalog_file(snapshot).context("failed to serialize catalog snapshot")?;
 
         let store = Arc::clone(&self.store);
 

--- a/influxdb3_catalog/src/serialize.rs
+++ b/influxdb3_catalog/src/serialize.rs
@@ -3,10 +3,11 @@ use std::io::Cursor;
 use anyhow::Context;
 use byteorder::{BigEndian, ReadBytesExt};
 use bytes::{Bytes, BytesMut};
+use serde::Serialize;
 
 use crate::{
     CatalogError, Result,
-    log::{self, OrderedCatalogBatch},
+    log::{self},
     snapshot::{self, CatalogSnapshot},
 };
 
@@ -15,75 +16,96 @@ const CHECKSUM_LEN: usize = size_of::<u32>();
 pub fn verify_and_deserialize_catalog_file(
     bytes: Bytes,
 ) -> Result<log::versions::v3::OrderedCatalogBatch> {
-    if bytes.starts_with(LOG_FILE_TYPE_IDENTIFIER_V1) {
-        // V1 Deserialization:
-        let id_len = LOG_FILE_TYPE_IDENTIFIER_V1.len();
-        let checksum = bytes.slice(id_len..id_len + CHECKSUM_LEN);
-        let data = bytes.slice(id_len + CHECKSUM_LEN..);
-        verify_checksum(&checksum, &data)?;
-        let log = bitcode::deserialize::<log::versions::v1::OrderedCatalogBatch>(&data)
-            .context("failed to deserialize v1 catalog log file contents")?;
+    let version_id: &[u8; 10] = bytes.first_chunk().ok_or(CatalogError::unexpected(
+        "file must contain at least 10 bytes",
+    ))?;
 
-        // explicit type annotations are needed once you start chaining `.into` (something to check
-        // later to see if that could be avoided, then this can just be a loop with starting and
-        // end point based on current log file's version)
-        let log_v2: log::versions::v2::OrderedCatalogBatch = log.into();
-        let log_v3: log::versions::v3::OrderedCatalogBatch = log_v2.into();
-        Ok(log_v3)
-    } else if bytes.starts_with(LOG_FILE_TYPE_IDENTIFIER_V2) {
-        // V2 Deserialization:
-        let id_len = LOG_FILE_TYPE_IDENTIFIER_V2.len();
-        let checksum = bytes.slice(id_len..id_len + CHECKSUM_LEN);
-        let data = bytes.slice(id_len + CHECKSUM_LEN..);
-        verify_checksum(&checksum, &data)?;
-        let log = serde_json::from_slice::<log::versions::v2::OrderedCatalogBatch>(&data)
-            .context("failed to deserialize v2 catalog log file contents")?;
-        Ok(log.into())
-    } else if bytes.starts_with(LOG_FILE_TYPE_IDENTIFIER_V3) {
-        // V3 Deserialization:
-        let id_len = LOG_FILE_TYPE_IDENTIFIER_V3.len();
-        let checksum = bytes.slice(id_len..id_len + CHECKSUM_LEN);
-        let data = bytes.slice(id_len + CHECKSUM_LEN..);
-        verify_checksum(&checksum, &data)?;
-        let log = serde_json::from_slice::<log::versions::v3::OrderedCatalogBatch>(&data)
-            .context("failed to deserialize v3 catalog log file contents")?;
-        Ok(log)
-    } else {
-        Err(CatalogError::unexpected("unrecognized catalog file format"))
+    match *version_id {
+        // Version 1 uses the `bitcode` crate for serialization/deserialization
+        log::versions::v1::OrderedCatalogBatch::VERSION_ID => {
+            // V1 Deserialization:
+            let checksum = bytes.slice(10..10 + CHECKSUM_LEN);
+            let data = bytes.slice(10 + CHECKSUM_LEN..);
+            verify_checksum(&checksum, &data)?;
+            let log = bitcode::deserialize::<log::versions::v1::OrderedCatalogBatch>(&data)
+                .context("failed to deserialize v1 catalog log file contents")?;
+
+            // explicit type annotations are needed once you start chaining `.into` (something to check
+            // later to see if that could be avoided, then this can just be a loop with starting and
+            // end point based on current log file's version)
+            let log_v2: log::versions::v2::OrderedCatalogBatch = log.into();
+            let log_v3: log::versions::v3::OrderedCatalogBatch = log_v2.into();
+            Ok(log_v3)
+        }
+        // Version 2 uses the `serde_json` crate for serialization/deserialization
+        log::versions::v2::OrderedCatalogBatch::VERSION_ID => {
+            // V2 Deserialization:
+            let checksum = bytes.slice(10..10 + CHECKSUM_LEN);
+            let data = bytes.slice(10 + CHECKSUM_LEN..);
+            verify_checksum(&checksum, &data)?;
+            let log = serde_json::from_slice::<log::versions::v2::OrderedCatalogBatch>(&data)
+                .context("failed to deserialize v2 catalog log file contents")?;
+            Ok(log.into())
+        }
+        // Version 3 added a conversion function to map db:*:write tokens to be db:*:create,write
+        // tokens, and because it's a one time migration it relies on the version in file the
+        // version has to be updated.
+        log::versions::v3::OrderedCatalogBatch::VERSION_ID => {
+            // V3 Deserialization:
+            let checksum = bytes.slice(10..10 + CHECKSUM_LEN);
+            let data = bytes.slice(10 + CHECKSUM_LEN..);
+            verify_checksum(&checksum, &data)?;
+            let log = serde_json::from_slice::<log::versions::v3::OrderedCatalogBatch>(&data)
+                .context("failed to deserialize v3 catalog log file contents")?;
+            Ok(log)
+        }
+        _ => Err(CatalogError::unexpected("unrecognized catalog file format")),
     }
 }
 
 pub fn verify_and_deserialize_catalog_checkpoint_file(bytes: Bytes) -> Result<CatalogSnapshot> {
-    if bytes.starts_with(SNAPSHOT_FILE_TYPE_IDENTIFIER_V1) {
-        let id_len = SNAPSHOT_FILE_TYPE_IDENTIFIER_V1.len();
-        let checksum = bytes.slice(id_len..id_len + CHECKSUM_LEN);
-        let data = bytes.slice(id_len + CHECKSUM_LEN..);
-        verify_checksum(&checksum, &data)?;
-        let snapshot = bitcode::deserialize::<snapshot::versions::v1::CatalogSnapshot>(&data)
-            .context("failed to deserialize catalog snapshot file contents")?;
-        let snapshot_v2: snapshot::versions::v2::CatalogSnapshot = snapshot.into();
-        let snapshot_v3: snapshot::versions::v3::CatalogSnapshot = snapshot_v2.into();
-        Ok(snapshot_v3)
-    } else if bytes.starts_with(SNAPSHOT_FILE_TYPE_IDENTIFIER_V2) {
-        let id_len = SNAPSHOT_FILE_TYPE_IDENTIFIER_V2.len();
-        let checksum = bytes.slice(id_len..id_len + CHECKSUM_LEN);
-        let data = bytes.slice(id_len + CHECKSUM_LEN..);
-        verify_checksum(&checksum, &data)?;
-        let snapshot: snapshot::versions::v2::CatalogSnapshot = serde_json::from_slice(&data)
-            .context("failed to deserialize catalog snapshot file contents")?;
-        Ok(snapshot.into())
-    } else if bytes.starts_with(SNAPSHOT_FILE_TYPE_IDENTIFIER_V3) {
-        let id_len = SNAPSHOT_FILE_TYPE_IDENTIFIER_V3.len();
-        let checksum = bytes.slice(id_len..id_len + CHECKSUM_LEN);
-        let data = bytes.slice(id_len + CHECKSUM_LEN..);
-        verify_checksum(&checksum, &data)?;
-        let snapshot: snapshot::versions::v3::CatalogSnapshot = serde_json::from_slice(&data)
-            .context("failed to deserialize catalog snapshot file contents")?;
-        Ok(snapshot)
-    } else {
-        Err(CatalogError::unexpected(
+    let version_id: &[u8; 10] = bytes.first_chunk().ok_or(CatalogError::unexpected(
+        "file must contain at least 10 bytes",
+    ))?;
+
+    match *version_id {
+        // Version 1 uses the `bitcode` crate for serialization/deserialization
+        snapshot::versions::v1::CatalogSnapshot::VERSION_ID => {
+            let checksum = bytes.slice(10..10 + CHECKSUM_LEN);
+            let data = bytes.slice(10 + CHECKSUM_LEN..);
+            verify_checksum(&checksum, &data)?;
+            let snapshot = bitcode::deserialize::<snapshot::versions::v1::CatalogSnapshot>(&data);
+            let snapshot =
+                snapshot.context("failed to deserialize v1 catalog snapshot file contents")?;
+            let snapshot_v2: snapshot::versions::v2::CatalogSnapshot = snapshot.into();
+            let snapshot_v3: snapshot::versions::v3::CatalogSnapshot = snapshot_v2.into();
+            Ok(snapshot_v3)
+        }
+        // Version 2 uses the `serde_json` crate for serialization/deserialization
+        snapshot::versions::v2::CatalogSnapshot::VERSION_ID => {
+            let checksum = bytes.slice(10..10 + CHECKSUM_LEN);
+            let data = bytes.slice(10 + CHECKSUM_LEN..);
+            verify_checksum(&checksum, &data)?;
+            let snapshot: snapshot::versions::v2::CatalogSnapshot =
+                serde_json::from_slice(&data)
+                    .context("failed to deserialize v2 catalog snapshot file contents")?;
+            Ok(snapshot.into())
+        }
+        // Version 3 added a conversion function to map db:*:write tokens to be db:*:create,write
+        // tokens, and because it's a one time migration it relies on the version in file the
+        // version has to be updated.
+        snapshot::versions::v3::CatalogSnapshot::VERSION_ID => {
+            let checksum = bytes.slice(10..10 + CHECKSUM_LEN);
+            let data = bytes.slice(10 + CHECKSUM_LEN..);
+            verify_checksum(&checksum, &data)?;
+            let snapshot: snapshot::versions::v3::CatalogSnapshot =
+                serde_json::from_slice(&data)
+                    .context("failed to deserialize v3 catalog snapshot file contents")?;
+            Ok(snapshot)
+        }
+        _ => Err(CatalogError::unexpected(
             "unrecognized catalog checkpoint file format",
-        ))
+        )),
     }
 }
 
@@ -103,34 +125,21 @@ fn verify_checksum(checksum: &[u8], data: &[u8]) -> Result<()> {
     Ok(())
 }
 
-/// Version 1 uses the `bitcode` crate for serialization/deserialization
-const LOG_FILE_TYPE_IDENTIFIER_V1: &[u8] = b"idb3.001.l";
-/// Version 2 uses the `serde_json` crate for serialization/deserialization
-const LOG_FILE_TYPE_IDENTIFIER_V2: &[u8] = b"idb3.002.l";
-/// Version 3 introduced to migration db write permission in pro
-const LOG_FILE_TYPE_IDENTIFIER_V3: &[u8] = b"idb3.003.l";
-
-pub fn serialize_catalog_log(log: &OrderedCatalogBatch) -> Result<Bytes> {
-    let mut buf = BytesMut::new();
-    buf.extend_from_slice(LOG_FILE_TYPE_IDENTIFIER_V2);
-
-    let data = serde_json::to_vec(log).context("failed to serialize catalog log file")?;
-
-    Ok(hash_and_freeze(buf, data))
+pub trait VersionedFileType {
+    const VERSION_ID: [u8; 10];
 }
 
-/// Version 1 uses the `bitcode` crate for serialization/deserialization
-const SNAPSHOT_FILE_TYPE_IDENTIFIER_V1: &[u8] = b"idb3.001.s";
-/// Version 2 uses the `serde_json` crate for serialization/deserialization
-const SNAPSHOT_FILE_TYPE_IDENTIFIER_V2: &[u8] = b"idb3.002.s";
-/// Version 3 introduced to migration db write permission in pro
-const SNAPSHOT_FILE_TYPE_IDENTIFIER_V3: &[u8] = b"idb3.003.s";
-
-pub fn serialize_catalog_snapshot(snapshot: &CatalogSnapshot) -> Result<Bytes> {
+pub fn serialize_catalog_file<T: Serialize + VersionedFileType>(file: &T) -> Result<Bytes> {
     let mut buf = BytesMut::new();
-    buf.extend_from_slice(SNAPSHOT_FILE_TYPE_IDENTIFIER_V2);
+    buf.extend_from_slice(&T::VERSION_ID);
 
-    let data = serde_json::to_vec(snapshot).context("failed to serialize catalog snapshot file")?;
+    let data = match T::VERSION_ID {
+        snapshot::versions::v1::CatalogSnapshot::VERSION_ID
+        | log::versions::v1::OrderedCatalogBatch::VERSION_ID => {
+            bitcode::serialize(file).context("failed to serialize catalog file")?
+        }
+        _ => serde_json::to_vec(file).context("failed to serialize catalog file")?,
+    };
 
     Ok(hash_and_freeze(buf, data))
 }
@@ -151,42 +160,34 @@ fn hash_and_freeze(mut buf: BytesMut, data: Vec<u8>) -> Bytes {
 mod v1_tests {
     use std::time::Duration;
 
-    use bytes::{Bytes, BytesMut};
     use influxdb3_id::{ColumnId, DbId, DistinctCacheId, LastCacheId, NodeId, TableId, TriggerId};
+    use uuid::Uuid;
 
     use crate::{
         catalog::CatalogSequenceNumber,
         log::{
             self,
-            versions::v1::{
-                AddFieldsLog, CreateDatabaseLog, CreateTableLog, DatabaseBatch, DatabaseCatalogOp,
-                DeleteDistinctCacheLog, DeleteLastCacheLog, DeleteTriggerLog,
-                DistinctCacheDefinition, FieldDefinition, LastCacheDefinition, LastCacheSize,
-                LastCacheTtl, MaxAge, MaxCardinality, NodeBatch, NodeCatalogOp, NodeMode,
-                OrderedCatalogBatch, RegisterNodeLog, SoftDeleteDatabaseLog, SoftDeleteTableLog,
-                TriggerDefinition, TriggerIdentifier, TriggerSettings,
+            versions::{
+                v1::{
+                    AddFieldsLog, CreateDatabaseLog, CreateTableLog, DatabaseBatch,
+                    DatabaseCatalogOp, DeleteDistinctCacheLog, DeleteLastCacheLog,
+                    DeleteTriggerLog, DistinctCacheDefinition, FieldDefinition,
+                    LastCacheDefinition, LastCacheSize, LastCacheTtl, MaxAge, MaxCardinality,
+                    NodeBatch, NodeCatalogOp, NodeMode, OrderedCatalogBatch, RegisterNodeLog,
+                    SoftDeleteDatabaseLog, SoftDeleteTableLog, TriggerDefinition,
+                    TriggerIdentifier, TriggerSettings,
+                },
+                v2,
             },
         },
-        snapshot::{
-            self,
-            versions::v1::{CatalogSnapshot, test_util::Generate},
-        },
+        serialize::VersionedFileType,
+        snapshot::versions::v1::{CatalogSnapshot, test_util::Generate},
     };
 
     use super::{
-        LOG_FILE_TYPE_IDENTIFIER_V1, SNAPSHOT_FILE_TYPE_IDENTIFIER_V1, hash_and_freeze,
-        verify_and_deserialize_catalog_checkpoint_file, verify_and_deserialize_catalog_file,
+        serialize_catalog_file, verify_and_deserialize_catalog_checkpoint_file,
+        verify_and_deserialize_catalog_file,
     };
-
-    /// Method that uses v1 serialization logic for catalog files
-    fn serialize_catalog_log_v1(log: &log::versions::v1::OrderedCatalogBatch) -> Bytes {
-        let mut buf = BytesMut::new();
-        buf.extend_from_slice(LOG_FILE_TYPE_IDENTIFIER_V1);
-
-        let data = bitcode::serialize(log).expect("failed to serialize catalog log file");
-
-        hash_and_freeze(buf, data)
-    }
 
     /// Test that uses the main `verify_and_deserialize_catalog_file` method which deseriales a
     /// versioned catalog file into the latest version, to test round-trip serialize/deserialize
@@ -196,30 +197,34 @@ mod v1_tests {
     #[test]
     fn test_deserialize_catalog_file_from_v1() {
         // test a node log file:
-        verify_and_deserialize_catalog_file(serialize_catalog_log_v1(&OrderedCatalogBatch {
-            catalog_batch: log::versions::v1::CatalogBatch::Node(NodeBatch {
-                time_ns: 0,
-                node_catalog_id: NodeId::new(0),
-                node_id: "test-node".into(),
-                ops: vec![NodeCatalogOp::RegisterNode(RegisterNodeLog {
+        verify_and_deserialize_catalog_file(
+            serialize_catalog_file(&OrderedCatalogBatch {
+                catalog_batch: log::versions::v1::CatalogBatch::Node(NodeBatch {
+                    time_ns: 0,
+                    node_catalog_id: NodeId::new(0),
                     node_id: "test-node".into(),
-                    instance_id: "uuid".into(),
-                    registered_time_ns: 0,
-                    core_count: 2,
-                    mode: vec![NodeMode::Core],
-                })],
-            }),
-            sequence_number: CatalogSequenceNumber::new(0),
-        }))
+                    ops: vec![NodeCatalogOp::RegisterNode(RegisterNodeLog {
+                        node_id: "test-node".into(),
+                        instance_id: "uuid".into(),
+                        registered_time_ns: 0,
+                        core_count: 2,
+                        mode: vec![NodeMode::Core],
+                    })],
+                }),
+                sequence_number: CatalogSequenceNumber::new(0),
+            })
+            .expect("must be able to serialize"),
+        )
         .expect("deserialize from v1");
 
         // test a database log file:
-        verify_and_deserialize_catalog_file(serialize_catalog_log_v1(&OrderedCatalogBatch {
-            catalog_batch: log::versions::v1::CatalogBatch::Database(DatabaseBatch {
-                time_ns: 0,
-                database_id: DbId::new(0),
-                database_name: "test-db".into(),
-                ops: vec![
+        verify_and_deserialize_catalog_file(
+            serialize_catalog_file(&OrderedCatalogBatch {
+                catalog_batch: log::versions::v1::CatalogBatch::Database(DatabaseBatch {
+                    time_ns: 0,
+                    database_id: DbId::new(0),
+                    database_name: "test-db".into(),
+                    ops: vec![
                     DatabaseCatalogOp::CreateDatabase(CreateDatabaseLog {
                         database_id: DbId::new(0),
                         database_name: "test-db".into(),
@@ -485,27 +490,690 @@ mod v1_tests {
                         trigger_name: "test-trigger".into(),
                     }),
                 ],
-            }),
-            sequence_number: CatalogSequenceNumber::new(0),
-        }))
-        .expect("deserialize from v1 to latest");
+                }),
+                sequence_number: CatalogSequenceNumber::new(0),
+            })
+            .expect("must serialize"),
+        )
+        .expect("must deserialize");
     }
 
-    /// Method that uses v1 serialization logic for catalog checkpoint/snapshot files
-    fn serialize_catalog_snapshot_v1(snapshot: &snapshot::versions::v1::CatalogSnapshot) -> Bytes {
-        let mut buf = BytesMut::new();
-        buf.extend_from_slice(SNAPSHOT_FILE_TYPE_IDENTIFIER_V1);
+    #[test]
+    fn test_deserialize_catalog_file_from_v2() {
+        // test a node log file:
+        verify_and_deserialize_catalog_file(
+            serialize_catalog_file(&v2::OrderedCatalogBatch {
+                catalog_batch: log::versions::v2::CatalogBatch::Node(v2::NodeBatch {
+                    time_ns: 0,
+                    node_catalog_id: NodeId::new(0),
+                    node_id: "test-node".into(),
+                    ops: vec![v2::NodeCatalogOp::RegisterNode(v2::RegisterNodeLog {
+                        node_id: "test-node".into(),
+                        instance_id: "uuid".into(),
+                        registered_time_ns: 0,
+                        core_count: 2,
+                        mode: vec![v2::NodeMode::Core],
+                        // v2 only
+                        process_uuid: Uuid::new_v4(),
+                    })],
+                }),
+                sequence_number: CatalogSequenceNumber::new(0),
+            })
+            .expect("must be able to serialize"),
+        )
+        .expect("deserialize from v2");
 
-        let data = bitcode::serialize(snapshot).expect("failed to serialize catalog snapshot file");
+        // test a database log file:
+        let log_v2 = v2::OrderedCatalogBatch {
+            catalog_batch: log::versions::v2::CatalogBatch::Database(v2::DatabaseBatch {
+                time_ns: 0,
+                database_id: DbId::new(0),
+                database_name: "test-db".into(),
+                ops: vec![
+                    v2::DatabaseCatalogOp::CreateDatabase(v2::CreateDatabaseLog {
+                        database_id: DbId::new(0),
+                        database_name: "test-db".into(),
+                    }),
+                    v2::DatabaseCatalogOp::SoftDeleteDatabase(v2::SoftDeleteDatabaseLog {
+                        database_id: DbId::new(0),
+                        database_name: "test-db".into(),
+                        deletion_time: 0,
+                    }),
+                    v2::DatabaseCatalogOp::CreateTable(v2::CreateTableLog {
+                        database_id: DbId::new(0),
+                        database_name: "test-db".into(),
+                        table_name: "test-table".into(),
+                        table_id: TableId::new(0),
+                        field_definitions: vec![
+                            v2::FieldDefinition {
+                                name: "string".into(),
+                                id: ColumnId::new(0),
+                                data_type: log::versions::v2::FieldDataType::String,
+                            },
+                            v2::FieldDefinition {
+                                name: "int".into(),
+                                id: ColumnId::new(1),
+                                data_type: log::versions::v2::FieldDataType::Integer,
+                            },
+                            v2::FieldDefinition {
+                                name: "uint".into(),
+                                id: ColumnId::new(2),
+                                data_type: log::versions::v2::FieldDataType::UInteger,
+                            },
+                            v2::FieldDefinition {
+                                name: "float".into(),
+                                id: ColumnId::new(3),
+                                data_type: log::versions::v2::FieldDataType::Float,
+                            },
+                            v2::FieldDefinition {
+                                name: "bool".into(),
+                                id: ColumnId::new(4),
+                                data_type: log::versions::v2::FieldDataType::Boolean,
+                            },
+                            v2::FieldDefinition {
+                                name: "tag".into(),
+                                id: ColumnId::new(5),
+                                data_type: log::versions::v2::FieldDataType::Tag,
+                            },
+                            v2::FieldDefinition {
+                                name: "time".into(),
+                                id: ColumnId::new(6),
+                                data_type: log::versions::v2::FieldDataType::Timestamp,
+                            },
+                        ],
+                        key: vec![ColumnId::new(5)],
+                    }),
+                    v2::DatabaseCatalogOp::SoftDeleteTable(v2::SoftDeleteTableLog {
+                        database_id: DbId::new(0),
+                        database_name: "test-db".into(),
+                        table_id: TableId::new(0),
+                        table_name: "test-table".into(),
+                        deletion_time: 10,
+                    }),
+                    v2::DatabaseCatalogOp::AddFields(v2::AddFieldsLog {
+                        database_name: "test-db".into(),
+                        database_id: DbId::new(0),
+                        table_name: "test-table".into(),
+                        table_id: TableId::new(0),
+                        field_definitions: vec![
+                            v2::FieldDefinition {
+                                name: "string".into(),
+                                id: ColumnId::new(0),
+                                data_type: log::versions::v2::FieldDataType::String,
+                            },
+                            v2::FieldDefinition {
+                                name: "int".into(),
+                                id: ColumnId::new(1),
+                                data_type: log::versions::v2::FieldDataType::Integer,
+                            },
+                            v2::FieldDefinition {
+                                name: "uint".into(),
+                                id: ColumnId::new(2),
+                                data_type: log::versions::v2::FieldDataType::UInteger,
+                            },
+                            v2::FieldDefinition {
+                                name: "float".into(),
+                                id: ColumnId::new(3),
+                                data_type: log::versions::v2::FieldDataType::Float,
+                            },
+                            v2::FieldDefinition {
+                                name: "bool".into(),
+                                id: ColumnId::new(4),
+                                data_type: log::versions::v2::FieldDataType::Boolean,
+                            },
+                            v2::FieldDefinition {
+                                name: "tag".into(),
+                                id: ColumnId::new(5),
+                                data_type: log::versions::v2::FieldDataType::Tag,
+                            },
+                            v2::FieldDefinition {
+                                name: "time".into(),
+                                id: ColumnId::new(6),
+                                data_type: log::versions::v2::FieldDataType::Timestamp,
+                            },
+                        ],
+                    }),
+                    v2::DatabaseCatalogOp::CreateDistinctCache(v2::DistinctCacheDefinition {
+                        table_id: TableId::new(0),
+                        table_name: "test-table".into(),
+                        cache_id: DistinctCacheId::new(0),
+                        cache_name: "test-distinct-cache".into(),
+                        column_ids: vec![ColumnId::new(0), ColumnId::new(1)],
+                        max_cardinality: v2::MaxCardinality::default(),
+                        max_age_seconds: v2::MaxAge::default(),
+                    }),
+                    v2::DatabaseCatalogOp::DeleteDistinctCache(v2::DeleteDistinctCacheLog {
+                        table_id: TableId::new(0),
+                        table_name: "test-table".into(),
+                        cache_id: DistinctCacheId::new(0),
+                        cache_name: "test-distinct-cache".into(),
+                    }),
+                    v2::DatabaseCatalogOp::CreateLastCache(v2::LastCacheDefinition {
+                        table_id: TableId::new(0),
+                        table: "test-table".into(),
+                        id: LastCacheId::new(0),
+                        name: "test-last-cache".into(),
+                        key_columns: vec![ColumnId::new(0), ColumnId::new(1)],
+                        value_columns:
+                            log::versions::v2::LastCacheValueColumnsDef::AllNonKeyColumns,
+                        count: v2::LastCacheSize::default(),
+                        ttl: v2::LastCacheTtl::default(),
+                    }),
+                    v2::DatabaseCatalogOp::CreateLastCache(v2::LastCacheDefinition {
+                        table_id: TableId::new(0),
+                        table: "test-table".into(),
+                        id: LastCacheId::new(0),
+                        name: "test-last-cache".into(),
+                        key_columns: vec![ColumnId::new(0), ColumnId::new(1)],
+                        value_columns: log::versions::v2::LastCacheValueColumnsDef::Explicit {
+                            columns: vec![ColumnId::new(2), ColumnId::new(3)],
+                        },
+                        count: v2::LastCacheSize::default(),
+                        ttl: v2::LastCacheTtl::default(),
+                    }),
+                    v2::DatabaseCatalogOp::DeleteLastCache(v2::DeleteLastCacheLog {
+                        table_id: TableId::new(0),
+                        table_name: "test-table".into(),
+                        id: LastCacheId::new(0),
+                        name: "test-last-cache".into(),
+                    }),
+                    v2::DatabaseCatalogOp::CreateTrigger(v2::TriggerDefinition {
+                        trigger_id: TriggerId::new(0),
+                        trigger_name: "test-trigger".into(),
+                        node_id: "test-node".into(),
+                        plugin_filename: "plugin.py".into(),
+                        database_name: "test-db".into(),
+                        trigger:
+                            log::versions::v2::TriggerSpecificationDefinition::AllTablesWalWrite,
+                        trigger_settings: v2::TriggerSettings {
+                            run_async: true,
+                            error_behavior: log::versions::v2::ErrorBehavior::Retry,
+                        },
+                        trigger_arguments: Some(
+                            [(String::from("k"), String::from("v"))]
+                                .into_iter()
+                                .collect(),
+                        ),
+                        disabled: false,
+                    }),
+                    v2::DatabaseCatalogOp::CreateTrigger(v2::TriggerDefinition {
+                        trigger_id: TriggerId::new(0),
+                        trigger_name: "test-trigger".into(),
+                        node_id: "test-node".into(),
+                        plugin_filename: "plugin.py".into(),
+                        database_name: "test-db".into(),
+                        trigger:
+                            log::versions::v2::TriggerSpecificationDefinition::SingleTableWalWrite {
+                                table_name: "test-table".into(),
+                            },
+                        trigger_settings: v2::TriggerSettings {
+                            run_async: true,
+                            error_behavior: log::versions::v2::ErrorBehavior::Log,
+                        },
+                        trigger_arguments: Some(
+                            [(String::from("k"), String::from("v"))]
+                                .into_iter()
+                                .collect(),
+                        ),
+                        disabled: false,
+                    }),
+                    v2::DatabaseCatalogOp::CreateTrigger(v2::TriggerDefinition {
+                        trigger_id: TriggerId::new(0),
+                        trigger_name: "test-trigger".into(),
+                        node_id: "test-node".into(),
+                        plugin_filename: "plugin.py".into(),
+                        database_name: "test-db".into(),
+                        trigger: log::versions::v2::TriggerSpecificationDefinition::Schedule {
+                            schedule: "* 1 * * *".into(),
+                        },
+                        trigger_settings: v2::TriggerSettings {
+                            run_async: false,
+                            error_behavior: log::versions::v2::ErrorBehavior::Disable,
+                        },
+                        trigger_arguments: Some(
+                            [(String::from("k"), String::from("v"))]
+                                .into_iter()
+                                .collect(),
+                        ),
+                        disabled: false,
+                    }),
+                    v2::DatabaseCatalogOp::CreateTrigger(v2::TriggerDefinition {
+                        trigger_id: TriggerId::new(0),
+                        trigger_name: "test-trigger".into(),
+                        node_id: "test-node".into(),
+                        plugin_filename: "plugin.py".into(),
+                        database_name: "test-db".into(),
+                        trigger: log::versions::v2::TriggerSpecificationDefinition::RequestPath {
+                            path: "/my/fancy/api".into(),
+                        },
+                        trigger_settings: v2::TriggerSettings {
+                            run_async: true,
+                            error_behavior: log::versions::v2::ErrorBehavior::Retry,
+                        },
+                        trigger_arguments: Some(
+                            [(String::from("k"), String::from("v"))]
+                                .into_iter()
+                                .collect(),
+                        ),
+                        disabled: false,
+                    }),
+                    v2::DatabaseCatalogOp::CreateTrigger(v2::TriggerDefinition {
+                        trigger_id: TriggerId::new(0),
+                        trigger_name: "test-trigger".into(),
+                        node_id: "test-node".into(),
+                        plugin_filename: "plugin.py".into(),
+                        database_name: "test-db".into(),
+                        trigger: log::versions::v2::TriggerSpecificationDefinition::Every {
+                            duration: Duration::from_secs(1337),
+                        },
+                        trigger_settings: v2::TriggerSettings {
+                            run_async: true,
+                            error_behavior: log::versions::v2::ErrorBehavior::Retry,
+                        },
+                        trigger_arguments: Some(
+                            [(String::from("k"), String::from("v"))]
+                                .into_iter()
+                                .collect(),
+                        ),
+                        disabled: false,
+                    }),
+                    v2::DatabaseCatalogOp::DeleteTrigger(v2::DeleteTriggerLog {
+                        trigger_id: TriggerId::new(0),
+                        trigger_name: "test-trigger".into(),
+                        force: false,
+                    }),
+                    v2::DatabaseCatalogOp::EnableTrigger(v2::TriggerIdentifier {
+                        db_id: DbId::new(0),
+                        db_name: "test-db".into(),
+                        trigger_id: TriggerId::new(0),
+                        trigger_name: "test-trigger".into(),
+                    }),
+                    v2::DatabaseCatalogOp::DisableTrigger(v2::TriggerIdentifier {
+                        db_id: DbId::new(0),
+                        db_name: "test-db".into(),
+                        trigger_id: TriggerId::new(0),
+                        trigger_name: "test-trigger".into(),
+                    }),
+                ],
+            }),
+            sequence_number: CatalogSequenceNumber::new(0),
+        };
 
-        hash_and_freeze(buf, data)
+        verify_and_deserialize_catalog_file(
+            serialize_catalog_file(&log_v2).expect("must be able to serialize"),
+        )
+        .expect("deserialize from v2 to latest");
+    }
+
+    #[test]
+    fn test_deserialize_catalog_file_from_latest() {
+        // test a node log file:
+        verify_and_deserialize_catalog_file(
+            super::serialize_catalog_file(&crate::log::OrderedCatalogBatch {
+                catalog_batch: crate::log::CatalogBatch::Node(crate::log::NodeBatch {
+                    time_ns: 0,
+                    node_catalog_id: NodeId::new(0),
+                    node_id: "test-node".into(),
+                    ops: vec![crate::log::NodeCatalogOp::RegisterNode(
+                        crate::log::RegisterNodeLog {
+                            node_id: "test-node".into(),
+                            instance_id: "uuid".into(),
+                            registered_time_ns: 0,
+                            core_count: 2,
+                            mode: vec![crate::log::NodeMode::Core],
+                            // v2 only
+                            process_uuid: Uuid::new_v4(),
+                        },
+                    )],
+                }),
+                sequence_number: CatalogSequenceNumber::new(0),
+            })
+            .expect("must be able to serialize to latest"),
+        )
+        .expect("deserialize from latest");
+
+        // test a database log file:
+        let log_vlatest = crate::log::OrderedCatalogBatch {
+            catalog_batch: crate::log::CatalogBatch::Database(crate::log::DatabaseBatch {
+                time_ns: 0,
+                database_id: DbId::new(0),
+                database_name: "test-db".into(),
+                ops: vec![
+                    crate::log::DatabaseCatalogOp::CreateDatabase(crate::log::CreateDatabaseLog {
+                        database_id: DbId::new(0),
+                        database_name: "test-db".into(),
+                    }),
+                    crate::log::DatabaseCatalogOp::SoftDeleteDatabase(
+                        crate::log::SoftDeleteDatabaseLog {
+                            database_id: DbId::new(0),
+                            database_name: "test-db".into(),
+                            deletion_time: 0,
+                        },
+                    ),
+                    crate::log::DatabaseCatalogOp::CreateTable(crate::log::CreateTableLog {
+                        database_id: DbId::new(0),
+                        database_name: "test-db".into(),
+                        table_name: "test-table".into(),
+                        table_id: TableId::new(0),
+                        field_definitions: vec![
+                            crate::log::FieldDefinition {
+                                name: "string".into(),
+                                id: ColumnId::new(0),
+                                data_type: crate::log::FieldDataType::String,
+                            },
+                            crate::log::FieldDefinition {
+                                name: "int".into(),
+                                id: ColumnId::new(1),
+                                data_type: crate::log::FieldDataType::Integer,
+                            },
+                            crate::log::FieldDefinition {
+                                name: "uint".into(),
+                                id: ColumnId::new(2),
+                                data_type: crate::log::FieldDataType::UInteger,
+                            },
+                            crate::log::FieldDefinition {
+                                name: "float".into(),
+                                id: ColumnId::new(3),
+                                data_type: crate::log::FieldDataType::Float,
+                            },
+                            crate::log::FieldDefinition {
+                                name: "bool".into(),
+                                id: ColumnId::new(4),
+                                data_type: crate::log::FieldDataType::Boolean,
+                            },
+                            crate::log::FieldDefinition {
+                                name: "tag".into(),
+                                id: ColumnId::new(5),
+                                data_type: crate::log::FieldDataType::Tag,
+                            },
+                            crate::log::FieldDefinition {
+                                name: "time".into(),
+                                id: ColumnId::new(6),
+                                data_type: crate::log::FieldDataType::Timestamp,
+                            },
+                        ],
+                        key: vec![ColumnId::new(5)],
+                    }),
+                    crate::log::DatabaseCatalogOp::SoftDeleteTable(
+                        crate::log::SoftDeleteTableLog {
+                            database_id: DbId::new(0),
+                            database_name: "test-db".into(),
+                            table_id: TableId::new(0),
+                            table_name: "test-table".into(),
+                            deletion_time: 10,
+                        },
+                    ),
+                    crate::log::DatabaseCatalogOp::AddFields(crate::log::AddFieldsLog {
+                        database_name: "test-db".into(),
+                        database_id: DbId::new(0),
+                        table_name: "test-table".into(),
+                        table_id: TableId::new(0),
+                        field_definitions: vec![
+                            crate::log::FieldDefinition {
+                                name: "string".into(),
+                                id: ColumnId::new(0),
+                                data_type: crate::log::FieldDataType::String,
+                            },
+                            crate::log::FieldDefinition {
+                                name: "int".into(),
+                                id: ColumnId::new(1),
+                                data_type: crate::log::FieldDataType::Integer,
+                            },
+                            crate::log::FieldDefinition {
+                                name: "uint".into(),
+                                id: ColumnId::new(2),
+                                data_type: crate::log::FieldDataType::UInteger,
+                            },
+                            crate::log::FieldDefinition {
+                                name: "float".into(),
+                                id: ColumnId::new(3),
+                                data_type: crate::log::FieldDataType::Float,
+                            },
+                            crate::log::FieldDefinition {
+                                name: "bool".into(),
+                                id: ColumnId::new(4),
+                                data_type: crate::log::FieldDataType::Boolean,
+                            },
+                            crate::log::FieldDefinition {
+                                name: "tag".into(),
+                                id: ColumnId::new(5),
+                                data_type: crate::log::FieldDataType::Tag,
+                            },
+                            crate::log::FieldDefinition {
+                                name: "time".into(),
+                                id: ColumnId::new(6),
+                                data_type: crate::log::FieldDataType::Timestamp,
+                            },
+                        ],
+                    }),
+                    crate::log::DatabaseCatalogOp::CreateDistinctCache(
+                        crate::log::DistinctCacheDefinition {
+                            table_id: TableId::new(0),
+                            table_name: "test-table".into(),
+                            cache_id: DistinctCacheId::new(0),
+                            cache_name: "test-distinct-cache".into(),
+                            column_ids: vec![ColumnId::new(0), ColumnId::new(1)],
+                            max_cardinality: crate::log::MaxCardinality::default(),
+                            max_age_seconds: crate::log::MaxAge::default(),
+                        },
+                    ),
+                    crate::log::DatabaseCatalogOp::DeleteDistinctCache(
+                        crate::log::DeleteDistinctCacheLog {
+                            table_id: TableId::new(0),
+                            table_name: "test-table".into(),
+                            cache_id: DistinctCacheId::new(0),
+                            cache_name: "test-distinct-cache".into(),
+                        },
+                    ),
+                    crate::log::DatabaseCatalogOp::CreateLastCache(
+                        crate::log::LastCacheDefinition {
+                            table_id: TableId::new(0),
+                            table: "test-table".into(),
+                            id: LastCacheId::new(0),
+                            name: "test-last-cache".into(),
+                            key_columns: vec![ColumnId::new(0), ColumnId::new(1)],
+                            value_columns: crate::log::LastCacheValueColumnsDef::AllNonKeyColumns,
+                            count: crate::log::LastCacheSize::default(),
+                            ttl: crate::log::LastCacheTtl::default(),
+                        },
+                    ),
+                    crate::log::DatabaseCatalogOp::CreateLastCache(
+                        crate::log::LastCacheDefinition {
+                            table_id: TableId::new(0),
+                            table: "test-table".into(),
+                            id: LastCacheId::new(0),
+                            name: "test-last-cache".into(),
+                            key_columns: vec![ColumnId::new(0), ColumnId::new(1)],
+                            value_columns: crate::log::LastCacheValueColumnsDef::Explicit {
+                                columns: vec![ColumnId::new(2), ColumnId::new(3)],
+                            },
+                            count: crate::log::LastCacheSize::default(),
+                            ttl: crate::log::LastCacheTtl::default(),
+                        },
+                    ),
+                    crate::log::DatabaseCatalogOp::DeleteLastCache(
+                        crate::log::DeleteLastCacheLog {
+                            table_id: TableId::new(0),
+                            table_name: "test-table".into(),
+                            id: LastCacheId::new(0),
+                            name: "test-last-cache".into(),
+                        },
+                    ),
+                    crate::log::DatabaseCatalogOp::CreateTrigger(crate::log::TriggerDefinition {
+                        trigger_id: TriggerId::new(0),
+                        trigger_name: "test-trigger".into(),
+                        node_id: "test-node".into(),
+                        plugin_filename: "plugin.py".into(),
+                        database_name: "test-db".into(),
+                        trigger: crate::log::TriggerSpecificationDefinition::AllTablesWalWrite,
+                        trigger_settings: crate::log::TriggerSettings {
+                            run_async: true,
+                            error_behavior: crate::log::ErrorBehavior::Retry,
+                        },
+                        trigger_arguments: Some(
+                            [(String::from("k"), String::from("v"))]
+                                .into_iter()
+                                .collect(),
+                        ),
+                        disabled: false,
+                    }),
+                    crate::log::DatabaseCatalogOp::CreateTrigger(crate::log::TriggerDefinition {
+                        trigger_id: TriggerId::new(0),
+                        trigger_name: "test-trigger".into(),
+                        node_id: "test-node".into(),
+                        plugin_filename: "plugin.py".into(),
+                        database_name: "test-db".into(),
+                        trigger: crate::log::TriggerSpecificationDefinition::SingleTableWalWrite {
+                            table_name: "test-table".into(),
+                        },
+                        trigger_settings: crate::log::TriggerSettings {
+                            run_async: true,
+                            error_behavior: crate::log::ErrorBehavior::Log,
+                        },
+                        trigger_arguments: Some(
+                            [(String::from("k"), String::from("v"))]
+                                .into_iter()
+                                .collect(),
+                        ),
+                        disabled: false,
+                    }),
+                    crate::log::DatabaseCatalogOp::CreateTrigger(crate::log::TriggerDefinition {
+                        trigger_id: TriggerId::new(0),
+                        trigger_name: "test-trigger".into(),
+                        node_id: "test-node".into(),
+                        plugin_filename: "plugin.py".into(),
+                        database_name: "test-db".into(),
+                        trigger:
+                            log::versions::v3::TriggerSpecificationDefinition::AllTablesWalWrite,
+                        trigger_settings: crate::log::TriggerSettings {
+                            run_async: false,
+                            error_behavior: crate::log::ErrorBehavior::Disable,
+                        },
+                        trigger_arguments: Some(
+                            [(String::from("k"), String::from("v"))]
+                                .into_iter()
+                                .collect(),
+                        ),
+                        disabled: false,
+                    }),
+                    crate::log::DatabaseCatalogOp::CreateTrigger(crate::log::TriggerDefinition {
+                        trigger_id: TriggerId::new(0),
+                        trigger_name: "test-trigger".into(),
+                        node_id: "test-node".into(),
+                        plugin_filename: "plugin.py".into(),
+                        database_name: "test-db".into(),
+                        trigger:
+                            log::versions::v3::TriggerSpecificationDefinition::AllTablesWalWrite,
+                        trigger_settings: crate::log::TriggerSettings {
+                            run_async: true,
+                            error_behavior: crate::log::ErrorBehavior::Retry,
+                        },
+                        trigger_arguments: Some(
+                            [(String::from("k"), String::from("v"))]
+                                .into_iter()
+                                .collect(),
+                        ),
+                        disabled: false,
+                    }),
+                    crate::log::DatabaseCatalogOp::CreateTrigger(crate::log::TriggerDefinition {
+                        trigger_id: TriggerId::new(0),
+                        trigger_name: "test-trigger".into(),
+                        node_id: "test-node".into(),
+                        plugin_filename: "plugin.py".into(),
+                        database_name: "test-db".into(),
+                        trigger:
+                            log::versions::v3::TriggerSpecificationDefinition::AllTablesWalWrite,
+                        trigger_settings: crate::log::TriggerSettings {
+                            run_async: true,
+                            error_behavior: crate::log::ErrorBehavior::Retry,
+                        },
+                        trigger_arguments: Some(
+                            [(String::from("k"), String::from("v"))]
+                                .into_iter()
+                                .collect(),
+                        ),
+                        disabled: false,
+                    }),
+                    crate::log::DatabaseCatalogOp::DeleteTrigger(crate::log::DeleteTriggerLog {
+                        trigger_id: TriggerId::new(0),
+                        trigger_name: "test-trigger".into(),
+                        force: false,
+                    }),
+                    crate::log::DatabaseCatalogOp::EnableTrigger(crate::log::TriggerIdentifier {
+                        db_id: DbId::new(0),
+                        db_name: "test-db".into(),
+                        trigger_id: TriggerId::new(0),
+                        trigger_name: "test-trigger".into(),
+                    }),
+                    crate::log::DatabaseCatalogOp::DisableTrigger(crate::log::TriggerIdentifier {
+                        db_id: DbId::new(0),
+                        db_name: "test-db".into(),
+                        trigger_id: TriggerId::new(0),
+                        trigger_name: "test-trigger".into(),
+                    }),
+                ],
+            }),
+            sequence_number: CatalogSequenceNumber::new(0),
+        };
+
+        verify_and_deserialize_catalog_file(
+            super::serialize_catalog_file(&log_vlatest)
+                .expect("must be able to serialize to latest"),
+        )
+        .expect("deserialize from latest");
+    }
+
+    #[test]
+    fn test_serialize_catalog_with_latest_identifier() {
+        // test a node log file:
+        let serialized = super::serialize_catalog_file(&crate::log::OrderedCatalogBatch {
+            catalog_batch: crate::log::CatalogBatch::Node(crate::log::NodeBatch {
+                time_ns: 0,
+                node_catalog_id: NodeId::new(0),
+                node_id: "test-node".into(),
+                ops: vec![crate::log::NodeCatalogOp::RegisterNode(
+                    crate::log::RegisterNodeLog {
+                        node_id: "test-node".into(),
+                        instance_id: "uuid".into(),
+                        registered_time_ns: 0,
+                        core_count: 2,
+                        mode: vec![crate::log::NodeMode::Core],
+                        // v2 only
+                        process_uuid: Uuid::new_v4(),
+                    },
+                )],
+            }),
+            sequence_number: CatalogSequenceNumber::new(0),
+        })
+        .expect("must be able to serialize to latest");
+
+        assert!(
+            serialized.starts_with(&crate::log::OrderedCatalogBatch::VERSION_ID),
+            "serialized catalog log file must always start with latest verison identifier"
+        );
+    }
+
+    #[test]
+    fn test_serialize_catalog_snapshot_with_latest_identifier() {
+        let snapshot = crate::snapshot::versions::v1::CatalogSnapshot::generate();
+        let snapshot: crate::snapshot::versions::v2::CatalogSnapshot = snapshot.into();
+        let snapshot: crate::snapshot::CatalogSnapshot = snapshot.into();
+        let serialized = super::serialize_catalog_file(&snapshot)
+            .expect("must be able to serialize generated snapshot");
+
+        assert!(
+            serialized.starts_with(&crate::snapshot::CatalogSnapshot::VERSION_ID),
+            "serialized catalog log file must always start with latest verison identifier"
+        );
     }
 
     #[test]
     fn test_deserialize_catalog_checkpoint_file_from_v1() {
-        verify_and_deserialize_catalog_checkpoint_file(serialize_catalog_snapshot_v1(
-            &CatalogSnapshot::generate(),
-        ))
-        .expect("deserialize from v1");
+        let result = verify_and_deserialize_catalog_checkpoint_file(
+            serialize_catalog_file(&CatalogSnapshot::generate())
+                .expect("must be able to serialize"),
+        );
+        println!("{result:?}");
+        result.expect("deserialize from v1");
     }
 }

--- a/influxdb3_catalog/src/snapshot/versions/v1.rs
+++ b/influxdb3_catalog/src/snapshot/versions/v1.rs
@@ -16,6 +16,7 @@ use crate::{
     log::versions::v1::{
         MaxAge, MaxCardinality, NodeMode, TriggerSettings, TriggerSpecificationDefinition,
     },
+    serialize::VersionedFileType,
 };
 use arrow::datatypes::DataType as ArrowDataType;
 use hashbrown::HashMap;
@@ -37,6 +38,10 @@ pub(crate) struct CatalogSnapshot {
     sequence: CatalogSequenceNumber,
     catalog_id: Arc<str>,
     catalog_uuid: Uuid,
+}
+
+impl VersionedFileType for CatalogSnapshot {
+    const VERSION_ID: [u8; 10] = *b"idb3.001.s";
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/influxdb3_catalog/src/snapshot/versions/v2.rs
+++ b/influxdb3_catalog/src/snapshot/versions/v2.rs
@@ -4,6 +4,7 @@ use crate::catalog::CatalogSequenceNumber;
 use crate::log::versions::v2::{
     MaxAge, MaxCardinality, NodeMode, TriggerSettings, TriggerSpecificationDefinition,
 };
+use crate::serialize::VersionedFileType;
 use arrow::datatypes::DataType as ArrowDataType;
 use hashbrown::HashMap;
 use influxdb3_id::{
@@ -24,6 +25,10 @@ pub struct CatalogSnapshot {
     pub(crate) tokens: RepositorySnapshot<TokenId, TokenInfoSnapshot>,
     pub(crate) catalog_id: Arc<str>,
     pub(crate) catalog_uuid: Uuid,
+}
+
+impl VersionedFileType for CatalogSnapshot {
+    const VERSION_ID: [u8; 10] = *b"idb3.002.s";
 }
 
 #[derive(Debug, Serialize, Deserialize, Default)]

--- a/influxdb3_catalog/src/snapshot/versions/v3.rs
+++ b/influxdb3_catalog/src/snapshot/versions/v3.rs
@@ -5,6 +5,7 @@ use crate::catalog::CatalogSequenceNumber;
 use crate::log::{
     MaxAge, MaxCardinality, NodeMode, TriggerSettings, TriggerSpecificationDefinition,
 };
+use crate::serialize::VersionedFileType;
 use arrow::datatypes::DataType as ArrowDataType;
 use hashbrown::HashMap;
 use influxdb3_id::{
@@ -25,6 +26,10 @@ pub struct CatalogSnapshot {
     pub(crate) tokens: RepositorySnapshot<TokenId, TokenInfoSnapshot>,
     pub(crate) catalog_id: Arc<str>,
     pub(crate) catalog_uuid: Uuid,
+}
+
+impl VersionedFileType for CatalogSnapshot {
+    const VERSION_ID: [u8; 10] = *b"idb3.003.s";
 }
 
 impl CatalogSnapshot {


### PR DESCRIPTION
When the new v3 catalog code was added recently, we mistakenly continued to always serialize even the v3 catalog logs and snapshots data structures with the v2 file ID. This PR makes uses of associated constants on the types being serialized to the object store to ensure we always use the file ID associated with that version of the type. Additionally, the deserialization functions are refactored to use match statements to get some level of compile time assurance that all associated constant instances are unique from one another.