### PR TITLE
chore: re-add compaction trace logging

### DIFF
--- a/tsdb/engine/tsm1/engine_test.go
+++ b/tsdb/engine/tsm1/engine_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/influxdata/influxql"
 	tassert "github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+ 	"go.uber.org/zap"
 )
 
 var notrack = tsdb.NoopStatsTracker()
@@ -2996,8 +2997,9 @@ func (m *mockPlanner) Release(groups []tsm1.CompactionGroup) {}
 func (m *mockPlanner) FullyCompacted() (bool, string) {
 	return false, "not compacted"
 }
-func (m *mockPlanner) ForceFull()                      {}
-func (m *mockPlanner) SetFileStore(fs *tsm1.FileStore) {}
+func (m *mockPlanner) ForceFull()                              {}
+func (m *mockPlanner) SetFileStore(fs *tsm1.FileStore)         {}
+func (m *mockPlanner) WithTraceLogger(traceLogger *zap.Logger) {}
 
 // ParseTags returns an instance of Tags for a comma-delimited list of key/values.
 func ParseTags(s string) query.Tags {

--- a/tsdb/engine/tsm1/scheduler.go
+++ b/tsdb/engine/tsm1/scheduler.go
@@ -2,6 +2,8 @@ package tsm1
 
 import (
 	"sync/atomic"
+
+	"go.uber.org/zap"
 )
 
 // Level 5 (optimize) is set so much lower because level 5 compactions take so much longer.
@@ -12,8 +14,9 @@ type Scheduler struct {
 	stats          *EngineStatistics
 
 	// queues is the depth of work pending for each compaction level
-	queues  [TotalCompactionLevels]int
-	weights [TotalCompactionLevels]float64
+	queues      [TotalCompactionLevels]int
+	weights     [TotalCompactionLevels]float64
+	traceLogger *zap.Logger
 }
 
 func newScheduler(stats *EngineStatistics, maxConcurrency int) *Scheduler {
@@ -21,7 +24,16 @@ func newScheduler(stats *EngineStatistics, maxConcurrency int) *Scheduler {
 		stats:          stats,
 		maxConcurrency: maxConcurrency,
 		weights:        defaultWeights,
+		traceLogger:    zap.NewNop(),
 	}
+}
+
+func (s *Scheduler) WithLogger(logger *zap.Logger) *Scheduler {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	s.traceLogger = logger.With(zap.String("service", "compaction_scheduler"))
+	return s
 }
 
 func (s *Scheduler) SetDepth(level, depth int) {
@@ -40,7 +52,16 @@ func (s *Scheduler) nextByQueueDepths(depths [TotalCompactionLevels]int) (int, b
 	level4Running := int(atomic.LoadInt64(&s.stats.TSMFullCompactionsActive))
 	level5Running := int(atomic.LoadInt64(&s.stats.TSMOptimizeCompactionsActive))
 
+	if level1Running+level2Running+level3Running+level4Running+level5Running > 0 {
+		s.traceLogger.Debug("running compactions",
+			zap.Int("level1", level1Running),
+			zap.Int("level2", level2Running),
+			zap.Int("level3", level3Running),
+			zap.Int("level4", level4Running),
+			zap.Int("level5", level5Running))
+	}
 	if level1Running+level2Running+level3Running+level4Running+level5Running >= s.maxConcurrency {
+		s.traceLogger.Debug("max compaction concurrency reached", zap.Int("maxConcurrency", s.maxConcurrency))
 		return 0, false
 	}
 
@@ -53,15 +74,20 @@ func (s *Scheduler) nextByQueueDepths(depths [TotalCompactionLevels]int) (int, b
 
 	end := len(depths)
 	if level3Running+level4Running+level5Running >= loLimit && s.maxConcurrency-(level1Running+level2Running) == 0 {
+		s.traceLogger.Debug("levels 3 through 5 compactions greater than low limit and levels 1 and 2 equal max concurrency, restricting to levels 1 and 2", zap.Int("loLimit", loLimit))
 		end = 2
 	}
 
 	var weight float64
 	for i := 0; i < end; i++ {
 		if float64(depths[i])*s.weights[i] > weight {
+			s.traceLogger.Debug("evaluating compaction level", zap.Int("level", i+1), zap.Int("depth", depths[i]), zap.Float64("weight", float64(depths[i])*s.weights[i]))
 			level, runnable = i+1, true
 			weight = float64(depths[i]) * s.weights[i]
 		}
+	}
+	if runnable {
+		s.traceLogger.Debug("selected runnable compaction level", zap.Int("level", level))
 	}
 	return level, runnable
 }


### PR DESCRIPTION
This re-adds the compaction trace logging that was removed in #26666. 

This reverts commit 633661a1712cf254f3ae173f55b38cf86d4f2dff.
