### PR TITLE
chore: update Rust toolchain to 1.89.0

### DIFF
--- a/influxdb3/src/commands/serve.rs
+++ b/influxdb3/src/commands/serve.rs
@@ -1277,17 +1277,16 @@ fn determine_package_manager() -> Arc<dyn PythonEnvironmentManager> {
     if let Ok(output) = Command::new(&python_exe)
         .args(["-m", "pip", "--version"])
         .output()
+        && output.status.success()
     {
-        if output.status.success() {
-            return Arc::new(PipManager);
-        }
+        return Arc::new(PipManager);
     }
 
     // Check for uv second (ie, prefer python standalone pip)
-    if let Ok(output) = Command::new("uv").arg("--version").output() {
-        if output.status.success() {
-            return Arc::new(UVManager);
-        }
+    if let Ok(output) = Command::new("uv").arg("--version").output()
+        && output.status.success()
+    {
+        return Arc::new(UVManager);
     }
 
     // If neither is available, return DisabledManager

--- a/influxdb3_cache/src/distinct_cache/cache.rs
+++ b/influxdb3_cache/src/distinct_cache/cache.rs
@@ -413,15 +413,16 @@ impl Node {
                         }
                     }
                     total_count += count;
-                } else if next_predicates.is_empty() && next_builders.is_empty() {
-                    if let Some(builder) = builder {
-                        if let Some(value) = value {
-                            builder.append_value(value.0);
-                        } else {
-                            builder.append_null();
-                        }
-                        total_count += 1;
+                } else if next_predicates.is_empty()
+                    && next_builders.is_empty()
+                    && let Some(builder) = builder
+                {
+                    if let Some(value) = value {
+                        builder.append_value(value.0);
+                    } else {
+                        builder.append_null();
                     }
+                    total_count += 1;
                 }
                 if let Some(new_limit) = limit.checked_sub(count) {
                     limit = new_limit;

--- a/influxdb3_cache/src/parquet_cache/mod.rs
+++ b/influxdb3_cache/src/parquet_cache/mod.rs
@@ -603,7 +603,7 @@ impl PartialEq for PruneHeapItem {
 
 impl PartialOrd for PruneHeapItem {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.hit_time.cmp(&other.hit_time))
+        Some(self.cmp(other))
     }
 }
 

--- a/influxdb3_catalog/src/catalog.rs
+++ b/influxdb3_catalog/src/catalog.rs
@@ -1243,12 +1243,12 @@ impl InnerCatalog {
                 }
                 DeleteOp::DeleteTable(db_id, table_id) => {
                     // Remove the table from the database schema
-                    if let Some(mut db_schema) = self.databases.get_by_id(db_id) {
-                        if db_schema.tables.get_by_id(table_id).is_some() {
-                            Arc::make_mut(&mut db_schema).tables.remove(table_id);
-                            self.databases.update(*db_id, db_schema)?;
-                            updated = true;
-                        }
+                    if let Some(mut db_schema) = self.databases.get_by_id(db_id)
+                        && db_schema.tables.get_by_id(table_id).is_some()
+                    {
+                        Arc::make_mut(&mut db_schema).tables.remove(table_id);
+                        self.databases.update(*db_id, db_schema)?;
+                        updated = true;
                     }
                 }
             }

--- a/influxdb3_load_generator/src/line_protocol_generator.rs
+++ b/influxdb3_load_generator/src/line_protocol_generator.rs
@@ -664,16 +664,16 @@ impl GeneratorRunner {
         loop {
             interval.tick().await;
             let now = Local::now();
-            if let Some(end_time) = self.end_time {
-                if now > end_time {
-                    println!(
-                        "writer {} completed at {}",
-                        self.generator.writer_id, end_time
-                    );
-                    return Output {
-                        measurements: self.generator.into(),
-                    };
-                }
+            if let Some(end_time) = self.end_time
+                && now > end_time
+            {
+                println!(
+                    "writer {} completed at {}",
+                    self.generator.writer_id, end_time
+                );
+                return Output {
+                    measurements: self.generator.into(),
+                };
             }
 
             sample_buffer = Vec::with_capacity(sample_len);

--- a/influxdb3_processing_engine/src/lib.rs
+++ b/influxdb3_processing_engine/src/lib.rs
@@ -75,34 +75,34 @@ impl PluginChannels {
         match trigger_spec {
             TriggerSpecificationDefinition::SingleTableWalWrite { .. }
             | TriggerSpecificationDefinition::AllTablesWalWrite => {
-                if let Some(trigger_map) = self.wal_triggers.get(&db) {
-                    if let Some(sender) = trigger_map.get(&trigger) {
-                        // create a one shot to wait for the shutdown to complete
-                        let (tx, rx) = oneshot::channel();
-                        if sender.send(WalEvent::Shutdown(tx)).await.is_err() {
-                            return Err(ProcessingEngineError::TriggerShutdownError {
-                                database: db,
-                                trigger_name: trigger,
-                            });
-                        }
-                        return Ok(Some(rx));
+                if let Some(trigger_map) = self.wal_triggers.get(&db)
+                    && let Some(sender) = trigger_map.get(&trigger)
+                {
+                    // create a one shot to wait for the shutdown to complete
+                    let (tx, rx) = oneshot::channel();
+                    if sender.send(WalEvent::Shutdown(tx)).await.is_err() {
+                        return Err(ProcessingEngineError::TriggerShutdownError {
+                            database: db,
+                            trigger_name: trigger,
+                        });
                     }
+                    return Ok(Some(rx));
                 }
             }
             TriggerSpecificationDefinition::Schedule { .. }
             | TriggerSpecificationDefinition::Every { .. } => {
-                if let Some(trigger_map) = self.schedule_triggers.get(&db) {
-                    if let Some(sender) = trigger_map.get(&trigger) {
-                        // create a one shot to wait for the shutdown to complete
-                        let (tx, rx) = oneshot::channel();
-                        if sender.send(ScheduleEvent::Shutdown(tx)).await.is_err() {
-                            return Err(ProcessingEngineError::TriggerShutdownError {
-                                database: db,
-                                trigger_name: trigger,
-                            });
-                        }
-                        return Ok(Some(rx));
+                if let Some(trigger_map) = self.schedule_triggers.get(&db)
+                    && let Some(sender) = trigger_map.get(&trigger)
+                {
+                    // create a one shot to wait for the shutdown to complete
+                    let (tx, rx) = oneshot::channel();
+                    if sender.send(ScheduleEvent::Shutdown(tx)).await.is_err() {
+                        return Err(ProcessingEngineError::TriggerShutdownError {
+                            database: db,
+                            trigger_name: trigger,
+                        });
                     }
+                    return Ok(Some(rx));
                 }
             }
             TriggerSpecificationDefinition::RequestPath { .. } => {
@@ -684,13 +684,12 @@ fn background_catalog_update(
                             disabled,
                             ..
                         }) => {
-                            if !disabled {
-                                if let Err(error) = processing_engine_manager
+                            if !disabled
+                                && let Err(error) = processing_engine_manager
                                     .run_trigger(database_name, trigger_name)
                                     .await
-                                {
-                                    error!(?error, "failed to run the created trigger");
-                                }
+                            {
+                                error!(?error, "failed to run the created trigger");
                             }
                         }
                         DatabaseCatalogOp::EnableTrigger(TriggerIdentifier {

--- a/influxdb3_processing_engine/src/plugins.rs
+++ b/influxdb3_processing_engine/src/plugins.rs
@@ -674,8 +674,8 @@ mod python_plugin {
 
             let mut errors = Vec::new();
 
-            if !plugin_return_state.write_back_lines.is_empty() {
-                if let Err(e) = self
+            if !plugin_return_state.write_back_lines.is_empty()
+                && let Err(e) = self
                     .write_buffer
                     .write_lp(
                         NamespaceName::new(self.db_name.clone()).unwrap(),
@@ -686,9 +686,8 @@ mod python_plugin {
                         false,
                     )
                     .await
-                {
-                    errors.push(format!("error writing back lines: {e}"));
-                }
+            {
+                errors.push(format!("error writing back lines: {e}"));
             }
 
             for (db_name, lines) in plugin_return_state.write_db_lines {

--- a/influxdb3_py_api/src/system_py.rs
+++ b/influxdb3_py_api/src/system_py.rs
@@ -504,10 +504,10 @@ pub fn execute_python_with_batch(
         let mut table_batches = Vec::with_capacity(write_batch.table_chunks.len());
 
         for (table_id, table_chunks) in &write_batch.table_chunks {
-            if let Some(table_filter) = table_filter {
-                if table_id != &table_filter {
-                    continue;
-                }
+            if let Some(table_filter) = table_filter
+                && table_id != &table_filter
+            {
+                continue;
             }
             let table_def = schema
                 .tables
@@ -995,13 +995,13 @@ impl ExpiringCache {
         // if key has a ttl, record its expiration.
         let expiration = entry.expires_at;
         // if this was an overwrite, remove from expirations
-        if let Some(old_entry) = self.entries.insert(key.clone(), entry) {
-            if let Some(old_expiration) = old_entry.expires_at {
-                self.expirations
-                    .get_mut(&old_expiration)
-                    .unwrap()
-                    .remove(&key);
-            }
+        if let Some(old_entry) = self.entries.insert(key.clone(), entry)
+            && let Some(old_expiration) = old_entry.expires_at
+        {
+            self.expirations
+                .get_mut(&old_expiration)
+                .unwrap()
+                .remove(&key);
         }
         if let Some(expiration) = expiration {
             self.expirations.entry(expiration).or_default().insert(key);
@@ -1010,11 +1010,11 @@ impl ExpiringCache {
 
     fn get(&mut self, key: &str, py: Python<'_>) -> Option<Py<PyAny>> {
         let entry = self.entries.get(key)?;
-        if let Some(expiration) = entry.expires_at {
-            if expiration <= self.time_provider.now() {
-                self.remove(key);
-                return None;
-            }
+        if let Some(expiration) = entry.expires_at
+            && expiration <= self.time_provider.now()
+        {
+            self.remove(key);
+            return None;
         }
         Some(entry.value.clone_ref(py))
     }

--- a/influxdb3_server/src/http/v1.rs
+++ b/influxdb3_server/src/http/v1.rs
@@ -296,10 +296,10 @@ impl From<QueryResponse> for Bytes {
                 .from_writer(vec![]);
             // Extract column names dynamically from the first series
             let mut headers = vec!["name", "tags"];
-            if let Some(first_statement) = s.results.first() {
-                if let Some(first_series) = first_statement.series.first() {
-                    headers.extend(first_series.columns.iter().map(|s| s.as_str()));
-                }
+            if let Some(first_statement) = s.results.first()
+                && let Some(first_series) = first_statement.series.first()
+            {
+                headers.extend(first_series.columns.iter().map(|s| s.as_str()));
             }
             // Write the header
             wtr.write_record(&headers)
@@ -647,25 +647,24 @@ impl QueryResponseStream {
 
                 // Handle the special case for the measurement column
                 if column_name == INFLUXQL_MEASUREMENT_COLUMN_NAME {
-                    if let Value::String(ref measurement_name) = cell_value {
-                        if self.buffer.current_measurement_name().is_none()
+                    if let Value::String(ref measurement_name) = cell_value
+                        && (self.buffer.current_measurement_name().is_none()
                             || self
                                 .buffer
                                 .current_measurement_name()
-                                .is_some_and(|n| n != measurement_name)
-                        {
-                            // we are on the "iox::measurement" column, which gives the name of the time series
-                            // if we are on the first row, or if the measurement changes, we push into the
-                            // buffer queue
-                            self.buffer.push_next_measurement(measurement_name);
-                        }
+                                .is_some_and(|n| n != measurement_name))
+                    {
+                        // we are on the "iox::measurement" column, which gives the name of the time series
+                        // if we are on the first row, or if the measurement changes, we push into the
+                        // buffer queue
+                        self.buffer.push_next_measurement(measurement_name);
                     }
                     continue;
                 }
-                if column_name == TIME_COLUMN_NAME {
-                    if let Some(precision) = self.epoch {
-                        cell_value = convert_ns_epoch(cell_value, precision)?
-                    }
+                if column_name == TIME_COLUMN_NAME
+                    && let Some(precision) = self.epoch
+                {
+                    cell_value = convert_ns_epoch(cell_value, precision)?
                 }
                 if let Some(index) = column_map.as_row_index(column_name) {
                     row[index] = cell_value;

--- a/influxdb3_server/src/query_planner.rs
+++ b/influxdb3_server/src/query_planner.rs
@@ -98,9 +98,10 @@ impl SchemaExec {
     fn compute_properties(input: &Arc<dyn ExecutionPlan>, schema: SchemaRef) -> PlanProperties {
         let eq_properties = match input.properties().output_ordering() {
             None => EquivalenceProperties::new(schema),
-            Some(output_odering) => {
-                EquivalenceProperties::new_with_orderings(schema, &[output_odering.clone()])
-            }
+            Some(output_odering) => EquivalenceProperties::new_with_orderings(
+                schema,
+                std::slice::from_ref(output_odering),
+            ),
         };
 
         let output_partitioning = input.output_partitioning().clone();

--- a/influxdb3_write/src/lib.rs
+++ b/influxdb3_write/src/lib.rs
@@ -302,7 +302,7 @@ impl std::cmp::Ord for ParquetFile {
 
 impl std::cmp::PartialOrd for ParquetFile {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
-        Some(self.id.cmp(&other.id))
+        Some(self.cmp(other))
     }
 }
 

--- a/influxdb3_write/src/paths.rs
+++ b/influxdb3_write/src/paths.rs
@@ -261,13 +261,13 @@ impl TryFrom<ObjPath> for TableIndexSnapshotPath {
             .ok_or_else(|| PathError::InvalidTableId(path_str.to_string()))?;
 
         // Validate sequence number
-        if let Some(filename) = path_str.split('/').next_back() {
-            if TableIndexSnapshotPath::parse_sequence_number(filename).is_none() {
-                return Err(PathError::InvalidSequenceNumber {
-                    context: "table snapshot".to_string(),
-                    filename: filename.to_string(),
-                });
-            }
+        if let Some(filename) = path_str.split('/').next_back()
+            && TableIndexSnapshotPath::parse_sequence_number(filename).is_none()
+        {
+            return Err(PathError::InvalidSequenceNumber {
+                context: "table snapshot".to_string(),
+                filename: filename.to_string(),
+            });
         }
 
         Ok(Self(path))
@@ -448,13 +448,13 @@ impl TryFrom<ObjPath> for SnapshotInfoFilePath {
         }
 
         // Additional validation: ensure we can parse the sequence number
-        if let Some(filename) = path_str.split('/').next_back() {
-            if SnapshotInfoFilePath::parse_sequence_number(filename).is_none() {
-                return Err(PathError::InvalidSequenceNumber {
-                    context: "snapshot".to_string(),
-                    filename: filename.to_string(),
-                });
-            }
+        if let Some(filename) = path_str.split('/').next_back()
+            && SnapshotInfoFilePath::parse_sequence_number(filename).is_none()
+        {
+            return Err(PathError::InvalidSequenceNumber {
+                context: "snapshot".to_string(),
+                filename: filename.to_string(),
+            });
         }
 
         Ok(Self(path))

--- a/influxdb3_write/src/table_index_cache.rs
+++ b/influxdb3_write/src/table_index_cache.rs
@@ -578,12 +578,12 @@ impl TableIndexCache {
         // First check if we have a cached entry (read lock)
         {
             let indices = self.inner.indices.read().await;
-            if let Some(db_map) = indices.get(&(table_id.node_id().to_string(), table_id.db_id())) {
-                if let Some(cached) = db_map.get(&table_id.table_id()) {
-                    debug!(table_id = %table_id, "Cache hit for table index");
-                    // Return Arc<CachedTableIndex> as Arc<dyn TableIndex>
-                    return Ok(Arc::new(cached.clone()) as Arc<dyn TableIndex>);
-                }
+            if let Some(db_map) = indices.get(&(table_id.node_id().to_string(), table_id.db_id()))
+                && let Some(cached) = db_map.get(&table_id.table_id())
+            {
+                debug!(table_id = %table_id, "Cache hit for table index");
+                // Return Arc<CachedTableIndex> as Arc<dyn TableIndex>
+                return Ok(Arc::new(cached.clone()) as Arc<dyn TableIndex>);
             }
         }
 

--- a/influxdb3_write/src/write_buffer/queryable_buffer.rs
+++ b/influxdb3_write/src/write_buffer/queryable_buffer.rs
@@ -354,10 +354,10 @@ impl QueryableBuffer {
                         // add file first
                         persisted_files.add_persisted_file(&database_id, &table_id, &parquet_file);
                         // then clear the buffer
-                        if let Some(db) = buffer.db_to_table.get_mut(&database_id) {
-                            if let Some(table) = db.get_mut(&table_id) {
-                                table.clear_snapshots();
-                            }
+                        if let Some(db) = buffer.db_to_table.get_mut(&database_id)
+                            && let Some(table) = db.get_mut(&table_id)
+                        {
+                            table.clear_snapshots();
                         }
                     }
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.88"
+channel = "1.89"
 components = ["rustfmt", "clippy", "rust-analyzer", "rust-src"]


### PR DESCRIPTION
* Updated version in `rust-toolchain.toml` to `1.89.0`
* Fixed all new `clippy` lints; most of which `clippy` handled with `clippy [...] --fix`; there were quite a few.