### PR TITLE
feat(influx_tools): report more than one error type (#26600)

### DIFF
--- a/cmd/influx_tools/parquet/exporter.go
+++ b/cmd/influx_tools/parquet/exporter.go
@@ -1,0 +1,511 @@
+package parquet
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"text/tabwriter"
+	"time"
+
+	"github.com/apache/arrow/go/v16/arrow"
+	"github.com/apache/arrow/go/v16/arrow/array"
+	"github.com/apache/arrow/go/v16/parquet"
+	"github.com/apache/arrow/go/v16/parquet/pqarrow"
+	"go.uber.org/zap"
+
+	"github.com/influxdata/flux/memory"
+	"github.com/influxdata/influxdb/cmd/influx_tools/server"
+	"github.com/influxdata/influxdb/models"
+	internal_errors "github.com/influxdata/influxdb/pkg/errors"
+	"github.com/influxdata/influxdb/services/meta"
+	"github.com/influxdata/influxdb/tsdb"
+	"github.com/influxdata/influxql"
+)
+
+type config struct {
+	Database        string
+	RP              string
+	Measurements    string
+	TypeResolutions string
+	NameResolutions string
+	Output          string
+}
+
+type exporter struct {
+	client server.MetaClient
+	store  *tsdb.Store
+
+	// Input selection
+	db, rp       string
+	measurements []string
+
+	// Output file settings
+	path      string
+	filenames map[string]int
+
+	// Source data and corresponding information
+	groups    []meta.ShardGroupInfo
+	startDate time.Time
+	endDate   time.Time
+	shards    []*tsdb.Shard
+
+	// Schema information and resolutions
+	schemata        map[string]*schemaCreator
+	typeResolutions map[string]map[string]influxql.DataType
+	nameResolutions map[string]map[string]string
+
+	// Parquet metadata information
+	exportStart time.Time
+
+	logger *zap.SugaredLogger
+}
+
+func newExporter(server server.Interface, cfg *config, logger *zap.Logger) (*exporter, error) {
+	client := server.MetaClient()
+
+	db := client.Database(cfg.Database)
+	if db == nil {
+		return nil, fmt.Errorf("database %q does not exist", cfg.Database)
+	}
+
+	if cfg.RP == "" {
+		cfg.RP = db.DefaultRetentionPolicy
+	}
+
+	rp, err := client.RetentionPolicy(cfg.Database, cfg.RP)
+	if rp == nil || err != nil {
+		return nil, fmt.Errorf("retention policy %q does not exist", cfg.RP)
+	}
+
+	store := tsdb.NewStore(server.TSDBConfig().Dir)
+	if server.Logger() != nil {
+		store.WithLogger(server.Logger())
+	}
+	store.EngineOptions.MonitorDisabled = true
+	store.EngineOptions.CompactionDisabled = true
+	store.EngineOptions.Config = server.TSDBConfig()
+	store.EngineOptions.EngineVersion = server.TSDBConfig().Engine
+	store.EngineOptions.IndexVersion = server.TSDBConfig().Index
+	store.EngineOptions.DatabaseFilter = func(database string) bool {
+		return database == cfg.Database
+	}
+	store.EngineOptions.RetentionPolicyFilter = func(_, rpolicy string) bool {
+		return rpolicy == cfg.RP
+	}
+
+	// Create the exporter
+	e := &exporter{
+		client:          client,
+		store:           store,
+		db:              cfg.Database,
+		rp:              cfg.RP,
+		path:            cfg.Output,
+		typeResolutions: make(map[string]map[string]influxql.DataType),
+		nameResolutions: make(map[string]map[string]string),
+		filenames:       make(map[string]int),
+		logger:          logger.Sugar().Named("exporter"),
+	}
+
+	// Split the given measurements
+	if cfg.Measurements != "" && cfg.Measurements != "*" {
+		e.measurements = strings.Split(cfg.Measurements, ",")
+	}
+
+	// Prepare type resolutions
+	if cfg.TypeResolutions != "" {
+		for _, r := range strings.Split(cfg.TypeResolutions, ",") {
+			field, ftype, found := strings.Cut(r, "=")
+			if !found {
+				return nil, fmt.Errorf("invalid format in type conflict resolution %q", r)
+			}
+			measurement, field, found := strings.Cut(field, ".")
+			if !found {
+				return nil, fmt.Errorf("invalid measurement in type conflict resolution %q", r)
+			}
+			if _, exists := e.typeResolutions[measurement]; !exists {
+				e.typeResolutions[measurement] = make(map[string]influxql.DataType)
+			}
+
+			switch strings.ToLower(ftype) {
+			case "float":
+				e.typeResolutions[measurement][field] = influxql.Float
+			case "int":
+				e.typeResolutions[measurement][field] = influxql.Integer
+			case "uint":
+				e.typeResolutions[measurement][field] = influxql.Unsigned
+			case "bool":
+				e.typeResolutions[measurement][field] = influxql.Boolean
+			case "string":
+				e.typeResolutions[measurement][field] = influxql.String
+			default:
+				return nil, fmt.Errorf("invalid type in conflict resolution %q", r)
+			}
+		}
+	}
+
+	// Prepare name resolutions
+	if cfg.NameResolutions != "" {
+		for _, r := range strings.Split(cfg.NameResolutions, ",") {
+			field, name, found := strings.Cut(r, "=")
+			if !found {
+				return nil, fmt.Errorf("invalid format in name conflict resolution %q", r)
+			}
+			measurement, field, found := strings.Cut(field, ".")
+			if !found {
+				return nil, fmt.Errorf("invalid measurement in name conflict resolution %q", r)
+			}
+			if _, exists := e.nameResolutions[measurement]; !exists {
+				e.nameResolutions[measurement] = make(map[string]string)
+			}
+			e.nameResolutions[measurement][field] = name
+		}
+	}
+	return e, nil
+}
+
+func (e *exporter) open(ctx context.Context) error {
+	if err := e.store.Open(); err != nil {
+		return err
+	}
+
+	// Determine all shard groups in the database
+	min := time.Unix(0, models.MinNanoTime)
+	max := time.Unix(0, models.MaxNanoTime)
+	groups, err := e.client.NodeShardGroupsByTimeRange(e.db, e.rp, min, max)
+	if err != nil {
+		return err
+	}
+
+	if len(groups) == 0 {
+		return nil
+	}
+
+	sort.Sort(meta.ShardGroupInfos(groups))
+	e.startDate = groups[0].StartTime
+	e.endDate = groups[len(groups)-1].EndTime
+	e.groups = groups
+
+	// Collect all shards
+	for _, grp := range groups {
+		ids := make([]uint64, 0, len(grp.Shards))
+		for _, s := range grp.Shards {
+			ids = append(ids, s.ID)
+		}
+		e.shards = append(e.shards, e.store.Shards(ids)...)
+	}
+
+	// Determine all measurements in all shards
+	if len(e.measurements) == 0 {
+		measurements := make(map[string]bool)
+		for _, shard := range e.shards {
+			if err := shard.ForEachMeasurementName(func(name []byte) error {
+				measurements[string(name)] = true
+				return nil
+			}); err != nil {
+				return fmt.Errorf("getting measurement names failed: %w", err)
+			}
+		}
+		for m := range measurements {
+			e.measurements = append(e.measurements, m)
+		}
+	}
+	sort.Strings(e.measurements)
+
+	// Collect the schemata for all measurments
+	e.schemata = make(map[string]*schemaCreator, len(e.measurements))
+	for _, m := range e.measurements {
+		creator := &schemaCreator{
+			measurement:     m,
+			shards:          e.shards,
+			series:          make(map[uint64][]seriesEntry, len(e.shards)),
+			typeResolutions: e.typeResolutions[m],
+			nameResolutions: e.nameResolutions[m],
+		}
+		if err := creator.extractSchema(ctx); err != nil {
+			return fmt.Errorf("extracting schema for measurement %q failed: %w", m, err)
+		}
+		e.schemata[m] = creator
+	}
+
+	return nil
+}
+
+func (e *exporter) close() error {
+	return e.store.Close()
+}
+
+func (e *exporter) printPlan(w io.Writer) {
+	tw := tabwriter.NewWriter(w, 10, 8, 1, '\t', 0)
+
+	fmt.Fprintf(w, "Exporting source data from %s to %s in %d shard group(s):\n", e.startDate, e.endDate, len(e.groups))
+	fmt.Fprintln(tw, "  Group\tStart\tEnd\t#Shards")
+	fmt.Fprintln(tw, "  -----\t-----\t---\t-------")
+	for _, g := range e.groups {
+		fmt.Fprintf(tw, "  %d\t%s\t%s\t%d\n", g.ID, g.StartTime, g.EndTime, len(g.Shards))
+	}
+	fmt.Fprintln(tw)
+
+	fmt.Fprintf(w, "Creating the following schemata for %d measurement(s):\n", len(e.measurements))
+	for _, measurement := range e.measurements {
+		creator := e.schemata[measurement]
+		hasConflicts, errs := creator.validate()
+		if len(errs) > 0 {
+			fmt.Fprintf(
+				w,
+				"! Measurement %q with conflict(s) in %d tag(s), %d field(s):\n",
+				measurement,
+				len(creator.tags),
+				len(creator.fieldKeys),
+			)
+		} else if hasConflicts {
+			fmt.Fprintf(
+				w,
+				"* Measurement %q with resolved conflicts in %d tag(s), %d field(s):\n",
+				measurement,
+				len(creator.tags),
+				len(creator.fieldKeys),
+			)
+		} else {
+			fmt.Fprintf(
+				w,
+				"  Measurement %q with %d tag(s) and  %d field(s):\n",
+				measurement,
+				len(creator.tags),
+				len(creator.fieldKeys),
+			)
+
+		}
+		fmt.Fprintln(tw, "    Column\tKind\tDatatype")
+		fmt.Fprintln(tw, "    ------\t----\t--------")
+		fmt.Fprintln(tw, "    time\ttimestamp\ttimestamp (nanosecond)")
+		for _, name := range creator.tags {
+			fmt.Fprintf(tw, "    %s\ttag\tstring\n", name)
+		}
+		for _, name := range creator.fieldKeys {
+			ftype := creator.fields[name].String()
+			if types, found := creator.conflicts[name]; found {
+				parts := make([]string, 0, len(types))
+				for _, t := range types {
+					parts = append(parts, t.String())
+				}
+				ftype = strings.Join(parts, "|")
+				if rftype, found := creator.typeResolutions[name]; found {
+					ftype += " -> " + rftype.String()
+				}
+			}
+			fname := name
+			if n, found := creator.nameResolutions[name]; found {
+				fname += " -> " + n
+			}
+			fmt.Fprintf(tw, "    %s\tfield\t%s\n", fname, ftype)
+		}
+		for _, err := range errs {
+			fmt.Fprintln(tw, " ", err)
+		}
+		fmt.Fprintln(tw)
+	}
+
+	tw.Flush()
+}
+
+func (e *exporter) export(ctx context.Context) error {
+	// Check if the schema has unresolved conflicts
+	for m, s := range e.schemata {
+		if _, errs := s.validate(); len(errs) > 0 {
+			err := errors.Join(errs...)
+			return fmt.Errorf("%w in schema of measurement %q", err, m)
+		}
+	}
+
+	// Create the export directory if it doesn't exist
+	if err := os.MkdirAll(e.path, 0700); err != nil {
+		return fmt.Errorf("creating directory %q failed: %w", e.path, err)
+	}
+
+	// Export shard-wise
+	e.exportStart = time.Now()
+	e.logger.Info("Starting export...")
+	for _, shard := range e.shards {
+		start := time.Now()
+		e.logger.Infof("Starting export of shard %d...", shard.ID())
+
+		for _, m := range e.measurements {
+			if err := e.exportMeasurement(ctx, shard, m); err != nil {
+				path := "unknown"
+				if f, serr := shard.SeriesFile(); serr != nil {
+					e.logger.Errorf("determining series file failed: %v", serr)
+				} else {
+					path = f.Path()
+				}
+				return fmt.Errorf("exporting measurement %q in shard %d at %q failed: %w", m, shard.ID(), path, err)
+			}
+		}
+		e.logger.Infof("Finished export of shard %d in %v...", shard.ID(), time.Since(start))
+	}
+	e.logger.Infof("Finished export in %v...", time.Since(e.exportStart))
+
+	return nil
+}
+
+func (e *exporter) exportMeasurement(ctx context.Context, shard *tsdb.Shard, measurement string) (err error) {
+	startMeasurement := time.Now()
+
+	// Get the cumulative scheme with all tags and fields for the measurement
+	creator, found := e.schemata[measurement]
+	if !found {
+		return errors.New("no schema creator found")
+	}
+
+	if len(creator.fieldKeys) == 0 {
+		e.logger.Warnf("  Skipping measurement %q without fields", measurement)
+		return nil
+	}
+
+	// Create a batch processor
+	batcher := &batcher{
+		measurement:     []byte(measurement),
+		shard:           shard,
+		series:          creator.series[shard.ID()],
+		typeResolutions: creator.typeResolutions,
+		nameResolutions: creator.nameResolutions,
+		start:           models.MinNanoTime,
+		logger:          e.logger.Named("batcher"),
+	}
+	if err := batcher.init(); err != nil {
+		return fmt.Errorf("creating batcher failed: %w", err)
+	}
+
+	// Check if we do have data for the measurement and skip the shard if
+	// that's not the case
+	rows, err := batcher.next(ctx)
+	if err != nil {
+		return fmt.Errorf("checking data failed: %w", err)
+	}
+	if len(rows) == 0 {
+		e.logger.Warnf("  Skipping measurement %q without data", measurement)
+		return nil
+	}
+	batcher.reset()
+
+	e.logger.Infof("  Exporting measurement %q...", measurement)
+
+	// Create a parquet schema for writing the data
+	metadata := map[string]string{
+		"export":      e.exportStart.Format(time.RFC3339),
+		"database":    e.db,
+		"retention":   e.rp,
+		"measurement": measurement,
+		"shard":       strconv.FormatUint(shard.ID(), 10),
+		"start_time":  e.startDate.Format(time.RFC3339Nano),
+		"end_time":    e.endDate.Format(time.RFC3339Nano),
+	}
+	schema, err := creator.schema(metadata)
+	if err != nil {
+		return fmt.Errorf("creating arrow schema failed: %w", err)
+	}
+
+	// Create parquet file with a increasing sequence number per measurement
+	filename := filepath.Join(
+		e.path,
+		fmt.Sprintf("%s-%05d.parquet", measurement, e.filenames[measurement]),
+	)
+	e.filenames[measurement]++
+	file, err := os.Create(filename)
+	if err != nil {
+		return fmt.Errorf("creating file %q failed: %w", filename, err)
+	}
+
+	writer, err := pqarrow.NewFileWriter(
+		schema,
+		file,
+		parquet.NewWriterProperties(parquet.WithCreatedBy("influx_tools")),
+		pqarrow.NewArrowWriterProperties(pqarrow.WithCoerceTimestamps(arrow.Nanosecond)),
+	)
+	if err != nil {
+		if err := file.Close(); err != nil {
+			e.logger.Errorf("closing file failed: %v", err)
+		}
+		return fmt.Errorf("creating parquet writer for file %q failed: %w", filename, err)
+	}
+	defer internal_errors.Capture(&err, writer.Close)()
+
+	// Prepare the record builder
+	builder := array.NewRecordBuilder(memory.DefaultAllocator, schema)
+	defer builder.Release()
+
+	// Process the data in batches
+	var count int
+	for {
+		last := time.Now()
+
+		// Read the next batch
+		rows, err := batcher.next(ctx)
+		if err != nil {
+			return fmt.Errorf("reading batch failed: %w", err)
+		}
+		if len(rows) == 0 {
+			break
+		}
+		count += len(rows)
+
+		// Convert the data to an arrow representation
+		record := e.convertData(rows, builder, creator.tags, creator.fieldKeys)
+
+		// Write data
+		if err := writer.Write(record); err != nil {
+			return fmt.Errorf("writing parquet file %q failed: %w", filename, err)
+		}
+		e.logger.Infof("    exported %d rows in %v", len(rows), time.Since(last))
+	}
+	e.logger.Infof(
+		"  exported %d rows of measurement %q to %q in %v...",
+		count,
+		measurement,
+		filename,
+		time.Since(startMeasurement),
+	)
+
+	return nil
+}
+
+func (e *exporter) convertData(rows []row, builder *array.RecordBuilder, tags, fields []string) arrow.Record {
+	for _, r := range rows {
+		builder.Field(0).(*array.TimestampBuilder).Append(arrow.Timestamp(r.timestamp))
+		base := 1
+		for i, k := range tags {
+			if v, found := r.tags[k]; found {
+				builder.Field(base + i).(*array.StringBuilder).Append(v)
+			} else {
+				builder.Field(base + i).AppendNull()
+			}
+		}
+		base = len(tags) + 1
+		for i, k := range fields {
+			v, found := r.fields[k]
+			if !found {
+				builder.Field(base + i).AppendNull()
+				continue
+			}
+			switch b := builder.Field(base + i).(type) {
+			case *array.Float64Builder:
+				b.Append(v.(float64))
+			case *array.Int64Builder:
+				b.Append(v.(int64))
+			case *array.Uint64Builder:
+				b.Append(v.(uint64))
+			case *array.StringBuilder:
+				b.Append(v.(string))
+			case *array.BooleanBuilder:
+				b.Append(v.(bool))
+			}
+		}
+	}
+
+	return builder.NewRecord()
+}

