### PR TITLE
chore: stop publishing nightly changelog

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -449,10 +449,6 @@ workflows:
         - equal: [ << pipeline.parameters.workflow >>, nightly ]
     jobs:
       - changelog
-      - publish_changelog:
-          workflow: nightly
-          requires:
-            - changelog
       - static_code_checks
       - fluxtest
       - unit_test:


### PR DESCRIPTION
Stop publishing nightly changelog since we do not publish nightly build artifacts. This addresses issues with dependent projects that check status of CI for influxdb.

This is a clean cherry-pick from master-1.x.

Closes: #26541
(cherry picked from commit 4378e857441aaca5b972ddda48441935658c551b)