### PR TITLE
feat: Adds 'config' to 'debug/vars' http endpoint

### DIFF
--- a/cmd/influx_tools/main.go
+++ b/cmd/influx_tools/main.go
@@ -137,7 +137,7 @@ func (s *ossServer) Close() {
 }
 
 func (s *ossServer) MetaClient() server.MetaClient { return s.mc }
-func (s *ossServer) TSDBConfig() *tsdb.Config      { return s.config.Data }
+func (s *ossServer) TSDBConfig() tsdb.Config       { return s.config.Data }
 func (s *ossServer) Logger() *zap.Logger           { return s.logger }
 func (s *ossServer) NodeID() uint64                { return 0 }
 

--- a/cmd/influx_tools/main.go
+++ b/cmd/influx_tools/main.go
@@ -137,7 +137,7 @@ func (s *ossServer) Close() {
 }
 
 func (s *ossServer) MetaClient() server.MetaClient { return s.mc }
-func (s *ossServer) TSDBConfig() tsdb.Config       { return s.config.Data }
+func (s *ossServer) TSDBConfig() *tsdb.Config      { return s.config.Data }
 func (s *ossServer) Logger() *zap.Logger           { return s.logger }
 func (s *ossServer) NodeID() uint64                { return 0 }
 

--- a/cmd/influxd/run/server.go
+++ b/cmd/influxd/run/server.go
@@ -199,7 +199,7 @@ func NewServer(c *Config, buildInfo *BuildInfo) (*Server, error) {
 
 		config: c,
 	}
