### PR TITLE
fix: correct locking bug when deleting a series

### DIFF
--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -1718,16 +1718,22 @@ func (e *Engine) deleteSeriesRange(seriesKeys [][]byte, min, max int64) error {
 			seriesKey, _ := SeriesAndFieldFromCompositeKey(indexKey)
 
 			// Skip over any deleted keys that are less than our tsm key
-			seriesKeysLock.RLock()
-			cmp := bytes.Compare(seriesKeys[j], seriesKey)
-			for j < len(seriesKeys) && cmp < 0 {
-				j++
-				if j >= len(seriesKeys) {
-					return nil
+			cmp, cont := func() (int, bool) {
+				seriesKeysLock.RLock()
+				defer seriesKeysLock.RUnlock()
+				cmp := bytes.Compare(seriesKeys[j], seriesKey)
+				for j < len(seriesKeys) && cmp < 0 {
+					j++
+					if j >= len(seriesKeys) {
+						return 0, false // don't continue processing seriesKeys.
+					}
+					cmp = bytes.Compare(seriesKeys[j], seriesKey)
 				}
-				cmp = bytes.Compare(seriesKeys[j], seriesKey)
+				return cmp, true // continue processing seriesKeys.
+			}()
+			if !cont {
+				return nil
 			}
-			seriesKeysLock.RUnlock()
 
 			// We've found a matching key, cross it out so we do not remove it from the index.
 			if j < len(seriesKeys) && cmp == 0 {

--- a/tsdb/engine/tsm1/engine_test.go
+++ b/tsdb/engine/tsm1/engine_test.go
@@ -1372,6 +1372,124 @@ func TestEngine_DeleteSeriesRange(t *testing.T) {
 	}
 }
 
+// TestEngine_DeleteSeriesRange_MultiTSMLocking checks for locking issues when deleting series
+// ranges from a large number of TSM files. This test is derived from TestEngine_DeleteSeriesRange.
+func TestEngine_DeleteSeriesRange_MultiTSMLocking(t *testing.T) {
+	for _, index := range tsdb.RegisteredIndexes() {
+		t.Run(index, func(t *testing.T) {
+			e, err := NewEngine(index)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// mock the planner so compactions don't run during the test
+			e.CompactionPlan = &mockPlanner{}
+			if err := e.Open(); err != nil {
+				t.Fatal(err)
+			}
+			defer e.Close()
+
+			numTSMFiles := runtime.NumCPU() * 20
+			var ts int64
+			for tsmCount := 0; tsmCount < numTSMFiles; tsmCount++ {
+				ts += 1000000000
+
+				// Create a few points.
+				p1 := MustParsePointString(fmt.Sprintf("cpu,host=0 value=1.1 %d", ts+5000000000)) // Should not be deleted
+				p2 := MustParsePointString(fmt.Sprintf("cpu,host=A value=1.2 %d", ts+1000000000))
+				p3 := MustParsePointString(fmt.Sprintf("cpu,host=A value=1.3 %d", ts+2000000000))
+				p4 := MustParsePointString(fmt.Sprintf("cpu,host=B value=1.3 %d", ts+3000000000)) // Should not be deleted
+				p5 := MustParsePointString(fmt.Sprintf("cpu,host=B value=1.3 %d", ts+4000000000)) // Should not be deleted
+				p6 := MustParsePointString(fmt.Sprintf("cpu,host=C value=1.3 %d", ts))
+				p7 := MustParsePointString(fmt.Sprintf("mem,host=C value=1.3 %d", ts))  // Should not be deleted
+				p8 := MustParsePointString(fmt.Sprintf("disk,host=C value=1.3 %d", ts)) // Should not be deleted
+
+				for _, p := range []models.Point{p1, p2, p3, p4, p5, p6, p7, p8} {
+					if err := e.CreateSeriesIfNotExists(p.Key(), p.Name(), p.Tags(), notrack); err != nil {
+						t.Fatalf("create series index error: %v", err)
+					}
+				}
+
+				if err := e.WritePoints([]models.Point{p1, p2, p3, p4, p5, p6, p7, p8}, tsdb.NoopStatsTracker()); err != nil {
+					t.Fatalf("failed to write points: %s", err.Error())
+				}
+				if err := e.WriteSnapshot(); err != nil {
+					t.Fatalf("failed to snapshot: %s", err.Error())
+				}
+			}
+
+			keys := e.FileStore.Keys()
+			if exp, got := 6, len(keys); exp != got {
+				t.Fatalf("series count mismatch: exp %v, got %v", exp, got)
+			}
+
+			itr := &seriesIterator{keys: [][]byte{[]byte("cpu,host=0"), []byte("cpu,host=A"), []byte("cpu,host=B"), []byte("cpu,host=C")}}
+			if err := e.DeleteSeriesRange(itr, 0, ts+2000000000); err != nil {
+				t.Fatalf("failed to delete series: %v", err)
+			}
+
+			keys = e.FileStore.Keys()
+			if exp, got := 4, len(keys); exp != got {
+				t.Fatalf("series count mismatch: exp %v, got %v", exp, got)
+			}
+
+			exp := "cpu,host=B#!~#value"
+			if _, ok := keys[exp]; !ok {
+				t.Fatalf("wrong series deleted: exp %v, got %v", exp, keys)
+			}
+
+			// Check that the series still exists in the index
+			indexSet := tsdb.IndexSet{Indexes: []tsdb.Index{e.index}, SeriesFile: e.sfile}
+			iter, err := indexSet.MeasurementSeriesIDIterator([]byte("cpu"))
+			if err != nil {
+				t.Fatalf("iterator error: %v", err)
+			}
+			defer iter.Close()
+
+			elem, err := iter.Next()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if elem.SeriesID == 0 {
+				t.Fatalf("series index mismatch: EOF, exp 2 series")
+			}
+
+			// Lookup series.
+			name, tags := e.sfile.Series(elem.SeriesID)
+			if got, exp := name, []byte("cpu"); !bytes.Equal(got, exp) {
+				t.Fatalf("series mismatch: got %s, exp %s", got, exp)
+			}
+
+			if !tags.Equal(models.NewTags(map[string]string{"host": "0"})) && !tags.Equal(models.NewTags(map[string]string{"host": "B"})) {
+				t.Fatalf(`series mismatch: got %s, exp either "host=0" or "host=B"`, tags)
+			}
+			iter.Close()
+
+			// Deleting remaining series should remove them from the series.
+			itr = &seriesIterator{keys: [][]byte{[]byte("cpu,host=0"), []byte("cpu,host=B")}}
+			if err := e.DeleteSeriesRange(itr, 0, ts+9000000000); err != nil {
+				t.Fatalf("failed to delete series: %v", err)
+			}
+
+			indexSet = tsdb.IndexSet{Indexes: []tsdb.Index{e.index}, SeriesFile: e.sfile}
+			if iter, err = indexSet.MeasurementSeriesIDIterator([]byte("cpu")); err != nil {
+				t.Fatalf("iterator error: %v", err)
+			}
+			if iter == nil {
+				return
+			}
+
+			defer iter.Close()
+			if elem, err = iter.Next(); err != nil {
+				t.Fatal(err)
+			}
+			if elem.SeriesID != 0 {
+				t.Fatalf("got an undeleted series id, but series should be dropped from index")
+			}
+		})
+	}
+}
+
 func TestEngine_DeleteSeriesRangeWithPredicate(t *testing.T) {
 	for _, index := range tsdb.RegisteredIndexes() {
 		t.Run(index, func(t *testing.T) {


### PR DESCRIPTION
Correct locking bug in `Engine.deleteReadSeries`. Under certain circumstances delete requests can cause a read lock to be leaked, which can then block further write locks in a `deleteReadSeries` call. This blocks the delete request from completing, and potentially blocks other options which use `FileStore.Apply`, such as compaction.

Also added tests that fail with a timeout with the previous improper locking.

Closes: #26648

