### PR TITLE
feat: track gen1 duration in catalog

### DIFF
--- a/influxdb3/tests/server/mod.rs
+++ b/influxdb3/tests/server/mod.rs
@@ -76,6 +76,7 @@ pub struct TestConfig {
     // If None, use memory object store.
     object_store_dir: Option<String>,
     disable_authz: Vec<String>,
+    gen1_duration: Option<String>,
 }
 
 impl TestConfig {
@@ -146,6 +147,11 @@ impl TestConfig {
         self.disable_authz = disabled_list;
         self
     }
+
+    pub fn with_gen1_duration(mut self, gen1_duration: impl Into<String>) -> Self {
+        self.gen1_duration = Some(gen1_duration.into());
+        self
+    }
 }
 
 impl ConfigProvider for TestConfig {
@@ -196,6 +202,14 @@ impl ConfigProvider for TestConfig {
                 self.disable_authz.join(","),
             ]);
         }
+
+        if let Some(gen1_duration) = &self.gen1_duration {
+            args.append(&mut vec![
+                "--gen1-duration".to_string(),
+                gen1_duration.to_owned(),
+            ])
+        }
+
         args
     }
 

--- a/influxdb3_cache/src/last_cache/snapshots/influxdb3_cache__last_cache__tests__catalog_initialization.snap
+++ b/influxdb3_cache/src/last_cache/snapshots/influxdb3_cache__last_cache__tests__catalog_initialization.snap
@@ -1,9 +1,11 @@
 ---
 source: influxdb3_cache/src/last_cache/mod.rs
 expression: catalog.snapshot()
-snapshot_kind: text
 ---
 {
+  "generation_config": {
+    "generation_durations": []
+  },
   "nodes": {
     "repo": [],
     "next_id": 0

--- a/influxdb3_catalog/src/catalog/metrics.rs
+++ b/influxdb3_catalog/src/catalog/metrics.rs
@@ -5,7 +5,7 @@ use metric::{Attributes, Metric, Registry, U64Counter};
 use crate::{
     channel::CatalogUpdateReceiver,
     log::{
-        CatalogBatch, DatabaseCatalogOp, NodeCatalogOp, TokenCatalogOp,
+        CatalogBatch, DatabaseCatalogOp, GenerationOp, NodeCatalogOp, TokenCatalogOp,
         versions::v3::{ClearRetentionPeriodLog, SetRetentionPeriodLog},
     },
 };
@@ -57,6 +57,11 @@ impl CatalogMetrics {
                         CatalogBatch::Token(token_batch) => {
                             for op in &token_batch.ops {
                                 metrics.catalog_operations.record(op)
+                            }
+                        }
+                        CatalogBatch::Generation(generation_batch) => {
+                            for op in &generation_batch.ops {
+                                metrics.catalog_operations.record(op);
                             }
                         }
                     }
@@ -131,6 +136,14 @@ impl AsMetricStr for DatabaseCatalogOp {
             DatabaseCatalogOp::ClearRetentionPeriod(ClearRetentionPeriodLog { .. }) => {
                 "clear_retention_period_db"
             }
+        }
+    }
+}
+
+impl AsMetricStr for GenerationOp {
+    fn as_metric_str(&self) -> &'static str {
+        match self {
+            GenerationOp::SetGenerationDuration(_) => "set_generation_duration",
         }
     }
 }

