### PR TITLE
chore: backport hard delete time in Catalog and deleter service from enterprise

### DIFF
--- a/influxdb3/src/commands/serve.rs
+++ b/influxdb3/src/commands/serve.rs
@@ -418,6 +418,15 @@ pub struct Config {
         env = "INFLUXDB3_WAL_REPLAY_CONCURRENCY_LIMIT"
     )]
     pub wal_replay_concurrency_limit: Option<usize>,
+
+    /// The duration from when a database or table is soft-deleted until the data is scheduled to
+    /// be hard deleted.
+    #[clap(
+        long = "hard-delete-default-duration",
+        env = "INFLUXDB3_HARD_DELETE_DEFAULT_DURATION",
+        default_value_t = Catalog::DEFAULT_HARD_DELETE_DURATION.into(),
+    )]
+    pub hard_delete_default_duration: humantime::Duration,
 }
 
 /// The minimum version of TLS to use for InfluxDB

--- a/influxdb3_catalog/src/log/versions/v2/conversion.rs
+++ b/influxdb3_catalog/src/log/versions/v2/conversion.rs
@@ -257,6 +257,7 @@ impl From<v2::SoftDeleteTableLog> for v3::SoftDeleteTableLog {
             table_id: value.table_id,
             table_name: value.table_name,
             deletion_time: value.deletion_time,
+            hard_deletion_time: None,
         }
     }
 }

--- a/influxdb3_catalog/src/log/versions/v3.rs
+++ b/influxdb3_catalog/src/log/versions/v3.rs
@@ -249,6 +249,7 @@ pub struct SoftDeleteTableLog {
     pub table_id: TableId,
     pub table_name: Arc<str>,
     pub deletion_time: i64,
+    // TODO(sgc): Remove `skip_serializing_if` when implementation is complete
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub hard_deletion_time: Option<i64>,
 }

--- a/influxdb3_catalog/src/log/versions/v3.rs
+++ b/influxdb3_catalog/src/log/versions/v3.rs
@@ -249,6 +249,8 @@ pub struct SoftDeleteTableLog {
     pub table_id: TableId,
     pub table_name: Arc<str>,
     pub deletion_time: i64,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub hard_deletion_time: Option<i64>,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]

--- a/influxdb3_catalog/src/serialize.rs
+++ b/influxdb3_catalog/src/serialize.rs
@@ -901,6 +901,7 @@ mod v1_tests {
                             table_id: TableId::new(0),
                             table_name: "test-table".into(),
                             deletion_time: 10,
+                            hard_deletion_time: None,
                         },
                     ),
                     crate::log::DatabaseCatalogOp::AddFields(crate::log::AddFieldsLog {

--- a/influxdb3_catalog/src/snapshot/versions/mod.rs
+++ b/influxdb3_catalog/src/snapshot/versions/mod.rs
@@ -5,6 +5,7 @@ use influxdb3_authz::{
     Actions, CrudActions, DatabaseActions, Permission, ResourceIdentifier, ResourceType, TokenInfo,
 };
 use influxdb3_id::{CatalogId, TokenId};
+use iox_time::Time;
 use schema::{InfluxColumnType, InfluxFieldType};
 use v3::{
     ActionsSnapshot, CatalogSnapshot, ColumnDefinitionSnapshot, CrudActionsSnapshot,
@@ -363,6 +364,7 @@ impl Snapshot for TableDefinition {
             last_caches: self.last_caches.snapshot(),
             distinct_caches: self.distinct_caches.snapshot(),
             deleted: self.deleted,
+            hard_delete_time: self.hard_delete_time.as_ref().map(Time::timestamp_nanos),
         }
     }
 
@@ -407,6 +409,7 @@ impl Snapshot for TableDefinition {
             last_caches: Repository::from_snapshot(snap.last_caches),
             distinct_caches: Repository::from_snapshot(snap.distinct_caches),
             deleted: snap.deleted,
+            hard_delete_time: snap.hard_delete_time.map(Time::from_timestamp_nanos),
         }
     }
 }

