### PR TITLE
fix: handle corrupt WAL files during replay without panic

### DIFF
--- a/influxdb3_processing_engine/src/lib.rs
+++ b/influxdb3_processing_engine/src/lib.rs
@@ -785,6 +785,7 @@ mod tests {
             max_write_buffer_size: 100,
             flush_interval: Duration::from_millis(10),
             snapshot_size: 1,
+            ..Default::default()
         };
         let (pem, file) = setup(start_time, test_store, wal_config).await;
         let file_name = file
@@ -880,6 +881,7 @@ mod tests {
             max_write_buffer_size: 100,
             flush_interval: Duration::from_millis(10),
             snapshot_size: 1,
+            ..Default::default()
         };
         let (pem, file) = setup(start_time, test_store, wal_config).await;
         let file_name = file
@@ -940,6 +942,7 @@ mod tests {
             max_write_buffer_size: 100,
             flush_interval: Duration::from_millis(10),
             snapshot_size: 1,
+            ..Default::default()
         };
         let (pem, _file_name) = setup(start_time, test_store, wal_config).await;
 

--- a/influxdb3_server/src/query_executor/mod.rs
+++ b/influxdb3_server/src/query_executor/mod.rs
@@ -886,6 +886,7 @@ mod tests {
                 max_write_buffer_size: 100,
                 flush_interval: Duration::from_millis(10),
                 snapshot_size: 1,
+                ..Default::default()
             },
             parquet_cache: Some(parquet_cache),
             metric_registry: Default::default(),

--- a/influxdb3_server/tests/lib.rs
+++ b/influxdb3_server/tests/lib.rs
@@ -33,6 +33,7 @@ async fn test_deduplicate_rows_in_write_buffer_memory() {
         flush_interval: Duration::from_millis(10),
         // use a large snapshot size so that queries are served only by in-memory buffer chunks:
         snapshot_size: 100,
+        ..Default::default()
     };
     let service = TestService::setup(wal_config).await;
 
@@ -82,6 +83,7 @@ async fn test_deduplicate_rows_in_write_buffer_parquet() {
         // uses a small snapshot size to get parquet persisted early, and therefore have queries
         // serve chunks from both in-memory buffer and persisted parquet
         snapshot_size: 1,
+        ..Default::default()
     };
     let service = TestService::setup(wal_config).await;
 
@@ -133,6 +135,7 @@ async fn test_deduplicate_rows_in_write_buffer_both_memory_and_parquet() {
         // uses a small snapshot size to get parquet persisted early, and therefore have queries
         // serve chunks from both in-memory buffer and persisted parquet
         snapshot_size: 1,
+        ..Default::default()
     };
     let service = TestService::setup(wal_config).await;
 

--- a/influxdb3_wal/src/lib.rs
+++ b/influxdb3_wal/src/lib.rs
@@ -143,6 +143,8 @@ pub struct WalConfig {
     pub flush_interval: Duration,
     /// The number of wal files to snapshot at a time
     pub snapshot_size: usize,
+    /// Fail on error when replaying corrupt WAL files
+    pub wal_replay_fail_on_error: bool,
 }
 
 impl WalConfig {
@@ -152,6 +154,7 @@ impl WalConfig {
             max_write_buffer_size: 1000,
             flush_interval: Duration::from_millis(10),
             snapshot_size: 100,
+            wal_replay_fail_on_error: false,
         }
     }
 }
@@ -163,6 +166,7 @@ impl Default for WalConfig {
             max_write_buffer_size: 100_000,
             flush_interval: Duration::from_secs(1),
             snapshot_size: 600,
+            wal_replay_fail_on_error: false,
         }
     }
 }

--- a/influxdb3_write/src/write_buffer/mod.rs
+++ b/influxdb3_write/src/write_buffer/mod.rs
@@ -892,6 +892,7 @@ mod tests {
                 max_write_buffer_size: 100,
                 flush_interval: Duration::from_millis(50),
                 snapshot_size: 100,
+                ..Default::default()
             },
             parquet_cache: Some(Arc::clone(&parquet_cache)),
             metric_registry: Default::default(),
@@ -921,6 +922,7 @@ mod tests {
                 max_write_buffer_size: 100,
                 flush_interval: Duration::from_millis(10),
                 snapshot_size: 1,
+                ..Default::default()
             },
         )
         .await;
@@ -986,6 +988,7 @@ mod tests {
                     max_write_buffer_size: 100,
                     flush_interval: Duration::from_millis(10),
                     snapshot_size: 1,
+                    ..Default::default()
                 },
                 parquet_cache: wbuf.parquet_cache.clone(),
                 metric_registry: Default::default(),
