### PR TITLE
fix: `--object-store` is explicitly marked required

### DIFF
--- a/influxdb3/src/commands/serve.rs
+++ b/influxdb3/src/commands/serve.rs
@@ -11,11 +11,8 @@ use influxdb3_cache::{
 use influxdb3_catalog::{CatalogError, catalog::Catalog};
 use influxdb3_clap_blocks::plugins::{PackageManager, ProcessingEngineConfig};
 use influxdb3_clap_blocks::{
-    datafusion::IoxQueryDatafusionConfig,
-    memory_size::MemorySize,
-    object_store::{ObjectStoreConfig, ObjectStoreType},
-    socket_addr::SocketAddr,
-    tokio::TokioDatafusionConfig,
+    datafusion::IoxQueryDatafusionConfig, memory_size::MemorySize, object_store::ObjectStoreConfig,
+    socket_addr::SocketAddr, tokio::TokioDatafusionConfig,
 };
 use influxdb3_process::{
     INFLUXDB3_GIT_HASH, INFLUXDB3_VERSION, PROCESS_START_TIME, PROCESS_UUID_STR, ProcessUuidGetter,
@@ -1112,9 +1109,7 @@ async fn setup_telemetry_store(
     let influxdb_pkg_name = env!("CARGO_PKG_NAME");
     // Following should show influxdb3-0.1.0
     let influx_version = format!("{influxdb_pkg_name}-{influxdb_pkg_version}");
-    let obj_store_type = object_store_config
-        .object_store
-        .unwrap_or(ObjectStoreType::Memory);
+    let obj_store_type = object_store_config.object_store;
     let storage_type = obj_store_type.as_str();
 
     if disable_upload {

--- a/influxdb3/src/help/serve.txt
+++ b/influxdb3/src/help/serve.txt
@@ -18,7 +18,7 @@ Examples
 {}
   --node-id <NODE_ID>              Node identifier used as prefix in object store file paths
                                   [env: INFLUXDB3_NODE_IDENTIFIER_PREFIX=]
-  --object-store <OBJECT_STORE>    Which object storage to use. If not specified, defaults to memory.
+  --object-store <OBJECT_STORE>    Which object storage to use.
                                   [env: INFLUXDB3_OBJECT_STORE=]
                                   [possible values: memory, memory-throttled, file, s3, google, azure]
 

--- a/influxdb3/src/help/serve_all.txt
+++ b/influxdb3/src/help/serve_all.txt
@@ -17,7 +17,7 @@ Examples:
 {}
   --node-id <NODE_ID>              Node identifier used as prefix in object store file paths
                                   [env: INFLUXDB3_NODE_IDENTIFIER_PREFIX=]
-  --object-store <STORE>           Object storage to use [default: memory]
+  --object-store <STORE>           Object storage to use
                                   [possible values: memory, memory-throttled, file, s3, google, azure]
 
 {}

--- a/influxdb3/tests/cli/mod.rs
+++ b/influxdb3/tests/cli/mod.rs
@@ -2987,3 +2987,29 @@ async fn test_db_name_cannot_start_with_underscore_on_create_table() {
         "db name did not start with a number or letter"
     );
 }
+
+#[test_log::test(tokio::test)]
+async fn test_serve_command_error_msg() {
+    let output = assert_cmd::Command::cargo_bin("influxdb3")
+        .unwrap()
+        .args(["serve", "--node-id", "node-1"])
+        .output()
+        .unwrap()
+        .stderr
+        .clone();
+
+    let full_cmd =
+        "influxdb3 serve --object-store <object-store> --node-id <NODE_IDENTIFIER_PREFIX>";
+    assert_object_store_error_msg(output, full_cmd);
+}
+
+fn assert_object_store_error_msg(error_output: Vec<u8>, full_command: &str) {
+    let str_msg = String::from_utf8(error_output).unwrap();
+    assert_contains!(&str_msg, full_command);
+
+    assert_contains!(
+        &str_msg,
+        "error: the following required arguments were not provided:
+  --object-store <object-store>"
+    );
+}


### PR DESCRIPTION
This is a back port of the `--object-store` commit from https://github.com/influxdata/influxdb_pro/pull/987

Before this commit, although `--object-store` is mandatory it is not reflected in the error messages. The examples are listed in the issue 976.

This commit makes `object_store` explicitly required which means error messages include `--object-store` listed as mandatory

closes: https://github.com/influxdata/influxdb_pro/issues/976