### PR TITLE
chore: remove README from packaged files in build

### DIFF
--- a/.circleci/packages/config.yaml
+++ b/.circleci/packages/config.yaml
@@ -113,6 +113,4 @@ packages:
         target: usr/share/influxdb3/LICENSE-APACHE
       - source: LICENSE-MIT
         target: usr/share/influxdb3/LICENSE-MIT
-      - source: README.md
-        target: usr/share/influxdb3/README.md
     source: .circleci/packages/influxdb3


### PR DESCRIPTION
Helps #26579

Follows guidance from https://github.com/influxdata/influxdb/issues/26579#issuecomment-3032151562 to remove the `README.md` file from being included as an extra artifact in the packaging during release builds.

This will need to be propagated to Enterprise to close the issue.