### PR TITLE
fix: update help text

### DIFF
--- a/influxdb3/src/help/serve.txt
+++ b/influxdb3/src/help/serve.txt
@@ -13,7 +13,7 @@ Examples
   3. Write and query with unhashed token
 
 
-{} [OPTIONS] --node-id <NODE_IDENTIFIER_PREFIX>
+{} [OPTIONS] --node-id <NODE_IDENTIFIER_PREFIX> --object-store <OBJECT_STORE_TYPE>
 
 {}
   --node-id <NODE_ID>              Node identifier used as prefix in object store file paths
@@ -26,7 +26,6 @@ Examples
   --http-bind <ADDR>               Address for HTTP API requests [default: 0.0.0.0:8181]
                                   [env: INFLUXDB3_HTTP_BIND_ADDR=]
   --log-filter <FILTER>            Logs: filter directive [env: LOG_FILTER=]
-  --without-auth                   Run InfluxDB 3 server without authorization
   --tls-key <KEY_FILE>             The path to the key file for TLS to be enabled
                                   [env: INFLUXDB3_TLS_KEY=]
   --tls-cert <CERT_FILE>           The path to the cert file for TLS to be enabled
@@ -34,14 +33,13 @@ Examples
   --tls-minimum-version <VERSION>  The minimum version for TLS. Valid values are
                                    tls-1.2 and tls-1.3, default is tls-1.2
                                   [env: INFLUXDB3_TLS_MINIMUM_VERSION=]
+  --without-auth                   Run InfluxDB 3 server without authorization
   --disable-authz <RESOURCES>      Optionally disable authz by passing in a comma separated
                                    list of resources. Valid values are health, ping, and metrics.
                                    To disable auth for multiple resources pass in a list, eg.
                                    `--disable-authz health,ping`
 
 {}
-  --object-store <STORE>           Object storage to use [default: memory]
-                                  [possible values: memory, memory-throttled, file, s3, google, azure]
   --data-dir <DIR>                 Location to store files locally [env: INFLUXDB3_DB_DIR=]
   --bucket <BUCKET>                Bucket name for cloud object storage [env: INFLUXDB3_BUCKET=]
 
@@ -59,7 +57,7 @@ Examples
 
 {}
   --plugin-dir <DIR>               Location of plugins [env: INFLUXDB3_PLUGIN_DIR=]
-  --virtual-env-location <PATH>    [env: VIRTUAL_ENV=/Users/peterbarnett/Development/testing]
+  --virtual-env-location <PATH>    [env: VIRTUAL_ENV=]
   --package-manager <MANAGER>      [default: discover] [possible values: discover, pip, uv]
 
 {}

--- a/influxdb3/src/help/serve_all.txt
+++ b/influxdb3/src/help/serve_all.txt
@@ -12,17 +12,18 @@ Examples:
   2. influxdb3 create token --admin
   3. Write and query with unhashed token
 
-{} [OPTIONS] --node-id <NODE_IDENTIFIER_PREFIX>
+{} [OPTIONS] --node-id <NODE_IDENTIFIER_PREFIX> --object-store <OBJECT_STORE_TYPE>
 
 {}
   --node-id <NODE_ID>              Node identifier used as prefix in object store file paths
                                   [env: INFLUXDB3_NODE_IDENTIFIER_PREFIX=]
+  --object-store <STORE>           Object storage to use [default: memory]
+                                  [possible values: memory, memory-throttled, file, s3, google, azure]
 
 {}
   --http-bind <ADDR>               Address for HTTP API requests [default: 0.0.0.0:8181]
                                   [env: INFLUXDB3_HTTP_BIND_ADDR=]
   --log-filter <FILTER>            Logs: filter directive [env: LOG_FILTER=]
-  --without-auth                   Run InfluxDB 3 server without authorization
   --tls-key <KEY_FILE>             The path to the key file for TLS to be enabled
                                   [env: INFLUXDB3_TLS_KEY=]
   --tls-cert <CERT_FILE>           The path to the cert file for TLS to be enabled
@@ -30,14 +31,13 @@ Examples:
   --tls-minimum-version <VERSION>  The minimum version for TLS. Valid values are
                                    tls-1.2 and tls-1.3, default is tls-1.2
                                   [env: INFLUXDB3_TLS_MINIMUM_VERSION=]
+  --without-auth                   Run InfluxDB 3 server without authorization
   --disable-authz <RESOURCES>      Optionally disable authz by passing in a comma separated
                                    list of resources. Valid values are health, ping, and metrics.
                                    To disable auth for multiple resources pass in a list, eg.
                                    `--disable-authz health,ping`
 
 {}
-  --object-store <STORE>           Object storage to use [default: memory]
-                                  [possible values: memory, memory-throttled, file, s3, google, azure]
   --data-dir <DIR>                 Location to store files locally [env: INFLUXDB3_DB_DIR=]
   --bucket <BUCKET>                Bucket name for cloud object storage [env: INFLUXDB3_BUCKET=]
   --gen1-duration <DURATION>       Duration for Parquet file arrangement [default: 10m]
@@ -61,7 +61,7 @@ Examples:
 
 {}
   --plugin-dir <DIR>               Location of plugins [env: INFLUXDB3_PLUGIN_DIR=]
-  --virtual-env-location <PATH>    [env: VIRTUAL_ENV=/Users/peterbarnett/Development/testing]
+  --virtual-env-location <PATH>    [env: VIRTUAL_ENV=]
   --package-manager <MANAGER>      [default: discover] [possible values: discover, pip, uv]
 
 {}
@@ -80,14 +80,12 @@ Examples:
 {}
   --max-http-request-size <SIZE>   Maximum size of HTTP requests [default: 10485760]
                                   [env: INFLUXDB3_MAX_HTTP_REQUEST_SIZE=]
-  --bearer-token <TOKEN>           Bearer token for requests [env: INFLUXDB3_BEARER_TOKEN=]
 
 {}
   --exec-mem-pool-bytes <SIZE>     Memory pool size for query execution [default: 20%]
                                   [env: INFLUXDB3_EXEC_MEM_POOL_BYTES=]
   --parquet-mem-cache-size <SIZE>  In-memory Parquet cache size [default: 20%]
                                   [env: INFLUXDB3_PARQUET_MEM_CACHE_SIZE=]
-  --disable-parquet-mem-cache      Disable in-memory Parquet cache [env: INFLUXDB3_DISABLE_PARQUET_MEM_CACHE=]
   --force-snapshot-mem-threshold <THRESH>
                                   Internal buffer threshold [default: 50%]
                                   [env: INFLUXDB3_FORCE_SNAPSHOT_MEM_THRESHOLD=]
@@ -100,6 +98,7 @@ Examples:
   --parquet-mem-cache-query-path-duration <DURATION>
                                   Duration to check for query path caching [default: 5h]
                                   [env: INFLUXDB3_PARQUET_MEM_CACHE_QUERY_PATH_DURATION=]
+  --disable-parquet-mem-cache      Disable in-memory Parquet cache [env: INFLUXDB3_DISABLE_PARQUET_MEM_CACHE=]
 
 {}
   --wal-flush-interval <INTERVAL>  Interval to flush data to WAL file [default: 1s]


### PR DESCRIPTION
Moves some commands to better locations, removes `--bearer-token`, and removes yours truly from the output.