--- a/influxdb3_catalog/src/channel.rs
+++ b/influxdb3_catalog/src/channel.rs
@@ -122,10 +122,7 @@ impl CatalogSubscriptions {
 mod tests {
     use observability_deps::tracing::debug;
 
-    use crate::{
-        catalog::Catalog,
-        log::{CatalogBatch, FieldDataType},
-    };
+    use crate::{catalog::Catalog, log::FieldDataType};
 
     #[test_log::test(tokio::test)]
     async fn test_catalog_update_sub() {
@@ -135,13 +132,6 @@ mod tests {
             let mut n_updates = 0;
             while let Some(update) = sub.recv().await {
                 debug!(?update, "got an update");
-                for b in update.batches() {
-                    match b {
-                        CatalogBatch::Node(_) => (),
-                        CatalogBatch::Database(_) => (),
-                        CatalogBatch::Token(_) => (),
-                    }
-                }
                 n_updates += 1;
             }
             n_updates

--- a/influxdb3_catalog/src/error.rs
+++ b/influxdb3_catalog/src/error.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use anyhow::anyhow;
+use humantime::Duration;
 use schema::InfluxColumnType;
 
 use crate::{
@@ -178,6 +179,16 @@ pub enum CatalogError {
 
     #[error("cannot delete operator token")]
     CannotDeleteOperatorToken,
+
+    #[error(
+        "cannot change the configured generation duration for level {level}; \
+        attempted to set to {attempted:#} but its already set to {existing:#}"
+    )]
+    CannotChangeGenerationDuration {
+        level: u8,
+        existing: Duration,
+        attempted: Duration,
+    },
 }
 
 impl CatalogError {

--- a/influxdb3_catalog/src/snapshot/versions/v2/conversion.rs
+++ b/influxdb3_catalog/src/snapshot/versions/v2/conversion.rs
@@ -11,6 +11,7 @@ impl From<super::CatalogSnapshot> for v3::CatalogSnapshot {
             catalog_id: value.catalog_id,
             catalog_uuid: value.catalog_uuid,
             tokens: value.tokens.into(),
+            generation_config: Default::default(),
         }
     }
 }

--- a/influxdb3_catalog/src/snapshot/versions/v3.rs
+++ b/influxdb3_catalog/src/snapshot/versions/v3.rs
@@ -20,6 +20,9 @@ use uuid::Uuid;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct CatalogSnapshot {
+    // NOTE(tjh): added as part of https://github.com/influxdata/influxdb_pro/issues/911
+    #[serde(default)]
+    pub(crate) generation_config: GenerationConfigSnapshot,
     pub(crate) nodes: RepositorySnapshot<NodeId, NodeSnapshot>,
     pub(crate) databases: RepositorySnapshot<DbId, DatabaseSnapshot>,
     pub(crate) sequence: CatalogSequenceNumber,
@@ -37,6 +40,11 @@ impl CatalogSnapshot {
     pub(crate) fn sequence_number(&self) -> CatalogSequenceNumber {
         self.sequence
     }
+}
+
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub(crate) struct GenerationConfigSnapshot {
+    pub(crate) generation_durations: SerdeVecMap<u8, Duration>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Default)]

--- a/influxdb3_catalog/src/snapshots/influxdb3_catalog__catalog__tests__catalog_file_ordering.snap
+++ b/influxdb3_catalog/src/snapshots/influxdb3_catalog__catalog__tests__catalog_file_ordering.snap
@@ -1,9 +1,11 @@
 ---
 source: influxdb3_catalog/src/catalog.rs
 expression: catalog.snapshot()
-snapshot_kind: text
 ---
 {
+  "generation_config": {
+    "generation_durations": []
+  },
   "nodes": {
     "repo": [],
     "next_id": 0

--- a/influxdb3_catalog/src/snapshots/influxdb3_catalog__catalog__tests__catalog_serialization.snap
+++ b/influxdb3_catalog/src/snapshots/influxdb3_catalog__catalog__tests__catalog_serialization.snap
@@ -2,9 +2,11 @@
 source: influxdb3_catalog/src/catalog.rs
 description: catalog serialization to help catch breaking changes
 expression: snapshot
-snapshot_kind: text
 ---
 {
+  "generation_config": {
+    "generation_durations": []
+  },
   "nodes": {
     "repo": [],
     "next_id": 0

--- a/influxdb3_catalog/src/snapshots/influxdb3_catalog__catalog__tests__serialize_distinct_cache.snap
+++ b/influxdb3_catalog/src/snapshots/influxdb3_catalog__catalog__tests__serialize_distinct_cache.snap
@@ -2,9 +2,11 @@
 source: influxdb3_catalog/src/catalog.rs
 description: catalog serialization to help catch breaking changes
 expression: snapshot
-snapshot_kind: text
 ---
 {
+  "generation_config": {
+    "generation_durations": []
+  },
   "nodes": {
     "repo": [],
     "next_id": 0

--- a/influxdb3_catalog/src/snapshots/influxdb3_catalog__catalog__tests__serialize_last_cache.snap
+++ b/influxdb3_catalog/src/snapshots/influxdb3_catalog__catalog__tests__serialize_last_cache.snap
@@ -2,9 +2,11 @@
 source: influxdb3_catalog/src/catalog.rs
 description: catalog serialization to help catch breaking changes
 expression: snapshot
-snapshot_kind: text
 ---
 {
+  "generation_config": {
+    "generation_durations": []
+  },
   "nodes": {
     "repo": [],
     "next_id": 0

--- a/influxdb3_catalog/src/snapshots/influxdb3_catalog__catalog__tests__serialize_series_keys.snap
+++ b/influxdb3_catalog/src/snapshots/influxdb3_catalog__catalog__tests__serialize_series_keys.snap
@@ -2,9 +2,11 @@
 source: influxdb3_catalog/src/catalog.rs
 description: catalog serialization to help catch breaking changes
 expression: snapshot
-snapshot_kind: text
 ---
 {
+  "generation_config": {
+    "generation_durations": []
+  },
   "nodes": {
     "repo": [],
     "next_id": 0

--- a/influxdb3_server/src/system_tables/generations.rs
+++ b/influxdb3_server/src/system_tables/generations.rs
@@ -1,0 +1,68 @@
+use arrow::array::{UInt8Builder, UInt64Builder};
+use arrow_array::RecordBatch;
+use arrow_schema::{DataType, Field, Schema, SchemaRef};
+use datafusion::{error::DataFusionError, prelude::Expr};
+use iox_system_tables::IoxSystemTable;
+use std::{sync::Arc, time::Duration};
+
+use influxdb3_catalog::catalog::Catalog;
+
+#[derive(Debug)]
+pub(super) struct GenerationDurationsTable {
+    schema: SchemaRef,
+    catalog: Arc<Catalog>,
+}
+
+impl GenerationDurationsTable {
+    pub(crate) fn new(catalog: Arc<Catalog>) -> Self {
+        Self {
+            schema: table_schema(),
+            catalog,
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl IoxSystemTable for GenerationDurationsTable {
+    fn schema(&self) -> SchemaRef {
+        Arc::clone(&self.schema)
+    }
+
+    async fn scan(
+        &self,
+        _filters: Option<Vec<Expr>>,
+        _limit: Option<usize>,
+    ) -> Result<RecordBatch, DataFusionError> {
+        let generations = self.catalog.list_generation_durations();
+        to_record_batch(&self.schema, generations)
+    }
+}
+
+fn table_schema() -> SchemaRef {
+    let fields = vec![
+        Field::new("level", DataType::UInt8, false),
+        Field::new("duration_seconds", DataType::UInt64, false),
+    ];
+    Arc::new(Schema::new(fields))
+}
+
+fn to_record_batch(
+    schema: &SchemaRef,
+    generations: Vec<(u8, Duration)>,
+) -> Result<RecordBatch, DataFusionError> {
+    let capacity = generations.len();
+    let mut level_arr = UInt8Builder::with_capacity(capacity);
+    let mut duration_arr = UInt64Builder::with_capacity(capacity);
+    for (level, duration) in generations {
+        level_arr.append_value(level);
+        duration_arr.append_value(duration.as_secs());
+    }
+    RecordBatch::try_new(
+        Arc::clone(schema),
+        vec![
+            Arc::new(level_arr.finish()),
+            Arc::new(duration_arr.finish()),
+        ],
+    )
+    .map_err(Into::into)
+}

--- a/influxdb3_server/src/system_tables/mod.rs
+++ b/influxdb3_server/src/system_tables/mod.rs
@@ -8,6 +8,7 @@ use datafusion::{
     scalar::ScalarValue,
 };
 use distinct_caches::DistinctCachesTable;
+use generations::GenerationDurationsTable;
 use influxdb3_catalog::catalog::{Catalog, DatabaseSchema, INTERNAL_DB_NAME};
 use influxdb3_sys_events::SysEventStore;
 use influxdb3_write::WriteBuffer;
@@ -20,6 +21,7 @@ use tonic::async_trait;
 use self::{last_caches::LastCachesTable, queries::QueriesTable};
 
 mod distinct_caches;
+mod generations;
 mod last_caches;
 mod parquet_files;
 use crate::system_tables::python_call::{ProcessingEngineLogsTable, ProcessingEngineTriggerTable};
@@ -36,6 +38,7 @@ pub(crate) const LAST_CACHES_TABLE_NAME: &str = "last_caches";
 pub(crate) const DISTINCT_CACHES_TABLE_NAME: &str = "distinct_caches";
 pub(crate) const PARQUET_FILES_TABLE_NAME: &str = "parquet_files";
 pub(crate) const TOKENS_TABLE_NAME: &str = "tokens";
+pub(crate) const GENERATION_DURATIONS_TABLE_NAME: &str = "generation_durations";
 
 const PROCESSING_ENGINE_TRIGGERS_TABLE_NAME: &str = "processing_engine_triggers";
 
@@ -136,6 +139,12 @@ impl AllSystemSchemaTablesProvider {
                     Arc::clone(&catalog),
                     started_with_auth,
                 )))),
+            );
+            tables.insert(
+                GENERATION_DURATIONS_TABLE_NAME,
+                Arc::new(SystemTableProvider::new(Arc::new(
+                    GenerationDurationsTable::new(Arc::clone(&catalog)),
+                ))),
             );
         }
         Self { tables }

--- a/influxdb3_server/src/system_tables/tokens.rs
+++ b/influxdb3_server/src/system_tables/tokens.rs
@@ -7,7 +7,6 @@ use datafusion::{error::DataFusionError, prelude::Expr};
 use influxdb3_authz::TokenInfo;
 use influxdb3_catalog::catalog::Catalog;
 use iox_system_tables::IoxSystemTable;
-use tonic::async_trait;
 
 #[derive(Debug)]
 pub(crate) struct TokenSystemTable {
@@ -26,7 +25,7 @@ impl TokenSystemTable {
     }
 }
 
-#[async_trait]
+#[async_trait::async_trait]
 impl IoxSystemTable for TokenSystemTable {
     fn schema(&self) -> SchemaRef {
         Arc::clone(&self.schema)

--- a/influxdb3_wal/src/lib.rs
+++ b/influxdb3_wal/src/lib.rs
@@ -218,6 +218,17 @@ impl FromStr for Gen1Duration {
     }
 }
 
+impl TryFrom<Duration> for Gen1Duration {
+    type Error = Error;
+
+    fn try_from(dur: Duration) -> std::result::Result<Self, Self::Error> {
+        match dur.as_secs() {
+            60 | 300 | 600 => Ok(Self(dur)),
+            d => Err(Error::InvalidGen1Duration(d.to_string())),
+        }
+    }
+}
+
 impl Default for Gen1Duration {
     fn default() -> Self {
         Self(Duration::from_secs(600))

--- a/influxdb3_write/src/write_buffer/snapshots/influxdb3_write__write_buffer__tests__catalog-after-last-cache-create-and-new-field.snap
+++ b/influxdb3_write/src/write_buffer/snapshots/influxdb3_write__write_buffer__tests__catalog-after-last-cache-create-and-new-field.snap
@@ -1,9 +1,11 @@
 ---
 source: influxdb3_write/src/write_buffer/mod.rs
 expression: catalog_json
-snapshot_kind: text
 ---
 {
+  "generation_config": {
+    "generation_durations": []
+  },
   "nodes": {
     "repo": [],
     "next_id": 0

--- a/influxdb3_write/src/write_buffer/snapshots/influxdb3_write__write_buffer__tests__catalog-immediately-after-last-cache-create.snap
+++ b/influxdb3_write/src/write_buffer/snapshots/influxdb3_write__write_buffer__tests__catalog-immediately-after-last-cache-create.snap
@@ -1,9 +1,11 @@
 ---
 source: influxdb3_write/src/write_buffer/mod.rs
 expression: catalog_json
-snapshot_kind: text
 ---
 {
+  "generation_config": {
+    "generation_durations": []
+  },
   "nodes": {
     "repo": [],
     "next_id": 0

--- a/influxdb3_write/src/write_buffer/snapshots/influxdb3_write__write_buffer__tests__catalog-immediately-after-last-cache-delete.snap
+++ b/influxdb3_write/src/write_buffer/snapshots/influxdb3_write__write_buffer__tests__catalog-immediately-after-last-cache-delete.snap
@@ -1,9 +1,11 @@
 ---
 source: influxdb3_write/src/write_buffer/mod.rs
 expression: catalog_json
-snapshot_kind: text
 ---
 {
+  "generation_config": {
+    "generation_durations": []
+  },
   "nodes": {
     "repo": [],
     "next_id": 0


### PR DESCRIPTION
Part of https://github.com/influxdata/influxdb_pro/issues/911

This PR stores the configured durations for each generation in the catalog. In Core, this only tracks the first generation, i.e., gen1, but it is set up to be extended in Enterprise where the compactor manages older generations.

### Setting the gen1 duration

The gen1 duration is set via the existing CLI arguments/environment on server startup and cannot be changed.

For example, if the user starts the server with
```
influxdb3 serve --gen1-duration 1m [...]
```
the gen1 duration of 1 minute will be stored in the catalog and used thereafter.

If the user attempts to start the server with a different `--gen1-duration`, the server will still start, but a `WARN` log will be emitted stating that it cannot be changed, e.g.,
```
2025-06-10T00:10:55.706474Z  WARN influxdb3::commands::serve: cannot change the existing gen1 duration after it has been set existing_secs=60 provided_secs=300
```

### Inspecting the gen1 duration

There is a new system table added by this PR that is accessible via the `_internal` database:
```sql
select * from system.generation_durations
```
This will return a table of the generations, displaying their `level` and `duration_seconds`:
```
+-------+------------------+
| level | duration_seconds |
+-------+------------------+
| 1     | 600              |
+-------+------------------+