### PR TITLE
fix: full compactions not scheduled under some circumstances

### DIFF
--- a/tsdb/engine/tsm1/compact.go
+++ b/tsdb/engine/tsm1/compact.go
@@ -781,6 +781,14 @@ func (c *DefaultPlanner) Release(groups []CompactionGroup) {
 	}
 }
 
+// InUseCount returns the number of files currently locked as in-use.
+// This method is primarily useful for test validation.
+func (c *DefaultPlanner) InUseCount() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return len(c.filesInUse)
+}
+
 // Compactor merges multiple TSM files into new files or
 // writes a Cache into 1 or more TSM files.
 type Compactor struct {

--- a/tsdb/engine/tsm1/compact_test.go
+++ b/tsdb/engine/tsm1/compact_test.go
@@ -2899,7 +2899,7 @@ func TestEnginePlanCompactions(t *testing.T) {
 		// so we can simulate the passage of time in tests
 		testShardTime time.Duration
 		// Each result is for the different plantypes
-		getResultByPlanType func(planType tsm1.PlanType) testLevelResults
+		expectedResult func() testLevelResults
 	}
 
 	tests := []testEnginePlanCompactionsRunner{
@@ -2936,8 +2936,8 @@ func TestEnginePlanCompactions(t *testing.T) {
 				},
 			},
 			testShardTime: -1,
-			getResultByPlanType: func(planType tsm1.PlanType) testLevelResults {
-				common := testLevelResults{
+			expectedResult: func() testLevelResults {
+				return testLevelResults{
 					level5Groups: []tsm1.PlannedCompactionGroup{
 						{
 							tsm1.CompactionGroup{"01-05.tsm", "02-05.tsm", "03-05.tsm", "04-04.tsm"},
@@ -2945,13 +2945,6 @@ func TestEnginePlanCompactions(t *testing.T) {
 						},
 					},
 				}
-				switch planType {
-				case tsm1.PT_Standard, tsm1.PT_SmartOptimize:
-					return common
-				case tsm1.PT_NoOptimize:
-					return testLevelResults{}
-				}
-				return testLevelResults{}
 			},
 		},
 		{
@@ -3029,8 +3022,8 @@ func TestEnginePlanCompactions(t *testing.T) {
 				},
 			},
 			testShardTime: -1,
-			getResultByPlanType: func(planType tsm1.PlanType) testLevelResults {
-				common := testLevelResults{
+			expectedResult: func() testLevelResults {
+				return testLevelResults{
 					level5Groups: []tsm1.PlannedCompactionGroup{
 						{
 							tsm1.CompactionGroup{"01-05.tsm1", "01-06.tsm1", "01-07.tsm1", "01-08.tsm1", "02-05.tsm1", "02-06.tsm1", "02-07.tsm1", "02-08.tsm1", "03-04.tsm1", "03-05.tsm1"},
@@ -3038,14 +3031,6 @@ func TestEnginePlanCompactions(t *testing.T) {
 						},
 					},
 				}
-
-				switch planType {
-				case tsm1.PT_Standard, tsm1.PT_SmartOptimize:
-					return common
-				case tsm1.PT_NoOptimize:
-					return testLevelResults{}
-				}
-				return testLevelResults{}
 			},
 		},
 		{
@@ -3078,8 +3063,8 @@ func TestEnginePlanCompactions(t *testing.T) {
 				},
 			},
 			testShardTime: -1,
-			getResultByPlanType: func(planType tsm1.PlanType) testLevelResults {
-				common := testLevelResults{
+			expectedResult: func() testLevelResults {
+				return testLevelResults{
 					level5Groups: []tsm1.PlannedCompactionGroup{
 						{
 							tsm1.CompactionGroup{"01-05.tsm1",
@@ -3091,14 +3076,6 @@ func TestEnginePlanCompactions(t *testing.T) {
 						},
 					},
 				}
-
-				switch planType {
-				case tsm1.PT_Standard, tsm1.PT_SmartOptimize:
-					return common
-				case tsm1.PT_NoOptimize:
-					return testLevelResults{}
-				}
-				return testLevelResults{}
 			},
 		},
 		{
@@ -3119,8 +3096,8 @@ func TestEnginePlanCompactions(t *testing.T) {
 				},
 			}.ToExtFileStats(),
 			testShardTime: -1,
-			getResultByPlanType: func(planType tsm1.PlanType) testLevelResults {
-				common := testLevelResults{
+			expectedResult: func() testLevelResults {
+				return testLevelResults{
 					level5Groups: []tsm1.PlannedCompactionGroup{
 						{
 							tsm1.CompactionGroup{"01-02.tsm1",
@@ -3131,14 +3108,6 @@ func TestEnginePlanCompactions(t *testing.T) {
 						},
 					},
 				}
-
-				switch planType {
-				case tsm1.PT_Standard, tsm1.PT_SmartOptimize:
-					return common
-				case tsm1.PT_NoOptimize:
-					return testLevelResults{}
-				}
-				return testLevelResults{}
 			},
 		},
 		{
@@ -3163,8 +3132,8 @@ func TestEnginePlanCompactions(t *testing.T) {
 			}.ToExtFileStats(),
 			defaultBlockCount: tsdb.DefaultMaxPointsPerBlock,
 			testShardTime:     -1,
-			getResultByPlanType: func(planType tsm1.PlanType) testLevelResults {
-				common := testLevelResults{
+			expectedResult: func() testLevelResults {
+				return testLevelResults{
 					level5Groups: []tsm1.PlannedCompactionGroup{
 						{
 							tsm1.CompactionGroup{"01-05.tsm1",
@@ -3176,14 +3145,6 @@ func TestEnginePlanCompactions(t *testing.T) {
 						},
 					},
 				}
-
-				switch planType {
-				case tsm1.PT_Standard, tsm1.PT_SmartOptimize:
-					return common
-				case tsm1.PT_NoOptimize:
-					return testLevelResults{}
-				}
-				return testLevelResults{}
 			},
 		},
 		{
@@ -3247,8 +3208,8 @@ func TestEnginePlanCompactions(t *testing.T) {
 				},
 			},
 			testShardTime: -1,
-			getResultByPlanType: func(planType tsm1.PlanType) testLevelResults {
-				common := testLevelResults{
+			expectedResult: func() testLevelResults {
+				return testLevelResults{
 					level5Groups: []tsm1.PlannedCompactionGroup{
 						{
 							tsm1.CompactionGroup{"01-05.tsm1",
@@ -3264,14 +3225,6 @@ func TestEnginePlanCompactions(t *testing.T) {
 						},
 					},
 				}
-
-				switch planType {
-				case tsm1.PT_Standard, tsm1.PT_SmartOptimize:
-					return common
-				case tsm1.PT_NoOptimize:
-					return testLevelResults{}
-				}
-				return testLevelResults{}
 			},
 		},
 		{
@@ -3301,8 +3254,8 @@ func TestEnginePlanCompactions(t *testing.T) {
 			},
 
 			testShardTime: -1,
-			getResultByPlanType: func(planType tsm1.PlanType) testLevelResults {
-				common := testLevelResults{
+			expectedResult: func() testLevelResults {
+				return testLevelResults{
 					level5Groups: []tsm1.PlannedCompactionGroup{
 						{
 							tsm1.CompactionGroup{"01-13.tsm1",
@@ -3313,14 +3266,6 @@ func TestEnginePlanCompactions(t *testing.T) {
 						},
 					},
 				}
-
-				switch planType {
-				case tsm1.PT_Standard, tsm1.PT_SmartOptimize:
-					return common
-				case tsm1.PT_NoOptimize:
-					return testLevelResults{}
-				}
-				return testLevelResults{}
 			},
 		},
 		{
@@ -3336,7 +3281,7 @@ func TestEnginePlanCompactions(t *testing.T) {
 				},
 			}.ToExtFileStats(),
 			testShardTime: -1,
-			getResultByPlanType: func(planType tsm1.PlanType) testLevelResults {
+			expectedResult: func() testLevelResults {
 				return testLevelResults{}
 			},
 		},
@@ -3357,7 +3302,7 @@ func TestEnginePlanCompactions(t *testing.T) {
 			}.ToExtFileStats(),
 			defaultBlockCount: tsdb.DefaultAggressiveMaxPointsPerBlock,
 			testShardTime:     -1,
-			getResultByPlanType: func(planType tsm1.PlanType) testLevelResults {
+			expectedResult: func() testLevelResults {
 				return testLevelResults{}
 			},
 		},
@@ -3384,7 +3329,7 @@ func TestEnginePlanCompactions(t *testing.T) {
 				},
 			},
 			testShardTime: -1,
-			getResultByPlanType: func(planType tsm1.PlanType) testLevelResults {
+			expectedResult: func() testLevelResults {
 				return testLevelResults{}
 			},
 		},
@@ -3408,7 +3353,7 @@ func TestEnginePlanCompactions(t *testing.T) {
 			}.ToExtFileStats(),
 			defaultBlockCount: tsdb.DefaultAggressiveMaxPointsPerBlock,
 			testShardTime:     -1,
-			getResultByPlanType: func(planType tsm1.PlanType) testLevelResults {
+			expectedResult: func() testLevelResults {
 				return testLevelResults{}
 			},
 		},
@@ -3466,8 +3411,8 @@ func TestEnginePlanCompactions(t *testing.T) {
 				},
 			}.ToExtFileStats(),
 			testShardTime: -1,
-			getResultByPlanType: func(planType tsm1.PlanType) testLevelResults {
-				common := testLevelResults{
+			expectedResult: func() testLevelResults {
+				return testLevelResults{
 					level5Groups: []tsm1.PlannedCompactionGroup{
 						{
 							tsm1.CompactionGroup{"01-05.tsm1",
@@ -3486,14 +3431,6 @@ func TestEnginePlanCompactions(t *testing.T) {
 						},
 					},
 				}
-
-				switch planType {
-				case tsm1.PT_Standard, tsm1.PT_SmartOptimize:
-					return common
-				case tsm1.PT_NoOptimize:
-					return testLevelResults{}
-				}
-				return testLevelResults{}
 			},
 		},
 		{
@@ -3589,8 +3526,8 @@ func TestEnginePlanCompactions(t *testing.T) {
 				},
 			},
 			testShardTime: -1,
-			getResultByPlanType: func(planType tsm1.PlanType) testLevelResults {
-				common := testLevelResults{
+			expectedResult: func() testLevelResults {
+				return testLevelResults{
 					level5Groups: []tsm1.PlannedCompactionGroup{
 						{
 							tsm1.CompactionGroup{
@@ -3609,14 +3546,6 @@ func TestEnginePlanCompactions(t *testing.T) {
 							}, tsdb.DefaultAggressiveMaxPointsPerBlock},
 					},
 				}
-
-				switch planType {
-				case tsm1.PT_Standard, tsm1.PT_SmartOptimize:
-					return common
-				case tsm1.PT_NoOptimize:
-					return testLevelResults{}
-				}
-				return testLevelResults{}
 			},
 		},
 		{
@@ -4110,8 +4039,8 @@ func TestEnginePlanCompactions(t *testing.T) {
 			},
 			defaultBlockCount: tsdb.DefaultMaxPointsPerBlock,
 			testShardTime:     -1,
-			getResultByPlanType: func(planType tsm1.PlanType) testLevelResults {
-				common := testLevelResults{
+			expectedResult: func() testLevelResults {
+				return testLevelResults{
 					level5Groups: []tsm1.PlannedCompactionGroup{
 						{
 							tsm1.CompactionGroup{
@@ -4200,14 +4129,6 @@ func TestEnginePlanCompactions(t *testing.T) {
 						},
 					},
 				}
-
-				switch planType {
-				case tsm1.PT_Standard, tsm1.PT_SmartOptimize:
-					return common
-				case tsm1.PT_NoOptimize:
-					return testLevelResults{}
-				}
-				return testLevelResults{}
 			},
 		},
 		{
@@ -4313,8 +4234,8 @@ func TestEnginePlanCompactions(t *testing.T) {
 				},
 			},
 			testShardTime: -1,
-			getResultByPlanType: func(planType tsm1.PlanType) testLevelResults {
-				standard := testLevelResults{
+			expectedResult: func() testLevelResults {
+				return testLevelResults{
 					level1Groups: []tsm1.PlannedCompactionGroup{
 						{
 							tsm1.CompactionGroup{"05-01.tsm", "06-01.tsm", "07-01.tsm", "08-01.tsm", "09-01.tsm", "10-01.tsm", "11-01.tsm", "12-01.tsm"},
@@ -4328,23 +4249,6 @@ func TestEnginePlanCompactions(t *testing.T) {
 						},
 					},
 				}
-
-				common := testLevelResults{
-					level1Groups: []tsm1.PlannedCompactionGroup{
-						{
-							tsm1.CompactionGroup{"05-01.tsm", "06-01.tsm", "07-01.tsm", "08-01.tsm", "09-01.tsm", "10-01.tsm", "11-01.tsm", "12-01.tsm"},
-							tsdb.DefaultMaxPointsPerBlock,
-						},
-					},
-				}
-
-				switch planType {
-				case tsm1.PT_Standard:
-					return standard
-				case tsm1.PT_SmartOptimize, tsm1.PT_NoOptimize:
-					return common
-				}
-				return testLevelResults{}
 			},
 		},
 		{
@@ -4450,8 +4354,8 @@ func TestEnginePlanCompactions(t *testing.T) {
 				},
 			},
 			testShardTime: -1,
-			getResultByPlanType: func(planType tsm1.PlanType) testLevelResults {
-				standard := testLevelResults{
+			expectedResult: func() testLevelResults {
+				return testLevelResults{
 					level1Groups: []tsm1.PlannedCompactionGroup{
 						{
 							tsm1.CompactionGroup{"05-01.tsm", "06-01.tsm", "07-01.tsm", "08-01.tsm", "09-01.tsm", "10-01.tsm", "11-01.tsm", "12-01.tsm"},
@@ -4465,23 +4369,6 @@ func TestEnginePlanCompactions(t *testing.T) {
 						},
 					},
 				}
-
-				common := testLevelResults{
-					level1Groups: []tsm1.PlannedCompactionGroup{
-						{
-							tsm1.CompactionGroup{"05-01.tsm", "06-01.tsm", "07-01.tsm", "08-01.tsm", "09-01.tsm", "10-01.tsm", "11-01.tsm", "12-01.tsm"},
-							tsdb.DefaultMaxPointsPerBlock,
-						},
-					},
-				}
-
-				switch planType {
-				case tsm1.PT_Standard:
-					return standard
-				case tsm1.PT_SmartOptimize, tsm1.PT_NoOptimize:
-					return common
-				}
-				return testLevelResults{}
 			},
 		},
 		{
@@ -4588,8 +4475,8 @@ func TestEnginePlanCompactions(t *testing.T) {
 				},
 			},
 			testShardTime: -1,
-			getResultByPlanType: func(planType tsm1.PlanType) testLevelResults {
-				standard := testLevelResults{
+			expectedResult: func() testLevelResults {
+				return testLevelResults{
 					level1Groups: []tsm1.PlannedCompactionGroup{
 						{
 							tsm1.CompactionGroup{"05-01.tsm", "06-01.tsm", "07-01.tsm", "08-01.tsm", "09-01.tsm", "10-01.tsm", "11-01.tsm", "12-01.tsm"},
@@ -4603,23 +4490,6 @@ func TestEnginePlanCompactions(t *testing.T) {
 						},
 					},
 				}
-
-				common := testLevelResults{
-					level1Groups: []tsm1.PlannedCompactionGroup{
-						{
-							tsm1.CompactionGroup{"05-01.tsm", "06-01.tsm", "07-01.tsm", "08-01.tsm", "09-01.tsm", "10-01.tsm", "11-01.tsm", "12-01.tsm"},
-							tsdb.DefaultMaxPointsPerBlock,
-						},
-					},
-				}
-
-				switch planType {
-				case tsm1.PT_Standard:
-					return standard
-				case tsm1.PT_SmartOptimize, tsm1.PT_NoOptimize:
-					return common
-				}
-				return testLevelResults{}
 			},
 		},
 	}
@@ -4632,49 +4502,43 @@ func TestEnginePlanCompactions(t *testing.T) {
 	e.Compactor = tsm1.NewCompactor()
 	defer e.Compactor.Close()
 
-	for i := 0; i < 3; i++ {
-		for _, test := range tests {
-			var testName string
-			switch i {
-			case 0:
-				testName = test.name + "_PT_Standard"
-			case 1:
-				testName = test.name + "_PT_SmartOptimize"
-			case 2:
-				testName = test.name + "_PT_NoOptimize"
-			}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ffs := newFakeFileStore(withExtFileStats(test.files), withDefaultBlockCount(test.defaultBlockCount))
+			cp := tsm1.NewDefaultPlanner(ffs, test.testShardTime)
 
-			t.Run(testName, func(t *testing.T) {
-				ffs := newFakeFileStore(withExtFileStats(test.files), withDefaultBlockCount(test.defaultBlockCount))
-				cp := tsm1.NewDefaultPlanner(ffs, test.testShardTime)
+			e.MaxPointsPerBlock = tsdb.DefaultMaxPointsPerBlock
+			e.CompactionPlan = cp
+			e.Compactor.FileStore = ffs
 
-				e.MaxPointsPerBlock = tsdb.DefaultMaxPointsPerBlock
-				e.CompactionPlan = cp
-				e.Compactor.FileStore = ffs
+			// Arbitrary group length to use in Scheduler.SetDepth
+			mockGroupLen := 5
+			// Set the scheduler depth for our lower level groups.
+			// During PT_Standard this should still plan a level5 compaction group
+			// but during PT_SmartOptimize this should not.
+			e.Scheduler.SetDepth(1, mockGroupLen)
+			e.Scheduler.SetDepth(2, mockGroupLen)
 
-				// Arbitrary group length to use in Scheduler.SetDepth
-				mockGroupLen := 5
-				// Set the scheduler depth for our lower level groups.
-				// During PT_Standard this should still plan a level5 compaction group
-				// but during PT_SmartOptimize this should not.
-				e.Scheduler.SetDepth(1, mockGroupLen)
-				e.Scheduler.SetDepth(2, mockGroupLen)
+			// Normally this is called within PlanCompactions but because we want to simulate already running
+			// some compactions we will set them manually here.
+			atomic.StoreInt64(&e.Stats.TSMCompactionsActive[0], int64(mockGroupLen))
+			atomic.StoreInt64(&e.Stats.TSMCompactionsActive[1], int64(mockGroupLen))
 
-				// Normally this is called within PlanCompactions but because we want to simulate already running
-				// some compactions we will set them manually here.
-				atomic.StoreInt64(&e.Stats.TSMCompactionsActive[0], int64(mockGroupLen))
-				atomic.StoreInt64(&e.Stats.TSMCompactionsActive[1], int64(mockGroupLen))
+			// Plan and check results.
+			level1Groups, level2Groups, Level3Groups, Level4Groups, Level5Groups := e.PlanCompactions()
+			results := test.expectedResult()
+			compareLevelGroups(t, results.level1Groups, level1Groups, "unexpected level 1 Group")
+			compareLevelGroups(t, results.level2Groups, level2Groups, "unexpected level 2 Group")
+			compareLevelGroups(t, results.level3Groups, Level3Groups, "unexpected level 3 Group")
+			compareLevelGroups(t, results.level4Groups, Level4Groups, "unexpected level 4 Group")
+			compareLevelGroups(t, results.level5Groups, Level5Groups, "unexpected level 5 Group")
 
-				// Should use PlanType 0 (PT_Standard), 1(PT_SmartOptimize), 2(PT_NoOptimize)
-				planType := tsm1.PlanType(i)
-				level1Groups, level2Groups, Level3Groups, Level4Groups, Level5Groups := e.PlanCompactions(planType)
-				compareLevelGroups(t, test.getResultByPlanType(planType).level1Groups, level1Groups, "unexpected level 1 Group")
-				compareLevelGroups(t, test.getResultByPlanType(planType).level2Groups, level2Groups, "unexpected level 2 Group")
-				compareLevelGroups(t, test.getResultByPlanType(planType).level3Groups, Level3Groups, "unexpected level 3 Group")
-				compareLevelGroups(t, test.getResultByPlanType(planType).level4Groups, Level4Groups, "unexpected level 4 Group")
-				compareLevelGroups(t, test.getResultByPlanType(planType).level5Groups, Level5Groups, "unexpected level 5 Group")
-			})
-		}
+			// Remove all the returned compaction levels and verify that no TSM files are marked as in-use.
+			// Calling e.PlanCompactions followed by e.ReleaseCompactionPlans replicates the code structure
+			// of the e.compact loop.
+			e.ReleaseCompactionPlans(level1Groups, level2Groups, Level3Groups, Level4Groups, Level5Groups)
+			require.Zero(t, cp.InUseCount(), "some TSM files were not released properly")
+		})
 	}
 }
 

--- a/tsdb/engine/tsm1/compact_test.go
+++ b/tsdb/engine/tsm1/compact_test.go
@@ -4514,8 +4514,6 @@ func TestEnginePlanCompactions(t *testing.T) {
 			// Arbitrary group length to use in Scheduler.SetDepth
 			mockGroupLen := 5
 			// Set the scheduler depth for our lower level groups.
-			// During PT_Standard this should still plan a level5 compaction group
-			// but during PT_SmartOptimize this should not.
 			e.Scheduler.SetDepth(1, mockGroupLen)
 			e.Scheduler.SetDepth(2, mockGroupLen)
 


### PR DESCRIPTION
Fix issue introduced with 1.12.1 that caused some TSM files to not be scheduled for full compaction when they should be. The user visible symptom was an unbounded increase in disk space for impacted shards.

This simplifies the compaction planning code by removing the PT_SmartOptimize and PT_NoOptimize special cases. These are no longer needed for performance thanks to the first block caching code that was also added in #26432. Issues with the PT_SmartOptimize and PT_NoOptimize cases could cause TSM files to be locked by the compaction planner as in-use, preventing them from being compacted.

The optimized compaction hold-off is now handled entirely in Engine.compact rather than by the compaction planner.

Update test cases as necessary for changes, plus add checks for issue that caused #26667.

Closes: #26667