### PR TITLE
feat: make persisted file buffer size configurable

### DIFF
--- a/influxdb3/src/help/serve_all.txt
+++ b/influxdb3/src/help/serve_all.txt
@@ -42,6 +42,10 @@ Examples:
   --bucket <BUCKET>                Bucket name for cloud object storage [env: INFLUXDB3_BUCKET=]
   --gen1-duration <DURATION>       Duration for Parquet file arrangement [default: 10m]
                                   [env: INFLUXDB3_GEN1_DURATION=]
+  --gen1-lookback-duration <DURATION>
+                                   The amount of time that the server looks back on startup
+                                   when populating the in-memory index of gen1 files.
+                                  [env: INFLUXDB3_GEN1_LOOKBACK_DURATION=]
 
 {}
   --aws-access-key-id <KEY>        S3 access key ID [env: AWS_ACCESS_KEY_ID=] [default: ]

--- a/influxdb3_processing_engine/src/lib.rs
+++ b/influxdb3_processing_engine/src/lib.rs
@@ -758,7 +758,9 @@ mod tests {
     use influxdb3_sys_events::SysEventStore;
     use influxdb3_wal::{Gen1Duration, WalConfig};
     use influxdb3_write::persister::Persister;
-    use influxdb3_write::write_buffer::{WriteBufferImpl, WriteBufferImplArgs};
+    use influxdb3_write::write_buffer::{
+        N_SNAPSHOTS_TO_LOAD_ON_START, WriteBufferImpl, WriteBufferImplArgs,
+    };
     use influxdb3_write::{Precision, WriteBuffer};
     use iox_query::exec::{
         DedicatedExecutor, Executor, ExecutorConfig, IOxSessionContext, PerQueryMemoryPoolConfig,
@@ -1011,6 +1013,7 @@ mod tests {
             snapshotted_wal_files_to_keep: 10,
             query_file_limit: None,
             shutdown: shutdown.register(),
+            n_snapshots_to_load_on_start: N_SNAPSHOTS_TO_LOAD_ON_START,
             wal_replay_concurrency_limit: Some(1),
         })
         .await

--- a/influxdb3_server/src/lib.rs
+++ b/influxdb3_server/src/lib.rs
@@ -300,6 +300,7 @@ mod tests {
     use influxdb3_telemetry::store::TelemetryStore;
     use influxdb3_wal::WalConfig;
     use influxdb3_write::persister::Persister;
+    use influxdb3_write::write_buffer::N_SNAPSHOTS_TO_LOAD_ON_START;
     use influxdb3_write::write_buffer::persisted_files::PersistedFiles;
     use influxdb3_write::{Bufferer, WriteBuffer};
     use iox_http_util::{
@@ -890,6 +891,7 @@ mod tests {
                 metric_registry: Arc::clone(&metrics),
                 snapshotted_wal_files_to_keep: 100,
                 query_file_limit: None,
+                n_snapshots_to_load_on_start: N_SNAPSHOTS_TO_LOAD_ON_START,
                 shutdown: shutdown_manager.register(),
                 wal_replay_concurrency_limit: Some(1),
             },

--- a/influxdb3_server/src/query_executor/mod.rs
+++ b/influxdb3_server/src/query_executor/mod.rs
@@ -793,7 +793,10 @@ mod tests {
     use influxdb3_write::{
         Bufferer, WriteBuffer,
         persister::Persister,
-        write_buffer::{WriteBufferImpl, WriteBufferImplArgs, persisted_files::PersistedFiles},
+        write_buffer::{
+            N_SNAPSHOTS_TO_LOAD_ON_START, WriteBufferImpl, WriteBufferImplArgs,
+            persisted_files::PersistedFiles,
+        },
     };
     use iox_query::exec::{DedicatedExecutor, Executor, ExecutorConfig, PerQueryMemoryPoolConfig};
     use iox_time::{MockProvider, Time};
@@ -888,6 +891,7 @@ mod tests {
             metric_registry: Default::default(),
             snapshotted_wal_files_to_keep: 1,
             query_file_limit,
+            n_snapshots_to_load_on_start: N_SNAPSHOTS_TO_LOAD_ON_START,
             shutdown: shutdown.register(),
             wal_replay_concurrency_limit: Some(1),
         })

--- a/influxdb3_server/tests/lib.rs
+++ b/influxdb3_server/tests/lib.rs
@@ -15,7 +15,7 @@ use influxdb3_wal::{Gen1Duration, WalConfig};
 use influxdb3_write::{
     Precision, WriteBuffer,
     persister::Persister,
-    write_buffer::{WriteBufferImpl, WriteBufferImplArgs},
+    write_buffer::{N_SNAPSHOTS_TO_LOAD_ON_START, WriteBufferImpl, WriteBufferImplArgs},
 };
 use iox_query::exec::{DedicatedExecutor, Executor, ExecutorConfig, PerQueryMemoryPoolConfig};
 use iox_time::{MockProvider, Time, TimeProvider};
@@ -259,6 +259,7 @@ impl TestService {
             snapshotted_wal_files_to_keep: 100,
             query_file_limit: None,
             shutdown: ShutdownManager::new_testing().register(),
+            n_snapshots_to_load_on_start: N_SNAPSHOTS_TO_LOAD_ON_START,
             wal_replay_concurrency_limit: Some(1),
         })
         .await

--- a/influxdb3_write/src/write_buffer/mod.rs
+++ b/influxdb3_write/src/write_buffer/mod.rs
@@ -184,6 +184,7 @@ pub struct WriteBufferImplArgs {
     pub metric_registry: Arc<Registry>,
     pub snapshotted_wal_files_to_keep: u64,
     pub query_file_limit: Option<usize>,
+    pub n_snapshots_to_load_on_start: usize,
     pub shutdown: ShutdownToken,
     pub wal_replay_concurrency_limit: Option<usize>,
 }
@@ -202,13 +203,14 @@ impl WriteBufferImpl {
             metric_registry,
             snapshotted_wal_files_to_keep,
             query_file_limit,
+            n_snapshots_to_load_on_start,
             shutdown,
             wal_replay_concurrency_limit,
         }: WriteBufferImplArgs,
     ) -> Result<Arc<Self>> {
         // load snapshots and replay the wal into the in memory buffer
         let persisted_snapshots = persister
-            .load_snapshots(N_SNAPSHOTS_TO_LOAD_ON_START)
+            .load_snapshots(n_snapshots_to_load_on_start)
             .await?
             .into_iter()
             // map the persisted snapshots into the newest version
@@ -785,6 +787,7 @@ mod tests {
             metric_registry: Default::default(),
             snapshotted_wal_files_to_keep: 10,
             query_file_limit: None,
+            n_snapshots_to_load_on_start: N_SNAPSHOTS_TO_LOAD_ON_START,
             shutdown: ShutdownManager::new_testing().register(),
             wal_replay_concurrency_limit: Some(1),
         })
@@ -894,6 +897,7 @@ mod tests {
             metric_registry: Default::default(),
             snapshotted_wal_files_to_keep: 10,
             query_file_limit: None,
+            n_snapshots_to_load_on_start: N_SNAPSHOTS_TO_LOAD_ON_START,
             shutdown: ShutdownManager::new_testing().register(),
             wal_replay_concurrency_limit: Some(1),
         })