--- a/influxdb3_catalog/src/snapshot/versions/v2/conversion.rs
+++ b/influxdb3_catalog/src/snapshot/versions/v2/conversion.rs
@@ -154,6 +154,7 @@ impl From<super::TableSnapshot> for v3::TableSnapshot {
             last_caches: value.last_caches.into(),
             distinct_caches: value.distinct_caches.into(),
             deleted: value.deleted,
+            hard_delete_time: None,
         }
     }
 }

--- a/influxdb3_catalog/src/snapshot/versions/v3.rs
+++ b/influxdb3_catalog/src/snapshot/versions/v3.rs
@@ -126,6 +126,8 @@ pub(crate) struct TableSnapshot {
     pub(crate) last_caches: RepositorySnapshot<LastCacheId, LastCacheSnapshot>,
     pub(crate) distinct_caches: RepositorySnapshot<DistinctCacheId, DistinctCacheSnapshot>,
     pub(crate) deleted: bool,
+    #[serde(skip_serializing_if = "Option::is_none", default)]
+    pub(crate) hard_delete_time: Option<i64>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/influxdb3_catalog/src/snapshot/versions/v3.rs
+++ b/influxdb3_catalog/src/snapshot/versions/v3.rs
@@ -126,6 +126,7 @@ pub(crate) struct TableSnapshot {
     pub(crate) last_caches: RepositorySnapshot<LastCacheId, LastCacheSnapshot>,
     pub(crate) distinct_caches: RepositorySnapshot<DistinctCacheId, DistinctCacheSnapshot>,
     pub(crate) deleted: bool,
+    // TODO(sgc): Remove `skip_serializing_if` when implementation is complete
     #[serde(skip_serializing_if = "Option::is_none", default)]
     pub(crate) hard_delete_time: Option<i64>,
 }

--- a/influxdb3_server/src/http.rs
+++ b/influxdb3_server/src/http.rs
@@ -27,6 +27,7 @@ use influxdb3_authz::{AuthProvider, NoAuthAuthenticator};
 use influxdb3_cache::distinct_cache;
 use influxdb3_cache::last_cache;
 use influxdb3_catalog::CatalogError;
+use influxdb3_catalog::catalog::HardDeletionTime;
 use influxdb3_catalog::log::FieldDataType;
 use influxdb3_internal_api::query_executor::{QueryExecutor, QueryExecutorError};
 use influxdb3_process::{
@@ -1323,7 +1324,8 @@ impl HttpApi {
         let delete_req = serde_urlencoded::from_str::<DeleteTableRequest>(query)?;
         self.write_buffer
             .catalog()
-            .soft_delete_table(&delete_req.db, &delete_req.table)
+            // NOTE(sgc): Until delete is implemented, default to no hard delete time.
+            .soft_delete_table(&delete_req.db, &delete_req.table, HardDeletionTime::Never)
             .await?;
         Ok(ResponseBuilder::new()
             .status(StatusCode::OK)

--- a/influxdb3_write/src/async_collections.rs
+++ b/influxdb3_write/src/async_collections.rs
@@ -1,0 +1,157 @@
+use iox_time::{Time, TimeProvider};
+use std::cmp::{Ordering, Reverse};
+use std::collections::BinaryHeap;
+use std::sync::{Arc, Mutex};
+use tokio::sync::Notify;
+use tokio::time::sleep;
+
+/// A priority queue that allows items to be pushed with a specific time and popped when their time
+/// is reached.
+///
+/// This queue is designed to be used in asynchronous contexts, where tasks can wait for
+/// items to become available based on their scheduled time.
+///
+/// It is cheap and safe to clone, so that a separate task can be used to push items into the queue.
+#[derive(Clone)]
+pub(crate) struct PriorityQueue<T> {
+    heap: Arc<Mutex<BinaryHeap<Reverse<Item<T>>>>>,
+    notify: Arc<Notify>,
+    time_provider: Arc<dyn TimeProvider>,
+}
+
+impl<T> PriorityQueue<T>
+where
+    T: Send + 'static,
+{
+    /// Creates a new empty `PriorityQueue`.
+    pub(crate) fn new(time_provider: Arc<dyn TimeProvider>) -> Self {
+        Self {
+            heap: Arc::new(Mutex::new(BinaryHeap::new())),
+            notify: Arc::new(Notify::new()),
+            time_provider,
+        }
+    }
+
+    /// Push an item into the queue with a specific time.
+    pub(crate) fn push(&self, time: Time, item: T) {
+        let mut heap = self.heap.lock().unwrap();
+        heap.push(Reverse(Item::new(time, item)));
+        self.notify.notify_one(); // Wake up the waiting task
+    }
+
+    /// Pop the next item from the queue that is ready to be processed.
+    pub(crate) async fn pop(&self) -> T {
+        loop {
+            let notify = Arc::clone(&self.notify);
+            let next_time = {
+                let mut heap = self.heap.lock().unwrap();
+                if let Some(Reverse(Item { time, .. })) = heap.peek() {
+                    if *time <= self.time_provider.now() {
+                        return heap
+                            .pop()
+                            .map(|Reverse(Item { item, .. })| item)
+                            // Expect is safe because we already checked the time via the peek.
+                            .expect("item");
+                    }
+                    Some(*time)
+                } else {
+                    None
+                }
+            };
+
+            if let Some(time) = next_time {
+                let now = self.time_provider.now();
+                if time > now {
+                    if let Some(delay) = time.checked_duration_since(now) {
+                        tokio::select! {
+                            _ = sleep(delay) => {},
+                            _ = notify.notified() => continue, // Re-evaluate if woken up
+                        }
+                    } else {
+                        // If duration calculation fails, just yield
+                        tokio::task::yield_now().await;
+                    }
+                }
+            } else {
+                notify.notified().await;
+            }
+        }
+    }
+}
+
+/// A wrapper around an item with its scheduled time, used for ordering in the priority queue.
+struct Item<T> {
+    /// The time when the item should be dequeued.
+    time: Time,
+    item: T,
+}
+
+impl<T> Item<T> {
+    fn new(time: Time, item: T) -> Self {
+        Self { time, item }
+    }
+}
+
+impl<T> Eq for Item<T> {}
+
+impl<T> PartialEq<Self> for Item<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.time == other.time
+    }
+}
+
+impl<T> PartialOrd<Self> for Item<T> {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl<T> Ord for Item<T> {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.time.cmp(&other.time)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures_util::FutureExt;
+    use iox_time::MockProvider;
+    use std::sync::Arc;
+    use test_helpers::timeout::FutureTimeout;
+    use tokio::time::Duration;
+
+    #[tokio::test]
+    async fn test_priority_queue() {
+        let mock = Arc::new(MockProvider::new(Time::from_timestamp_nanos(0)));
+        let queue = PriorityQueue::new(Arc::clone(&mock) as _);
+
+        queue.push(mock.now() + Duration::from_millis(20), "Task 1");
+        queue.push(mock.now() + Duration::from_millis(10), "Task 2");
+
+        // Verifies that the tasks are popped in the order of their scheduled time.
+        // Time hasn't progressed yet, so popping should yield nothing.
+        assert!(queue.pop().now_or_never().is_none());
+        mock.inc(Duration::from_millis(15));
+        // Now the first task should be ready to pop.
+        assert_eq!(queue.pop().await, "Task 2");
+        mock.inc(Duration::from_millis(15));
+        assert_eq!(queue.pop().await, "Task 1");
+
+        // Verifies that popping from an empty queue waits until an item is pushed.
+        queue
+            .pop()
+            .with_timeout(Duration::from_millis(10))
+            .await
+            .expect_err("should fail");
+
+        // Push another item and verify it can be popped.
+        queue.push(mock.now() + Duration::from_millis(10), "Task 3");
+        mock.inc(Duration::from_millis(10));
+        assert_eq!(queue.pop().await, "Task 3");
+
+        // An item in the past will be popped immediately.
+        queue.push(mock.now() - Duration::from_millis(5), "Task 4");
+        assert_eq!(queue.pop().await, "Task 4");
+    }
+}

--- a/influxdb3_write/src/deleter.rs
+++ b/influxdb3_write/src/deleter.rs
@@ -1,0 +1,318 @@
+use crate::async_collections;
+use async_trait::async_trait;
+use influxdb3_catalog::catalog::Catalog;
+use influxdb3_catalog::channel::CatalogUpdateReceiver;
+use influxdb3_catalog::log::{CatalogBatch, DatabaseCatalogOp, SoftDeleteTableLog};
+use influxdb3_catalog::resource::CatalogResource;
+use influxdb3_id::{DbId, TableId};
+use influxdb3_shutdown::ShutdownToken;
+use iox_time::{Time, TimeProvider};
+use observability_deps::tracing::info;
+use std::sync::Arc;
+
+/// Trait for deleting database objects from object storage.
+#[async_trait]
+pub trait ObjectDeleter: std::fmt::Debug + Send + Sync {
+    /// Deletes a database from object storage.
+    async fn delete_database(&self, db_id: DbId);
+    /// Deletes a table from object storage.
+    async fn delete_table(&self, db_id: DbId, table_id: TableId);
+}
+
+#[derive(Debug)]
+pub struct DeleteManagerArgs {
+    catalog: Arc<Catalog>,
+    time_provider: Arc<dyn TimeProvider>,
+    object_deleter: Arc<dyn ObjectDeleter>,
+}
+
+/// Starts the delete manager, which processes hard deletion tasks for database objects.
+pub fn run(
+    DeleteManagerArgs {
+        catalog,
+        time_provider,
+        object_deleter,
+    }: DeleteManagerArgs,
+    shutdown: ShutdownToken,
+) {
+    let tasks = async_collections::PriorityQueue::<DeleteTask>::new(Arc::clone(&time_provider));
+    // Find all tables in catalog that are marked as deleted with a hard delete time.
+    for db_schema in catalog.list_db_schema() {
+        // TODO(sgc): handle db_schema.deleted in the future.
+
+        for (time, table_def) in db_schema.tables().filter_map(|td| {
+            // Table is marked as deleted
+            td.deleted
+                // and it has a hard delete time set.
+                .then(|| td.hard_delete_time.map(|t| (t, td)))
+                .flatten()
+        }) {
+            tasks.push(
+                time,
+                DeleteTask::Table {
+                    db_id: db_schema.id(),
+                    table_id: table_def.id(),
+                },
+            );
+        }
+    }
+
+    tokio::spawn(async move {
+        let delete_manager = DeleteManager {
+            tasks: tasks.clone(),
+        };
+
+        background_catalog_update(
+            delete_manager,
+            catalog.subscribe_to_updates("object_deleter").await,
+        );
+
+        loop {
+            tokio::select! {
+                task = tasks.pop() => {
+                    match task {
+                        DeleteTask::Table { db_id, table_id } => {
+                            info!(?db_id, ?table_id, "Processing delete task for table.");
+                            object_deleter.delete_table(db_id, table_id).await;
+                        }
+                    }
+                }
+                _ = shutdown.wait_for_shutdown() => {
+                    info!("Shutdown signal received, exiting object deleter loop.");
+                    break;
+                }
+            }
+        }
+    });
+}
+
+/// Represents a task to delete a database object's data.
+#[derive(Clone)]
+enum DeleteTask {
+    Table { db_id: DbId, table_id: TableId },
+}
+
+struct DeleteManager {
+    tasks: async_collections::PriorityQueue<DeleteTask>,
+}
+
+fn background_catalog_update(
+    manager: DeleteManager,
+    mut subscription: CatalogUpdateReceiver,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        while let Some(catalog_update) = subscription.recv().await {
+            for batch in catalog_update
+                .batches()
+                .filter_map(CatalogBatch::as_database)
+            {
+                for op in batch.ops.iter() {
+                    #[allow(
+                        clippy::single_match,
+                        reason = "we're going to handle database deletion in the future"
+                    )]
+                    match op {
+                        DatabaseCatalogOp::SoftDeleteTable(SoftDeleteTableLog {
+                            database_id,
+                            table_id,
+                            hard_deletion_time,
+                            ..
+                        }) => {
+                            let Some(time) = hard_deletion_time.map(Time::from_timestamp_nanos)
+                            else {
+                                continue;
+                            };
+                            manager.tasks.push(
+                                time,
+                                DeleteTask::Table {
+                                    db_id: *database_id,
+                                    table_id: *table_id,
+                                },
+                            );
+                        }
+                        _ => (),
+                    }
+                }
+            }
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{DeleteManagerArgs, ObjectDeleter, run};
+    use influxdb3_catalog::catalog::{Catalog, HardDeletionTime};
+    use influxdb3_catalog::log::FieldDataType;
+    use influxdb3_catalog::resource::CatalogResource;
+    use influxdb3_id::{DbId, TableId};
+    use influxdb3_shutdown::ShutdownManager;
+    use iox_time::{MockProvider, Time};
+    use std::sync::Arc;
+    use std::time::Duration;
+    use test_helpers::timeout::FutureTimeout;
+    use tokio::sync::mpsc;
+
+    #[derive(Debug)]
+    struct MockObjectDeleter {
+        db_sender: mpsc::UnboundedSender<DbId>,
+        table_sender: mpsc::UnboundedSender<(DbId, TableId)>,
+    }
+
+    #[allow(dead_code, reason = "used in future PR")]
+    struct MockObjectDeleterWaiter {
+        db_receiver: mpsc::UnboundedReceiver<DbId>,
+        table_receiver: mpsc::UnboundedReceiver<(DbId, TableId)>,
+    }
+
+    impl MockObjectDeleter {
+        fn new() -> (Self, MockObjectDeleterWaiter) {
+            let (db_sender, db_receiver) = mpsc::unbounded_channel();
+            let (table_sender, table_receiver) = mpsc::unbounded_channel();
+            (
+                Self {
+                    db_sender,
+                    table_sender,
+                },
+                MockObjectDeleterWaiter {
+                    db_receiver,
+                    table_receiver,
+                },
+            )
+        }
+    }
+
+    impl MockObjectDeleterWaiter {
+        #[allow(dead_code, reason = "used in future PR")]
+        async fn wait_delete_database(&mut self) -> Option<DbId> {
+            self.db_receiver.recv().await
+        }
+        async fn wait_delete_table(&mut self) -> Option<(DbId, TableId)> {
+            self.table_receiver.recv().await
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl ObjectDeleter for MockObjectDeleter {
+        async fn delete_database(&self, db_id: DbId) {
+            let _ = self.db_sender.send(db_id);
+        }
+        async fn delete_table(&self, db_id: DbId, table_id: TableId) {
+            let _ = self.table_sender.send((db_id, table_id));
+        }
+    }
+
+    #[test_log::test(tokio::test(flavor = "multi_thread", worker_threads = 2))]
+    async fn test_delete_table() {
+        let time_provider = Arc::new(MockProvider::new(Time::from_timestamp_nanos(0)));
+        let args = influxdb3_catalog::catalog::CatalogArgs::new(Duration::from_millis(10));
+        let catalog = Arc::new(
+            Catalog::new_in_memory_with_args("cats", Arc::clone(&time_provider) as _, args)
+                .await
+                .unwrap(),
+        );
+
+        catalog.create_database("foo").await.unwrap();
+        let db_id = catalog.db_schema("foo").unwrap().id();
+
+        let new_table = async |name: &str| {
+            catalog
+                .create_table("foo", name, &["tag"], &[("field", FieldDataType::String)])
+                .await
+                .expect("create table");
+
+            catalog
+                .db_schema("foo")
+                .unwrap()
+                .table_name_to_id(name)
+                .expect("table schema")
+        };
+
+        let t1_id = new_table("table_1").await;
+        let t2_id = new_table("table_2").await;
+        let t3_id = new_table("table_3").await;
+        let t4_id = new_table("table_4").await;
+
+        // Mark table_2 as deleted, which will default to a hard delete time of 10 ms from now.
+        catalog
+            .soft_delete_table("foo", "table_2", HardDeletionTime::Default)
+            .await
+            .expect("soft delete table");
+
+        let (object_deleter, mut waiter) = MockObjectDeleter::new();
+        let shutdown_manager = ShutdownManager::new_testing();
+
+        run(
+            DeleteManagerArgs {
+                catalog: Arc::clone(&catalog),
+                time_provider: Arc::clone(&time_provider) as _,
+                object_deleter: Arc::new(object_deleter),
+            },
+            shutdown_manager.register(),
+        );
+
+        // First check that the object deleter was not called before the hard delete time
+        waiter
+            .wait_delete_table()
+            // We wait 15 ms, which is greater than the hard delete time of 10 ms, and the longest interval
+            // the deleter would wait to retry.
+            .with_timeout(Duration::from_millis(15))
+            .await
+            .expect_err("should not have been called");
+
+        // Advance time to trigger the deletion.
+        time_provider.inc(Duration::from_millis(15));
+
+        // Now the object deleter should have been called to delete table_2.
+        let res = waiter
+            .wait_delete_table()
+            .with_timeout(Duration::from_millis(15))
+            .await
+            .expect("should have been called")
+            .unwrap();
+        assert_eq!(res, (db_id, t2_id));
+
+        // Delete a table and verify the object deleter is called.
+        catalog
+            .soft_delete_table("foo", "table_1", HardDeletionTime::Default)
+            .await
+            .expect("soft delete table");
+        time_provider.inc(Duration::from_millis(15));
+        let res = waiter
+            .wait_delete_table()
+            .with_timeout(Duration::from_millis(15))
+            .await
+            .expect("should have been called")
+            .unwrap();
+        assert_eq!(res, (db_id, t1_id));
+
+        // Delete a table without a delay and verify the object deleter is called immediately.
+        catalog
+            .soft_delete_table("foo", "table_3", HardDeletionTime::Now)
+            .await
+            .expect("soft delete table");
+        let res = waiter
+            .wait_delete_table()
+            .with_timeout(Duration::from_millis(15))
+            .await
+            .expect("should have been called")
+            .unwrap();
+        assert_eq!(res, (db_id, t3_id));
+
+        // Soft-delete the table only.
+        catalog
+            .soft_delete_table("foo", "table_4", HardDeletionTime::Never)
+            .await
+            .expect("soft delete table");
+        waiter
+            .wait_delete_table()
+            // Wait for a time that is greater than the default hard delete time of 10 ms.
+            .with_timeout(Duration::from_millis(15))
+            .await
+            .expect_err("should be an error");
+
+        assert!(catalog.db_schema("foo").unwrap().table_exists(&t4_id));
+
+        shutdown_manager.shutdown();
+        shutdown_manager.join().await;
+    }
+}

--- a/influxdb3_write/src/lib.rs
+++ b/influxdb3_write/src/lib.rs
@@ -4,7 +4,9 @@
 //! data into parquet files that are persisted to object storage. A snapshot file is written that contains the
 //! metadata of the parquet files that were written in that snapshot.
 
+pub(crate) mod async_collections;
 pub mod chunk;
+pub mod deleter;
 pub mod paths;
 pub mod persister;
 pub mod write_buffer;

--- a/influxdb3_write/src/write_buffer/mod.rs
+++ b/influxdb3_write/src/write_buffer/mod.rs
@@ -675,7 +675,7 @@ mod tests {
     use executor::DedicatedExecutor;
     use futures_util::StreamExt;
     use influxdb3_cache::parquet_cache::test_cached_obj_store_and_oracle;
-    use influxdb3_catalog::catalog::CatalogSequenceNumber;
+    use influxdb3_catalog::catalog::{CatalogSequenceNumber, HardDeletionTime};
     use influxdb3_catalog::log::FieldDataType;
     use influxdb3_id::{ColumnId, DbId, ParquetFileId};
     use influxdb3_shutdown::ShutdownManager;
@@ -2218,7 +2218,10 @@ mod tests {
             .await
             .unwrap();
 
-        let result = write_buffer.catalog().soft_delete_table("foo", "cpu").await;
+        let result = write_buffer
+            .catalog()
+            .soft_delete_table("foo", "cpu", HardDeletionTime::Never)
+            .await;
 
         assert!(result.is_ok());
     }


### PR DESCRIPTION
This PR backports a couple commits by @stuartcarnie from the enterprise repo to here. I'm backporting these myself because I believe some of the work in these commits may be useful for implementing database-level retention policies here in this repo.
