### PR TITLE
chore: update `influxdb3_core`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -383,7 +383,7 @@ dependencies = [
 [[package]]
 name = "arrow_util"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ad3a2b250d92f21c39ad38d60919b127ae5af1fc#ad3a2b250d92f21c39ad38d60919b127ae5af1fc"
 dependencies = [
  "ahash",
  "arrow",
@@ -500,7 +500,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 [[package]]
 name = "authz"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ad3a2b250d92f21c39ad38d60919b127ae5af1fc#ad3a2b250d92f21c39ad38d60919b127ae5af1fc"
 dependencies = [
  "async-trait",
  "backoff",
@@ -568,7 +568,7 @@ dependencies = [
 [[package]]
 name = "backoff"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ad3a2b250d92f21c39ad38d60919b127ae5af1fc#ad3a2b250d92f21c39ad38d60919b127ae5af1fc"
 dependencies = [
  "observability_deps",
  "rand 0.9.1",
@@ -947,7 +947,7 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 [[package]]
 name = "client_util"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ad3a2b250d92f21c39ad38d60919b127ae5af1fc#ad3a2b250d92f21c39ad38d60919b127ae5af1fc"
 dependencies = [
  "http 0.2.12",
  "reqwest 0.11.27",
@@ -1319,7 +1319,7 @@ dependencies = [
 [[package]]
 name = "data_types"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ad3a2b250d92f21c39ad38d60919b127ae5af1fc#ad3a2b250d92f21c39ad38d60919b127ae5af1fc"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -1751,7 +1751,7 @@ dependencies = [
 [[package]]
 name = "datafusion_util"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ad3a2b250d92f21c39ad38d60919b127ae5af1fc#ad3a2b250d92f21c39ad38d60919b127ae5af1fc"
 dependencies = [
  "async-trait",
  "datafusion",
@@ -1915,7 +1915,7 @@ dependencies = [
 [[package]]
 name = "error_reporting"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ad3a2b250d92f21c39ad38d60919b127ae5af1fc#ad3a2b250d92f21c39ad38d60919b127ae5af1fc"
 dependencies = [
  "workspace-hack",
 ]
@@ -1945,7 +1945,7 @@ dependencies = [
 [[package]]
 name = "executor"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ad3a2b250d92f21c39ad38d60919b127ae5af1fc#ad3a2b250d92f21c39ad38d60919b127ae5af1fc"
 dependencies = [
  "futures",
  "metric",
@@ -1993,7 +1993,7 @@ dependencies = [
 [[package]]
 name = "flightsql"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ad3a2b250d92f21c39ad38d60919b127ae5af1fc#ad3a2b250d92f21c39ad38d60919b127ae5af1fc"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -2151,7 +2151,7 @@ dependencies = [
 [[package]]
 name = "generated_types"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ad3a2b250d92f21c39ad38d60919b127ae5af1fc#ad3a2b250d92f21c39ad38d60919b127ae5af1fc"
 dependencies = [
  "observability_deps",
  "pbjson",
@@ -2743,7 +2743,7 @@ checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
 [[package]]
 name = "influxdb-line-protocol"
 version = "1.0.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ad3a2b250d92f21c39ad38d60919b127ae5af1fc#ad3a2b250d92f21c39ad38d60919b127ae5af1fc"
 dependencies = [
  "bytes",
  "log",
@@ -3391,7 +3391,7 @@ dependencies = [
 [[package]]
 name = "influxdb_influxql_parser"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ad3a2b250d92f21c39ad38d60919b127ae5af1fc#ad3a2b250d92f21c39ad38d60919b127ae5af1fc"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -3406,7 +3406,7 @@ dependencies = [
 [[package]]
 name = "influxdb_iox_client"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ad3a2b250d92f21c39ad38d60919b127ae5af1fc#ad3a2b250d92f21c39ad38d60919b127ae5af1fc"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -3453,7 +3453,7 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 [[package]]
 name = "iox_http"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ad3a2b250d92f21c39ad38d60919b127ae5af1fc#ad3a2b250d92f21c39ad38d60919b127ae5af1fc"
 dependencies = [
  "async-trait",
  "authz",
@@ -3470,7 +3470,7 @@ dependencies = [
 [[package]]
 name = "iox_http_util"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ad3a2b250d92f21c39ad38d60919b127ae5af1fc#ad3a2b250d92f21c39ad38d60919b127ae5af1fc"
 dependencies = [
  "futures",
  "http 0.2.12",
@@ -3481,7 +3481,7 @@ dependencies = [
 [[package]]
 name = "iox_query"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ad3a2b250d92f21c39ad38d60919b127ae5af1fc#ad3a2b250d92f21c39ad38d60919b127ae5af1fc"
 dependencies = [
  "arrow",
  "arrow_util",
@@ -3520,7 +3520,7 @@ dependencies = [
 [[package]]
 name = "iox_query_influxql"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ad3a2b250d92f21c39ad38d60919b127ae5af1fc#ad3a2b250d92f21c39ad38d60919b127ae5af1fc"
 dependencies = [
  "arrow",
  "assert_matches",
@@ -3553,7 +3553,7 @@ dependencies = [
 [[package]]
 name = "iox_query_params"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ad3a2b250d92f21c39ad38d60919b127ae5af1fc#ad3a2b250d92f21c39ad38d60919b127ae5af1fc"
 dependencies = [
  "arrow",
  "datafusion",
@@ -3568,7 +3568,7 @@ dependencies = [
 [[package]]
 name = "iox_system_tables"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ad3a2b250d92f21c39ad38d60919b127ae5af1fc#ad3a2b250d92f21c39ad38d60919b127ae5af1fc"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3580,7 +3580,7 @@ dependencies = [
 [[package]]
 name = "iox_time"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ad3a2b250d92f21c39ad38d60919b127ae5af1fc#ad3a2b250d92f21c39ad38d60919b127ae5af1fc"
 dependencies = [
  "chrono",
  "parking_lot",
@@ -3666,7 +3666,7 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 [[package]]
 name = "jemalloc_stats"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ad3a2b250d92f21c39ad38d60919b127ae5af1fc#ad3a2b250d92f21c39ad38d60919b127ae5af1fc"
 dependencies = [
  "snafu",
  "tikv-jemalloc-ctl",
@@ -3822,7 +3822,7 @@ checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 [[package]]
 name = "logfmt"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ad3a2b250d92f21c39ad38d60919b127ae5af1fc#ad3a2b250d92f21c39ad38d60919b127ae5af1fc"
 dependencies = [
  "humantime",
  "observability_deps",
@@ -3900,7 +3900,7 @@ dependencies = [
 [[package]]
 name = "meta_data_cache"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ad3a2b250d92f21c39ad38d60919b127ae5af1fc#ad3a2b250d92f21c39ad38d60919b127ae5af1fc"
 dependencies = [
  "arrow",
  "data_types",
@@ -3916,7 +3916,7 @@ dependencies = [
 [[package]]
 name = "metric"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ad3a2b250d92f21c39ad38d60919b127ae5af1fc#ad3a2b250d92f21c39ad38d60919b127ae5af1fc"
 dependencies = [
  "parking_lot",
  "workspace-hack",
@@ -3925,7 +3925,7 @@ dependencies = [
 [[package]]
 name = "metric_exporters"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ad3a2b250d92f21c39ad38d60919b127ae5af1fc#ad3a2b250d92f21c39ad38d60919b127ae5af1fc"
 dependencies = [
  "metric",
  "observability_deps",
@@ -4243,7 +4243,7 @@ dependencies = [
 [[package]]
 name = "object_store_mem_cache"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ad3a2b250d92f21c39ad38d60919b127ae5af1fc#ad3a2b250d92f21c39ad38d60919b127ae5af1fc"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4266,7 +4266,7 @@ dependencies = [
 [[package]]
 name = "object_store_metrics"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ad3a2b250d92f21c39ad38d60919b127ae5af1fc#ad3a2b250d92f21c39ad38d60919b127ae5af1fc"
 dependencies = [
  "async-trait",
  "bloom2",
@@ -4285,7 +4285,7 @@ dependencies = [
 [[package]]
 name = "object_store_mock"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ad3a2b250d92f21c39ad38d60919b127ae5af1fc#ad3a2b250d92f21c39ad38d60919b127ae5af1fc"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4298,7 +4298,7 @@ dependencies = [
 [[package]]
 name = "object_store_size_hinting"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ad3a2b250d92f21c39ad38d60919b127ae5af1fc#ad3a2b250d92f21c39ad38d60919b127ae5af1fc"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4310,7 +4310,7 @@ dependencies = [
 [[package]]
 name = "observability_deps"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ad3a2b250d92f21c39ad38d60919b127ae5af1fc#ad3a2b250d92f21c39ad38d60919b127ae5af1fc"
 dependencies = [
  "tracing",
  "workspace-hack",
@@ -4373,7 +4373,7 @@ checksum = "26995317201fa17f3656c36716aed4a7c81743a9634ac4c99c0eeda495db0cec"
 [[package]]
 name = "panic_logging"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ad3a2b250d92f21c39ad38d60919b127ae5af1fc#ad3a2b250d92f21c39ad38d60919b127ae5af1fc"
 dependencies = [
  "metric",
  "observability_deps",
@@ -4447,7 +4447,7 @@ dependencies = [
 [[package]]
 name = "parquet_file"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ad3a2b250d92f21c39ad38d60919b127ae5af1fc#ad3a2b250d92f21c39ad38d60919b127ae5af1fc"
 dependencies = [
  "arrow",
  "arrow_util",
@@ -4765,7 +4765,7 @@ dependencies = [
 [[package]]
 name = "predicate"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ad3a2b250d92f21c39ad38d60919b127ae5af1fc#ad3a2b250d92f21c39ad38d60919b127ae5af1fc"
 dependencies = [
  "arrow",
  "async-trait",
@@ -5038,7 +5038,7 @@ dependencies = [
 [[package]]
 name = "query_functions"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ad3a2b250d92f21c39ad38d60919b127ae5af1fc#ad3a2b250d92f21c39ad38d60919b127ae5af1fc"
 dependencies = [
  "arrow",
  "chrono",
@@ -5631,7 +5631,7 @@ dependencies = [
 [[package]]
 name = "schema"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ad3a2b250d92f21c39ad38d60919b127ae5af1fc#ad3a2b250d92f21c39ad38d60919b127ae5af1fc"
 dependencies = [
  "arrow",
  "hashbrown 0.14.5",
@@ -5794,7 +5794,7 @@ dependencies = [
 [[package]]
 name = "service_common"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ad3a2b250d92f21c39ad38d60919b127ae5af1fc#ad3a2b250d92f21c39ad38d60919b127ae5af1fc"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -5808,7 +5808,7 @@ dependencies = [
 [[package]]
 name = "service_grpc_flight"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ad3a2b250d92f21c39ad38d60919b127ae5af1fc#ad3a2b250d92f21c39ad38d60919b127ae5af1fc"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -6406,7 +6406,7 @@ dependencies = [
 [[package]]
 name = "test_helpers"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ad3a2b250d92f21c39ad38d60919b127ae5af1fc#ad3a2b250d92f21c39ad38d60919b127ae5af1fc"
 dependencies = [
  "async-trait",
  "dotenvy",
@@ -6702,7 +6702,7 @@ dependencies = [
 [[package]]
 name = "tokio_metrics_bridge"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ad3a2b250d92f21c39ad38d60919b127ae5af1fc#ad3a2b250d92f21c39ad38d60919b127ae5af1fc"
 dependencies = [
  "metric",
  "parking_lot",
@@ -6713,7 +6713,7 @@ dependencies = [
 [[package]]
 name = "tokio_watchdog"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ad3a2b250d92f21c39ad38d60919b127ae5af1fc#ad3a2b250d92f21c39ad38d60919b127ae5af1fc"
 dependencies = [
  "metric",
  "observability_deps",
@@ -6874,7 +6874,7 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 [[package]]
 name = "tower_trailer"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ad3a2b250d92f21c39ad38d60919b127ae5af1fc#ad3a2b250d92f21c39ad38d60919b127ae5af1fc"
 dependencies = [
  "futures",
  "http 0.2.12",
@@ -6888,7 +6888,7 @@ dependencies = [
 [[package]]
 name = "trace"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ad3a2b250d92f21c39ad38d60919b127ae5af1fc#ad3a2b250d92f21c39ad38d60919b127ae5af1fc"
 dependencies = [
  "chrono",
  "observability_deps",
@@ -6900,7 +6900,7 @@ dependencies = [
 [[package]]
 name = "trace_exporters"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ad3a2b250d92f21c39ad38d60919b127ae5af1fc#ad3a2b250d92f21c39ad38d60919b127ae5af1fc"
 dependencies = [
  "async-trait",
  "clap",
@@ -6918,7 +6918,7 @@ dependencies = [
 [[package]]
 name = "trace_http"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ad3a2b250d92f21c39ad38d60919b127ae5af1fc#ad3a2b250d92f21c39ad38d60919b127ae5af1fc"
 dependencies = [
  "bytes",
  "futures",
@@ -7015,7 +7015,7 @@ dependencies = [
 [[package]]
 name = "tracker"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ad3a2b250d92f21c39ad38d60919b127ae5af1fc#ad3a2b250d92f21c39ad38d60919b127ae5af1fc"
 dependencies = [
  "futures",
  "hashbrown 0.14.5",
@@ -7035,7 +7035,7 @@ dependencies = [
 [[package]]
 name = "trogging"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ad3a2b250d92f21c39ad38d60919b127ae5af1fc#ad3a2b250d92f21c39ad38d60919b127ae5af1fc"
 dependencies = [
  "clap",
  "logfmt",
@@ -7404,7 +7404,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7722,7 +7722,7 @@ dependencies = [
 [[package]]
 name = "workspace-hack"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ad3a2b250d92f21c39ad38d60919b127ae5af1fc#ad3a2b250d92f21c39ad38d60919b127ae5af1fc"
 dependencies = [
  "ahash",
  "arrayvec",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6843,9 +6843,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc2d9e086a412a451384326f521c8123a99a466b329941a9403696bff9b0da2"
+checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
 dependencies = [
  "bitflags 2.9.1",
  "bytes",
@@ -7404,7 +7404,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,12 +123,12 @@ dependencies = [
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.7"
+version = "3.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
+checksum = "6680de5231bd6ee4c6191b8a1325daa282b415391ec9d3a37bd34f2060dc73fa"
 dependencies = [
  "anstyle",
- "once_cell",
+ "once_cell_polyfill",
  "windows-sys 0.59.0",
 ]
 
@@ -383,7 +383,7 @@ dependencies = [
 [[package]]
 name = "arrow_util"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=fd0e474a6c0af5ba867399d753f5df18f59907cb#fd0e474a6c0af5ba867399d753f5df18f59907cb"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
 dependencies = [
  "ahash",
  "arrow",
@@ -500,7 +500,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 [[package]]
 name = "authz"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=fd0e474a6c0af5ba867399d753f5df18f59907cb#fd0e474a6c0af5ba867399d753f5df18f59907cb"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
 dependencies = [
  "async-trait",
  "backoff",
@@ -568,7 +568,7 @@ dependencies = [
 [[package]]
 name = "backoff"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=fd0e474a6c0af5ba867399d753f5df18f59907cb#fd0e474a6c0af5ba867399d753f5df18f59907cb"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
 dependencies = [
  "observability_deps",
  "rand 0.9.1",
@@ -782,9 +782,9 @@ dependencies = [
 
 [[package]]
 name = "camino"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3"
+checksum = "0da45bc31171d8d6960122e222a67740df867c1dd53b4d51caa297084c185cab"
 dependencies = [
  "serde",
 ]
@@ -820,9 +820,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.23"
+version = "1.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4ac86a9e5bc1e2b3449ab9d7d3a6a405e3d1bb28d7b9be8614f55846ae3766"
+checksum = "d0fc897dc1e865cc67c0e05a836d9d3f1df3cbe442aa4a9473b18e12624a4951"
 dependencies = [
  "jobserver",
  "libc",
@@ -906,9 +906,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.38"
+version = "4.5.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed93b9805f8ba930df42c2590f05453d5ec36cbb85d018868a5b24d31f6ac000"
+checksum = "fd60e63e9be68e5fb56422e397cf9baddded06dae1d2e523401542383bc72a9f"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -916,9 +916,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.38"
+version = "4.5.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "379026ff283facf611b0ea629334361c4211d1b12ee01024eec1591133b04120"
+checksum = "89cc6392a1f72bbeb820d71f32108f61fdaf18bc526e1d23954168a67759ef51"
 dependencies = [
  "anstream",
  "anstyle",
@@ -947,7 +947,7 @@ checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 [[package]]
 name = "client_util"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=fd0e474a6c0af5ba867399d753f5df18f59907cb#fd0e474a6c0af5ba867399d753f5df18f59907cb"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
 dependencies = [
  "http 0.2.12",
  "reqwest 0.11.27",
@@ -1075,9 +1075,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1160,18 +1160,18 @@ dependencies = [
 
 [[package]]
 name = "croaring"
-version = "2.3.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1583a0c6ed2e2fe1a948e23d62ca42e0f2f3b45c59276c884a947c0dab47a20d"
+checksum = "0a7378e8f3ede464bd5d6dbdb1b6f2ed907c0dd27dcbe465a7991c4bb78b5ddd"
 dependencies = [
  "croaring-sys",
 ]
 
 [[package]]
 name = "croaring-sys"
-version = "4.3.1"
+version = "4.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3124cf04e54f50ecc5f53874e1b1e3a803e35523221bd2864851977b48ba7d00"
+checksum = "5008a00afde0b8493eae0f33975f1d0af95f2e654a7c9938c27e654c09119dcd"
 dependencies = [
  "cc",
 ]
@@ -1319,7 +1319,7 @@ dependencies = [
 [[package]]
 name = "data_types"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=fd0e474a6c0af5ba867399d753f5df18f59907cb#fd0e474a6c0af5ba867399d753f5df18f59907cb"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -1751,7 +1751,7 @@ dependencies = [
 [[package]]
 name = "datafusion_util"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=fd0e474a6c0af5ba867399d753f5df18f59907cb#fd0e474a6c0af5ba867399d753f5df18f59907cb"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
 dependencies = [
  "async-trait",
  "datafusion",
@@ -1915,7 +1915,7 @@ dependencies = [
 [[package]]
 name = "error_reporting"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=fd0e474a6c0af5ba867399d753f5df18f59907cb#fd0e474a6c0af5ba867399d753f5df18f59907cb"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
 dependencies = [
  "workspace-hack",
 ]
@@ -1945,7 +1945,7 @@ dependencies = [
 [[package]]
 name = "executor"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=fd0e474a6c0af5ba867399d753f5df18f59907cb#fd0e474a6c0af5ba867399d753f5df18f59907cb"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
 dependencies = [
  "futures",
  "metric",
@@ -1993,7 +1993,7 @@ dependencies = [
 [[package]]
 name = "flightsql"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=fd0e474a6c0af5ba867399d753f5df18f59907cb#fd0e474a6c0af5ba867399d753f5df18f59907cb"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -2151,7 +2151,7 @@ dependencies = [
 [[package]]
 name = "generated_types"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=fd0e474a6c0af5ba867399d753f5df18f59907cb#fd0e474a6c0af5ba867399d753f5df18f59907cb"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
 dependencies = [
  "observability_deps",
  "pbjson",
@@ -2332,12 +2332,6 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hermit-abi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hermit-abi"
@@ -2530,11 +2524,10 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.5"
+version = "0.27.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
+checksum = "03a01595e11bdcec50946522c32dde3fc6914743000a68b93000965f2f02406d"
 dependencies = [
- "futures-util",
  "http 1.3.1",
  "hyper 1.6.0",
  "hyper-util",
@@ -2560,17 +2553,21 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.12"
+version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf9f1e950e0d9d1d3c47184416723cf29c0d1f93bd8cccf37e4beb6b44f31710"
+checksum = "b1c293b6b3d21eca78250dc7dbebd6b9210ec5530e038cbfe0661b5c47ab06e8"
 dependencies = [
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
+ "futures-core",
  "futures-util",
  "http 1.3.1",
  "http-body 1.0.1",
  "hyper 1.6.0",
+ "ipnet",
  "libc",
+ "percent-encoding",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -2746,7 +2743,7 @@ checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
 [[package]]
 name = "influxdb-line-protocol"
 version = "1.0.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=fd0e474a6c0af5ba867399d753f5df18f59907cb#fd0e474a6c0af5ba867399d753f5df18f59907cb"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
 dependencies = [
  "bytes",
  "log",
@@ -3394,7 +3391,7 @@ dependencies = [
 [[package]]
 name = "influxdb_influxql_parser"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=fd0e474a6c0af5ba867399d753f5df18f59907cb#fd0e474a6c0af5ba867399d753f5df18f59907cb"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
 dependencies = [
  "chrono",
  "chrono-tz",
@@ -3409,7 +3406,7 @@ dependencies = [
 [[package]]
 name = "influxdb_iox_client"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=fd0e474a6c0af5ba867399d753f5df18f59907cb#fd0e474a6c0af5ba867399d753f5df18f59907cb"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -3456,7 +3453,7 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 [[package]]
 name = "iox_http"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=fd0e474a6c0af5ba867399d753f5df18f59907cb#fd0e474a6c0af5ba867399d753f5df18f59907cb"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
 dependencies = [
  "async-trait",
  "authz",
@@ -3473,7 +3470,7 @@ dependencies = [
 [[package]]
 name = "iox_http_util"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=fd0e474a6c0af5ba867399d753f5df18f59907cb#fd0e474a6c0af5ba867399d753f5df18f59907cb"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
 dependencies = [
  "futures",
  "http 0.2.12",
@@ -3484,7 +3481,7 @@ dependencies = [
 [[package]]
 name = "iox_query"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=fd0e474a6c0af5ba867399d753f5df18f59907cb#fd0e474a6c0af5ba867399d753f5df18f59907cb"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
 dependencies = [
  "arrow",
  "arrow_util",
@@ -3523,7 +3520,7 @@ dependencies = [
 [[package]]
 name = "iox_query_influxql"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=fd0e474a6c0af5ba867399d753f5df18f59907cb#fd0e474a6c0af5ba867399d753f5df18f59907cb"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
 dependencies = [
  "arrow",
  "assert_matches",
@@ -3556,7 +3553,7 @@ dependencies = [
 [[package]]
 name = "iox_query_params"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=fd0e474a6c0af5ba867399d753f5df18f59907cb#fd0e474a6c0af5ba867399d753f5df18f59907cb"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
 dependencies = [
  "arrow",
  "datafusion",
@@ -3571,7 +3568,7 @@ dependencies = [
 [[package]]
 name = "iox_system_tables"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=fd0e474a6c0af5ba867399d753f5df18f59907cb#fd0e474a6c0af5ba867399d753f5df18f59907cb"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
 dependencies = [
  "arrow",
  "async-trait",
@@ -3583,7 +3580,7 @@ dependencies = [
 [[package]]
 name = "iox_time"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=fd0e474a6c0af5ba867399d753f5df18f59907cb#fd0e474a6c0af5ba867399d753f5df18f59907cb"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
 dependencies = [
  "chrono",
  "parking_lot",
@@ -3598,12 +3595,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
+name = "iri-string"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "is-terminal"
 version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
- "hermit-abi 0.5.1",
+ "hermit-abi",
  "libc",
  "windows-sys 0.59.0",
 ]
@@ -3659,7 +3666,7 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 [[package]]
 name = "jemalloc_stats"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=fd0e474a6c0af5ba867399d753f5df18f59907cb#fd0e474a6c0af5ba867399d753f5df18f59907cb"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
 dependencies = [
  "snafu",
  "tikv-jemalloc-ctl",
@@ -3797,9 +3804,9 @@ checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "lock_api"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -3815,7 +3822,7 @@ checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 [[package]]
 name = "logfmt"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=fd0e474a6c0af5ba867399d753f5df18f59907cb#fd0e474a6c0af5ba867399d753f5df18f59907cb"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
 dependencies = [
  "humantime",
  "observability_deps",
@@ -3893,7 +3900,7 @@ dependencies = [
 [[package]]
 name = "meta_data_cache"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=fd0e474a6c0af5ba867399d753f5df18f59907cb#fd0e474a6c0af5ba867399d753f5df18f59907cb"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
 dependencies = [
  "arrow",
  "data_types",
@@ -3909,7 +3916,7 @@ dependencies = [
 [[package]]
 name = "metric"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=fd0e474a6c0af5ba867399d753f5df18f59907cb#fd0e474a6c0af5ba867399d753f5df18f59907cb"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
 dependencies = [
  "parking_lot",
  "workspace-hack",
@@ -3918,7 +3925,7 @@ dependencies = [
 [[package]]
 name = "metric_exporters"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=fd0e474a6c0af5ba867399d753f5df18f59907cb#fd0e474a6c0af5ba867399d753f5df18f59907cb"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
 dependencies = [
  "metric",
  "observability_deps",
@@ -3950,13 +3957,13 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
+checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4166,11 +4173,11 @@ dependencies = [
 
 [[package]]
 name = "num_cpus"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
- "hermit-abi 0.3.9",
+ "hermit-abi",
  "libc",
 ]
 
@@ -4221,7 +4228,7 @@ dependencies = [
  "percent-encoding",
  "quick-xml",
  "rand 0.8.5",
- "reqwest 0.12.15",
+ "reqwest 0.12.19",
  "ring",
  "rustls-pemfile 2.2.0",
  "serde",
@@ -4236,7 +4243,7 @@ dependencies = [
 [[package]]
 name = "object_store_mem_cache"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=fd0e474a6c0af5ba867399d753f5df18f59907cb#fd0e474a6c0af5ba867399d753f5df18f59907cb"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4259,7 +4266,7 @@ dependencies = [
 [[package]]
 name = "object_store_metrics"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=fd0e474a6c0af5ba867399d753f5df18f59907cb#fd0e474a6c0af5ba867399d753f5df18f59907cb"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
 dependencies = [
  "async-trait",
  "bloom2",
@@ -4278,7 +4285,7 @@ dependencies = [
 [[package]]
 name = "object_store_mock"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=fd0e474a6c0af5ba867399d753f5df18f59907cb#fd0e474a6c0af5ba867399d753f5df18f59907cb"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4291,7 +4298,7 @@ dependencies = [
 [[package]]
 name = "object_store_size_hinting"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=fd0e474a6c0af5ba867399d753f5df18f59907cb#fd0e474a6c0af5ba867399d753f5df18f59907cb"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4303,7 +4310,7 @@ dependencies = [
 [[package]]
 name = "observability_deps"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=fd0e474a6c0af5ba867399d753f5df18f59907cb#fd0e474a6c0af5ba867399d753f5df18f59907cb"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
 dependencies = [
  "tracing",
  "workspace-hack",
@@ -4314,6 +4321,12 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
 name = "oorandom"
@@ -4360,7 +4373,7 @@ checksum = "26995317201fa17f3656c36716aed4a7c81743a9634ac4c99c0eeda495db0cec"
 [[package]]
 name = "panic_logging"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=fd0e474a6c0af5ba867399d753f5df18f59907cb#fd0e474a6c0af5ba867399d753f5df18f59907cb"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
 dependencies = [
  "metric",
  "observability_deps",
@@ -4375,9 +4388,9 @@ checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -4385,9 +4398,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
 dependencies = [
  "cfg-if",
  "libc",
@@ -4434,7 +4447,7 @@ dependencies = [
 [[package]]
 name = "parquet_file"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=fd0e474a6c0af5ba867399d753f5df18f59907cb#fd0e474a6c0af5ba867399d753f5df18f59907cb"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
 dependencies = [
  "arrow",
  "arrow_util",
@@ -4752,7 +4765,7 @@ dependencies = [
 [[package]]
 name = "predicate"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=fd0e474a6c0af5ba867399d753f5df18f59907cb#fd0e474a6c0af5ba867399d753f5df18f59907cb"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4806,9 +4819,9 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.32"
+version = "0.2.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "664ec5419c51e34154eec046ebcba56312d5a2fc3b09a06da188e1ad21afadf6"
+checksum = "9dee91521343f4c5c6a63edd65e54f31f5c92fe8978c40a4282f8372194c6a7d"
 dependencies = [
  "proc-macro2",
  "syn 2.0.101",
@@ -5025,7 +5038,7 @@ dependencies = [
 [[package]]
 name = "query_functions"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=fd0e474a6c0af5ba867399d753f5df18f59907cb#fd0e474a6c0af5ba867399d753f5df18f59907cb"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
 dependencies = [
  "arrow",
  "chrono",
@@ -5337,9 +5350,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.15"
+version = "0.12.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d19c46a6fdd48bc4dab94b6103fccc55d34c67cc0ad04653aad4ea2a07cd7bbb"
+checksum = "a2f8e5513d63f2e5b386eb5106dc67eaf3f84e95258e210489136b8b92ad6119"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -5350,7 +5363,7 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.6.0",
- "hyper-rustls 0.27.5",
+ "hyper-rustls 0.27.6",
  "hyper-util",
  "ipnet",
  "js-sys",
@@ -5362,7 +5375,6 @@ dependencies = [
  "quinn",
  "rustls 0.23.27",
  "rustls-native-certs 0.8.1",
- "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "serde",
  "serde_json",
@@ -5372,13 +5384,13 @@ dependencies = [
  "tokio-rustls 0.26.2",
  "tokio-util",
  "tower 0.5.2",
+ "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "windows-registry",
 ]
 
 [[package]]
@@ -5588,9 +5600,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
 
 [[package]]
 name = "ryu"
@@ -5619,7 +5631,7 @@ dependencies = [
 [[package]]
 name = "schema"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=fd0e474a6c0af5ba867399d753f5df18f59907cb#fd0e474a6c0af5ba867399d753f5df18f59907cb"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
 dependencies = [
  "arrow",
  "hashbrown 0.14.5",
@@ -5674,7 +5686,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271720403f46ca04f7ba6f55d438f8bd878d6b8ca0a1046e8228c4145bcbb316"
 dependencies = [
  "bitflags 2.9.1",
- "core-foundation 0.10.0",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -5782,7 +5794,7 @@ dependencies = [
 [[package]]
 name = "service_common"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=fd0e474a6c0af5ba867399d753f5df18f59907cb#fd0e474a6c0af5ba867399d753f5df18f59907cb"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -5796,7 +5808,7 @@ dependencies = [
 [[package]]
 name = "service_grpc_flight"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=fd0e474a6c0af5ba867399d753f5df18f59907cb#fd0e474a6c0af5ba867399d753f5df18f59907cb"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -5912,18 +5924,18 @@ dependencies = [
 
 [[package]]
 name = "snafu"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "223891c85e2a29c3fe8fb900c1fae5e69c2e42415e3177752e8718475efa5019"
+checksum = "320b01e011bf8d5d7a4a4a4be966d9160968935849c83b918827f6a435e7f627"
 dependencies = [
  "snafu-derive",
 ]
 
 [[package]]
 name = "snafu-derive"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c3c6b7927ffe7ecaa769ee0e3994da3b8cafc8f444578982c83ecb161af917"
+checksum = "1961e2ef424c1424204d3a5d6975f934f56b6d50ff5732382d84ebf460e147f7"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -5939,9 +5951,9 @@ checksum = "1b6b67fb9a61334225b5b790716f609cd58395f895b3fe8b328786812a40bc3b"
 
 [[package]]
 name = "socket2"
-version = "0.5.9"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
@@ -6394,7 +6406,7 @@ dependencies = [
 [[package]]
 name = "test_helpers"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=fd0e474a6c0af5ba867399d753f5df18f59907cb#fd0e474a6c0af5ba867399d753f5df18f59907cb"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
 dependencies = [
  "async-trait",
  "dotenvy",
@@ -6592,9 +6604,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.45.0"
+version = "1.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2513ca694ef9ede0fb23fe71a4ee4107cb102b9dc1930f6d0fd77aae068ae165"
+checksum = "75ef51a33ef1da925cea3e4eb122833cb377c61439ca401b770f54902b806779"
 dependencies = [
  "backtrace",
  "bytes",
@@ -6690,7 +6702,7 @@ dependencies = [
 [[package]]
 name = "tokio_metrics_bridge"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=fd0e474a6c0af5ba867399d753f5df18f59907cb#fd0e474a6c0af5ba867399d753f5df18f59907cb"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
 dependencies = [
  "metric",
  "parking_lot",
@@ -6701,7 +6713,7 @@ dependencies = [
 [[package]]
 name = "tokio_watchdog"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=fd0e474a6c0af5ba867399d753f5df18f59907cb#fd0e474a6c0af5ba867399d753f5df18f59907cb"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
 dependencies = [
  "metric",
  "observability_deps",
@@ -6830,6 +6842,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower-http"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cc2d9e086a412a451384326f521c8123a99a466b329941a9403696bff9b0da2"
+dependencies = [
+ "bitflags 2.9.1",
+ "bytes",
+ "futures-util",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "iri-string",
+ "pin-project-lite",
+ "tower 0.5.2",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "tower-layer"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6844,7 +6874,7 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 [[package]]
 name = "tower_trailer"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=fd0e474a6c0af5ba867399d753f5df18f59907cb#fd0e474a6c0af5ba867399d753f5df18f59907cb"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
 dependencies = [
  "futures",
  "http 0.2.12",
@@ -6858,7 +6888,7 @@ dependencies = [
 [[package]]
 name = "trace"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=fd0e474a6c0af5ba867399d753f5df18f59907cb#fd0e474a6c0af5ba867399d753f5df18f59907cb"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
 dependencies = [
  "chrono",
  "observability_deps",
@@ -6870,7 +6900,7 @@ dependencies = [
 [[package]]
 name = "trace_exporters"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=fd0e474a6c0af5ba867399d753f5df18f59907cb#fd0e474a6c0af5ba867399d753f5df18f59907cb"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
 dependencies = [
  "async-trait",
  "clap",
@@ -6888,7 +6918,7 @@ dependencies = [
 [[package]]
 name = "trace_http"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=fd0e474a6c0af5ba867399d753f5df18f59907cb#fd0e474a6c0af5ba867399d753f5df18f59907cb"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
 dependencies = [
  "bytes",
  "futures",
@@ -6985,7 +7015,7 @@ dependencies = [
 [[package]]
 name = "tracker"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=fd0e474a6c0af5ba867399d753f5df18f59907cb#fd0e474a6c0af5ba867399d753f5df18f59907cb"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
 dependencies = [
  "futures",
  "hashbrown 0.14.5",
@@ -7005,7 +7035,7 @@ dependencies = [
 [[package]]
 name = "trogging"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=fd0e474a6c0af5ba867399d753f5df18f59907cb#fd0e474a6c0af5ba867399d753f5df18f59907cb"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
 dependencies = [
  "clap",
  "logfmt",
@@ -7137,9 +7167,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.16.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458f7a779bf54acc9f347480ac654f68407d3aab21269a6e3c9f922acd9e2da9"
+checksum = "3cf4199d1e5d15ddd86a694e4d0dffa9c323ce759fea589f00fef9d81cc1931d"
 dependencies = [
  "getrandom 0.3.3",
  "js-sys",
@@ -7434,7 +7464,7 @@ dependencies = [
  "windows-interface",
  "windows-link",
  "windows-result",
- "windows-strings 0.4.2",
+ "windows-strings",
 ]
 
 [[package]]
@@ -7487,30 +7517,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-registry"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4286ad90ddb45071efd1a66dfa43eb02dd0dfbae1545ad6cc3c51cf34d7e8ba3"
-dependencies = [
- "windows-result",
- "windows-strings 0.3.1",
- "windows-targets 0.53.0",
-]
-
-[[package]]
 name = "windows-result"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
 dependencies = [
  "windows-link",
 ]
@@ -7575,27 +7585,11 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
+ "windows_i686_gnullvm",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1e4c7e8ceaaf9cb7d7507c974735728ab453b67ef8f18febdd7c11fe59dca8b"
-dependencies = [
- "windows_aarch64_gnullvm 0.53.0",
- "windows_aarch64_msvc 0.53.0",
- "windows_i686_gnu 0.53.0",
- "windows_i686_gnullvm 0.53.0",
- "windows_i686_msvc 0.53.0",
- "windows_x86_64_gnu 0.53.0",
- "windows_x86_64_gnullvm 0.53.0",
- "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -7620,12 +7614,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7636,12 +7624,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -7656,22 +7638,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -7686,12 +7656,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7702,12 +7666,6 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -7722,12 +7680,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7738,12 +7690,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
@@ -7776,7 +7722,7 @@ dependencies = [
 [[package]]
 name = "workspace-hack"
 version = "0.1.0"
-source = "git+https://github.com/influxdata/influxdb3_core?rev=fd0e474a6c0af5ba867399d753f5df18f59907cb#fd0e474a6c0af5ba867399d753f5df18f59907cb"
+source = "git+https://github.com/influxdata/influxdb3_core?rev=ddd9d7d9bed8e00819d989ea552a31f8ee1a2539#ddd9d7d9bed8e00819d989ea552a31f8ee1a2539"
 dependencies = [
  "ahash",
  "arrayvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,37 +153,37 @@ uuid = { version = "1", features = ["v4", "v7", "serde"] }
 num = { version = "0.4.3" }
 
 # Core.git crates we depend on
-arrow_util = { git = "https://github.com/influxdata/influxdb3_core", rev = "ddd9d7d9bed8e00819d989ea552a31f8ee1a2539" }
-authz = { git = "https://github.com/influxdata/influxdb3_core", rev = "ddd9d7d9bed8e00819d989ea552a31f8ee1a2539" }
-data_types = { git = "https://github.com/influxdata/influxdb3_core", rev = "ddd9d7d9bed8e00819d989ea552a31f8ee1a2539" }
-datafusion_util = { git = "https://github.com/influxdata/influxdb3_core", rev = "ddd9d7d9bed8e00819d989ea552a31f8ee1a2539" }
-executor = { git = "https://github.com/influxdata/influxdb3_core", rev = "ddd9d7d9bed8e00819d989ea552a31f8ee1a2539" }
-influxdb-line-protocol = { git = "https://github.com/influxdata/influxdb3_core", rev = "ddd9d7d9bed8e00819d989ea552a31f8ee1a2539", features = ["v3"]}
-influxdb_influxql_parser = { git = "https://github.com/influxdata/influxdb3_core", rev = "ddd9d7d9bed8e00819d989ea552a31f8ee1a2539" }
-influxdb_iox_client = { git = "https://github.com/influxdata/influxdb3_core", rev = "ddd9d7d9bed8e00819d989ea552a31f8ee1a2539" }
-iox_http = { git = "https://github.com/influxdata/influxdb3_core", rev = "ddd9d7d9bed8e00819d989ea552a31f8ee1a2539" }
-iox_http_util = { git = "https://github.com/influxdata/influxdb3_core", rev = "ddd9d7d9bed8e00819d989ea552a31f8ee1a2539" }
-iox_query = { git = "https://github.com/influxdata/influxdb3_core", rev = "ddd9d7d9bed8e00819d989ea552a31f8ee1a2539" }
-iox_query_params = { git = "https://github.com/influxdata/influxdb3_core", rev = "ddd9d7d9bed8e00819d989ea552a31f8ee1a2539" }
-iox_query_influxql = { git = "https://github.com/influxdata/influxdb3_core", rev = "ddd9d7d9bed8e00819d989ea552a31f8ee1a2539" }
-iox_system_tables = { git = "https://github.com/influxdata/influxdb3_core", rev = "ddd9d7d9bed8e00819d989ea552a31f8ee1a2539" }
-iox_time = { git = "https://github.com/influxdata/influxdb3_core", rev = "ddd9d7d9bed8e00819d989ea552a31f8ee1a2539" }
-metric = { git = "https://github.com/influxdata/influxdb3_core", rev = "ddd9d7d9bed8e00819d989ea552a31f8ee1a2539" }
-metric_exporters = { git = "https://github.com/influxdata/influxdb3_core", rev = "ddd9d7d9bed8e00819d989ea552a31f8ee1a2539" }
-object_store_metrics = { git = "https://github.com/influxdata/influxdb3_core", rev = "ddd9d7d9bed8e00819d989ea552a31f8ee1a2539" }
-observability_deps = { git = "https://github.com/influxdata/influxdb3_core", rev = "ddd9d7d9bed8e00819d989ea552a31f8ee1a2539" }
-panic_logging = { git = "https://github.com/influxdata/influxdb3_core", rev = "ddd9d7d9bed8e00819d989ea552a31f8ee1a2539" }
-parquet_file = { git = "https://github.com/influxdata/influxdb3_core", rev = "ddd9d7d9bed8e00819d989ea552a31f8ee1a2539" }
-schema = { git = "https://github.com/influxdata/influxdb3_core", rev = "ddd9d7d9bed8e00819d989ea552a31f8ee1a2539", features = ["v3"]}
-service_common = { git = "https://github.com/influxdata/influxdb3_core", rev = "ddd9d7d9bed8e00819d989ea552a31f8ee1a2539" }
-service_grpc_flight = { git = "https://github.com/influxdata/influxdb3_core", rev = "ddd9d7d9bed8e00819d989ea552a31f8ee1a2539" }
-test_helpers = { git = "https://github.com/influxdata/influxdb3_core", rev = "ddd9d7d9bed8e00819d989ea552a31f8ee1a2539" }
-tokio_metrics_bridge = { git = "https://github.com/influxdata/influxdb3_core", rev = "ddd9d7d9bed8e00819d989ea552a31f8ee1a2539" }
-trace = { git = "https://github.com/influxdata/influxdb3_core", rev = "ddd9d7d9bed8e00819d989ea552a31f8ee1a2539" }
-trace_exporters = { git = "https://github.com/influxdata/influxdb3_core", rev = "ddd9d7d9bed8e00819d989ea552a31f8ee1a2539" }
-trace_http = { git = "https://github.com/influxdata/influxdb3_core", rev = "ddd9d7d9bed8e00819d989ea552a31f8ee1a2539" }
-tracker = { git = "https://github.com/influxdata/influxdb3_core", rev = "ddd9d7d9bed8e00819d989ea552a31f8ee1a2539" }
-trogging = { git = "https://github.com/influxdata/influxdb3_core", rev = "ddd9d7d9bed8e00819d989ea552a31f8ee1a2539", features = ["clap"] }
+arrow_util = { git = "https://github.com/influxdata/influxdb3_core", rev = "ad3a2b250d92f21c39ad38d60919b127ae5af1fc" }
+authz = { git = "https://github.com/influxdata/influxdb3_core", rev = "ad3a2b250d92f21c39ad38d60919b127ae5af1fc" }
+data_types = { git = "https://github.com/influxdata/influxdb3_core", rev = "ad3a2b250d92f21c39ad38d60919b127ae5af1fc" }
+datafusion_util = { git = "https://github.com/influxdata/influxdb3_core", rev = "ad3a2b250d92f21c39ad38d60919b127ae5af1fc" }
+executor = { git = "https://github.com/influxdata/influxdb3_core", rev = "ad3a2b250d92f21c39ad38d60919b127ae5af1fc" }
+influxdb-line-protocol = { git = "https://github.com/influxdata/influxdb3_core", rev = "ad3a2b250d92f21c39ad38d60919b127ae5af1fc", features = ["v3"]}
+influxdb_influxql_parser = { git = "https://github.com/influxdata/influxdb3_core", rev = "ad3a2b250d92f21c39ad38d60919b127ae5af1fc" }
+influxdb_iox_client = { git = "https://github.com/influxdata/influxdb3_core", rev = "ad3a2b250d92f21c39ad38d60919b127ae5af1fc" }
+iox_http = { git = "https://github.com/influxdata/influxdb3_core", rev = "ad3a2b250d92f21c39ad38d60919b127ae5af1fc" }
+iox_http_util = { git = "https://github.com/influxdata/influxdb3_core", rev = "ad3a2b250d92f21c39ad38d60919b127ae5af1fc" }
+iox_query = { git = "https://github.com/influxdata/influxdb3_core", rev = "ad3a2b250d92f21c39ad38d60919b127ae5af1fc" }
+iox_query_params = { git = "https://github.com/influxdata/influxdb3_core", rev = "ad3a2b250d92f21c39ad38d60919b127ae5af1fc" }
+iox_query_influxql = { git = "https://github.com/influxdata/influxdb3_core", rev = "ad3a2b250d92f21c39ad38d60919b127ae5af1fc" }
+iox_system_tables = { git = "https://github.com/influxdata/influxdb3_core", rev = "ad3a2b250d92f21c39ad38d60919b127ae5af1fc" }
+iox_time = { git = "https://github.com/influxdata/influxdb3_core", rev = "ad3a2b250d92f21c39ad38d60919b127ae5af1fc" }
+metric = { git = "https://github.com/influxdata/influxdb3_core", rev = "ad3a2b250d92f21c39ad38d60919b127ae5af1fc" }
+metric_exporters = { git = "https://github.com/influxdata/influxdb3_core", rev = "ad3a2b250d92f21c39ad38d60919b127ae5af1fc" }
+object_store_metrics = { git = "https://github.com/influxdata/influxdb3_core", rev = "ad3a2b250d92f21c39ad38d60919b127ae5af1fc" }
+observability_deps = { git = "https://github.com/influxdata/influxdb3_core", rev = "ad3a2b250d92f21c39ad38d60919b127ae5af1fc" }
+panic_logging = { git = "https://github.com/influxdata/influxdb3_core", rev = "ad3a2b250d92f21c39ad38d60919b127ae5af1fc" }
+parquet_file = { git = "https://github.com/influxdata/influxdb3_core", rev = "ad3a2b250d92f21c39ad38d60919b127ae5af1fc" }
+schema = { git = "https://github.com/influxdata/influxdb3_core", rev = "ad3a2b250d92f21c39ad38d60919b127ae5af1fc", features = ["v3"]}
+service_common = { git = "https://github.com/influxdata/influxdb3_core", rev = "ad3a2b250d92f21c39ad38d60919b127ae5af1fc" }
+service_grpc_flight = { git = "https://github.com/influxdata/influxdb3_core", rev = "ad3a2b250d92f21c39ad38d60919b127ae5af1fc" }
+test_helpers = { git = "https://github.com/influxdata/influxdb3_core", rev = "ad3a2b250d92f21c39ad38d60919b127ae5af1fc" }
+tokio_metrics_bridge = { git = "https://github.com/influxdata/influxdb3_core", rev = "ad3a2b250d92f21c39ad38d60919b127ae5af1fc" }
+trace = { git = "https://github.com/influxdata/influxdb3_core", rev = "ad3a2b250d92f21c39ad38d60919b127ae5af1fc" }
+trace_exporters = { git = "https://github.com/influxdata/influxdb3_core", rev = "ad3a2b250d92f21c39ad38d60919b127ae5af1fc" }
+trace_http = { git = "https://github.com/influxdata/influxdb3_core", rev = "ad3a2b250d92f21c39ad38d60919b127ae5af1fc" }
+tracker = { git = "https://github.com/influxdata/influxdb3_core", rev = "ad3a2b250d92f21c39ad38d60919b127ae5af1fc" }
+trogging = { git = "https://github.com/influxdata/influxdb3_core", rev = "ad3a2b250d92f21c39ad38d60919b127ae5af1fc", features = ["clap"] }
 
 [workspace.lints.rust]
 missing_copy_implementations = "deny"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,37 +153,37 @@ uuid = { version = "1", features = ["v4", "v7", "serde"] }
 num = { version = "0.4.3" }
 
 # Core.git crates we depend on
-arrow_util = { git = "https://github.com/influxdata/influxdb3_core", rev = "fd0e474a6c0af5ba867399d753f5df18f59907cb" }
-authz = { git = "https://github.com/influxdata/influxdb3_core", rev = "fd0e474a6c0af5ba867399d753f5df18f59907cb" }
-data_types = { git = "https://github.com/influxdata/influxdb3_core", rev = "fd0e474a6c0af5ba867399d753f5df18f59907cb" }
-datafusion_util = { git = "https://github.com/influxdata/influxdb3_core", rev = "fd0e474a6c0af5ba867399d753f5df18f59907cb" }
-executor = { git = "https://github.com/influxdata/influxdb3_core", rev = "fd0e474a6c0af5ba867399d753f5df18f59907cb" }
-influxdb-line-protocol = { git = "https://github.com/influxdata/influxdb3_core", rev = "fd0e474a6c0af5ba867399d753f5df18f59907cb", features = ["v3"]}
-influxdb_influxql_parser = { git = "https://github.com/influxdata/influxdb3_core", rev = "fd0e474a6c0af5ba867399d753f5df18f59907cb" }
-influxdb_iox_client = { git = "https://github.com/influxdata/influxdb3_core", rev = "fd0e474a6c0af5ba867399d753f5df18f59907cb" }
-iox_http = { git = "https://github.com/influxdata/influxdb3_core", rev = "fd0e474a6c0af5ba867399d753f5df18f59907cb" }
-iox_http_util = { git = "https://github.com/influxdata/influxdb3_core", rev = "fd0e474a6c0af5ba867399d753f5df18f59907cb" }
-iox_query = { git = "https://github.com/influxdata/influxdb3_core", rev = "fd0e474a6c0af5ba867399d753f5df18f59907cb" }
-iox_query_params = { git = "https://github.com/influxdata/influxdb3_core", rev = "fd0e474a6c0af5ba867399d753f5df18f59907cb" }
-iox_query_influxql = { git = "https://github.com/influxdata/influxdb3_core", rev = "fd0e474a6c0af5ba867399d753f5df18f59907cb" }
-iox_system_tables = { git = "https://github.com/influxdata/influxdb3_core", rev = "fd0e474a6c0af5ba867399d753f5df18f59907cb" }
-iox_time = { git = "https://github.com/influxdata/influxdb3_core", rev = "fd0e474a6c0af5ba867399d753f5df18f59907cb" }
-metric = { git = "https://github.com/influxdata/influxdb3_core", rev = "fd0e474a6c0af5ba867399d753f5df18f59907cb" }
-metric_exporters = { git = "https://github.com/influxdata/influxdb3_core", rev = "fd0e474a6c0af5ba867399d753f5df18f59907cb" }
-object_store_metrics = { git = "https://github.com/influxdata/influxdb3_core", rev = "fd0e474a6c0af5ba867399d753f5df18f59907cb" }
-observability_deps = { git = "https://github.com/influxdata/influxdb3_core", rev = "fd0e474a6c0af5ba867399d753f5df18f59907cb" }
-panic_logging = { git = "https://github.com/influxdata/influxdb3_core", rev = "fd0e474a6c0af5ba867399d753f5df18f59907cb" }
-parquet_file = { git = "https://github.com/influxdata/influxdb3_core", rev = "fd0e474a6c0af5ba867399d753f5df18f59907cb" }
-schema = { git = "https://github.com/influxdata/influxdb3_core", rev = "fd0e474a6c0af5ba867399d753f5df18f59907cb", features = ["v3"]}
-service_common = { git = "https://github.com/influxdata/influxdb3_core", rev = "fd0e474a6c0af5ba867399d753f5df18f59907cb" }
-service_grpc_flight = { git = "https://github.com/influxdata/influxdb3_core", rev = "fd0e474a6c0af5ba867399d753f5df18f59907cb" }
-test_helpers = { git = "https://github.com/influxdata/influxdb3_core", rev = "fd0e474a6c0af5ba867399d753f5df18f59907cb" }
-tokio_metrics_bridge = { git = "https://github.com/influxdata/influxdb3_core", rev = "fd0e474a6c0af5ba867399d753f5df18f59907cb" }
-trace = { git = "https://github.com/influxdata/influxdb3_core", rev = "fd0e474a6c0af5ba867399d753f5df18f59907cb" }
-trace_exporters = { git = "https://github.com/influxdata/influxdb3_core", rev = "fd0e474a6c0af5ba867399d753f5df18f59907cb" }
-trace_http = { git = "https://github.com/influxdata/influxdb3_core", rev = "fd0e474a6c0af5ba867399d753f5df18f59907cb" }
-tracker = { git = "https://github.com/influxdata/influxdb3_core", rev = "fd0e474a6c0af5ba867399d753f5df18f59907cb" }
-trogging = { git = "https://github.com/influxdata/influxdb3_core", rev = "fd0e474a6c0af5ba867399d753f5df18f59907cb", features = ["clap"] }
+arrow_util = { git = "https://github.com/influxdata/influxdb3_core", rev = "ddd9d7d9bed8e00819d989ea552a31f8ee1a2539" }
+authz = { git = "https://github.com/influxdata/influxdb3_core", rev = "ddd9d7d9bed8e00819d989ea552a31f8ee1a2539" }
+data_types = { git = "https://github.com/influxdata/influxdb3_core", rev = "ddd9d7d9bed8e00819d989ea552a31f8ee1a2539" }
+datafusion_util = { git = "https://github.com/influxdata/influxdb3_core", rev = "ddd9d7d9bed8e00819d989ea552a31f8ee1a2539" }
+executor = { git = "https://github.com/influxdata/influxdb3_core", rev = "ddd9d7d9bed8e00819d989ea552a31f8ee1a2539" }
+influxdb-line-protocol = { git = "https://github.com/influxdata/influxdb3_core", rev = "ddd9d7d9bed8e00819d989ea552a31f8ee1a2539", features = ["v3"]}
+influxdb_influxql_parser = { git = "https://github.com/influxdata/influxdb3_core", rev = "ddd9d7d9bed8e00819d989ea552a31f8ee1a2539" }
+influxdb_iox_client = { git = "https://github.com/influxdata/influxdb3_core", rev = "ddd9d7d9bed8e00819d989ea552a31f8ee1a2539" }
+iox_http = { git = "https://github.com/influxdata/influxdb3_core", rev = "ddd9d7d9bed8e00819d989ea552a31f8ee1a2539" }
+iox_http_util = { git = "https://github.com/influxdata/influxdb3_core", rev = "ddd9d7d9bed8e00819d989ea552a31f8ee1a2539" }
+iox_query = { git = "https://github.com/influxdata/influxdb3_core", rev = "ddd9d7d9bed8e00819d989ea552a31f8ee1a2539" }
+iox_query_params = { git = "https://github.com/influxdata/influxdb3_core", rev = "ddd9d7d9bed8e00819d989ea552a31f8ee1a2539" }
+iox_query_influxql = { git = "https://github.com/influxdata/influxdb3_core", rev = "ddd9d7d9bed8e00819d989ea552a31f8ee1a2539" }
+iox_system_tables = { git = "https://github.com/influxdata/influxdb3_core", rev = "ddd9d7d9bed8e00819d989ea552a31f8ee1a2539" }
+iox_time = { git = "https://github.com/influxdata/influxdb3_core", rev = "ddd9d7d9bed8e00819d989ea552a31f8ee1a2539" }
+metric = { git = "https://github.com/influxdata/influxdb3_core", rev = "ddd9d7d9bed8e00819d989ea552a31f8ee1a2539" }
+metric_exporters = { git = "https://github.com/influxdata/influxdb3_core", rev = "ddd9d7d9bed8e00819d989ea552a31f8ee1a2539" }
+object_store_metrics = { git = "https://github.com/influxdata/influxdb3_core", rev = "ddd9d7d9bed8e00819d989ea552a31f8ee1a2539" }
+observability_deps = { git = "https://github.com/influxdata/influxdb3_core", rev = "ddd9d7d9bed8e00819d989ea552a31f8ee1a2539" }
+panic_logging = { git = "https://github.com/influxdata/influxdb3_core", rev = "ddd9d7d9bed8e00819d989ea552a31f8ee1a2539" }
+parquet_file = { git = "https://github.com/influxdata/influxdb3_core", rev = "ddd9d7d9bed8e00819d989ea552a31f8ee1a2539" }
+schema = { git = "https://github.com/influxdata/influxdb3_core", rev = "ddd9d7d9bed8e00819d989ea552a31f8ee1a2539", features = ["v3"]}
+service_common = { git = "https://github.com/influxdata/influxdb3_core", rev = "ddd9d7d9bed8e00819d989ea552a31f8ee1a2539" }
+service_grpc_flight = { git = "https://github.com/influxdata/influxdb3_core", rev = "ddd9d7d9bed8e00819d989ea552a31f8ee1a2539" }
+test_helpers = { git = "https://github.com/influxdata/influxdb3_core", rev = "ddd9d7d9bed8e00819d989ea552a31f8ee1a2539" }
+tokio_metrics_bridge = { git = "https://github.com/influxdata/influxdb3_core", rev = "ddd9d7d9bed8e00819d989ea552a31f8ee1a2539" }
+trace = { git = "https://github.com/influxdata/influxdb3_core", rev = "ddd9d7d9bed8e00819d989ea552a31f8ee1a2539" }
+trace_exporters = { git = "https://github.com/influxdata/influxdb3_core", rev = "ddd9d7d9bed8e00819d989ea552a31f8ee1a2539" }
+trace_http = { git = "https://github.com/influxdata/influxdb3_core", rev = "ddd9d7d9bed8e00819d989ea552a31f8ee1a2539" }
+tracker = { git = "https://github.com/influxdata/influxdb3_core", rev = "ddd9d7d9bed8e00819d989ea552a31f8ee1a2539" }
+trogging = { git = "https://github.com/influxdata/influxdb3_core", rev = "ddd9d7d9bed8e00819d989ea552a31f8ee1a2539", features = ["clap"] }
 
 [workspace.lints.rust]
 missing_copy_implementations = "deny"


### PR DESCRIPTION
Update `influxdb3_core` dependencies to use changes from https://github.com/influxdata/influxdb3_core/pull/48