### PR TITLE
chore: porting some utilities that were created in pro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3228,8 +3228,11 @@ version = "3.2.0-nightly"
 dependencies = [
  "futures",
  "futures-util",
+ "iox_time",
  "observability_deps",
  "parking_lot",
+ "test-log",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-util",
 ]

--- a/influxdb3_catalog/src/catalog.rs
+++ b/influxdb3_catalog/src/catalog.rs
@@ -13,6 +13,7 @@ use influxdb3_id::{
     CatalogId, ColumnId, DbId, DistinctCacheId, LastCacheId, NodeId, SerdeVecMap, TableId, TokenId,
     TriggerId,
 };
+use influxdb3_process::ProcessUuidGetter;
 use influxdb3_shutdown::ShutdownToken;
 use influxdb3_telemetry::ProcessingEngineMetrics;
 use iox_time::{Time, TimeProvider};
@@ -260,6 +261,7 @@ impl Catalog {
         time_provider: Arc<dyn TimeProvider>,
         metric_registry: Arc<Registry>,
         shutdown_token: ShutdownToken,
+        process_uuid_getter: Arc<dyn ProcessUuidGetter>,
     ) -> Result<Arc<Self>> {
         let node_id = node_id.into();
         let catalog =
@@ -272,7 +274,7 @@ impl Catalog {
                 "updating node state to stopped in catalog"
             );
             if let Err(error) = catalog_cloned
-                .update_node_state_stopped(node_id.as_ref())
+                .update_node_state_stopped(node_id.as_ref(), process_uuid_getter)
                 .await
             {
                 error!(

--- a/influxdb3_catalog/src/catalog/metrics.rs
+++ b/influxdb3_catalog/src/catalog/metrics.rs
@@ -152,6 +152,7 @@ impl AsMetricStr for GenerationOp {
 mod tests {
     use std::sync::Arc;
 
+    use influxdb3_process::{ProcessUuidGetter, ProcessUuidWrapper};
     use iox_time::{MockProvider, Time};
     use metric::{Attributes, Metric, Registry, U64Counter};
     use object_store::memory::InMemory;
@@ -232,6 +233,7 @@ mod tests {
         )
         .await
         .unwrap();
+        let process_uuid_getter: Arc<dyn ProcessUuidGetter> = Arc::new(ProcessUuidWrapper::new());
         check_metric_empty(&metrics, "create_database");
         catalog.create_database("foo").await.unwrap();
         check_metric(&metrics, "create_database", 1);
@@ -257,7 +259,12 @@ mod tests {
 
         check_metric_empty(&metrics, "register_node");
         catalog
-            .register_node("node2", 4, vec![NodeMode::Core])
+            .register_node(
+                "node2",
+                4,
+                vec![NodeMode::Core],
+                Arc::clone(&process_uuid_getter),
+            )
             .await
             .unwrap();
         check_metric(&metrics, "register_node", 1);

--- a/influxdb3_server/src/http.rs
+++ b/influxdb3_server/src/http.rs
@@ -31,7 +31,7 @@ use influxdb3_catalog::catalog::HardDeletionTime;
 use influxdb3_catalog::log::FieldDataType;
 use influxdb3_internal_api::query_executor::{QueryExecutor, QueryExecutorError};
 use influxdb3_process::{
-    INFLUXDB3_BUILD, INFLUXDB3_GIT_HASH_SHORT, INFLUXDB3_VERSION, PROCESS_UUID,
+    INFLUXDB3_BUILD, INFLUXDB3_GIT_HASH_SHORT, INFLUXDB3_VERSION, ProcessUuidWrapper,
 };
 use influxdb3_processing_engine::ProcessingEngineManagerImpl;
 use influxdb3_processing_engine::manager::ProcessingEngineError;
@@ -726,10 +726,11 @@ impl HttpApi {
     }
 
     fn ping(&self) -> Result<Response> {
+        let process_uuid = ProcessUuidWrapper::new();
         let body = serde_json::to_string(&PingResponse {
             version: INFLUXDB3_VERSION.to_string(),
             revision: INFLUXDB3_GIT_HASH_SHORT.to_string(),
-            process_id: *PROCESS_UUID,
+            process_id: *process_uuid.get(),
         })?;
 
         // InfluxDB 1.x used time-based UUIDs.

--- a/influxdb3_shutdown/Cargo.toml
+++ b/influxdb3_shutdown/Cargo.toml
@@ -7,14 +7,19 @@ license.workspace = true
 
 [dependencies]
 # influxdb3_core dependencies
+iox_time.workspace = true
 observability_deps.workspace = true
 
 # crates.io dependencies
 futures.workspace = true
 futures-util.workspace = true
 parking_lot.workspace = true
+thiserror.workspace = true
 tokio.workspace = true
 tokio-util.workspace = true
+
+[dev-dependencies]
+test-log.workspace = true
 
 [lints]
 workspace = true


### PR DESCRIPTION
(no issue for this)

- `AbortableTaskRunner` and it's friends in influxdb3_shutdown
- `ProcessUuidWrapper` and it's friends in influxdb3_process
- Change sleep time in test

They're not used currently in any of the core code, but helps when sync'ing core back to enterprise

