### PR TITLE
fix: v1 query API should default to ns for CSV output

### DIFF
--- a/influxdb3/tests/server/query.rs
+++ b/influxdb3/tests/server/query.rs
@@ -1022,9 +1022,9 @@ async fn api_v1_query_csv_format() {
             epoch: None,
             query: "SELECT time, host, usage FROM cpu",
             expected: "name,tags,time,host,usage\n\
-            cpu,,2065-01-07T17:28:51Z,a,0.9\n\
-            cpu,,2065-01-07T17:28:52Z,a,0.89\n\
-            cpu,,2065-01-07T17:28:53Z,a,0.85\n\r\n",
+            cpu,,2998574931000000000,a,0.9\n\
+            cpu,,2998574932000000000,a,0.89\n\
+            cpu,,2998574933000000000,a,0.85\n\r\n",
         },
         // Basic Query with multiple measurements:
         TestCase {
@@ -1032,12 +1032,12 @@ async fn api_v1_query_csv_format() {
             epoch: None,
             query: "SELECT time, host, usage FROM cpu, mem",
             expected: "name,tags,time,host,usage\n\
-            mem,,2065-01-07T17:28:54Z,a,0.5\n\
-            mem,,2065-01-07T17:28:55Z,a,0.6\n\
-            mem,,2065-01-07T17:28:56Z,a,0.7\n\
-            cpu,,2065-01-07T17:28:51Z,a,0.9\n\
-            cpu,,2065-01-07T17:28:52Z,a,0.89\n\
-            cpu,,2065-01-07T17:28:53Z,a,0.85\n\r\n",
+            mem,,2998574934000000000,a,0.5\n\
+            mem,,2998574935000000000,a,0.6\n\
+            mem,,2998574936000000000,a,0.7\n\
+            cpu,,2998574931000000000,a,0.9\n\
+            cpu,,2998574932000000000,a,0.89\n\
+            cpu,,2998574933000000000,a,0.85\n\r\n",
         },
         // Basic Query with db in query string:
         TestCase {
@@ -1045,9 +1045,9 @@ async fn api_v1_query_csv_format() {
             epoch: None,
             query: "SELECT time, host, usage FROM foo.autogen.cpu",
             expected: "name,tags,time,host,usage\n\
-          cpu,,2065-01-07T17:28:51Z,a,0.9\n\
-          cpu,,2065-01-07T17:28:52Z,a,0.89\n\
-          cpu,,2065-01-07T17:28:53Z,a,0.85\n\r\n",
+          cpu,,2998574931000000000,a,0.9\n\
+          cpu,,2998574932000000000,a,0.89\n\
+          cpu,,2998574933000000000,a,0.85\n\r\n",
         },
         // Basic Query epoch parameter set:
         TestCase {

--- a/influxdb3_server/src/http/v1.rs
+++ b/influxdb3_server/src/http/v1.rs
@@ -67,6 +67,11 @@ impl HttpApi {
             query,
         } = qualified_params;
 
+        let epoch = epoch.or(match format {
+            QueryFormat::Csv => Some(Precision::Nanoseconds),
+            _ => None,
+        });
+
         if pretty {
             format = format.to_pretty();
         }


### PR DESCRIPTION
This fixes https://github.com/influxdata/influxdb/issues/26570

See additional discussion in that issue, particularly around the difference in default output timestamp formatting for CSV vs JSON.
