### PR TITLE
test: Allow passing git hash via environment variable in build.rs

### DIFF
--- a/influxdb3_process/build.rs
+++ b/influxdb3_process/build.rs
@@ -32,29 +32,40 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 }
 
 fn get_git_hash() -> String {
-    let git_hash = {
-        let output = Command::new("git")
-            // We used `git describe`, but when you tag a build the commit hash goes missing when
-            // using describe. So, switching it to use `rev-parse` which is consistent with the
-            // `get_git_hash_short` below as well.
-            //
-            // And we already have cargo version appearing as a separate string so using `git
-            // describe` looks redundant on tagged release builds
-            .args(["rev-parse", "HEAD"])
-            .output()
-            .expect("failed to execute git rev-parse to read the current git hash");
+    let out = match std::env::var("GIT_HASH") {
+        Ok(v) => v,
+        Err(_) => {
+            let output = Command::new("git")
+                // We used `git describe`, but when you tag a build the commit hash goes missing when
+                // using describe. So, switching it to use `rev-parse` which is consistent with the
+                // `get_git_hash_short` below as well.
+                //
+                // And we already have cargo version appearing as a separate string so using `git
+                // describe` looks redundant on tagged release builds
+                .args(["rev-parse", "HEAD"])
+                .output()
+                .expect("failed to execute git rev-parse to read the current git hash");
 
-        String::from_utf8(output.stdout).expect("non-utf8 found in git hash")
+            String::from_utf8(output.stdout).expect("non-utf8 found in git hash")
+        }
     };
 
-    assert!(!git_hash.is_empty(), "attempting to embed empty git hash");
-    git_hash
+    assert!(!out.is_empty(), "attempting to embed empty git hash");
+    out
 }
 
 fn get_git_hash_short() -> String {
-    let output = Command::new("git")
-        .args(["rev-parse", "--short", "HEAD"])
-        .output()
-        .expect("failed to execute git rev-parse to read the current git hash");
-    String::from_utf8(output.stdout).expect("non-utf8 found in git hash")
+    let out = match std::env::var("GIT_HASH_SHORT") {
+        Ok(v) => v,
+        Err(_) => {
+            let output = Command::new("git")
+                .args(["rev-parse", "--short", "HEAD"])
+                .output()
+                .expect("failed to execute git rev-parse to read the current git hash");
+            String::from_utf8(output.stdout).expect("non-utf8 found in git hash")
+        }
+    };
+
+    assert!(!out.is_empty(), "attempting to embed empty git hash");
+    out
 }


### PR DESCRIPTION
Testing CI for changes from #26618

Opening from main repo to trigger full CI suite that doesn't run on forks.

Original PR: https://github.com/influxdata/influxdb/pull/26618