### PR TITLE
fix(py): update to python 3.13.5-20250612 for security fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -103,8 +103,8 @@ parameters:
 
 # Consistent environment setup for Python Build Standalone
 pbs_config: &pbs_config
-  PBS_DATE: "20250212"
-  PBS_VERSION: "3.13.2"
+  PBS_DATE: "20250612"
+  PBS_VERSION: "3.13.5"
 
 # Consistent Cargo environment configuration
 cargo_env: &cargo_env


### PR DESCRIPTION
3.13.4 fixed various CVEs. Upgrade to 3.13.5 per upstream expedited release to fix problems with 3.13.4.

* https://www.python.org/downloads/release/python-3133/
* https://www.python.org/downloads/release/python-3134/
* https://www.python.org/downloads/release/python-3135/