### PR TITLE
feat: Adds LastModifiedOrErr to expose error for LastModified

### DIFF
--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -459,19 +459,14 @@ func (s *Shard) ready() error {
 }
 
 // LastModified returns the time when this shard was last modified.
+// On error and 0 TSM files this will return time.Time{} (0001-01-01 00:00:00 +0000 UTC)
 func (s *Shard) LastModified() time.Time {
-	t, err := s.LastModifiedOrErr()
-	if err != nil {
-		return time.Time{}
-	}
-
+	t, _ := s.LastModifiedWithErr()
 	return t
 }
 
-// LastModifiedOrErr returns the time when this shard was last modified or an error.
-// See: https://github.com/influxdata/plutonium/pull/4275#discussion_r2214077374
-// Previously we would throw away any error from Shard.LastModified
-func (s *Shard) LastModifiedOrErr() (time.Time, error) {
+// LastModifiedOrErr returns the time when this shard was last modified and an error.
+func (s *Shard) LastModifiedWithErr() (time.Time, error) {
 	engine, err := s.Engine()
 	if err != nil {
 		return time.Time{}, err

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -479,15 +479,6 @@ func (s *Shard) LastModifiedOrErr() (time.Time, error) {
 	return engine.LastModified(), nil
 }
 
-// SetLastModified updates the last modified time for this shard.
-func (s *Shard) SetLastModified(t time.Time) error {
-	engine, err := s.Engine()
-	if err != nil {
-		return err
-	}
-	return engine.SetLastModified(t)
-}
-
 // Index returns a reference to the underlying index. It returns an error if
 // the index is nil.
 func (s *Shard) Index() (Index, error) {

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -460,11 +460,32 @@ func (s *Shard) ready() error {
 
 // LastModified returns the time when this shard was last modified.
 func (s *Shard) LastModified() time.Time {
-	engine, err := s.Engine()
+	t, err := s.LastModifiedOrErr()
 	if err != nil {
 		return time.Time{}
 	}
-	return engine.LastModified()
+
+	return t
+}
+
+// LastModifiedOrErr returns the time when this shard was last modified or an error.
+// See: https://github.com/influxdata/plutonium/pull/4275#discussion_r2214077374
+// Previously we would throw away any error from Shard.LastModified
+func (s *Shard) LastModifiedOrErr() (time.Time, error) {
+	engine, err := s.Engine()
+	if err != nil {
+		return time.Time{}, err
+	}
+	return engine.LastModified(), nil
+}
+
+// SetLastModified updates the last modified time for this shard.
+func (s *Shard) SetLastModified(t time.Time) error {
+	engine, err := s.Engine()
+	if err != nil {
+		return err
+	}
+	return engine.SetLastModified(t)
 }
 
 // Index returns a reference to the underlying index. It returns an error if


### PR DESCRIPTION
Currently we do not expose the error thrown by Shard.LastModified, this PR will add `Shard.LastModifiedOrErr` which will expose the actual error when it's called. 
