### PR TITLE
fix: Existing soft-deleted schema can be hard-deleted

### DIFF
--- a/influxdb3/tests/cli/api.rs
+++ b/influxdb3/tests/cli/api.rs
@@ -255,6 +255,7 @@ impl ShowDatabasesQuery<'_> {
 pub struct DeleteDatabaseQuery<'a> {
     server: &'a TestServer,
     name: String,
+    hard_delete: Option<String>,
 }
 
 impl TestServer {
@@ -262,12 +263,25 @@ impl TestServer {
         DeleteDatabaseQuery {
             server: self,
             name: name.into(),
+            hard_delete: None,
         }
     }
 }
 
 impl DeleteDatabaseQuery<'_> {
+    pub fn with_hard_delete(mut self, when: impl Into<String>) -> Self {
+        self.hard_delete = Some(when.into());
+        self
+    }
+
     pub fn run(self) -> Result<String> {
+        let mut args = vec![self.name.as_str()];
+
+        if let Some(hard_delete) = &self.hard_delete {
+            args.push("--hard-delete");
+            args.push(hard_delete);
+        }
+
         self.server.run_with_confirmation(
             vec![
                 "delete",
@@ -275,7 +289,7 @@ impl DeleteDatabaseQuery<'_> {
                 "--tls-ca",
                 "../testing-certs/rootCA.pem",
             ],
-            &[self.name.as_str()],
+            &args,
         )
     }
 }

--- a/influxdb3/tests/cli/api.rs
+++ b/influxdb3/tests/cli/api.rs
@@ -378,6 +378,7 @@ pub struct DeleteTableQuery<'a> {
     server: &'a TestServer,
     db_name: String,
     table_name: String,
+    hard_delete: Option<String>,
 }
 
 impl TestServer {
@@ -390,19 +391,31 @@ impl TestServer {
             server: self,
             db_name: db_name.into(),
             table_name: table_name.into(),
+            hard_delete: None,
         }
     }
 }
 
 impl DeleteTableQuery<'_> {
