### PR TITLE
chore: version bump in Cargo.toml to 3.3.0-nightly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2764,7 +2764,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3"
-version = "3.2.0-nightly"
+version = "3.3.0-nightly"
 dependencies = [
  "anyhow",
  "arrow",
@@ -2845,7 +2845,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_authz"
-version = "3.2.0-nightly"
+version = "3.3.0-nightly"
 dependencies = [
  "async-trait",
  "authz",
@@ -2862,7 +2862,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_cache"
-version = "3.2.0-nightly"
+version = "3.3.0-nightly"
 dependencies = [
  "anyhow",
  "arrow",
@@ -2897,7 +2897,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_catalog"
-version = "3.2.0-nightly"
+version = "3.3.0-nightly"
 dependencies = [
  "anyhow",
  "arrow",
@@ -2945,7 +2945,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_clap_blocks"
-version = "3.2.0-nightly"
+version = "3.3.0-nightly"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2979,7 +2979,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_client"
-version = "3.2.0-nightly"
+version = "3.3.0-nightly"
 dependencies = [
  "bytes",
  "hashbrown 0.15.3",
@@ -2999,7 +2999,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_id"
-version = "3.2.0-nightly"
+version = "3.3.0-nightly"
 dependencies = [
  "indexmap 2.9.0",
  "serde",
@@ -3009,7 +3009,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_internal_api"
-version = "3.2.0-nightly"
+version = "3.3.0-nightly"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3025,7 +3025,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_load_generator"
-version = "3.2.0-nightly"
+version = "3.3.0-nightly"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3054,7 +3054,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_process"
-version = "3.2.0-nightly"
+version = "3.3.0-nightly"
 dependencies = [
  "cargo_metadata",
  "iox_time",
@@ -3063,7 +3063,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_processing_engine"
-version = "3.2.0-nightly"
+version = "3.3.0-nightly"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3105,7 +3105,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_py_api"
-version = "3.2.0-nightly"
+version = "3.3.0-nightly"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -3132,7 +3132,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_server"
-version = "3.2.0-nightly"
+version = "3.3.0-nightly"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3226,7 +3226,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_shutdown"
-version = "3.2.0-nightly"
+version = "3.3.0-nightly"
 dependencies = [
  "futures",
  "futures-util",
@@ -3241,7 +3241,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_sys_events"
-version = "3.2.0-nightly"
+version = "3.3.0-nightly"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3260,7 +3260,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_telemetry"
-version = "3.2.0-nightly"
+version = "3.3.0-nightly"
 dependencies = [
  "futures",
  "futures-util",
@@ -3281,7 +3281,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_test_helpers"
-version = "3.2.0-nightly"
+version = "3.3.0-nightly"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3294,7 +3294,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_types"
-version = "3.2.0-nightly"
+version = "3.3.0-nightly"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3314,7 +3314,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_wal"
-version = "3.2.0-nightly"
+version = "3.3.0-nightly"
 dependencies = [
  "async-trait",
  "bitcode",
@@ -3345,7 +3345,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_write"
-version = "3.2.0-nightly"
+version = "3.3.0-nightly"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3562,7 +3562,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query_influxql_rewrite"
-version = "3.2.0-nightly"
+version = "3.3.0-nightly"
 dependencies = [
  "influxdb_influxql_parser",
  "thiserror 1.0.69",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ exclude = [
 # then this will be `3.1.0-nightly`. Once `3.1.0` is released, this will be bumped to `3.2.0-nightly`,
 # and will remain that regardless of how many `3.1.x` patch releases are done prior to the `3.2.0`
 # release.
-version = "3.2.0-nightly"
+version = "3.3.0-nightly"
 authors = ["InfluxData OSS Developers"]
 edition = "2024"
 license = "MIT OR Apache-2.0"

--- a/install_influxdb.sh
+++ b/install_influxdb.sh
@@ -16,7 +16,7 @@ INSTALL_LOC=~/.influxdb
 BINARY_NAME="influxdb3"
 PORT=8181
 
-INFLUXDB_VERSION="3.1.0"
+INFLUXDB_VERSION="3.2.0"
 EDITION="Core"
 EDITION_TAG="core"
 if [ "$1" = "enterprise" ]; then


### PR DESCRIPTION
- Version bump `Cargo.toml`
- Update `install_influxdb.sh` script to point to `3.2.0`