### PR TITLE
chore: add back-port claude command

### DIFF
--- a/.claude/commands/back-port-enterprise-pr.md
+++ b/.claude/commands/back-port-enterprise-pr.md
@@ -1,0 +1,23 @@
+---
+argument-hint: [number]
+description: Back-port the specified PR from the Enterprise repository.
+---
+Port changes from the `influxdb_pro` repository to this repository for the following pull request (PR): https://github.com/influxdata/influxdb_pro/pull/#$ARGUMENTS.
+
+## Approach
+
+1. Pull the latest changes on the `main` branch and start a new branch off of `main`
+2. Create a patch file using the changes in the linked PR (see the "Patch rules" section below)
+3. Apply the generated patch to the repository
+4. Run all tests (`cargo nextest run --workspace --no-fail-fast`) and address any test failures that arise (you may need to use `cargo insta review` if any `insta` snapshots need to be updated)
+5. Run `cargo clippy` to check lints, any fix any linter errors (you can use the `--fix` argument to `cargo clippy` to have it attempt to apply fixes manually)
+6. Run `cargo fmt --all` to format the code
+7. Commit your changes and open a PR to this repository (the commit message should be named `chore: backport <changes>` where changes are a short description of what is being back-ported from the `influxdb_pro` repository)
+8. The PR should reference the original PR on the `influxdb_pro` repository that the changes were backported from
+
+## Patch rules
+
+1. The patch should not include any files with `enterprise` in the name or file path.
+2. The patch should not include any files under the `influxdb3` directory
+3. The patch should not include any files that end in `.snap`
+4. The patch should not include changes to the `Cargo.lock` file


### PR DESCRIPTION
Helps with https://github.com/influxdata/influxdb_pro/issues/1080

Adds a `/back-port-enterprise-pr` command when using claude to back-port changes from a PR in enterprise to this repository.