### PR TITLE
feat: experimental snapshot replay oom tuning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3305,6 +3305,7 @@ dependencies = [
  "clap",
  "crc32fast",
  "data_types",
+ "futures",
  "futures-util",
  "hashbrown 0.15.3",
  "humantime",

--- a/influxdb3_wal/Cargo.toml
+++ b/influxdb3_wal/Cargo.toml
@@ -23,6 +23,7 @@ bitcode.workspace = true
 bytes.workspace = true
 byteorder.workspace = true
 crc32fast.workspace  = true
+futures.workspace = true
 futures-util.workspace = true
 hashbrown.workspace = true
 humantime.workspace = true


### PR DESCRIPTION
When troubleshooting OOM on WAL replay I noticed unbounded concurrency is leading to the issue. This experimental PR is a way to address it (i.e limit concurrency), by exposing this as a CLI parameter it'll give users a handle to set the limit so that if they run into errors with default, concurrency can be reduced and retried.

This does not guarantee it won't OOM after that when snapshotting as part of WAL replay, but this will take it further than where it fails at the moment.   