-	s.Monitor = monitor.New(s, c.Monitor)
+	s.Monitor = monitor.New(s, c.Monitor, &c.Data)
 	s.config.registerDiagnostics(s.Monitor)
 
 	if err := s.MetaClient.Open(); err != nil {

--- a/monitor/build_info_test.go
+++ b/monitor/build_info_test.go
@@ -5,10 +5,11 @@ import (
 	"testing"
 
 	"github.com/influxdata/influxdb/monitor"
+	"github.com/influxdata/influxdb/tsdb"
 )
 
 func TestDiagnostics_BuildInfo(t *testing.T) {
-	s := monitor.New(nil, monitor.Config{})
+	s := monitor.New(nil, monitor.Config{}, &tsdb.Config{})
 	s.Version = "1.2.0"
 	s.Commit = "b7bb7e8359642b6e071735b50ae41f5eb343fd42"
 	s.Branch = "1.2"

--- a/monitor/go_runtime_test.go
+++ b/monitor/go_runtime_test.go
@@ -6,10 +6,11 @@ import (
 	"testing"
 
 	"github.com/influxdata/influxdb/monitor"
+	"github.com/influxdata/influxdb/tsdb"
 )
 
 func TestDiagnostics_GoRuntime(t *testing.T) {
-	s := monitor.New(nil, monitor.Config{})
+	s := monitor.New(nil, monitor.Config{}, &tsdb.Config{})
 	if err := s.Open(); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}

--- a/monitor/network_test.go
+++ b/monitor/network_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/influxdata/influxdb/monitor"
+	"github.com/influxdata/influxdb/tsdb"
 )
 
 func TestDiagnostics_Network(t *testing.T) {
@@ -14,7 +15,7 @@ func TestDiagnostics_Network(t *testing.T) {
 		t.Fatalf("unexpected error retrieving hostname: %s", err)
 	}
 
-	s := monitor.New(nil, monitor.Config{})
+	s := monitor.New(nil, monitor.Config{}, &tsdb.Config{})
 	if err := s.Open(); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}

--- a/monitor/service_test.go
+++ b/monitor/service_test.go
@@ -15,12 +15,13 @@ import (
 	"github.com/influxdata/influxdb/monitor"
 	"github.com/influxdata/influxdb/services/meta"
 	"github.com/influxdata/influxdb/toml"
+	"github.com/influxdata/influxdb/tsdb"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest/observer"
 )
 
 func TestMonitor_Open(t *testing.T) {
-	s := monitor.New(nil, monitor.Config{})
+	s := monitor.New(nil, monitor.Config{}, &tsdb.Config{})
 	if err := s.Open(); err != nil {
 		t.Fatalf("unexpected open error: %s", err)
 	}
@@ -48,7 +49,7 @@ func TestMonitor_SetPointsWriter_StoreEnabled(t *testing.T) {
 	}
 
 	config := monitor.NewConfig()
-	s := monitor.New(nil, config)
+	s := monitor.New(nil, config, &tsdb.Config{})
 	s.MetaClient = &mc
 	core, logs := observer.New(zap.DebugLevel)
 	s.WithLogger(zap.New(core))
@@ -67,7 +68,7 @@ func TestMonitor_SetPointsWriter_StoreEnabled(t *testing.T) {
 }
 
 func TestMonitor_SetPointsWriter_StoreDisabled(t *testing.T) {
-	s := monitor.New(nil, monitor.Config{})
+	s := monitor.New(nil, monitor.Config{}, &tsdb.Config{})
 	core, logs := observer.New(zap.DebugLevel)
 	s.WithLogger(zap.New(core))
 
@@ -134,7 +135,7 @@ func TestMonitor_StoreStatistics(t *testing.T) {
 
 	config := monitor.NewConfig()
 	config.StoreInterval = toml.Duration(10 * time.Millisecond)
-	s := monitor.New(nil, config)
+	s := monitor.New(nil, config, &tsdb.Config{})
 	s.MetaClient = &mc
 	s.PointsWriter = &pw
 
@@ -210,7 +211,7 @@ func TestMonitor_Reporter(t *testing.T) {
 
 	config := monitor.NewConfig()
 	config.StoreInterval = toml.Duration(10 * time.Millisecond)
-	s := monitor.New(reporter, config)
+	s := monitor.New(reporter, config, &tsdb.Config{})
 	s.MetaClient = &mc
 	s.PointsWriter = &pw
 
@@ -306,7 +307,7 @@ func TestMonitor_Expvar(t *testing.T) {
 
 	config := monitor.NewConfig()
 	config.StoreInterval = toml.Duration(10 * time.Millisecond)
-	s := monitor.New(nil, config)
+	s := monitor.New(nil, config, &tsdb.Config{})
 	s.MetaClient = &mc
 	s.PointsWriter = &pw
 
@@ -400,7 +401,7 @@ func TestMonitor_QuickClose(t *testing.T) {
 	var pw PointsWriter
 	config := monitor.NewConfig()
 	config.StoreInterval = toml.Duration(24 * time.Hour)
-	s := monitor.New(nil, config)
+	s := monitor.New(nil, config, &tsdb.Config{})
 	s.MetaClient = &mc
 	s.PointsWriter = &pw
 

--- a/monitor/system_test.go
+++ b/monitor/system_test.go
@@ -7,10 +7,11 @@ import (
 	"time"
 
 	"github.com/influxdata/influxdb/monitor"
+	"github.com/influxdata/influxdb/tsdb"
 )
 
 func TestDiagnostics_System(t *testing.T) {
-	s := monitor.New(nil, monitor.Config{})
+	s := monitor.New(nil, monitor.Config{}, &tsdb.Config{})
 	if err := s.Open(); err != nil {
 		t.Fatalf("unexpected error: %s", err)
 	}

--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -2305,13 +2305,13 @@ func (h *Handler) serveExpvar(w http.ResponseWriter, r *http.Request) {
 			h.httpError(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
-		
+
 		data, err := json.Marshal(jv)
 		if err != nil {
 			h.httpError(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
-		
+
 		if !first {
 			fmt.Fprintln(w, ",")
 		}
@@ -2597,7 +2597,7 @@ func parseConfigDiagnostics(d *diagnostics.Diagnostics) (map[string]interface{},
 		if i >= len(d.Rows[0]) {
 			continue
 		}
-		
+
 		val := d.Rows[0][i]
 		switch v := val.(type) {
 		case toml.Size:
@@ -2608,7 +2608,7 @@ func parseConfigDiagnostics(d *diagnostics.Diagnostics) (map[string]interface{},
 			m[col] = v
 		}
 	}
-	
+
 	return m, nil
 }
 

--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -2313,10 +2313,18 @@ func (h *Handler) serveExpvar(w http.ResponseWriter, r *http.Request) {
 		}
 
 		if !first {
-			fmt.Fprintln(w, ",")
+			_, err := fmt.Fprintln(w, ",")
+			if err != nil {
+				h.httpError(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
 		}
 		first = false
-		fmt.Fprintf(w, "\"config\": %s", data)
+		_, err = fmt.Fprintf(w, "\"config\": %s", data)
+		if err != nil {
+			h.httpError(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
 	}
 
 	// We're going to print some kind of crypto data, we just

--- a/tsdb/config.go
+++ b/tsdb/config.go
@@ -286,5 +286,8 @@ func (c Config) Diagnostics() (*diagnostics.Diagnostics, error) {
 		"max-index-log-file-size":                c.MaxIndexLogFileSize,
 		"series-id-set-cache-size":               c.SeriesIDSetCacheSize,
 		"series-file-max-concurrent-compactions": c.SeriesFileMaxConcurrentSnapshotCompactions,
+		"aggressive-points-per-block":            c.AggressivePointsPerBlock,
+		"compact-throughput":                     c.CompactThroughput,
+		"compact-throughput-burst":               c.CompactThroughputBurst,
 	}), nil
 }


### PR DESCRIPTION
* Adds new field to debug/vars which includes various configuration information about a data node\ Example output:
```
    "config": {
        "aggressive-points-per-block": 10000,
        "cache-max-memory-size": 1073741824,
        "cache-snapshot-memory-size": 26214400,
        "cache-snapshot-write-cold-duration": "10m0s",
        "compact-full-write-cold-duration": "4h0m0s",
        "compact-throughput": 50331648,
        "compact-throughput-burst": 50331648,
        "dir": "/home/foo/.influxdb/data",
        "max-concurrent-compactions": 0,
        "max-index-log-file-size": 1048576,
        "max-series-per-database": 1000000,
        "max-values-per-tag": 100000,
        "series-file-max-concurrent-compactions": 0,
        "series-id-set-cache-size": 100,
        "strict-error-handling": false,
        "wal-dir": "/home/foo/.influxdb/wal",
        "wal-fsync-delay": "0s"
    },
```

