### PR TITLE
chore: update version to 3.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2757,7 +2757,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3"
-version = "3.1.0-nightly"
+version = "3.1.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -2838,7 +2838,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_authz"
-version = "3.1.0-nightly"
+version = "3.1.0"
 dependencies = [
  "async-trait",
  "authz",
@@ -2855,7 +2855,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_cache"
-version = "3.1.0-nightly"
+version = "3.1.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -2890,7 +2890,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_catalog"
-version = "3.1.0-nightly"
+version = "3.1.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -2938,7 +2938,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_clap_blocks"
-version = "3.1.0-nightly"
+version = "3.1.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2970,7 +2970,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_client"
-version = "3.1.0-nightly"
+version = "3.1.0"
 dependencies = [
  "bytes",
  "hashbrown 0.15.3",
@@ -2990,7 +2990,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_id"
-version = "3.1.0-nightly"
+version = "3.1.0"
 dependencies = [
  "indexmap 2.9.0",
  "serde",
@@ -3000,7 +3000,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_internal_api"
-version = "3.1.0-nightly"
+version = "3.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3016,7 +3016,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_load_generator"
-version = "3.1.0-nightly"
+version = "3.1.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3044,7 +3044,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_process"
-version = "3.1.0-nightly"
+version = "3.1.0"
 dependencies = [
  "cargo_metadata",
  "iox_time",
@@ -3053,7 +3053,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_processing_engine"
-version = "3.1.0-nightly"
+version = "3.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3094,7 +3094,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_py_api"
-version = "3.1.0-nightly"
+version = "3.1.0"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -3121,7 +3121,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_server"
-version = "3.1.0-nightly"
+version = "3.1.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3212,7 +3212,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_shutdown"
-version = "3.1.0-nightly"
+version = "3.1.0"
 dependencies = [
  "futures",
  "futures-util",
@@ -3224,7 +3224,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_sys_events"
-version = "3.1.0-nightly"
+version = "3.1.0"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3243,7 +3243,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_telemetry"
-version = "3.1.0-nightly"
+version = "3.1.0"
 dependencies = [
  "futures",
  "futures-util",
@@ -3264,7 +3264,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_test_helpers"
-version = "3.1.0-nightly"
+version = "3.1.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3277,7 +3277,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_types"
-version = "3.1.0-nightly"
+version = "3.1.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3296,7 +3296,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_wal"
-version = "3.1.0-nightly"
+version = "3.1.0"
 dependencies = [
  "async-trait",
  "bitcode",
@@ -3326,7 +3326,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_write"
-version = "3.1.0-nightly"
+version = "3.1.0"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3543,7 +3543,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query_influxql_rewrite"
-version = "3.1.0-nightly"
+version = "3.1.0"
 dependencies = [
  "influxdb_influxql_parser",
  "thiserror 1.0.69",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ exclude = [
 # then this will be `3.1.0-nightly`. Once `3.1.0` is released, this will be bumped to `3.2.0-nightly`,
 # and will remain that regardless of how many `3.1.x` patch releases are done prior to the `3.2.0`
 # release.
-version = "3.1.0-nightly"
+version = "3.1.0"
 authors = ["InfluxData OSS Developers"]
 edition = "2024"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Update version in `Cargo.toml` to `3.1.0` for the `3.1` release branch.