--- a/cmd/influx_tools/parquet/schema.go
+++ b/cmd/influx_tools/parquet/schema.go
@@ -1,0 +1,276 @@
+package parquet
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/apache/arrow/go/v16/arrow"
+
+	"github.com/influxdata/influxdb/models"
+	"github.com/influxdata/influxdb/pkg/errors"
+	"github.com/influxdata/influxdb/tsdb"
+	"github.com/influxdata/influxql"
+)
+
+type seriesEntry struct {
+	key    string
+	tags   models.Tags
+	fields map[string]influxql.DataType
+}
+
+type schemaCreator struct {
+	measurement string
+	shards      []*tsdb.Shard
+
+	series map[uint64][]seriesEntry
+
+	tags      []string
+	fields    map[string]influxql.DataType
+	fieldKeys []string
+	conflicts map[string][]influxql.DataType
+
+	typeResolutions map[string]influxql.DataType
+	nameResolutions map[string]string
+}
+
+func (s *schemaCreator) extractSchema(ctx context.Context) (err error) {
+	// Iterate over the shards and extract all series
+	for _, shard := range s.shards {
+		// Extract all fields of the measurement
+		fields := shard.MeasurementFields([]byte(s.measurement)).FieldSet()
+		if len(fields) == 0 {
+			continue
+		}
+
+		// Collect all available series in the shard and measurement and store
+		// them for later use and series accumulation
+		seriesCursor, err := shard.CreateSeriesCursor(
+			ctx,
+			tsdb.SeriesCursorRequest{},
+			influxql.MustParseExpr("_name = '"+s.measurement+"'"),
+		)
+		if err != nil {
+			return fmt.Errorf("getting series cursor failed: %w", err)
+		}
+		defer errors.Capture(&err, seriesCursor.Close)()
+
+		for {
+			cur, err := seriesCursor.Next()
+			if err != nil {
+				return fmt.Errorf("advancing series cursor failed: %w", err)
+			}
+			if cur == nil {
+				break
+			}
+			mname := string(cur.Name)
+			if mname != s.measurement {
+				continue
+			}
+
+			s.series[shard.ID()] = append(s.series[shard.ID()], seriesEntry{
+				key:    s.measurement + "." + string(cur.Tags.HashKey(true)),
+				tags:   cur.Tags.Clone(),
+				fields: fields,
+			})
+		}
+	}
+
+	// Collect all tags and fields for creating the overall schema
+	tags := make(map[string]bool)
+	conflicts := make(map[string]map[influxql.DataType]bool)
+	s.fields = make(map[string]influxql.DataType)
+	for _, series := range s.series {
+		for _, serie := range series {
+			// Dedup tag keys
+			for _, tag := range serie.tags {
+				tags[string(tag.Key)] = true
+			}
+			// Detect field type conflicts and collect the fields
+			for name, current := range serie.fields {
+				if existing, found := s.fields[name]; found && current != existing {
+					if _, exists := conflicts[name]; !exists {
+						conflicts[name] = make(map[influxql.DataType]bool)
+					}
+					conflicts[name][current] = true
+					conflicts[name][existing] = true
+				}
+				s.fields[name] = current
+			}
+		}
+	}
+
+	// Apply the type resolutions
+	for name, ftype := range s.typeResolutions {
+		if _, found := s.fields[name]; !found {
+			continue
+		}
+		s.fields[name] = ftype
+	}
+
+	// Boil down all tags, fields and conflicts for later reuse
+	s.tags = make([]string, 0, len(tags))
+	for name := range tags {
+		s.tags = append(s.tags, name)
+	}
+	sort.Strings(s.tags)
+
+	s.fieldKeys = make([]string, 0, len(s.fields))
+	for name, ftype := range s.fields {
+		// Detect unconvertible fields
+		switch ftype {
+		case influxql.Float, influxql.Integer, influxql.String, influxql.Boolean, influxql.Unsigned:
+			// Accepted type
+			s.fieldKeys = append(s.fieldKeys, name)
+		default:
+			// Unconvertible type
+			return fmt.Errorf("unconvertible field %q with type %v", name, ftype)
+		}
+	}
+	sort.Strings(s.fieldKeys)
+
+	s.conflicts = make(map[string][]influxql.DataType, len(conflicts))
+	for name, conflict := range conflicts {
+		s.conflicts[name] = make([]influxql.DataType, 0, len(conflict))
+		for ftype := range conflict {
+			s.conflicts[name] = append(s.conflicts[name], ftype)
+		}
+	}
+
+	return nil
+}
+
+func (s *schemaCreator) validate() (hasConflicts bool, errs []error) {
+
+	// Check for unresolved conflicting field types
+	var typeConflicts []string
+	for field := range s.conflicts {
+		hasConflicts = true
+		if _, resolved := s.typeResolutions[field]; !resolved {
+			typeConflicts = append(typeConflicts, field)
+		}
+	}
+
+	if len(typeConflicts) > 0 {
+		errs = append(errs, fmt.Errorf("unresolved type conflicts for %q", strings.Join(typeConflicts, ",")))
+	}
+
+	// Check for unresolved name clashes between tags and fields
+	var nameConflicts []string
+	for _, field := range s.fieldKeys {
+		for _, tag := range s.tags {
+			if tag == field {
+				hasConflicts = true
+				if _, resolved := s.nameResolutions[field]; !resolved {
+					nameConflicts = append(nameConflicts, tag)
+				}
+			}
+		}
+	}
+
+	if len(nameConflicts) > 0 {
+		errs = append(errs, fmt.Errorf("unresolved name conflicts for %q", strings.Join(nameConflicts, ",")))
+	}
+
+	if len(errs) > 0 {
+		// we have unresolved named or type conflicts; we cannot continue.
+		return hasConflicts, errs
+	}
+
+	// Check for name clashes after resolving field names
+	resolvedFieldKeys := make([]string, 0, len(s.fieldKeys))
+	for _, field := range s.fieldKeys {
+		if n, found := s.nameResolutions[field]; found {
+			resolvedFieldKeys = append(resolvedFieldKeys, n)
+		} else {
+			resolvedFieldKeys = append(resolvedFieldKeys, field)
+		}
+	}
+	var resolvedConflicts []string
+	for i, field := range resolvedFieldKeys {
+		origField := s.fieldKeys[i]
+		for _, tag := range s.tags {
+			if tag == field {
+				hasConflicts = true
+				resolvedConflicts = append(resolvedConflicts, "resolved '"+origField+"' with tag '"+tag+"'")
+			}
+		}
+		for j, f := range resolvedFieldKeys {
+			if i > j && field == f {
+				hasConflicts = true
+				resolvedConflicts = append(resolvedConflicts, "resolved '"+origField+"' with field '"+f+"'")
+			}
+		}
+	}
+	if len(resolvedConflicts) > 0 {
+		return hasConflicts, []error{fmt.Errorf("conflicts after field name resolution for %s", strings.Join(resolvedConflicts, ", "))}
+	}
+
+	return hasConflicts, nil
+}
+
+func (s *schemaCreator) schema(info map[string]string) (*arrow.Schema, error) {
+	columns := make([]arrow.Field, 0, 1+len(s.tags)+len(s.fields))
+
+	// Add the timestamp column first
+	columns = append(columns, arrow.Field{
+		Name:     "time",
+		Type:     &arrow.TimestampType{Unit: arrow.Nanosecond},
+		Metadata: arrow.MetadataFrom(map[string]string{"kind": "timestamp"}),
+	})
+
+	// Add tags in alphabetical order
+	for _, tag := range s.tags {
+		columns = append(columns, arrow.Field{
+			Name:     tag,
+			Type:     &arrow.StringType{},
+			Nullable: true,
+			Metadata: arrow.MetadataFrom(map[string]string{"kind": "tag"}),
+		})
+	}
+
+	// Add fields in alphabetical order with the corresponding arrow type
+	for _, name := range s.fieldKeys {
+		ftype := s.fields[name]
+		if t, found := s.typeResolutions[name]; found {
+			ftype = t
+		}
+		fname := name
+		if n, found := s.nameResolutions[name]; found {
+			fname = n
+		}
+
+		var dtype arrow.DataType
+		switch ftype {
+		case influxql.Float:
+			dtype = &arrow.Float64Type{}
+		case influxql.Integer:
+			dtype = &arrow.Int64Type{}
+		case influxql.String:
+			dtype = &arrow.StringType{}
+		case influxql.Boolean:
+			dtype = &arrow.BooleanType{}
+		case influxql.Unsigned:
+			dtype = &arrow.Uint64Type{}
+		default:
+			return nil, fmt.Errorf("unconvertible field %q", name)
+		}
+		columns = append(columns, arrow.Field{
+			Name:     fname,
+			Type:     dtype,
+			Nullable: true,
+			Metadata: arrow.MetadataFrom(map[string]string{"kind": "field"}),
+		})
+	}
+
+	// Add the metadata given as argument and add info about column kinds
+	if info == nil {
+		info = make(map[string]string)
+	}
+	info["tags"] = strings.Join(s.tags, ",")
+	info["fields"] = strings.Join(s.fieldKeys, ",")
+	metadata := arrow.MetadataFrom(info)
+
+	return arrow.NewSchema(columns, &metadata), nil
+}


### PR DESCRIPTION
Without this PR, the export-parquet tool would report on type conflict errors and not name conflict errors in the schema if type conflicts were encountered first. It stopped checking for validation issues once type conflicts were found.

This PR changes it so that both type and name schema issues are both identified and reported in the commands output. Either still fails an export to parquet; but in --dry-run mode the validation is an useful tool to check for schemas that will be an issue in parquet of influxdbv3.

* follows #25297

(cherry picked from commit 1c082def6c2ef5922087182854ce7f516fb011e8)

Closes #

Describe your proposed changes here.

- [ ] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb/blob/main/README.md).
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
