### PR TITLE
fix: URL encoded table name failures

### DIFF
--- a/influxdb3/src/commands/show/system.rs
+++ b/influxdb3/src/commands/show/system.rs
@@ -185,7 +185,7 @@ impl SystemCommandRunner {
         };
 
         let mut clauses = vec![format!(
-            "SELECT {select_expr} FROM system.{system_table_name}"
+            "SELECT {select_expr} FROM system.\"{system_table_name}\""
         )];
 
         if let Some(default_filter) = default_filter(&system_table_name) {
@@ -264,7 +264,7 @@ impl SystemCommandRunner {
 
     async fn summarize_table(&self, table_name: &str, limit: u16, format: Format) -> Result<()> {
         let Self { db, client } = self;
-        let mut clauses = vec![format!("SELECT * FROM system.{table_name}")];
+        let mut clauses = vec![format!("SELECT * FROM system.\"{table_name}\"")];
 
         if let Some(default_filter) = default_filter(table_name) {
             clauses.push(format!("WHERE {default_filter}"));

--- a/influxdb3/tests/server/flight.rs
+++ b/influxdb3/tests/server/flight.rs
@@ -154,6 +154,47 @@ async fn flight() -> Result<(), influxdb3_client::Error> {
     Ok(())
 }
 
+#[test_log::test(tokio::test)]
+async fn test_percentage_table_flight() -> Result<(), influxdb3_client::Error> {
+    let server = TestServer::spawn().await;
+
+    server
+        .write_lp_to_db(
+            "foo",
+            "%,host=s1,region=us-east usage=0.9 2998574936\n\
+             %,host=s1,region=us-east usage=0.89 2998574937\n\
+             %,host=s1,region=us-east usage=0.85 2998574938",
+            Precision::Second,
+        )
+        .await?;
+
+    let mut client = server.flight_sql_client("foo").await;
+
+    // Ad-hoc Query:
+    {
+        let response = client
+            .query("SELECT host, region, time, usage FROM '%'")
+            .await
+            .unwrap();
+
+        let batches = collect_stream(response).await;
+        assert_batches_sorted_eq!(
+            [
+                "+------+---------+----------------------+-------+",
+                "| host | region  | time                 | usage |",
+                "+------+---------+----------------------+-------+",
+                "| s1   | us-east | 2065-01-07T17:28:56Z | 0.9   |",
+                "| s1   | us-east | 2065-01-07T17:28:57Z | 0.89  |",
+                "| s1   | us-east | 2065-01-07T17:28:58Z | 0.85  |",
+                "+------+---------+----------------------+-------+",
+            ],
+            &batches
+        );
+    }
+
+    Ok(())
+}
+
 #[tokio::test]
 async fn flight_influxql() {
     let server = TestServer::spawn().await;

--- a/influxdb3_write/src/write_buffer/mod.rs
+++ b/influxdb3_write/src/write_buffer/mod.rs
@@ -510,7 +510,7 @@ pub fn parquet_chunk_from_file(
         &NoColumnRanges,
     );
 
-    let location = ObjPath::from(parquet_file.path.clone());
+    let location = ObjPath::parse(&parquet_file.path).expect("path should be parseable");
 
     let parquet_exec = ParquetExecInput {
         object_store_url,

--- a/influxdb3_write/src/write_buffer/queryable_buffer.rs
+++ b/influxdb3_write/src/write_buffer/queryable_buffer.rs
@@ -857,7 +857,7 @@ mod tests {
 
         // Verify the `iox::series::key` metadata is present in the parquet file
         {
-            let path = Path::from(files[0].path.as_str());
+            let path = Path::parse(&files[0].path).expect("path should be parseable");
             let res = object_store
                 .get(&path)
                 .await


### PR DESCRIPTION
This commit fixes queries that could come back as failures due to improperly quoted table names in queries. It also fixes issues in Enterprise where compaction would fail due to double escaped names.

The fix is relatively simple:

- Use the parse not from function for the Path type in the object_store crate
- Quote escape table names in queries

With these two changes the failing tests that Praveen made to hightlight the issue have been fixed.