### PR TITLE
fix: do not allow _ in db names on API-based create

### DIFF
--- a/influxdb3/tests/cli/mod.rs
+++ b/influxdb3/tests/cli/mod.rs
@@ -2968,3 +2968,29 @@ async fn test_query_with_null_tags() {
     assert!(json[2]["is_empty"].is_null());
     assert!(json[2]["value"].is_null());
 }
+
+#[test_log::test(tokio::test)]
+async fn test_db_name_cannot_start_with_underscore_on_create_database() {
+    let server = TestServer::configure().spawn().await;
+    let result = server.create_database("_foo_bar").run().unwrap_err();
+    debug!(%result);
+    assert_contains!(
+        result.to_string(),
+        "db name did not start with a number or letter"
+    );
+}
+
+#[test_log::test(tokio::test)]
+async fn test_db_name_cannot_start_with_underscore_on_create_table() {
+    let server = TestServer::configure().spawn().await;
+    let result = server
+        .create_table("_foo_bar", "my_table")
+        .with_fields([("f1", "utf8")])
+        .run()
+        .unwrap_err();
+    debug!(%result);
+    assert_contains!(
+        result.to_string(),
+        "db name did not start with a number or letter"
+    );
+}

--- a/influxdb3_server/src/http.rs
+++ b/influxdb3_server/src/http.rs
@@ -1199,6 +1199,7 @@ impl HttpApi {
 
     async fn create_database(&self, req: Request) -> Result<Response> {
         let CreateDatabaseRequest { db } = self.read_body_json(req).await?;
+        validate_db_name(&db, false)?;
         self.write_buffer.catalog().create_database(&db).await?;
         Ok(ResponseBuilder::new()
             .status(StatusCode::OK)
@@ -1301,6 +1302,7 @@ impl HttpApi {
             tags,
             fields,
         } = self.read_body_json(req).await?;
+        validate_db_name(&db, false)?;
         self.write_buffer
             .catalog()
             .create_table(


### PR DESCRIPTION
Prevents database names that start with `_` when created explicitly through the Create Database or Create Table APIs.

Closes #26505