### PR TITLE
feat: Add --azure-endpoint argument to the CLI

### DIFF
--- a/influxdb3/src/help/serve_all.txt
+++ b/influxdb3/src/help/serve_all.txt
@@ -12,6 +12,14 @@ Examples:
   2. influxdb3 create token --admin
   3. Write and query with unhashed token
 
+  # Run with Azure Blob Storage:
+  1. influxdb3 serve --node-id node1 --object-store azure --bucket influxdb-data \
+    --azure-storage-account STORAGE_ACCOUNT \
+    --azure-storage-access-key STORAGE_ACCESS_KEY \
+    --azure-endpoint ENDPOINT_URL
+  2. influxdb3 create token --admin
+  3. Write and query with unhashed token
+
 {} [OPTIONS] --node-id <NODE_IDENTIFIER_PREFIX> --object-store <OBJECT_STORE_TYPE>
 
 {}
@@ -95,6 +103,7 @@ Examples:
 {}
   --azure-storage-account <ACCT>   Azure storage account name [env: AZURE_STORAGE_ACCOUNT=]
   --azure-storage-access-key <KEY> Azure storage access key [env: AZURE_STORAGE_ACCESS_KEY=]
+  --azure-endpoint <ENDPOINT>      Azure blob storage endpoint [env: AZURE_ENDPOINT=]
 
 {}
   --plugin-dir <DIR>               Location of plugins [env: INFLUXDB3_PLUGIN_DIR=]

--- a/influxdb3/src/help/serve_all.txt
+++ b/influxdb3/src/help/serve_all.txt
@@ -15,8 +15,7 @@ Examples:
   # Run with Azure Blob Storage:
   1. influxdb3 serve --node-id node1 --object-store azure --bucket influxdb-data \
     --azure-storage-account STORAGE_ACCOUNT \
-    --azure-storage-access-key STORAGE_ACCESS_KEY \
-    --azure-endpoint ENDPOINT_URL
+    --azure-storage-access-key STORAGE_ACCESS_KEY
   2. influxdb3 create token --admin
   3. Write and query with unhashed token
 
@@ -104,6 +103,7 @@ Examples:
   --azure-storage-account <ACCT>   Azure storage account name [env: AZURE_STORAGE_ACCOUNT=]
   --azure-storage-access-key <KEY> Azure storage access key [env: AZURE_STORAGE_ACCESS_KEY=]
   --azure-endpoint <ENDPOINT>      Azure blob storage endpoint [env: AZURE_ENDPOINT=]
+  --azure-allow-http                Allow unencrypted HTTP to Azure [env: AZURE_ALLOW_HTTP=]
 
 {}
   --plugin-dir <DIR>               Location of plugins [env: INFLUXDB3_PLUGIN_DIR=]

--- a/influxdb3_clap_blocks/src/object_store.rs
+++ b/influxdb3_clap_blocks/src/object_store.rs
@@ -588,6 +588,15 @@ macro_rules! object_store_config_inner {
                 )]
                 pub azure_endpoint: Option<Endpoint>,
 
+                /// Allow unencrypted HTTP connection to Azure.
+                #[clap(
+                    id = gen_name!($prefix, "azure-allow-http"),
+                    long = gen_name!($prefix, "azure-allow-http"),
+                    env = gen_env!($prefix, "AZURE_ALLOW_HTTP"),
+                    action
+                )]
+                pub azure_allow_http: bool,
+
                 /// When using a network-based object store, limit the number of connection to this value.
                 #[clap(
                     id = gen_name!($prefix, "object-store-connection-limit"),
@@ -693,6 +702,7 @@ macro_rules! object_store_config_inner {
                         azure_storage_access_key: Default::default(),
                         azure_storage_account: Default::default(),
                         azure_endpoint: Default::default(),
+                        azure_allow_http: Default::default(),
                         bucket: Default::default(),
                         database_directory,
                         google_service_account: Default::default(),
@@ -871,8 +881,10 @@ macro_rules! object_store_config_inner {
                     if let Some(key) = &self.azure_storage_access_key {
                         builder = builder.with_access_key(key);
                     }
+
+                    builder = builder.with_allow_http(self.azure_allow_http);
+
                     if let Some(endpoint) = &self.azure_endpoint {
-                        builder = builder.with_allow_http(true);
                         builder = builder.with_endpoint(endpoint.to_string());
                     }
 


### PR DESCRIPTION
This commit allows users to specify the endpoint that they want when using Azure for blob storage. We also automatically enable the allow http flag so that they can specify localhost as their URL if using something like Azurite to test Azure Blob Storage locally.

Closes #26390