### PR TITLE
feat: admin token recovery

### DIFF
--- a/influxdb3/src/commands/create.rs
+++ b/influxdb3/src/commands/create.rs
@@ -78,8 +78,7 @@ impl Config {
             }) => (host_url, auth_token, ca_cert),
             SubCommand::Token(create_token_config) => {
                 let host_settings = create_token_config.get_connection_settings()?;
-                let effective_host_url =
-                    create_token_config.get_effective_host_url(&host_settings.host_url);
+                let effective_host_url = create_token_config.get_effective_host_url();
                 // We need to return references, so we'll handle this differently
                 return Ok({
                     let mut client =

--- a/influxdb3/src/commands/create.rs
+++ b/influxdb3/src/commands/create.rs
@@ -78,11 +78,12 @@ impl Config {
             }) => (host_url, auth_token, ca_cert),
             SubCommand::Token(create_token_config) => {
                 let host_settings = create_token_config.get_connection_settings()?;
-                let effective_host_url = create_token_config.get_effective_host_url();
                 // We need to return references, so we'll handle this differently
                 return Ok({
-                    let mut client =
-                        Client::new(effective_host_url, host_settings.ca_cert.clone())?;
+                    let mut client = Client::new(
+                        host_settings.host_url.clone(),
+                        host_settings.ca_cert.clone(),
+                    )?;
                     if let Some(token) = &host_settings.auth_token {
                         client = client.with_auth_token(token.expose_secret());
                     }

--- a/influxdb3/src/help/serve_all.txt
+++ b/influxdb3/src/help/serve_all.txt
@@ -36,6 +36,11 @@ Examples:
                                    list of resources. Valid values are health, ping, and metrics.
                                    To disable auth for multiple resources pass in a list, eg.
                                    `--disable-authz health,ping`
+  --admin-token-recovery-http-bind <ADDR>
+                                   Address for HTTP API for admin token recovery requests [default: 127.0.0.1:8182]
+                                   WARNING: This endpoint allows unauthenticated admin token regeneration - use with caution!
+                                   [env: INFLUXDB3_ADMIN_TOKEN_RECOVERY_HTTP_BIND_ADDR]
+
 
 {}
   --data-dir <DIR>                 Location to store files locally [env: INFLUXDB3_DB_DIR=]

--- a/influxdb3/tests/cli/api.rs
+++ b/influxdb3/tests/cli/api.rs
@@ -39,18 +39,6 @@ impl TestServer {
         run_cmd_with_result(args, input, command_args)
     }
 
-    pub fn run_regenerate_with_confirmation(
-        &self,
-        commands: Vec<&str>,
-        args: &[&str],
-    ) -> Result<String> {
-        let client_addr = self.admin_token_recovery_client_addr();
-        let mut command_args = commands.clone();
-        command_args.push("--host");
-        command_args.push(client_addr.as_str());
-        run_cmd_with_result(args, Some("yes"), command_args)
-    }
-
     pub fn run(&self, commands: Vec<&str>, args: &[&str]) -> Result<String> {
         self.run_with_options(commands, args, None)
     }
@@ -60,7 +48,7 @@ impl TestServer {
     }
 }
 
-fn run_cmd_with_result(
+pub(super) fn run_cmd_with_result(
     args: &[&str],
     input: Option<&str>,
     command_args: Vec<&str>,

--- a/influxdb3/tests/server/mod.rs
+++ b/influxdb3/tests/server/mod.rs
@@ -53,6 +53,9 @@ pub trait ConfigProvider: Send + Sync + 'static {
     /// Get if logs should be captured
     fn capture_logs(&self) -> bool;
 
+    /// Get if recovery endpoint should be enabled
+    fn recovery_endpoint_enabled(&self) -> bool;
+
     /// Spawn a new [`TestServer`] with this configuration
     ///
     /// This will run the `influxdb3 serve` command and bind its HTTP address to a random port
@@ -82,6 +85,7 @@ pub struct TestConfig {
     disable_authz: Vec<String>,
     gen1_duration: Option<String>,
     capture_logs: bool,
+    enable_recovery_endpoint: bool,
 }
 
 impl TestConfig {
@@ -104,6 +108,12 @@ impl TestConfig {
     /// Set the auth token for this [`TestServer`]
     pub fn with_no_admin_token(mut self) -> Self {
         self.without_admin_token = true;
+        self
+    }
+
+    /// Enable the admin token recovery endpoint
+    pub fn with_recovery_endpoint(mut self) -> Self {
+        self.enable_recovery_endpoint = true;
         self
     }
 
@@ -247,6 +257,10 @@ impl ConfigProvider for TestConfig {
     fn capture_logs(&self) -> bool {
         self.capture_logs
     }
+
+    fn recovery_endpoint_enabled(&self) -> bool {
+        self.enable_recovery_endpoint
+    }
 }
 
 /// A running instance of the `influxdb3 serve` process
@@ -266,7 +280,7 @@ impl ConfigProvider for TestConfig {
 pub struct TestServer {
     auth_token: Option<String>,
     bind_addr: String,
-    admin_token_recovery_bind_addr: String,
+    admin_token_recovery_bind_addr: Option<String>,
     server_process: Child,
     http_client: reqwest::Client,
     stdout: Option<Arc<Mutex<String>>>,
@@ -325,11 +339,10 @@ impl TestServer {
         let tcp_addr_file_2 = admin_token_recover_tmp_dir_path.join("tcp-listener");
 
         let mut command = Command::cargo_bin("influxdb3").expect("create the influxdb3 command");
-        let command = command
+        let mut command = command
             .arg("serve")
             .arg("--disable-telemetry-upload")
             .args(["--http-bind", "0.0.0.0:0"])
-            .args(["--admin-token-recovery-http-bind", "0.0.0.0:0"])
             .args(["--wal-flush-interval", "10ms"])
             .args(["--wal-snapshot-size", "1"])
             .args([
@@ -337,13 +350,21 @@ impl TestServer {
                 tcp_addr_file
                     .to_str()
                     .expect("valid tcp listener file path"),
-            ])
-            .args([
-                "--admin-token-recovery-tcp-listener-file-path",
-                tcp_addr_file_2
-                    .to_str()
-                    .expect("valid tcp listener file path"),
-            ])
+            ]);
+
+        // Only add recovery endpoint args if explicitly enabled
+        if config.recovery_endpoint_enabled() {
+            command = command
+                .args(["--admin-token-recovery-http-bind", "0.0.0.0:0"])
+                .args([
+                    "--admin-token-recovery-tcp-listener-file-path",
+                    tcp_addr_file_2
+                        .to_str()
+                        .expect("valid tcp listener file path"),
+                ]);
+        }
+
+        let command = command
             .args([
                 "--tls-cert",
                 if config.bad_tls() {
@@ -433,7 +454,11 @@ impl TestServer {
 
         let bind_addr = find_bind_addr(tcp_addr_file).await;
 
-        let admin_token_recovery_bind_addr = find_bind_addr(tcp_addr_file_2).await;
+        let admin_token_recovery_bind_addr = if config.recovery_endpoint_enabled() {
+            Some(find_bind_addr(tcp_addr_file_2).await)
+        } else {
+            None
+        };
 
         let http_client = reqwest::ClientBuilder::new()
             .min_tls_version(Version::TLS_1_3)
@@ -487,13 +512,17 @@ impl TestServer {
 
     /// Get the URL of admin token recovery service for use with an HTTP client
     pub fn admin_token_recovery_client_addr(&self) -> String {
-        format!(
-            "https://localhost:{}",
-            self.admin_token_recovery_bind_addr
-                .split(':')
-                .nth(1)
-                .unwrap()
-        )
+        match &self.admin_token_recovery_bind_addr {
+            Some(addr) => format!("https://localhost:{}", addr.split(':').nth(1).unwrap()),
+            None => panic!(
+                "admin_token_recovery_client_addr called on TestServer without recovery endpoint enabled. Use .with_recovery_endpoint() when configuring the test server."
+            ),
+        }
+    }
+
+    /// Check if the recovery endpoint is enabled
+    pub fn has_recovery_endpoint(&self) -> bool {
+        self.admin_token_recovery_bind_addr.is_some()
     }
 
     /// Get the token for the server

--- a/influxdb3/tests/server/mod.rs
+++ b/influxdb3/tests/server/mod.rs
@@ -329,7 +329,7 @@ impl TestServer {
             .arg("serve")
             .arg("--disable-telemetry-upload")
             .args(["--http-bind", "0.0.0.0:0"])
-            .args(["--admin-token-regen-bind", "0.0.0.0:0"])
+            .args(["--admin-token-recovery-http-bind", "0.0.0.0:0"])
             .args(["--wal-flush-interval", "10ms"])
             .args(["--wal-snapshot-size", "1"])
             .args([
@@ -339,7 +339,7 @@ impl TestServer {
                     .expect("valid tcp listener file path"),
             ])
             .args([
-                "--admin-token-regen-tcp-listener-file-path",
+                "--admin-token-recovery-tcp-listener-file-path",
                 tcp_addr_file_2
                     .to_str()
                     .expect("valid tcp listener file path"),

--- a/influxdb3_server/src/http.rs
+++ b/influxdb3_server/src/http.rs
@@ -1868,6 +1868,7 @@ pub(crate) async fn route_admin_token_recovery_request(
 
     let response = match (method.clone(), uri.path()) {
         (Method::POST, all_paths::API_V3_CONFIGURE_ADMIN_TOKEN_REGENERATE) => {
+            info!("Regenerating admin token without password through token recovery API request");
             http_server.regenerate_admin_token(req).await
         }
         _ => {


### PR DESCRIPTION
### Summary

- new server to only serve admin token regeneration without an admin token has been added
- minor refactors to allow reuse of some of the utilities like trace layer for metrics moved to their own functions to allow them to be instantiated for both servers
- tests added to check if both the new server works right for regenerating token and also ensure none of the other functionalities are available on the admin token recovery server

closes: #26330

### Security considerations

The admin token recovery (using `--regenerate`) currently requires a valid admin token to be passed in. If that's lost for some reason there is no way to get back into the server other than switching back to running `--without-auth`. This PR addresses it by assuming the following workflow,

- User starts the server passing in `--admin-token-recovery-http-bind` or `--admin-token-recovery-http-bind $IP:$PORT`. In either of those cases the recovery server will be started either on the explicit `$IP:$PORT` or on default `127.0.0.1:8182` when explicit ip/port is not specified.
- In case of regeneration of admin token _with_ admin token, the user can still use `0.0.0.0:8181` (the main server).
- When user does not have admin token, then the regeneration of admin token can be triggered on either the default ip/port or on the ip/port passed into `--admin-token-recovery-http-bind` argument. Note: this operation is only allowed once after the server restart. After successful regeneration the recovery server should shutdown immediately, but the main server will still be online.

### Manual Tests

- Help sections show that `--regenerate` defaults to port `127.0.0.1:8182`, so that it is not necessary to mention `--regenerate --host https://127.0.0.1:8182`
  ```
  ❯ ./target/debug/influxdb3 create token --admin --help
  Create or regenerate an admin token

  Usage: influxdb3 create token --admin [OPTIONS]

  Options:
        --regenerate       Regenerate the operator token (uses port 8182 by default instead of 8181)
        --name <NAME>      Name of the token
        --expiry <EXPIRY>  Expires in `duration`, e.g 10d for 10 days 1y for 1 year
        --host <host>      The host URL of the running InfluxDB 3 Core server [env: INFLUXDB3_HOST_URL=]
        --token <token>    The token for authentication with the InfluxDB 3 Core server to create permissions. This will be the admin token to create tokens with permissions [env: INFLUXDB3_AUTH_TOKEN=]
        --tls-ca <tls-ca>  An optional arg to use a custom ca for useful for testing with self signed certs
        --format <FORMAT>  Output format for token, supports just json or text [possible values: json, text]
    -h, --help             Print help information
        --help-all         Print more detailed help information

  ```
- serve shows new parameter only in `--help-all`, it's listed under `Common Options` section
  ```
    ❯ cargo run -- serve --help-all
      Common Options:
        --http-bind <ADDR>               Address for HTTP API requests [default: 0.0.0.0:8181]
                                        [env: INFLUXDB3_HTTP_BIND_ADDR=]
        --log-filter <FILTER>            Logs: filter directive [env: LOG_FILTER=]
        --tls-key <KEY_FILE>             The path to the key file for TLS to be enabled
                                        [env: INFLUXDB3_TLS_KEY=]
        --tls-cert <CERT_FILE>           The path to the cert file for TLS to be enabled
                                        [env: INFLUXDB3_TLS_CERT=]
        --tls-minimum-version <VERSION>  The minimum version for TLS. Valid values are
                                        tls-1.2 and tls-1.3, default is tls-1.2
                                        [env: INFLUXDB3_TLS_MINIMUM_VERSION=]
        --without-auth                   Run InfluxDB 3 server without authorization
        --disable-authz <RESOURCES>      Optionally disable authz by passing in a comma separated
                                        list of resources. Valid values are health, ping, and metrics.
                                        To disable auth for multiple resources pass in a list, eg.
                                        `--disable-authz health,ping`
        --admin-token-recovery-http-bind <ADDR>
                                        Address for HTTP API for admin token recovery requests [default: 127.0.0.1:8182]
                                        WARNING: This endpoint allows unauthenticated admin token regeneration - use with caution!
                                        [env: INFLUXDB3_ADMIN_TOKEN_RECOVERY_HTTP_BIND_ADDR]

  ```
- Starting server without `--admin-token-recovery-http-bind` should have no recovery server running
  ```
    cargo run -- serve --node-id node-1 --object-store file --data-dir /home/praveen/projects/influx/test-data/core  --disable-telemetry-upload --http-bind 127.0.0.1:8181
  ```
  - try `--regenerate`, it should fail
    ```
      ❯ ./target/debug/influxdb3 create token --admin --regenerate
      Are you sure you want to regenerate admin token? Enter 'yes' to confirm
      yes
      Failed to create token, error: RequestSend { method: POST, url: "http://127.0.0.1:8182/api/v3/configure/token/admin/regenerate", source: reqwest::Error { kind: Request, url: Url { scheme: "http", cannot_be_a_base: false, username: "", password: None, host: Some(Ipv4(127.0.0.1)), port: Some(8182), path: "/api/v3/configure/token/admin/regenerate", query: None, fragment: None }, source: hyper::Error(Connect, ConnectError("tcp connect error", Os { code: 111, kind: ConnectionRefused, message: "Connection refused" })) } }
    ```

- Create admin token and see if it can be regenerated using default `127.0.0.1:8182`.
    - start the server
      ```
        ❯ cargo run -- serve --node-id node-1 --object-store file --data-dir /home/praveen/projects/influx/test-data/core  --disable-telemetry-upload --admin-token-recovery-http-bind --http-bind 127.0.0.1:8181
      ```

    - try regenerating admin token
      - create admin token
        ```
          ❯ ./target/debug/influxdb3 create token --admin

          New token created successfully!

          Token: apiv3_VDD60uw8PbaEmE7a2flTnghRNxq4wCEJJs7lhHBza6FUdcr07gJmITfmXzKjVeilRx8vsPxdmgY2HzpUYWqW4g
          HTTP Requests Header: Authorization: Bearer apiv3_VDD60uw8PbaEmE7a2flTnghRNxq4wCEJJs7lhHBza6FUdcr07gJmITfmXzKjVeilRx8vsPxdmgY2HzpUYWqW4g

          IMPORTANT: Store this token securely, as it will not be shown again.
        ```
      - regenerate using default host and port
        ```
          ❯ ./target/debug/influxdb3 create token --admin --regenerate
          Are you sure you want to regenerate admin token? Enter 'yes' to confirm
          yes

          New token created successfully!

          Token: apiv3_TfRmlFixgJiszXySJ5i-vqOcdVgK6jSPSnWfV--7si7cutWTm0h_MSFN4JUHh0shDpo6eCCCyaQrh9TXk3ZA1g
          HTTP Requests Header: Authorization: Bearer apiv3_TfRmlFixgJiszXySJ5i-vqOcdVgK6jSPSnWfV--7si7cutWTm0h_MSFN4JUHh0shDpo6eCCCyaQrh9TXk3ZA1g

          IMPORTANT: Store this token securely, as it will not be shown again.
        ```
      - regenerate again should fail as the server has been shutdown
        ```
          ❯ ./target/debug/influxdb3 create token --admin --regenerate
          Are you sure you want to regenerate admin token? Enter 'yes' to confirm
          yes
          Failed to create token, error: RequestSend { method: POST, url: "http://127.0.0.1:8182/api/v3/configure/token/admin/regenerate", source: reqwest::Error { kind: Request, url: Url { scheme: "http", cannot_be_a_base: false, username: "", password: None, host: Some(Ipv4(127.0.0.1)), port: Some(8182), path: "/api/v3/configure/token/admin/regenerate", query: None, fragment: None }, source: hyper::Error(Connect, ConnectError("tcp connect error", Os { code: 111, kind: ConnectionRefused, message: "Connection refused" })) } }
        ```
      - regenerate using the main http server without admin token, it should fail
        ```
          ❯ ./target/debug/influxdb3 create token --admin --regenerate --host http://127.0.0.1:8181
          Are you sure you want to regenerate admin token? Enter 'yes' to confirm
          yes
          Failed to create token, error: ApiError { code: 401, message: "" }

        ```
      - regenerate admin token with token, it should work on the main http server
        ```
          ❯ ./target/debug/influxdb3 create token --admin --regenerate --host http://127.0.0.1:8181 --token apiv3_TfRmlFixgJiszXySJ5i-vqOcdVgK6jSPSnWfV--7si7cutWTm0h_MSFN4JUHh0shDpo6eCCCyaQrh9TXk3ZA1g
          Are you sure you want to regenerate admin token? Enter 'yes' to confirm
          yes

          New token created successfully!

          Token: apiv3_LtXc15zm_5Le3bD01hBeo7vC0Zb_-rmCsvN2X6nYllwaAqeBQglDK1TqLwao9C-DLyknVH-BV-EV2RBsMRs13A
          HTTP Requests Header: Authorization: Bearer apiv3_LtXc15zm_5Le3bD01hBeo7vC0Zb_-rmCsvN2X6nYllwaAqeBQglDK1TqLwao9C-DLyknVH-BV-EV2RBsMRs13A

          IMPORTANT: Store this token securely, as it will not be shown again.
        ```


- Create admin token and see if it can be regenerated using non-default `$host:$port`.
    - create admin token
      ```
        ❯ ./target/debug/influxdb3 create token --admin

        New token created successfully!

        Token: apiv3_65-K7ATO6sPtBu5L0C5RGitOxKmpZMinCgdUDfm5fPyRaxF5q_ldOgAp2-NqMGAMDiagbaRS5Mm4uw3mJ38OQg
        HTTP Requests Header: Authorization: Bearer apiv3_65-K7ATO6sPtBu5L0C5RGitOxKmpZMinCgdUDfm5fPyRaxF5q_ldOgAp2-NqMGAMDiagbaRS5Mm4uw3mJ38OQg

        IMPORTANT: Store this token securely, as it will not be shown again.
      ```

    - try regenerating admin token (note, when I started the server I passed in `--admin-token-recovery-http-bind 192.168.1.94:8181` so it expects the host to be passed in), default `127.0.0.1:8182` it uses fails (todo: make these errors display easy to read messages than the full error)

      ```
        ❯ ./target/debug/influxdb3 create token --admin --regenerate
        Are you sure you want to regenerate admin token? Enter 'yes' to confirm
        yes
        Failed to create token, error: RequestSend { method: POST, url: "http://127.0.0.1:8182/api/v3/configure/token/admin/regenerate", source: reqwest::Error { kind: Request, url: Url { scheme: "http", cannot_be_a_base: false, username: "", password: None, host: Some(Ipv4(127.0.0.1)), port: Some(8182), path: "/api/v3/configure/token/admin/regenerate", query: None, fragment: None }, source: hyper::Error(Connect, ConnectError("tcp connect error", Os { code: 111, kind: ConnectionRefused, message: "Connection refused" })) } }
      ```

    - run `--regenerate`, this time passing in `--host`

      ```
        ❯ ./target/debug/influxdb3 create token --admin --regenerate --host http://192.168.1.94:8181

        Are you sure you want to regenerate admin token? Enter 'yes' to confirm
        yes

        New token created successfully!

        Token: apiv3_Wyr7d-6rSXjT-peH7xkmY30HqjIjCShB9goXZ0eGdo1t_KgabehsnXE73V9LDY2peNVdwfDCeTHgPwXqE2ABVQ
        HTTP Requests Header: Authorization: Bearer apiv3_Wyr7d-6rSXjT-peH7xkmY30HqjIjCShB9goXZ0eGdo1t_KgabehsnXE73V9LDY2peNVdwfDCeTHgPwXqE2ABVQ

        IMPORTANT: Store this token securely, as it will not be shown again.
      ```

    - run `--regenerate` again with `--host http://192.168.1.94:8181` (it should fail as the recovery server is shutdown after successful regeneration)
      ```
        ❯ ./target/debug/influxdb3 create token --admin --regenerate --host http://192.168.1.94:8181

        Are you sure you want to regenerate admin token? Enter 'yes' to confirm
        yes
        Failed to create token, error: RequestSend { method: POST, url: "http://192.168.1.94:8181/api/v3/configure/token/admin/regenerate", source: reqwest::Error { kind: Request, url: Url { scheme: "http", cannot_be_a_base: false, username: "", password: None, host: Some(Ipv4(192.168.1.94)), port: Some(8181), path: "/api/v3/configure/token/admin/regenerate", query: None, fragment: None }, source: hyper::Error(Connect, ConnectError("tcp connect error", Os { code: 111, kind: ConnectionRefused, message: "Connection refused" })) } }
      ```

- Other endpoints are not accessible through this server, create db, table etc. returns a `404`
  ```
  ❯ ./target/debug/influxdb3 create database --host http://127.0.0.1:8182 foo
  Create command failed: server responded with error [404 Not Found]: not found


  ❯ ./target/debug/influxdb3 create table --host http://127.0.0.1:8182 --database foo bar
  Create command failed: server responded with error [404 Not Found]: not found
  ```