@@ -987,6 +991,7 @@ mod tests {
                 metric_registry: Default::default(),
                 snapshotted_wal_files_to_keep: 10,
                 query_file_limit: None,
+                n_snapshots_to_load_on_start: N_SNAPSHOTS_TO_LOAD_ON_START,
                 shutdown: ShutdownManager::new_testing().register(),
                 wal_replay_concurrency_limit: Some(1),
             })
@@ -1247,6 +1252,7 @@ mod tests {
             metric_registry: Default::default(),
             snapshotted_wal_files_to_keep: 10,
             query_file_limit: None,
+            n_snapshots_to_load_on_start: N_SNAPSHOTS_TO_LOAD_ON_START,
             shutdown: ShutdownManager::new_testing().register(),
             wal_replay_concurrency_limit: Some(1),
         })
@@ -3391,6 +3397,7 @@ mod tests {
             metric_registry: Arc::clone(&metric_registry),
             snapshotted_wal_files_to_keep: 10,
             query_file_limit: None,
+            n_snapshots_to_load_on_start: N_SNAPSHOTS_TO_LOAD_ON_START,
             shutdown: ShutdownManager::new_testing().register(),
             wal_replay_concurrency_limit: None,
         })


### PR DESCRIPTION
This PR addresses a shortcoming in `PersistedFiles` (an index of gen1 files kept in querier/ingester memory) load during startup by:

* Making the "lookback" duration configurable with the number of persisted files determined by dividing the configured gen1 file duration into this new gen1 lookback duration.
* Setting the default lookback to 1 month. With the default gen1 file duration of 10m, this would lead to roughly 4320 files loaded by default.

One good bit of feedback reviewers could give here would be whether we should consider looking further back, maybe as far back as 3 or 6 months? This would lead to 12960 or 25920 files loaded on startup by default.