@@ -1087,6 +1090,7 @@ mod tests {
                 max_write_buffer_size: 100,
                 flush_interval: Duration::from_millis(10),
                 snapshot_size: 2,
+                ..Default::default()
             },
         )
         .await;
@@ -1247,6 +1251,7 @@ mod tests {
                 max_write_buffer_size: 100,
                 flush_interval: Duration::from_millis(10),
                 snapshot_size: 2,
+                ..Default::default()
             },
             parquet_cache: write_buffer.parquet_cache.clone(),
             metric_registry: Default::default(),
@@ -1327,6 +1332,7 @@ mod tests {
                 max_write_buffer_size: 100,
                 flush_interval: Duration::from_millis(5),
                 snapshot_size: 1,
+                ..Default::default()
             },
         )
         .await;
@@ -1445,6 +1451,7 @@ mod tests {
                 max_write_buffer_size: 100,
                 flush_interval: Duration::from_millis(5),
                 snapshot_size: 1,
+                ..Default::default()
             },
         )
         .await;
@@ -1579,6 +1586,7 @@ mod tests {
                 max_write_buffer_size: 100,
                 flush_interval: Duration::from_millis(5),
                 snapshot_size: 1,
+                ..Default::default()
             },
         )
         .await;
@@ -1598,6 +1606,7 @@ mod tests {
             max_write_buffer_size: 100,
             flush_interval: Duration::from_millis(10),
             snapshot_size: 1,
+            ..Default::default()
         };
         let (mut wbuf, mut ctx, _time_provider) = setup(
             Time::from_timestamp_nanos(0),
@@ -1687,6 +1696,7 @@ mod tests {
                 max_write_buffer_size: 100,
                 flush_interval: Duration::from_millis(10),
                 snapshot_size: 2,
+                ..Default::default()
             },
         )
         .await;
@@ -1739,6 +1749,7 @@ mod tests {
                 max_write_buffer_size: 100,
                 flush_interval: Duration::from_millis(10),
                 snapshot_size: 2,
+                ..Default::default()
             },
         )
         .await;
@@ -1775,6 +1786,7 @@ mod tests {
                 max_write_buffer_size: 100,
                 flush_interval: Duration::from_millis(10),
                 snapshot_size: 1,
+                ..Default::default()
             },
         )
         .await;
@@ -1819,6 +1831,7 @@ mod tests {
                 max_write_buffer_size: 100,
                 flush_interval: Duration::from_millis(10),
                 snapshot_size: 1,
+                ..Default::default()
             },
         )
         .await;
@@ -1852,6 +1865,7 @@ mod tests {
                 max_write_buffer_size: 100,
                 flush_interval: Duration::from_millis(10),
                 snapshot_size: 1,
+                ..Default::default()
             },
         )
         .await;
@@ -1901,6 +1915,7 @@ mod tests {
                 max_write_buffer_size: 100,
                 flush_interval: Duration::from_millis(10),
                 snapshot_size: 1,
+                ..Default::default()
             },
         )
         .await;
@@ -1946,6 +1961,7 @@ mod tests {
                 max_write_buffer_size: 100,
                 flush_interval: Duration::from_millis(10),
                 snapshot_size: 1,
+                ..Default::default()
             },
         )
         .await;
@@ -1968,6 +1984,7 @@ mod tests {
                 max_write_buffer_size: 100,
                 flush_interval: Duration::from_millis(10),
                 snapshot_size: 1,
+                ..Default::default()
             },
             true,
         )
@@ -2076,6 +2093,7 @@ mod tests {
                 max_write_buffer_size: 100,
                 flush_interval: Duration::from_millis(10),
                 snapshot_size: 1,
+                ..Default::default()
             },
             false,
         )
@@ -2180,6 +2198,7 @@ mod tests {
             max_write_buffer_size: 100,
             flush_interval: Duration::from_millis(10),
             snapshot_size: 1,
+            ..Default::default()
         };
         let (write_buffer, _, _) =
             setup_cache_optional(start_time, test_store, wal_config, false).await;
@@ -2209,6 +2228,7 @@ mod tests {
             max_write_buffer_size: 100,
             flush_interval: Duration::from_millis(10),
             snapshot_size: 1,
+            ..Default::default()
         };
         let (write_buffer, _, _) =
             setup_cache_optional(start_time, test_store, wal_config, false).await;
