### PR TITLE
fix: Persister doesn't actually need a TableIndexCache

### DIFF
--- a/influxdb3/src/commands/serve.rs
+++ b/influxdb3/src/commands/serve.rs
@@ -834,15 +834,7 @@ pub async fn command(config: Config) -> Result<()> {
         Arc::clone(&object_store),
         config.node_identifier_prefix.as_str(),
         Arc::clone(&time_provider) as _,
-        table_index_cache,
     ));
-
-    // Retrieve the table index cache that will be shared between persister and retention handler
-    //
-    // We construct the `TableIndexCache` instance in the persister mostly for convenience at this
-    // point -- it avoids having to deal with updating a lot of `Persister` references throughout
-    // the code base with new `TableIndexCache` instances.
-    let table_index_cache = persister.get_table_index_cache().await;
 
     let process_uuid_getter: Arc<dyn ProcessUuidGetter> = Arc::new(ProcessUuidWrapper::new());
     let catalog = Catalog::new_with_shutdown(

--- a/influxdb3_processing_engine/src/lib.rs
+++ b/influxdb3_processing_engine/src/lib.rs
@@ -976,7 +976,7 @@ mod tests {
     ) -> (Arc<ProcessingEngineManagerImpl>, NamedTempFile) {
         let time_provider: Arc<dyn TimeProvider> = Arc::new(MockProvider::new(start));
         let metric_registry = Arc::new(Registry::new());
-        let persister = Arc::new(Persister::new_with_default_cache_config(
+        let persister = Arc::new(Persister::new(
             Arc::clone(&object_store),
             "test_host",
             Arc::clone(&time_provider) as _,

--- a/influxdb3_server/src/lib.rs
+++ b/influxdb3_server/src/lib.rs
@@ -1695,7 +1695,7 @@ mod tests {
             DedicatedExecutor::new_testing(),
         ));
         let node_identifier_prefix = "test_host";
-        let persister = Arc::new(Persister::new_with_default_cache_config(
+        let persister = Arc::new(Persister::new(
             Arc::clone(&object_store),
             node_identifier_prefix,
             Arc::clone(&time_provider) as _,

--- a/influxdb3_server/src/query_executor/mod.rs
+++ b/influxdb3_server/src/query_executor/mod.rs
@@ -853,7 +853,7 @@ mod tests {
             Arc::clone(&time_provider) as _,
             Default::default(),
         );
-        let persister = Arc::new(Persister::new_with_default_cache_config(
+        let persister = Arc::new(Persister::new(
             Arc::clone(&object_store),
             "test_host",
             Arc::clone(&time_provider) as _,

--- a/influxdb3_server/tests/lib.rs
+++ b/influxdb3_server/tests/lib.rs
@@ -237,7 +237,7 @@ impl TestService {
             },
             DedicatedExecutor::new_testing(),
         ));
-        let persister = Arc::new(Persister::new_with_default_cache_config(
+        let persister = Arc::new(Persister::new(
             Arc::clone(&object_store) as _,
             node_id,
             Arc::clone(&time_provider) as _,

--- a/influxdb3_write/src/write_buffer/mod.rs
+++ b/influxdb3_write/src/write_buffer/mod.rs
@@ -762,7 +762,7 @@ mod tests {
             Arc::clone(&time_provider),
             Default::default(),
         );
-        let persister = Arc::new(Persister::new_with_default_cache_config(
+        let persister = Arc::new(Persister::new(
             catalog.object_store(),
             "test_host",
             Arc::clone(&time_provider),
@@ -3419,7 +3419,7 @@ mod tests {
         } else {
             (object_store, None)
         };
-        let persister = Arc::new(Persister::new_with_default_cache_config(
+        let persister = Arc::new(Persister::new(
             Arc::clone(&object_store),
             "test_host",
             Arc::clone(&time_provider) as _,

--- a/influxdb3_write/src/write_buffer/queryable_buffer.rs
+++ b/influxdb3_write/src/write_buffer/queryable_buffer.rs
@@ -705,7 +705,7 @@ mod tests {
             .await
             .unwrap(),
         );
-        let persister = Arc::new(Persister::new_with_default_cache_config(
+        let persister = Arc::new(Persister::new(
             Arc::clone(&object_store),
             "hosta",
             time_provider,
@@ -911,7 +911,7 @@ mod tests {
             .unwrap(),
         );
 
-        let persister = Arc::new(Persister::new_with_default_cache_config(
+        let persister = Arc::new(Persister::new(
             Arc::clone(&object_store),
             "hosta",
             Arc::clone(&time_provider) as _,


### PR DESCRIPTION
This addresses a verbose logging issue reported by internal testers.

While working on https://github.com/influxdata/influxdb/pull/26636 I had initially added a `TableIndexCache` to the `Persister` because it looked like that might be a good place to implement a retention period handling background loop. I ultimately ended up implementing a separate background loop and neglected to refactor the `TableIndexCache` out of the `Persister` afterward.

This PR cleans that up.
