### PR TITLE
fix: Automatic intermediate directory cleanup for file object store

### DIFF
--- a/influxdb3_clap_blocks/src/object_store.rs
+++ b/influxdb3_clap_blocks/src/object_store.rs
@@ -117,11 +117,14 @@ impl std::fmt::Display for LocalFileSystemWithSortedListOp {
 impl LocalFileSystemWithSortedListOp {
     fn new_with_prefix(prefix: impl AsRef<std::path::Path>) -> Result<Self, ParseError> {
         Ok(Self {
-            inner: Arc::new(LocalFileSystem::new_with_prefix(prefix.as_ref()).context(
-                CreateLocalFileSystemSnafu {
-                    path: prefix.as_ref().to_path_buf(),
-                },
-            )?),
+            inner: Arc::new(
+                LocalFileSystem::new_with_prefix(prefix.as_ref())
+                    .context(CreateLocalFileSystemSnafu {
+                        path: prefix.as_ref().to_path_buf(),
+                    })?
+                    // Clean up intermediate directories automatically.
+                    .with_automatic_cleanup(true),
+            ),
         })
     }
 }


### PR DESCRIPTION
Removes empty intermediate directories when a key is removed from local file system object storage, which matches cloud-based providers.

Prior to this comment, when using the `file` object store, if the two keys (12.parquet, 9.json) are deleted:

```
/Volumes/RAMDisk/influxdb3_pro/ingest/c/4c/537/cb4/12.parquet
/Volumes/RAMDisk/influxdb3_pro/ingest/c/4c/537/cb4/9.json
/Volumes/RAMDisk/influxdb3_pro/ingest/c/8b/417/4dd/14.parquet
/Volumes/RAMDisk/influxdb3_pro/ingest/c/8b/417/4dd/10.parquet
```

The on-disk structure will leave an orphaned intermediate directory structure `/Volumes/RAMDisk/influxdb3_pro/ingest/c/4c/537/cb4`:

```
/Volumes/RAMDisk/influxdb3_pro/ingest/c/4c/537/cb4
/Volumes/RAMDisk/influxdb3_pro/ingest/c/8b/417/4dd/14.parquet
/Volumes/RAMDisk/influxdb3_pro/ingest/c/8b/417/4dd/10.parquet
```

However, cloud-based object stores don't store the intermediate directories. With the additional flag in this PR, the empty intermediate directories are also removed, resulting in the following:

```
/Volumes/RAMDisk/influxdb3_pro/ingest/c/8b/417/4dd/14.parquet
/Volumes/RAMDisk/influxdb3_pro/ingest/c/8b/417/4dd/10.parquet
```
