### PR TITLE
chore: stop publishing nightly changelog

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -450,10 +450,6 @@ workflows:
         - equal: [ << pipeline.parameters.workflow >>, nightly ]
     jobs:
       - changelog
-      - publish_changelog:
-          workflow: nightly
-          requires:
-            - changelog
       - static_code_checks
       - fluxtest
       - unit_test:


### PR DESCRIPTION
Stop publishing nightly changelog since we do not publish nightly build artifacts. This addresses issues with dependent projects that check status of CI for influxdb.

Closes: #26538
