### PR TITLE
chore: backport visibility changes for system tables from PR #1031

### DIFF
--- a/influxdb3_server/src/system_tables/databases.rs
+++ b/influxdb3_server/src/system_tables/databases.rs
@@ -10,13 +10,13 @@ use influxdb3_catalog::log::RetentionPeriod;
 use iox_system_tables::IoxSystemTable;
 
 #[derive(Debug)]
-pub(super) struct DatabasesTable {
+pub(crate) struct DatabasesTable {
     catalog: Arc<Catalog>,
     schema: SchemaRef,
 }
 
 impl DatabasesTable {
-    pub(super) fn new(catalog: Arc<Catalog>) -> Self {
+    pub(crate) fn new(catalog: Arc<Catalog>) -> Self {
         Self {
             catalog,
             schema: databases_schema(),

--- a/influxdb3_server/src/system_tables/mod.rs
+++ b/influxdb3_server/src/system_tables/mod.rs
@@ -24,9 +24,9 @@ use self::{
     tables::TablesTable,
 };
 
-mod databases;
+pub(crate) mod databases;
 mod distinct_caches;
-mod generations;
+pub(crate) mod generations;
 mod influxdb_schema;
 mod last_caches;
 mod nodes;
@@ -40,8 +40,8 @@ use crate::system_tables::{
 };
 mod python_call;
 mod queries;
-mod tables;
-mod tokens;
+pub(crate) mod tables;
+pub(crate) mod tokens;
 
 pub(crate) const SYSTEM_SCHEMA_NAME: &str = "system";
 pub(crate) const TABLE_NAME_PREDICATE: &str = "table_name";

--- a/influxdb3_server/src/system_tables/tables.rs
+++ b/influxdb3_server/src/system_tables/tables.rs
@@ -9,13 +9,13 @@ use influxdb3_catalog::catalog::Catalog;
 use iox_system_tables::IoxSystemTable;
 
 #[derive(Debug)]
-pub(super) struct TablesTable {
+pub(crate) struct TablesTable {
     catalog: Arc<Catalog>,
     schema: SchemaRef,
 }
 
 impl TablesTable {
-    pub(super) fn new(catalog: Arc<Catalog>) -> Self {
+    pub(crate) fn new(catalog: Arc<Catalog>) -> Self {
         Self {
             catalog,
             schema: tables_schema(),


### PR DESCRIPTION
## Summary
This PR backports changes from [influxdb_pro PR #1031](https://github.com/influxdata/influxdb_pro/pull/1031) which fixes missing system tables in compact mode.

The changes modify the visibility of `DatabasesTable` and `TablesTable` from `pub(super)` to `pub(crate)` to allow them to be used in other modules, specifically in the enterprise compact mode implementation.

## Test plan
- [x] All tests pass (`cargo nextest run --workspace --no-fail-fast`)
- [x] No clippy warnings (`cargo clippy`)
- [x] Code is properly formatted (`cargo fmt --all`)