### PR TITLE
ci: migrate `test_pkgs_64bit` circle ci job to self-hosted runners

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -166,13 +166,11 @@ jobs:
           path: /tmp/workspace/packages
 
   test_pkgs_64bit:
-    machine:
-      enabled: true
-      docker_layer_caching: true
-      image: ubuntu-2204:current
+    machine: true
+    resource_class: runner-ns/clustered-linux-vm
     steps:
       - attach_workspace:
-          at: /tmp/workspace
+          at: /tmp/workspace/<< pipeline.id >>
       - checkout
       - run:
           name: Test 64 bit packages install
@@ -183,10 +181,10 @@ jobs:
             # The glob pattern with -prune causes find to only return files rooted in packages,
             # thereby avoiding files whose names would match, but are in subdirectories, i.e. packages/static.
             "${WORKING_DIR}/releng/packages/spec/clean_install/run.bash" -D \
-              -p "$(find "/tmp/workspace/packages"/* -prune -name 'influxdb*amd64.deb')"
+              -p "$(find "/tmp/workspace/${CIRCLE_PIPELINE_ID}/packages"/* -prune -name 'influxdb*amd64.deb')"
 
             "${WORKING_DIR}/releng/packages/spec/clean_install/run.bash" -R \
-              -p "$(find "/tmp/workspace/packages"/* -prune -name 'influxdb*x86_64.rpm')"
+              -p "$(find "/tmp/workspace/${CIRCLE_PIPELINE_ID}/packages"/* -prune -name 'influxdb*x86_64.rpm')"
 
   static_code_checks:
     docker:


### PR DESCRIPTION
[this circle pipeline run](https://app.circleci.com/pipelines/github/influxdata/influxdb/46767) includes a commit (that has now been dropped) that updates the filters so that the job that’s being moved to self-hosted runners did run (and passed) when it otherwise wouldn’t on a normal branch