### PR TITLE
chore: use influxdata-archive.key in docker/Dockerfile.ci

### DIFF
--- a/docker/Dockerfile.ci
+++ b/docker/Dockerfile.ci
@@ -43,7 +43,7 @@ ENV CURL_FLAGS="--proto =https --tlsv1.2 -sSf"
 # Install InfluxDB 2.0 OSS to enable integration tests of the influxdb2_client crate
 ENV INFLUXDB2_VERSION=2.0.4
 ENV INFLUXDB2_DOWNLOAD_BASE="https://dl.influxdata.com/influxdb/releases"
-RUN curl ${CURL_FLAGS} https://repos.influxdata.com/influxdata-archive_compat.key | gpg --import - \
+RUN curl ${CURL_FLAGS} https://repos.influxdata.com/influxdata-archive.key | gpg --import - \
     && curl ${CURL_FLAGS} -o influxdb2.tar.gz ${INFLUXDB2_DOWNLOAD_BASE}/influxdb2-${INFLUXDB2_VERSION}-linux-amd64.tar.gz \
     && curl ${CURL_FLAGS} -O ${INFLUXDB2_DOWNLOAD_BASE}/influxdb2-${INFLUXDB2_VERSION}-linux-amd64.tar.gz.asc \
     && gpg --verify influxdb2-${INFLUXDB2_VERSION}-linux-amd64.tar.gz.asc influxdb2.tar.gz \


### PR DESCRIPTION
https://www.influxdata.com/blog/linux-package-signing-key-rotation/ discusses the signing key rotation we did in 2023. We are getting to the point of having to rotate the key and this will assist in that work. Most docs and containers are still using the `influxdata-archive_compat.key` which was created for maximum compatibility, but it has limitations because it does not use the modern primary/subkey approach used by `influxdata-archive.key`. The compat key is required for very old systems like RHEL 7 (standard support ended in June 2024), Debian 9 (EOL in June 2022), Ubuntu 18.04 (standard support ended in April 2023).

RHEL 8, Debian 10 (buster; already EOL), Ubuntu 20.04 (standard support ended in April 2025), et al have new enough RPM and APT that supports `influxdata-archive.key`. While the `influxdata-archive_compat.key` isn't going away and we'll recreate it when we perform the key rotation, it is time to default to and document using `influxdata-archive.key` which will allow a better key rotation experience.

I verified with `docker build --build-arg RUST_VERSION="1.85" -f ./docker/Dockerfile.ci .` that the image still builds.