### PR TITLE
fix(packaging): init.sh should run buildtsi as influxdb user

### DIFF
--- a/.circleci/packages/influxdb/fs/usr/lib/influxdb/scripts/init.sh
+++ b/.circleci/packages/influxdb/fs/usr/lib/influxdb/scripts/init.sh
@@ -158,9 +158,10 @@ function start() {
         # buildtsi prompts with a warning it is is run as root as the files it makes will be owned by root.
         # In that case, it awaits an interactive Yes but that can't be supplied. All around, best to run it
         # as the influxdb user. sudo is also an option but not as available as su
-        su - influxdb -c "/usr/bin/influx_inspect buildtsi -compact-series-file \
-            -datadir "${DATA_DIR}"                                  \
-            -waldir  "${WAL_DIR}""
+        echo "Building tsi with influxd_inspect buildtsi."
+        runuser -u influxdb -- /usr/bin/influx_inspect buildtsi -compact-series-file \
+            -datadir "${DATA_DIR}"                                                   \
+            -waldir  "${WAL_DIR}"
     fi
 
     # Launch process

--- a/.circleci/packages/influxdb/fs/usr/lib/influxdb/scripts/init.sh
+++ b/.circleci/packages/influxdb/fs/usr/lib/influxdb/scripts/init.sh
@@ -159,7 +159,7 @@ function start() {
         # In that case, it awaits an interactive Yes but that can't be supplied. All around, best to run it
         # as the influxdb user. sudo is also an option but not as available as su
         echo "Building tsi with influxd_inspect buildtsi."
-        runuser -u influxdb -- /usr/bin/influx_inspect buildtsi -compact-series-file \
+        setpriv --reuid influxdb --regid influxdb --clear-groups /usr/bin/influx_inspect buildtsi -compact-series-file \
             -datadir "${DATA_DIR}"                                                   \
             -waldir  "${WAL_DIR}"
     fi

--- a/.circleci/packages/influxdb/fs/usr/lib/influxdb/scripts/init.sh
+++ b/.circleci/packages/influxdb/fs/usr/lib/influxdb/scripts/init.sh
@@ -158,7 +158,7 @@ function start() {
         # If this daemon is configured to run as root, influx_inspect hangs
         # waiting for confirmation before executing. Supplying "yes" allows
         # the service to continue without interruption.
-        yes | /usr/bin/influx_inspect buildtsi -compact-series-file \
+        sudo -u influxdb /usr/bin/influx_inspect buildtsi -compact-series-file \
             -datadir "${DATA_DIR}"                                  \
             -waldir  "${WAL_DIR}"
     fi

--- a/.circleci/packages/influxdb/fs/usr/lib/influxdb/scripts/init.sh
+++ b/.circleci/packages/influxdb/fs/usr/lib/influxdb/scripts/init.sh
@@ -155,9 +155,9 @@ function start() {
     WAL_DIR="$(  influxd_config data wal-dir )"
     if [[ ( -d "${DATA_DIR}" ) && ( -d "${WAL_DIR}" ) ]]
     then
-        # buildtsi prompts with a warning it is is run as root as the files it makes will be owned by root.
-        # In that case, it awaits an interactive Yes but that can't be supplied. All around, best to run it
-        # as the influxdb user. sudo is also an option but not as available as su
+        # buildtsi prompts with a warning if it is run as root as the files it creates will be owned by root which
+        # influxd won't be able to read. Best to run it as the influxdb user instead. sudo and su are options but
+        # difficult to use; setpriv is more direct and available in the util-linux package
         echo "Building tsi with influxd_inspect buildtsi."
         setpriv --reuid influxdb --regid influxdb --clear-groups /usr/bin/influx_inspect buildtsi -compact-series-file \
             -datadir "${DATA_DIR}"                                                   \

--- a/.circleci/packages/influxdb/fs/usr/lib/influxdb/scripts/init.sh
+++ b/.circleci/packages/influxdb/fs/usr/lib/influxdb/scripts/init.sh
@@ -155,12 +155,12 @@ function start() {
     WAL_DIR="$(  influxd_config data wal-dir )"
     if [[ ( -d "${DATA_DIR}" ) && ( -d "${WAL_DIR}" ) ]]
     then
-        # If this daemon is configured to run as root, influx_inspect hangs
-        # waiting for confirmation before executing. Supplying "yes" allows
-        # the service to continue without interruption.
-        sudo -u influxdb /usr/bin/influx_inspect buildtsi -compact-series-file \
+        # buildtsi prompts with a warning it is is run as root as the files it makes will be owned by root.
+        # In that case, it awaits an interactive Yes but that can't be supplied. All around, best to run it
+        # as the influxdb user. sudo is also an option but not as available as su
+        su - influxdb -c "/usr/bin/influx_inspect buildtsi -compact-series-file \
             -datadir "${DATA_DIR}"                                  \
-            -waldir  "${WAL_DIR}"
+            -waldir  "${WAL_DIR}""
     fi
 
     # Launch process


### PR DESCRIPTION
The init.sh script assumes that it being run as root so thus we can use
sudo to switch user to the influxdb user to run buildtsi; otherwise the
files are owned by root and influxdb can't start.

* fixes #26698