### PR TITLE
ci: add `sync`s for `fetch-python`

### DIFF
--- a/.circleci/scripts/fetch-python-standalone.bash
+++ b/.circleci/scripts/fetch-python-standalone.bash
@@ -165,6 +165,8 @@ done
 # This speeds up CircleCI
 echo "Creating '${DOWNLOAD_DIR}/all.tar.gz'"
 cd "${DOWNLOAD_DIR}"
+sync
 tar -zcf ./.all.tar.gz ./[a-z]*
 rm -rf ./[a-z]*
 mv ./.all.tar.gz ./all.tar.gz
+sync


### PR DESCRIPTION
after moving to the self-hosted runners we've seen issues before and
after creating `all.tar.gz`. add `sync` before & after creating it to
make sure the files don't change during the relevant operations