+    pub fn with_hard_delete(mut self, when: impl Into<String>) -> Self {
+        self.hard_delete = Some(when.into());
+        self
+    }
+
     pub fn run(self) -> Result<String> {
-        let args = vec![
+        let mut args = vec![
             self.table_name.as_str(),
             "--database",
             self.db_name.as_str(),
-            "--tls-ca",
-            "../testing-certs/rootCA.pem",
         ];
+
+        if let Some(hard_delete) = &self.hard_delete {
+            args.push("--hard-delete");
+            args.push(hard_delete);
+        }
+
+        args.push("--tls-ca");
+        args.push("../testing-certs/rootCA.pem");
 
         self.server
             .run_with_confirmation(vec!["delete", "table"], &args)

--- a/influxdb3/tests/cli/mod.rs
+++ b/influxdb3/tests/cli/mod.rs
@@ -349,12 +349,12 @@ async fn test_delete_database_with_hard_delete_now() {
         format!("Database \"{db_name}\" deleted successfully")
     );
 
-    // Query system.databases to verify hard_deletion_date is set
+    // Query system.databases to verify hard_deletion_time is set
     // Note: deleted databases have their names changed to include the deletion timestamp
     let result = server
         .query_sql("_internal")
         .with_sql(format!(
-            "SELECT database_name, deleted, hard_deletion_date FROM system.databases WHERE database_name LIKE '{db_name}-%' AND deleted = true"
+            "SELECT database_name, deleted, hard_deletion_time FROM system.databases WHERE database_name LIKE '{db_name}-%' AND deleted = true"
         ))
         .run()
         .expect("query system.databases");
@@ -363,8 +363,8 @@ async fn test_delete_database_with_hard_delete_now() {
     let data = result.as_array().expect("result should be an array");
     assert_eq!(data.len(), 1);
     assert_eq!(data[0]["deleted"], true);
-    // hard_deletion_date should be set (not null) and close to current time
-    assert!(data[0]["hard_deletion_date"].is_string());
+    // hard_deletion_time should be set (not null) and close to current time
+    assert!(data[0]["hard_deletion_time"].is_string());
 }
 
 #[test_log::test(tokio::test)]
@@ -390,11 +390,11 @@ async fn test_delete_database_with_hard_delete_never() {
         format!("Database \"{db_name}\" deleted successfully")
     );
 
-    // Query system.databases to verify hard_deletion_date is NULL
+    // Query system.databases to verify hard_deletion_time is NULL
     let result = server
         .query_sql("_internal")
         .with_sql(format!(
-            "SELECT database_name, deleted, hard_deletion_date FROM system.databases WHERE database_name LIKE '{db_name}-%' AND deleted = true"
+            "SELECT database_name, deleted, hard_deletion_time FROM system.databases WHERE database_name LIKE '{db_name}-%' AND deleted = true"
         ))
         .run()
         .expect("query system.databases");
@@ -402,8 +402,8 @@ async fn test_delete_database_with_hard_delete_never() {
     let data = result.as_array().expect("result should be an array");
     assert_eq!(data.len(), 1);
     assert_eq!(data[0]["deleted"], true);
-    // hard_deletion_date should be null for "never"
-    assert!(data[0]["hard_deletion_date"].is_null());
+    // hard_deletion_time should be null for "never"
+    assert!(data[0]["hard_deletion_time"].is_null());
 }
 
 #[test_log::test(tokio::test)]
@@ -429,11 +429,11 @@ async fn test_delete_database_with_hard_delete_default() {
         format!("Database \"{db_name}\" deleted successfully")
     );
 
-    // Query system.databases to verify hard_deletion_date is set to a future time
+    // Query system.databases to verify hard_deletion_time is set to a future time
     let result = server
         .query_sql("_internal")
         .with_sql(format!(
-            "SELECT database_name, deleted, hard_deletion_date FROM system.databases WHERE database_name LIKE '{db_name}-%' AND deleted = true"
+            "SELECT database_name, deleted, hard_deletion_time FROM system.databases WHERE database_name LIKE '{db_name}-%' AND deleted = true"
         ))
         .run()
         .expect("query system.databases");
@@ -441,8 +441,8 @@ async fn test_delete_database_with_hard_delete_default() {
     let data = result.as_array().expect("result should be an array");
     assert_eq!(data.len(), 1);
     assert_eq!(data[0]["deleted"], true);
-    // hard_deletion_date should be set and in the future
-    assert!(data[0]["hard_deletion_date"].is_string());
+    // hard_deletion_time should be set and in the future
+    assert!(data[0]["hard_deletion_time"].is_string());
 }
 
 #[test_log::test(tokio::test)]
@@ -469,11 +469,11 @@ async fn test_delete_database_with_hard_delete_timestamp() {
         format!("Database \"{db_name}\" deleted successfully")
     );
 
-    // Query system.databases to verify hard_deletion_date matches the timestamp
+    // Query system.databases to verify hard_deletion_time matches the timestamp
     let result = server
         .query_sql("_internal")
         .with_sql(format!(
-            "SELECT database_name, deleted, hard_deletion_date FROM system.databases WHERE database_name LIKE '{db_name}-%' AND deleted = true"
+            "SELECT database_name, deleted, hard_deletion_time FROM system.databases WHERE database_name LIKE '{db_name}-%' AND deleted = true"
         ))
         .run()
         .expect("query system.databases");
@@ -481,8 +481,8 @@ async fn test_delete_database_with_hard_delete_timestamp() {
     let data = result.as_array().expect("result should be an array");
     assert_eq!(data.len(), 1);
     assert_eq!(data[0]["deleted"], true);
-    // hard_deletion_date should match our timestamp
-    assert_eq!(data[0]["hard_deletion_date"], "2025-12-31T23:59:59");
+    // hard_deletion_time should match our timestamp
+    assert_eq!(data[0]["hard_deletion_time"], timestamp);
 }
 
 #[test_log::test(tokio::test)]
@@ -507,11 +507,11 @@ async fn test_delete_database_without_hard_delete_option() {
         format!("Database \"{db_name}\" deleted successfully")
     );
 
-    // Query system.databases to verify hard_deletion_date follows default behavior
+    // Query system.databases to verify hard_deletion_time follows default behavior
     let result = server
         .query_sql("_internal")
         .with_sql(format!(
-            "SELECT database_name, deleted, hard_deletion_date FROM system.databases WHERE database_name LIKE '{db_name}-%' AND deleted = true"
+            "SELECT database_name, deleted, hard_deletion_time FROM system.databases WHERE database_name LIKE '{db_name}-%' AND deleted = true"
         ))
         .run()
         .expect("query system.databases");
@@ -519,8 +519,8 @@ async fn test_delete_database_without_hard_delete_option() {
     let data = result.as_array().expect("result should be an array");
     assert_eq!(data.len(), 1);
     assert_eq!(data[0]["deleted"], true);
-    // hard_deletion_date should be set to a future time (default retention) when no option specified
-    assert!(data[0]["hard_deletion_date"].is_string());
+    // hard_deletion_time should be set to a future time when no option specified
+    assert!(data[0]["hard_deletion_time"].is_string());
 }
 
 #[test_log::test(tokio::test)]
@@ -550,14 +550,14 @@ async fn test_update_hard_delete_time_on_deleted_database() {
     let result = server
         .query_sql("_internal")
         .with_sql(format!(
-            "SELECT database_name, deleted, hard_deletion_date FROM system.databases WHERE database_name LIKE '{db_name}-%' AND deleted = true"
+            "SELECT database_name, deleted, hard_deletion_time FROM system.databases WHERE database_name LIKE '{db_name}-%' AND deleted = true"
         ))
         .run()
         .expect("query system.databases");
 
     let data = result.as_array().expect("result should be an array");
     assert_eq!(data.len(), 1);
-    assert!(data[0]["hard_deletion_date"].is_null());
+    assert!(data[0]["hard_deletion_time"].is_null());
 
     // Get the renamed database name
     let renamed_db_name = data[0]["database_name"]
@@ -576,11 +576,11 @@ async fn test_update_hard_delete_time_on_deleted_database() {
         format!("Database \"{renamed_db_name}\" deleted successfully")
     );
 
-    // Verify hard_deletion_date is now set
+    // Verify hard_deletion_time is now set
     let result = server
         .query_sql("_internal")
         .with_sql(format!(
-            "SELECT database_name, deleted, hard_deletion_date FROM system.databases WHERE database_name = '{renamed_db_name}'"
+            "SELECT database_name, deleted, hard_deletion_time FROM system.databases WHERE database_name = '{renamed_db_name}'"
         ))
         .run()
         .expect("query system.databases after update");
@@ -588,8 +588,8 @@ async fn test_update_hard_delete_time_on_deleted_database() {
     let data = result.as_array().expect("result should be an array");
     assert_eq!(data.len(), 1);
     assert_eq!(data[0]["deleted"], true);
-    // hard_deletion_date should now be set
-    assert!(data[0]["hard_deletion_date"].is_string());
+    // hard_deletion_time should now be set
+    assert!(data[0]["hard_deletion_time"].is_string());
 }
 
 #[test_log::test(tokio::test)]
@@ -865,11 +865,11 @@ async fn test_delete_table_with_hard_delete_now() {
         format!("Table \"{db_name}\".\"{table_name}\" deleted successfully")
     );
 
-    // Query system.tables to verify hard_deletion_date is set
+    // Query system.tables to verify hard_deletion_time is set
     let result = server
         .query_sql("_internal")
         .with_sql(format!(
-            "SELECT table_name, deleted, hard_deletion_date FROM system.tables WHERE table_name LIKE '{table_name}-%' AND deleted = true AND database_name = '{db_name}'"
+            "SELECT table_name, deleted, hard_deletion_time FROM system.tables WHERE table_name LIKE '{table_name}-%' AND deleted = true AND database_name = '{db_name}'"
         ))
         .run()
         .expect("query system.tables");
@@ -877,8 +877,8 @@ async fn test_delete_table_with_hard_delete_now() {
     let data = result.as_array().expect("result should be an array");
     assert_eq!(data.len(), 1);
     assert_eq!(data[0]["deleted"], true);
-    // hard_deletion_date should be set (not null) and close to current time
-    assert!(data[0]["hard_deletion_date"].is_string());
+    // hard_deletion_time should be set (not null) and close to current time
+    assert!(data[0]["hard_deletion_time"].is_string());
 }
 
 #[test_log::test(tokio::test)]
@@ -914,11 +914,11 @@ async fn test_delete_table_with_hard_delete_never() {
         format!("Table \"{db_name}\".\"{table_name}\" deleted successfully")
     );
 
-    // Query system.tables to verify hard_deletion_date is NULL
+    // Query system.tables to verify hard_deletion_time is NULL
     let result = server
         .query_sql("_internal")
         .with_sql(format!(
-            "SELECT table_name, deleted, hard_deletion_date FROM system.tables WHERE table_name LIKE '{table_name}-%' AND deleted = true AND database_name = '{db_name}'"
+            "SELECT table_name, deleted, hard_deletion_time FROM system.tables WHERE table_name LIKE '{table_name}-%' AND deleted = true AND database_name = '{db_name}'"
         ))
         .run()
         .expect("query system.tables");
@@ -926,8 +926,8 @@ async fn test_delete_table_with_hard_delete_never() {
     let data = result.as_array().expect("result should be an array");
     assert_eq!(data.len(), 1);
     assert_eq!(data[0]["deleted"], true);
-    // hard_deletion_date should be null
-    assert!(data[0]["hard_deletion_date"].is_null());
+    // hard_deletion_time should be null
+    assert!(data[0]["hard_deletion_time"].is_null());
 }
 
 #[test_log::test(tokio::test)]
@@ -963,11 +963,11 @@ async fn test_delete_table_with_hard_delete_default() {
         format!("Table \"{db_name}\".\"{table_name}\" deleted successfully")
     );
 
-    // Query system.tables to verify hard_deletion_date is set to future time
+    // Query system.tables to verify hard_deletion_time is set to future time
     let result = server
         .query_sql("_internal")
         .with_sql(format!(
-            "SELECT table_name, deleted, hard_deletion_date FROM system.tables WHERE table_name LIKE '{table_name}-%' AND deleted = true AND database_name = '{db_name}'"
+            "SELECT table_name, deleted, hard_deletion_time FROM system.tables WHERE table_name LIKE '{table_name}-%' AND deleted = true AND database_name = '{db_name}'"
         ))
         .run()
         .expect("query system.tables");
@@ -975,8 +975,8 @@ async fn test_delete_table_with_hard_delete_default() {
     let data = result.as_array().expect("result should be an array");
     assert_eq!(data.len(), 1);
     assert_eq!(data[0]["deleted"], true);
-    // hard_deletion_date should be set to a future time (default retention)
-    assert!(data[0]["hard_deletion_date"].is_string());
+    // hard_deletion_time should be set to a future time
+    assert!(data[0]["hard_deletion_time"].is_string());
 }
 
 #[test_log::test(tokio::test)]
@@ -1013,11 +1013,11 @@ async fn test_delete_table_with_hard_delete_timestamp() {
         format!("Table \"{db_name}\".\"{table_name}\" deleted successfully")
     );
 
-    // Query system.tables to verify hard_deletion_date matches timestamp
+    // Query system.tables to verify hard_deletion_time matches timestamp
     let result = server
         .query_sql("_internal")
         .with_sql(format!(
-            "SELECT table_name, deleted, hard_deletion_date FROM system.tables WHERE table_name LIKE '{table_name}-%' AND deleted = true AND database_name = '{db_name}'"
+            "SELECT table_name, deleted, hard_deletion_time FROM system.tables WHERE table_name LIKE '{table_name}-%' AND deleted = true AND database_name = '{db_name}'"
         ))
         .run()
         .expect("query system.tables");
@@ -1025,9 +1025,8 @@ async fn test_delete_table_with_hard_delete_timestamp() {
     let data = result.as_array().expect("result should be an array");
     assert_eq!(data.len(), 1);
     assert_eq!(data[0]["deleted"], true);
-    // hard_deletion_date should match the specified timestamp (may be without Z suffix)
-    let hard_deletion_date = data[0]["hard_deletion_date"].as_str().unwrap();
-    assert!(hard_deletion_date == timestamp || hard_deletion_date == "2025-12-31T23:59:59");
+    // hard_deletion_time should match the specified timestamp
+    assert_eq!(data[0]["hard_deletion_time"], timestamp);
 }
 
 #[test_log::test(tokio::test)]
@@ -1066,7 +1065,7 @@ async fn test_delete_table_without_hard_delete_option() {
     let result = server
         .query_sql("_internal")
         .with_sql(format!(
-            "SELECT table_name, deleted, hard_deletion_date FROM system.tables WHERE table_name LIKE '{table_name}-%' AND deleted = true AND database_name = '{db_name}'"
+            "SELECT table_name, deleted, hard_deletion_time FROM system.tables WHERE table_name LIKE '{table_name}-%' AND deleted = true AND database_name = '{db_name}'"
         ))
         .run()
         .expect("query system.tables");
@@ -1074,8 +1073,8 @@ async fn test_delete_table_without_hard_delete_option() {
     let data = result.as_array().expect("result should be an array");
     assert_eq!(data.len(), 1);
     assert_eq!(data[0]["deleted"], true);
-    // hard_deletion_date should be set to a future time (default retention) when no option specified
-    assert!(data[0]["hard_deletion_date"].is_string());
+    // hard_deletion_time should be set to a future time (default retention) when no option specified
+    assert!(data[0]["hard_deletion_time"].is_string());
 }
 
 #[tokio::test]

--- a/influxdb3/tests/cli/mod.rs
+++ b/influxdb3/tests/cli/mod.rs
@@ -443,7 +443,6 @@ async fn test_delete_database_with_hard_delete_default() {
     assert_eq!(data[0]["deleted"], true);
     // hard_deletion_date should be set and in the future
     assert!(data[0]["hard_deletion_date"].is_string());
-    // TODO: Could verify it's in the future if we parse the timestamp
 }
 
 #[test_log::test(tokio::test)]

--- a/influxdb3_catalog/src/catalog.rs
+++ b/influxdb3_catalog/src/catalog.rs
@@ -5274,4 +5274,461 @@ mod tests {
             other => panic!("Expected Hard deletion status for table3, got {other:?}"),
         }
     }
+
+    // Tests for idempotent default hard deletion behavior
+
+    #[test_log::test(tokio::test)]
+    async fn test_database_soft_delete_default_preserves_existing_hard_delete_time() {
+        // Test that soft deleting a database with Default preserves existing hard_delete_time
+        use iox_time::MockProvider;
+        let now = Time::from_timestamp_nanos(1000000000);
+        let time_provider = Arc::new(MockProvider::new(now));
+        let catalog = Catalog::new_in_memory_with_args(
+            "test-catalog",
+            Arc::clone(&time_provider) as _,
+            CatalogArgs::default(),
+        )
+        .await
+        .unwrap();
+
+        catalog.create_database("test_db").await.unwrap();
+
+        // Get database ID before soft delete
+        let db_id = catalog.db_name_to_id("test_db").unwrap();
+
+        // First soft delete with a specific timestamp
+        let specific_time = Time::from_timestamp_nanos(5000000000);
+        catalog
+            .soft_delete_database("test_db", HardDeletionTime::Timestamp(specific_time))
+            .await
+            .unwrap();
+
+        // Verify the database is soft deleted with the specific hard_delete_time
+        let db_schema = catalog.db_schema_by_id(&db_id).unwrap();
+        assert!(db_schema.deleted);
+        assert_eq!(db_schema.hard_delete_time, Some(specific_time));
+
+        // Get the renamed database name using the ID
+        let renamed_db_name = catalog
+            .db_schema_by_id(&db_id)
+            .expect("soft-deleted database should exist")
+            .name();
+
+        // Now soft delete again with Default using the renamed name
+        // This should return AlreadyDeleted since nothing changes
+        let result = catalog
+            .soft_delete_database(&renamed_db_name, HardDeletionTime::Default)
+            .await;
+
+        // Should get AlreadyDeleted error since hard_delete_time doesn't change
+        assert!(
+            matches!(result, Err(CatalogError::AlreadyDeleted)),
+            "Expected AlreadyDeleted error, got {result:?}"
+        );
+
+        // Verify hard_delete_time is unchanged
+        let db_schema = catalog.db_schema_by_id(&db_id).unwrap();
+        assert!(db_schema.deleted);
+        assert_eq!(db_schema.hard_delete_time, Some(specific_time));
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn test_database_soft_delete_default_sets_new_when_none_exists() {
+        // Test that soft deleting a database with Default sets new hard_delete_time when none exists
+        use iox_time::MockProvider;
+        let now = Time::from_timestamp_nanos(1000000000);
+        let time_provider = Arc::new(MockProvider::new(now));
+        let catalog = Catalog::new_in_memory_with_args(
+            "test-catalog",
+            Arc::clone(&time_provider) as _,
+            CatalogArgs::default(),
+        )
+        .await
+        .unwrap();
+
+        catalog.create_database("test_db").await.unwrap();
+
+        // Get database ID before soft delete
+        let db_id = catalog.db_name_to_id("test_db").unwrap();
+
+        // Soft delete with Default - should set new hard_delete_time
+        catalog
+            .soft_delete_database("test_db", HardDeletionTime::Default)
+            .await
+            .unwrap();
+
+        // Verify hard_delete_time is set to now + default duration
+        let expected_time = now + Catalog::DEFAULT_HARD_DELETE_DURATION;
+        let db_schema = catalog.db_schema_by_id(&db_id).unwrap();
+        assert!(db_schema.deleted);
+        assert_eq!(db_schema.hard_delete_time, Some(expected_time));
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn test_database_soft_delete_default_multiple_calls_idempotent() {
+        // Test that multiple soft delete calls with Default are idempotent
+        use iox_time::MockProvider;
+        let now = Time::from_timestamp_nanos(1000000000);
+        let time_provider = Arc::new(MockProvider::new(now));
+        let catalog = Catalog::new_in_memory_with_args(
+            "test-catalog",
+            Arc::clone(&time_provider) as _,
+            CatalogArgs::default(),
+        )
+        .await
+        .unwrap();
+
+        catalog.create_database("test_db").await.unwrap();
+
+        // Get database ID before soft delete
+        let db_id = catalog.db_name_to_id("test_db").unwrap();
+
+        // First soft delete with a specific timestamp
+        let specific_time = Time::from_timestamp_nanos(5000000000);
+        catalog
+            .soft_delete_database("test_db", HardDeletionTime::Timestamp(specific_time))
+            .await
+            .unwrap();
+
+        // Verify initial state
+        let db_schema = catalog.db_schema_by_id(&db_id).unwrap();
+        assert!(db_schema.deleted);
+        assert_eq!(db_schema.hard_delete_time, Some(specific_time));
+
+        // Get the renamed database name using the ID
+        let renamed_db_name = catalog
+            .db_schema_by_id(&db_id)
+            .expect("soft-deleted database should exist")
+            .name();
+
+        // Call soft delete with Default multiple times - all should be idempotent
+        for i in 1..=3 {
+            let result = catalog
+                .soft_delete_database(&renamed_db_name, HardDeletionTime::Default)
+                .await;
+
+            // Should always get AlreadyDeleted since nothing changes
+            assert!(
+                matches!(result, Err(CatalogError::AlreadyDeleted)),
+                "Call {i} expected AlreadyDeleted error, got {result:?}"
+            );
+
+            // Verify hard_delete_time remains unchanged
+            let db_schema = catalog.db_schema_by_id(&db_id).unwrap();
+            assert!(db_schema.deleted);
+            assert_eq!(
+                db_schema.hard_delete_time,
+                Some(specific_time),
+                "hard_delete_time should remain unchanged after call {}",
+                i
+            );
+        }
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn test_database_soft_delete_override_existing_with_specific_time() {
+        // Test that soft deleting with specific time overrides existing hard_delete_time
+        use iox_time::MockProvider;
+        let now = Time::from_timestamp_nanos(1000000000);
+        let time_provider = Arc::new(MockProvider::new(now));
+        let catalog = Catalog::new_in_memory_with_args(
+            "test-catalog",
+            Arc::clone(&time_provider) as _,
+            CatalogArgs::default(),
+        )
+        .await
+        .unwrap();
+
+        catalog.create_database("test_db").await.unwrap();
+
+        // Get database ID before soft delete
+        let db_id = catalog.db_name_to_id("test_db").unwrap();
+
+        // First soft delete with Default
+        catalog
+            .soft_delete_database("test_db", HardDeletionTime::Default)
+            .await
+            .unwrap();
+
+        // Verify initial state with default hard_delete_time
+        let expected_default_time = now + Catalog::DEFAULT_HARD_DELETE_DURATION;
+        let db_schema = catalog.db_schema_by_id(&db_id).unwrap();
+        assert!(db_schema.deleted);
+        assert_eq!(db_schema.hard_delete_time, Some(expected_default_time));
+
+        // Get the renamed database name using the ID
+        let renamed_db_name = catalog
+            .db_schema_by_id(&db_id)
+            .expect("soft-deleted database should exist")
+            .name();
+
+        // Now soft delete again with a specific timestamp - should update the hard_delete_time
+        let new_specific_time = Time::from_timestamp_nanos(7000000000);
+        catalog
+            .soft_delete_database(
+                &renamed_db_name,
+                HardDeletionTime::Timestamp(new_specific_time),
+            )
+            .await
+            .unwrap();
+
+        // Verify hard_delete_time was updated to the new specific time
+        let db_schema = catalog.db_schema_by_id(&db_id).unwrap();
+        assert!(db_schema.deleted);
+        assert_eq!(db_schema.hard_delete_time, Some(new_specific_time));
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn test_table_soft_delete_default_preserves_existing_hard_delete_time() {
+        // Test that soft deleting a table with Default preserves existing hard_delete_time
+        use iox_time::MockProvider;
+        let now = Time::from_timestamp_nanos(1000000000);
+        let time_provider = Arc::new(MockProvider::new(now));
+        let catalog = Catalog::new_in_memory_with_args(
+            "test-catalog",
+            Arc::clone(&time_provider) as _,
+            CatalogArgs::default(),
+        )
+        .await
+        .unwrap();
+
+        catalog.create_database("test_db").await.unwrap();
+        catalog
+            .create_table(
+                "test_db",
+                "test_table",
+                &["tag1", "tag2"],
+                &[("field1", FieldDataType::String)],
+            )
+            .await
+            .unwrap();
+
+        // Get the table ID before soft delete
+        let db_schema = catalog.db_schema("test_db").unwrap();
+        let table_id = db_schema.table_name_to_id("test_table").unwrap();
+
+        // First soft delete with a specific timestamp
+        let specific_time = Time::from_timestamp_nanos(5000000000);
+        catalog
+            .soft_delete_table(
+                "test_db",
+                "test_table",
+                HardDeletionTime::Timestamp(specific_time),
+            )
+            .await
+            .unwrap();
+
+        // Get the renamed table using the table ID
+        let db_schema = catalog.db_schema("test_db").unwrap();
+        let table_def = db_schema
+            .table_definition_by_id(&table_id)
+            .expect("soft-deleted table should exist");
+        let renamed_table_name = Arc::<str>::clone(&table_def.table_name);
+
+        // Verify the table is soft deleted with the specific hard_delete_time
+        assert!(table_def.deleted);
+        assert_eq!(table_def.hard_delete_time, Some(specific_time));
+
+        // Now soft delete again with Default using the renamed name
+        // This should return AlreadyDeleted since nothing changes
+        let result = catalog
+            .soft_delete_table("test_db", &renamed_table_name, HardDeletionTime::Default)
+            .await;
+
+        // Should get AlreadyDeleted error since hard_delete_time doesn't change
+        assert!(
+            matches!(result, Err(CatalogError::AlreadyDeleted)),
+            "Expected AlreadyDeleted error, got {result:?}"
+        );
+
+        // Verify hard_delete_time is unchanged
+        let db_schema = catalog.db_schema("test_db").unwrap();
+        let table_def = db_schema.table_definition(&renamed_table_name).unwrap();
+        assert!(table_def.deleted);
+        assert_eq!(table_def.hard_delete_time, Some(specific_time));
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn test_table_soft_delete_default_sets_new_when_none_exists() {
+        // Test that soft deleting a table with Default sets new hard_delete_time when none exists
+        use iox_time::MockProvider;
+        let now = Time::from_timestamp_nanos(1000000000);
+        let time_provider = Arc::new(MockProvider::new(now));
+        let catalog = Catalog::new_in_memory_with_args(
+            "test-catalog",
+            Arc::clone(&time_provider) as _,
+            CatalogArgs::default(),
+        )
+        .await
+        .unwrap();
+
+        catalog.create_database("test_db").await.unwrap();
+        catalog
+            .create_table(
+                "test_db",
+                "test_table",
+                &["tag1"],
+                &[("field1", FieldDataType::Float)],
+            )
+            .await
+            .unwrap();
+
+        // Get the table ID before soft delete
+        let db_schema = catalog.db_schema("test_db").unwrap();
+        let table_id = db_schema.table_name_to_id("test_table").unwrap();
+
+        // Soft delete with Default - should set new hard_delete_time
+        catalog
+            .soft_delete_table("test_db", "test_table", HardDeletionTime::Default)
+            .await
+            .unwrap();
+
+        // Get the table using the table ID
+        let db_schema = catalog.db_schema("test_db").unwrap();
+        let table_def = db_schema
+            .table_definition_by_id(&table_id)
+            .expect("soft-deleted table should exist");
+
+        // Verify hard_delete_time is set to now + default duration
+        let expected_time = now + Catalog::DEFAULT_HARD_DELETE_DURATION;
+        assert!(table_def.deleted);
+        assert_eq!(table_def.hard_delete_time, Some(expected_time));
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn test_table_soft_delete_default_multiple_calls_idempotent() {
+        // Test that multiple soft delete calls with Default are idempotent
+        use iox_time::MockProvider;
+        let now = Time::from_timestamp_nanos(1000000000);
+        let time_provider = Arc::new(MockProvider::new(now));
+        let catalog = Catalog::new_in_memory_with_args(
+            "test-catalog",
+            Arc::clone(&time_provider) as _,
+            CatalogArgs::default(),
+        )
+        .await
+        .unwrap();
+
+        catalog.create_database("test_db").await.unwrap();
+        catalog
+            .create_table(
+                "test_db",
+                "test_table",
+                &["tag1", "tag2"],
+                &[("field1", FieldDataType::Integer)],
+            )
+            .await
+            .unwrap();
+
+        // Get the table ID before soft delete
+        let db_schema = catalog.db_schema("test_db").unwrap();
+        let table_id = db_schema.table_name_to_id("test_table").unwrap();
+
+        // First soft delete with a specific timestamp
+        let specific_time = Time::from_timestamp_nanos(5000000000);
+        catalog
+            .soft_delete_table(
+                "test_db",
+                "test_table",
+                HardDeletionTime::Timestamp(specific_time),
+            )
+            .await
+            .unwrap();
+
+        // Get the renamed table name using the table ID
+        let db_schema = catalog.db_schema("test_db").unwrap();
+        let table_def = db_schema
+            .table_definition_by_id(&table_id)
+            .expect("soft-deleted table should exist");
+        let renamed_table_name = Arc::<str>::clone(&table_def.table_name);
+
+        // Call soft delete with Default multiple times - all should be idempotent
+        for i in 1..=3 {
+            let result = catalog
+                .soft_delete_table("test_db", &renamed_table_name, HardDeletionTime::Default)
+                .await;
+
+            // Should always get AlreadyDeleted since nothing changes
+            assert!(
+                matches!(result, Err(CatalogError::AlreadyDeleted)),
+                "Call {i} expected AlreadyDeleted error, got {result:?}"
+            );
+
+            // Verify hard_delete_time remains unchanged
+            let db_schema = catalog.db_schema("test_db").unwrap();
+            let table_def = db_schema.table_definition_by_id(&table_id).unwrap();
+            assert!(table_def.deleted);
+            assert_eq!(
+                table_def.hard_delete_time,
+                Some(specific_time),
+                "hard_delete_time should remain unchanged after call {}",
+                i
+            );
+        }
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn test_table_soft_delete_override_existing_with_specific_time() {
+        // Test that soft deleting with specific time overrides existing hard_delete_time
+        use iox_time::MockProvider;
+        let now = Time::from_timestamp_nanos(1000000000);
+        let time_provider = Arc::new(MockProvider::new(now));
+        let catalog = Catalog::new_in_memory_with_args(
+            "test-catalog",
+            Arc::clone(&time_provider) as _,
+            CatalogArgs::default(),
+        )
+        .await
+        .unwrap();
+
+        catalog.create_database("test_db").await.unwrap();
+        catalog
+            .create_table(
+                "test_db",
+                "test_table",
+                &["tag1"],
+                &[("field1", FieldDataType::UInteger)],
+            )
+            .await
+            .unwrap();
+
+        // Get the table ID before soft delete
+        let db_schema = catalog.db_schema("test_db").unwrap();
+        let table_id = db_schema.table_name_to_id("test_table").unwrap();
+
+        // First soft delete with Default
+        catalog
+            .soft_delete_table("test_db", "test_table", HardDeletionTime::Default)
+            .await
+            .unwrap();
+
+        // Get the renamed table and verify initial state
+        let db_schema = catalog.db_schema("test_db").unwrap();
+        let table_def = db_schema
+            .table_definition_by_id(&table_id)
+            .expect("soft-deleted table should exist");
+        let renamed_table_name = Arc::<str>::clone(&table_def.table_name);
+
+        // Verify initial state with default hard_delete_time
+        let expected_default_time = now + Catalog::DEFAULT_HARD_DELETE_DURATION;
+        assert!(table_def.deleted);
+        assert_eq!(table_def.hard_delete_time, Some(expected_default_time));
+
+        // Now soft delete again with a specific timestamp - should update the hard_delete_time
+        let new_specific_time = Time::from_timestamp_nanos(7000000000);
+        catalog
+            .soft_delete_table(
+                "test_db",
+                &renamed_table_name,
+                HardDeletionTime::Timestamp(new_specific_time),
+            )
+            .await
+            .unwrap();
+
+        // Verify hard_delete_time was updated to the new specific time
+        let db_schema = catalog.db_schema("test_db").unwrap();
+        let table_def = db_schema.table_definition_by_id(&table_id).unwrap();
+        assert!(table_def.deleted);
+        assert_eq!(table_def.hard_delete_time, Some(new_specific_time));
+    }
 }

--- a/influxdb3_catalog/src/catalog/update.rs
+++ b/influxdb3_catalog/src/catalog/update.rs
@@ -51,12 +51,27 @@ pub enum HardDeletionTime {
 }
 
 impl HardDeletionTime {
-    fn value(self, time_provider: &dyn TimeProvider, default: Duration) -> Option<i64> {
+    fn as_time(
+        self,
+        time_provider: &dyn TimeProvider,
+        default: Duration,
+    ) -> Option<iox_time::Time> {
         match self {
             HardDeletionTime::Never => None,
-            HardDeletionTime::Default => Some(time_provider.now().add(default).timestamp_nanos()),
-            HardDeletionTime::Timestamp(time) => Some(time.timestamp_nanos()),
-            HardDeletionTime::Now => Some(time_provider.now().timestamp_nanos()),
+            HardDeletionTime::Default => Some(time_provider.now().add(default)),
+            HardDeletionTime::Timestamp(time) => Some(time),
+            HardDeletionTime::Now => Some(time_provider.now()),
+        }
+    }
+}
+
+impl std::fmt::Display for HardDeletionTime {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            HardDeletionTime::Never => write!(f, "never"),
+            HardDeletionTime::Default => write!(f, "default"),
+            HardDeletionTime::Timestamp(time) => write!(f, "{time}"),
+            HardDeletionTime::Now => write!(f, "now"),
         }
     }
 }
@@ -285,7 +300,6 @@ impl Catalog {
         name: &str,
         hard_delete_time: HardDeletionTime,
     ) -> Result<OrderedCatalogBatch> {
-        info!(name, "soft delete database");
         self.catalog_update_with_retry(|| {
             if name == INTERNAL_DB_NAME {
                 return Err(CatalogError::CannotDeleteInternalDatabase);
@@ -294,7 +308,12 @@ impl Catalog {
             let Some(db) = self.db_schema(name) else {
                 return Err(CatalogError::NotFound);
             };
-            if db.deleted {
+
+            let hard_deletion_time =
+                hard_delete_time.as_time(&self.time_provider, self.default_hard_delete_duration());
+
+            let hard_delete_changed = db.hard_delete_time != hard_deletion_time;
+            if db.deleted && !hard_delete_changed {
                 return Err(CatalogError::AlreadyDeleted);
             }
             let deletion_time = self.time_provider.now().timestamp_nanos();
@@ -308,13 +327,24 @@ impl Catalog {
                         database_id,
                         database_name: db.name(),
                         deletion_time,
-                        hard_deletion_time: hard_delete_time
-                            .value(&self.time_provider, self.default_hard_delete_duration()),
+                        hard_deletion_time: hard_deletion_time.map(|t|t.timestamp_nanos()),
                     },
                 )],
             ))
         })
         .await
+        .inspect(|batch| {
+            let Some(op) = batch
+                .catalog_batch
+                .as_database()
+                .and_then(|db| db.ops.first())
+                .and_then(|op| op.as_soft_delete_database())
+            else {
+                return;
+            };
+
+            info!(db_name = %op.database_name, db_id = %op.database_id, %hard_delete_time, "Delete database.");
+        })
     }
 
     pub async fn create_table(
@@ -339,7 +369,6 @@ impl Catalog {
         table_name: &str,
         hard_delete_time: HardDeletionTime,
     ) -> Result<OrderedCatalogBatch> {
-        info!(db_name, table_name, "soft delete database");
         self.catalog_update_with_retry(|| {
             let Some(db) = self.db_schema(db_name) else {
                 return Err(CatalogError::NotFound);
@@ -347,6 +376,14 @@ impl Catalog {
             let Some(tbl_def) = db.table_definition(table_name) else {
                 return Err(CatalogError::NotFound);
             };
+
+            let hard_deletion_time =
+                hard_delete_time.as_time(&self.time_provider, self.default_hard_delete_duration());
+
+            let hard_delete_changed = db.hard_delete_time != hard_deletion_time;
+            if tbl_def.deleted && !hard_delete_changed {
+                return Err(CatalogError::AlreadyDeleted);
+            }
             let deletion_time = self.time_provider.now().timestamp_nanos();
             Ok(CatalogBatch::database(
                 deletion_time,
@@ -358,12 +395,23 @@ impl Catalog {
                     table_id: tbl_def.table_id,
                     table_name: Arc::clone(&tbl_def.table_name),
                     deletion_time,
-                    hard_deletion_time: hard_delete_time
-                        .value(&self.time_provider, self.default_hard_delete_duration()),
+                    hard_deletion_time: hard_deletion_time.map(|t|t.timestamp_nanos()),
                 })],
             ))
         })
         .await
+            .inspect(|batch| {
+                let Some(op) = batch
+                    .catalog_batch
+                    .as_database()
+                    .and_then(|db| db.ops.first())
+                    .and_then(|op| op.as_soft_delete_table())
+                else {
+                    return;
+                };
+
+                info!(db_name = %op.database_name, db_id = %op.database_id, table_name = %op.table_name, table_id = %op.table_id, %hard_delete_time, "Delete table.")
+            })
     }
 
     /// Permanently delete a table from the catalog.

--- a/influxdb3_catalog/src/log/versions/v3.rs
+++ b/influxdb3_catalog/src/log/versions/v3.rs
@@ -258,9 +258,21 @@ pub enum DatabaseCatalogOp {
 impl DatabaseCatalogOp {
     pub fn to_create_last_cache(self) -> Option<LastCacheDefinition> {
         match self {
-            DatabaseCatalogOp::CreateLastCache(create_last_cache_log) => {
-                Some(create_last_cache_log)
-            }
+            Self::CreateLastCache(create_last_cache_log) => Some(create_last_cache_log),
+            _ => None,
+        }
+    }
+
+    pub fn as_soft_delete_database(&self) -> Option<&SoftDeleteDatabaseLog> {
+        match self {
+            Self::SoftDeleteDatabase(log) => Some(log),
+            _ => None,
+        }
+    }
+
+    pub fn as_soft_delete_table(&self) -> Option<&SoftDeleteTableLog> {
+        match self {
+            Self::SoftDeleteTable(log) => Some(log),
             _ => None,
         }
     }

--- a/influxdb3_server/src/lib.rs
+++ b/influxdb3_server/src/lib.rs
@@ -696,7 +696,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn delete_table_defaults_to_hard_delete_never() {
+    async fn delete_table_defaults_to_hard_delete_default() {
         let start_time = 0;
         let (server, shutdown, write_buffer) = setup_server(start_time).await;
 
@@ -737,11 +737,12 @@ mod tests {
             .find(|table| table.deleted && table.table_name.starts_with(table_name))
             .expect("deleted table should exist");
 
-        // Verify the table is marked as deleted and hard_delete_time is None (Never)
+        // Verify the table is marked as deleted and hard_delete_time is set to default duration
         assert!(deleted_table.deleted, "table should be marked as deleted");
-        assert!(
-            deleted_table.hard_delete_time.is_none(),
-            "hard_delete_time should be None (Never) when hard_delete_at is omitted"
+        assert_eq!(
+            deleted_table.hard_delete_time.unwrap().timestamp_nanos(),
+            start_time + Catalog::DEFAULT_HARD_DELETE_DURATION.as_nanos() as i64,
+            "hard_delete_time should be set to default duration when hard_delete_at is omitted"
         );
 
         shutdown.cancel();
@@ -1021,7 +1022,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn delete_database_defaults_to_hard_delete_never() {
+    async fn delete_database_defaults_to_hard_delete_default() {
         let start_time = 0;
         let (server, shutdown, write_buffer) = setup_server(start_time).await;
 
@@ -1058,11 +1059,12 @@ mod tests {
             .find(|db| db.deleted && db.name.starts_with(db_name))
             .expect("deleted database should exist");
 
-        // Verify the database is marked as deleted and hard_delete_time is None (Never)
+        // Verify the database is marked as deleted and hard_delete_time is set to default duration
         assert!(deleted_db.deleted, "database should be marked as deleted");
-        assert!(
-            deleted_db.hard_delete_time.is_none(),
-            "hard_delete_time should be None (Never) when hard_delete_at is omitted"
+        assert_eq!(
+            deleted_db.hard_delete_time.unwrap().timestamp_nanos(),
+            start_time + Catalog::DEFAULT_HARD_DELETE_DURATION.as_nanos() as i64,
+            "hard_delete_time should be set to default duration when hard_delete_at is omitted"
         );
 
         shutdown.cancel();

--- a/influxdb3_server/src/system_tables/databases.rs
+++ b/influxdb3_server/src/system_tables/databases.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use crate::system_tables::DEFAULT_TIMEZONE;
 use arrow::array::{StringViewBuilder, UInt64Builder};
 use arrow_array::{ArrayRef, RecordBatch};
 use arrow_schema::{DataType, Field, Schema, SchemaRef, TimeUnit};
@@ -28,8 +29,8 @@ fn databases_schema() -> SchemaRef {
         Field::new("retention_period_ns", DataType::UInt64, true),
         Field::new("deleted", DataType::Boolean, false),
         Field::new(
-            "hard_deletion_date",
-            DataType::Timestamp(TimeUnit::Second, None),
+            "hard_deletion_time",
+            DataType::Timestamp(TimeUnit::Second, Some(DEFAULT_TIMEZONE.into())),
             true,
         ),
     ];
@@ -52,8 +53,10 @@ impl IoxSystemTable for DatabasesTable {
         let mut database_name_arr = StringViewBuilder::with_capacity(databases.len());
         let mut retention_period_arr = UInt64Builder::with_capacity(databases.len());
         let mut deleted_arr = arrow::array::BooleanBuilder::with_capacity(databases.len());
-        let mut hard_deletion_date_arr =
-            arrow::array::TimestampSecondBuilder::with_capacity(databases.len());
+        let mut hard_deletion_time_arr =
+            arrow::array::TimestampSecondBuilder::with_capacity(databases.len()).with_data_type(
+                DataType::Timestamp(TimeUnit::Second, Some(DEFAULT_TIMEZONE.into())),
+            );
 
         for db in databases {
             database_name_arr.append_value(&db.name);
@@ -68,9 +71,9 @@ impl IoxSystemTable for DatabasesTable {
             deleted_arr.append_value(db.deleted);
 
             if let Some(hard_delete_time) = &db.hard_delete_time {
-                hard_deletion_date_arr.append_value(hard_delete_time.timestamp())
+                hard_deletion_time_arr.append_value(hard_delete_time.timestamp())
             } else {
-                hard_deletion_date_arr.append_null()
+                hard_deletion_time_arr.append_null()
             }
         }
 
@@ -78,7 +81,7 @@ impl IoxSystemTable for DatabasesTable {
             Arc::new(database_name_arr.finish()),
             Arc::new(retention_period_arr.finish()),
             Arc::new(deleted_arr.finish()),
-            Arc::new(hard_deletion_date_arr.finish()),
+            Arc::new(hard_deletion_time_arr.finish()),
         ];
 
         RecordBatch::try_new(self.schema(), columns).map_err(DataFusionError::from)

--- a/influxdb3_server/src/system_tables/databases.rs
+++ b/influxdb3_server/src/system_tables/databases.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use arrow::array::{StringViewBuilder, UInt64Builder};
 use arrow_array::{ArrayRef, RecordBatch};
-use arrow_schema::{DataType, Field, Schema, SchemaRef};
+use arrow_schema::{DataType, Field, Schema, SchemaRef, TimeUnit};
 use datafusion::{error::DataFusionError, logical_expr::Expr};
 use influxdb3_catalog::catalog::{Catalog, RetentionPeriod};
 use iox_system_tables::IoxSystemTable;
@@ -27,6 +27,11 @@ fn databases_schema() -> SchemaRef {
         Field::new("database_name", DataType::Utf8View, false),
         Field::new("retention_period_ns", DataType::UInt64, true),
         Field::new("deleted", DataType::Boolean, false),
+        Field::new(
+            "hard_deletion_date",
+            DataType::Timestamp(TimeUnit::Second, None),
+            true,
+        ),
     ];
     Arc::new(Schema::new(columns))
 }
@@ -47,6 +52,8 @@ impl IoxSystemTable for DatabasesTable {
         let mut database_name_arr = StringViewBuilder::with_capacity(databases.len());
         let mut retention_period_arr = UInt64Builder::with_capacity(databases.len());
         let mut deleted_arr = arrow::array::BooleanBuilder::with_capacity(databases.len());
+        let mut hard_deletion_date_arr =
+            arrow::array::TimestampSecondBuilder::with_capacity(databases.len());
 
         for db in databases {
             database_name_arr.append_value(&db.name);
@@ -59,12 +66,19 @@ impl IoxSystemTable for DatabasesTable {
             }
 
             deleted_arr.append_value(db.deleted);
+
+            if let Some(hard_delete_time) = &db.hard_delete_time {
+                hard_deletion_date_arr.append_value(hard_delete_time.timestamp())
+            } else {
+                hard_deletion_date_arr.append_null()
+            }
         }
 
         let columns: Vec<ArrayRef> = vec![
             Arc::new(database_name_arr.finish()),
             Arc::new(retention_period_arr.finish()),
             Arc::new(deleted_arr.finish()),
+            Arc::new(hard_deletion_date_arr.finish()),
         ];
 
         RecordBatch::try_new(self.schema(), columns).map_err(DataFusionError::from)

--- a/influxdb3_server/src/system_tables/mod.rs
+++ b/influxdb3_server/src/system_tables/mod.rs
@@ -45,6 +45,8 @@ pub(crate) const TOKENS_TABLE_NAME: &str = "tokens";
 pub(crate) const DATABASES_TABLE_NAME: &str = "databases";
 pub(crate) const TABLES_TABLE_NAME: &str = "tables";
 pub(crate) const GENERATION_DURATIONS_TABLE_NAME: &str = "generation_durations";
+/// The default timezone used in the system schema.
+pub(crate) const DEFAULT_TIMEZONE: &str = "UTC";
 
 const PROCESSING_ENGINE_TRIGGERS_TABLE_NAME: &str = "processing_engine_triggers";
 

--- a/influxdb3_types/src/http.rs
+++ b/influxdb3_types/src/http.rs
@@ -18,10 +18,10 @@ use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Default)]
 pub enum HardDeletionTime {
-    #[default]
     Never,
     Timestamp(String),
     Now,
+    #[default]
     Default,
 }
 


### PR DESCRIPTION
Helps

- #26568

This PR addresses the following TODO items from #26568

- [x] **Update DELETE API**: Allow users to update the `hard_delete_time` of a database that has already been deleted
- [x] **Improve Log Messages**: Update log output to display correctly and include the `hard_delete_time` information, when specified

Further, it extends the `databases` and `tables` system tables for the `_internal` database to include a new column for the `hard_deletion_date`:

```sh
influxdb3 query --database _internal 'select * from system.tables'
```

```text
+---------------+--------------------+--------------+--------------------+------------------+----------------------+---------+---------------------+
| database_name | table_name         | column_count | series_key_columns | last_cache_count | distinct_cache_count | deleted | hard_deletion_date  |
+---------------+--------------------+--------------+--------------------+------------------+----------------------+---------+---------------------+
| dev           | t1-20250701T063942 | 9            | tag0, tag1, tag2   | 0                | 0                    | true    | 2025-07-04T06:39:42 |
+---------------+--------------------+--------------+--------------------+------------------+----------------------+---------+---------------------+
```

If the schema is only soft-deleted, `hard_deletion_date` will be `NULL`.

## Improved Log Messages

Shows explicitly the parameters used to delete the schema, such as in this case where `--hard-delete now` was specified:

```
2025-07-01T06:42:16.420899Z  INFO influxdb3_catalog::catalog::update: Delete database. db_name=dev-20250701T064143 db_id=1 hard_delete_time=now
```

and correctly shows `Delete table`, when deleting a table:

```
2025-07-01T06:39:42.680881Z  INFO influxdb3_catalog::catalog::update: Delete table. db_name=dev db_id=1 table_name=t1 table_id=2 hard_delete_time=default
```