### PR TITLE
fix: stop noisy logging about phantom shards that do not belong to node

### DIFF
--- a/storage/engine.go
+++ b/storage/engine.go
@@ -143,7 +143,7 @@ func NewEngine(path string, c Config, options ...Option) *Engine {
 
 	e.retentionService = retention.NewService(c.RetentionService)
 	e.retentionService.TSDBStore = e.tsdbStore
-	e.retentionService.MetaClient = e.metaClient
+	e.retentionService.SetOSSMetaClient(e.metaClient)
 	e.retentionService.DropShardMetaRef = retention.OSSDropShardMetaRef(e.MetaClient())
 
 	e.precreatorService = precreator.NewService(c.PrecreatorConfig)

--- a/v1/services/retention/service_test.go
+++ b/v1/services/retention/service_test.go
@@ -268,7 +268,7 @@ func TestRetention_DeletionCheck(t *testing.T) {
 	}
 
 	s := retention.NewService(cfg)
-	s.MetaClient = mc
+	s.SetOSSMetaClient(mc)
 	s.TSDBStore = store
 	s.DropShardMetaRef = retention.OSSDropShardMetaRef(s.MetaClient)
 	require.NoError(t, s.Open(context.Background()))
@@ -728,7 +728,7 @@ func NewService(tb testing.TB, c retention.Config) *Service {
 	s.LogBuf = logbuf
 	s.WithLogger(log)
 
-	s.Service.MetaClient = s.MetaClient
+	s.Service.SetOSSMetaClient(s.MetaClient)
 	s.Service.TSDBStore = s.TSDBStore
 	s.Service.DropShardMetaRef = retention.OSSDropShardMetaRef(s.Service.MetaClient)
 	return s


### PR DESCRIPTION
Stop noisy logging about phantom shards that do not belong to the current node by checking the shard ownership before logging about the phantom shard. Note that only the logging was inaccurate. This did not accidentally remove shards from the metadata that weren't really phantom shards due to checks in `DropShardMetaRef` implementations.

Cherry-picked from master-1.x and then conflicts resolved.

closes: #26534
(cherry picked from commit 8ef2aca1ca70622a01c3f47f38018a918b98a032)