@@ -2392,6 +2412,7 @@ mod tests {
                 max_write_buffer_size: 100_000,
                 flush_interval: Duration::from_millis(10),
                 snapshot_size: 10,
+                ..Default::default()
             },
         )
         .await;
@@ -2486,6 +2507,7 @@ mod tests {
                 max_write_buffer_size: 100_000,
                 flush_interval: Duration::from_millis(10),
                 snapshot_size: 10,
+                ..Default::default()
             },
         )
         .await;
@@ -2504,6 +2526,7 @@ mod tests {
                 max_write_buffer_size: 100_000,
                 flush_interval: Duration::from_millis(10),
                 snapshot_size: 10,
+                ..Default::default()
             },
         )
         .await;
@@ -2528,6 +2551,7 @@ mod tests {
                 max_write_buffer_size: 100_000,
                 flush_interval: Duration::from_millis(10),
                 snapshot_size: 5,
+                ..Default::default()
             },
         )
         .await;
@@ -2651,6 +2675,7 @@ mod tests {
                 max_write_buffer_size: 100_000,
                 flush_interval: Duration::from_millis(10),
                 snapshot_size: 5,
+                ..Default::default()
             },
         )
         .await;
@@ -2780,6 +2805,7 @@ mod tests {
                 max_write_buffer_size: 100,
                 flush_interval: Duration::from_millis(10),
                 snapshot_size: 1,
+                ..Default::default()
             },
             false,
         )
@@ -2849,6 +2875,7 @@ mod tests {
                 max_write_buffer_size: 100,
                 flush_interval: Duration::from_millis(10),
                 snapshot_size: 1,
+                ..Default::default()
             },
             true,
         )
@@ -2988,6 +3015,7 @@ mod tests {
                     max_write_buffer_size: 1,
                     flush_interval: Duration::from_millis(10),
                     snapshot_size: 1,
+                    ..Default::default()
                 },
             )
             .await;
@@ -3045,6 +3073,7 @@ mod tests {
             max_write_buffer_size: 100,
             flush_interval: Duration::from_millis(10),
             snapshot_size: 1,
+            ..Default::default()
         };
         let (wb, _ctx, _tp) = setup(
             Time::from_timestamp_nanos(0),
@@ -3160,6 +3189,7 @@ mod tests {
             max_write_buffer_size: 100,
             flush_interval: Duration::from_millis(10),
             snapshot_size: 1,
+            ..Default::default()
         };
         let (wb, ctx, metrics) = setup_with_metrics_and_parquet_cache(
             Time::from_timestamp_nanos(0),


### PR DESCRIPTION
## Summary

This PR fixes a critical issue where InfluxDB3 would panic on startup when encountering corrupt or empty WAL files, typically after power outages or disk failures.

## Issue

When WAL files become corrupted (e.g., truncated to 0 bytes during power loss), the server would panic with:
```
thread 'main' panicked at influxdb3_wal/src/serialize.rs:50:30:
range end index 8 out of range for slice of length 0
```

This prevented the server from starting, requiring manual intervention to remove corrupt files.

Now, the user will see a WARN log when encountering corrupt WAL files:

```
2025-06-24T07:19:41.278619Z  WARN influxdb3_wal::object_store: Skipping corrupt WAL file error=WAL file too small: expected at least 12 bytes, but got 0 bytes path=ingest/wal/00000000009.wal
```

The user can opt-out of this behaviour by specifying the `--wal-replay-fail-on-error` CLI argument.

## Solution

1. **Added bounds checking in WAL deserialization**:
   - New `WalFileTooSmall` error variant that clearly indicates expected vs actual file size
   - Validation ensures files have at least 12 bytes (8-byte identifier + 4-byte CRC32) before attempting to read
   - Graceful error handling instead of panic

2. **Made WAL replay behavior configurable**:
   - New CLI flag `--wal-replay-fail-on-error` (env: `INFLUXDB3_WAL_REPLAY_FAIL_ON_ERROR`)
   - Default behaviour: skip corrupt files and continue
   - Optional strict mode: fail on any corrupt file

3. **Enhanced error handling in WAL replay**:
   - Modified replay logic to handle corrupt files based on configuration
   - Clear error messages distinguish between different corruption types
   - Proper propagation of errors through the replay pipeline

## Test plan

- [x] Added unit tests for empty WAL files
- [x] Added unit tests for truncated WAL files (< 12 bytes)
- [x] Added unit tests for files with only header but no data
- [x] Verified existing tests pass
- [x] Manual testing with corrupted WAL files

Closes #26549