### PR TITLE
chore(cli): hide the token's env var value in cli help

### DIFF
--- a/influxdb3/src/commands/common.rs
+++ b/influxdb3/src/commands/common.rs
@@ -23,7 +23,7 @@ pub struct InfluxDb3Config {
     pub database_name: String,
 
     /// The token for authentication with the InfluxDB 3 Core server
-    #[clap(long = "token", env = "INFLUXDB3_AUTH_TOKEN")]
+    #[clap(long = "token", env = "INFLUXDB3_AUTH_TOKEN", hide_env_values = true)]
     pub auth_token: Option<Secret<String>>,
 }
 

--- a/influxdb3/src/commands/create.rs
+++ b/influxdb3/src/commands/create.rs
@@ -130,7 +130,7 @@ pub struct DatabaseConfig {
     pub host_url: Url,
 
     /// The token for authentication with the InfluxDB 3 Core server
-    #[clap(long = "token", env = "INFLUXDB3_AUTH_TOKEN")]
+    #[clap(long = "token", env = "INFLUXDB3_AUTH_TOKEN", hide_env_values = true)]
     pub auth_token: Option<Secret<String>>,
 
     /// The name of the database to create. Valid database names are

--- a/influxdb3/src/commands/create/token.rs
+++ b/influxdb3/src/commands/create/token.rs
@@ -87,7 +87,12 @@ pub struct InfluxDb3ServerConfig {
 
     /// The token for authentication with the InfluxDB 3 Core server to create permissions.
     /// This will be the admin token to create tokens with permissions
-    #[clap(name = "token", long = "token", env = "INFLUXDB3_AUTH_TOKEN")]
+    #[clap(
+        name = "token",
+        long = "token",
+        env = "INFLUXDB3_AUTH_TOKEN",
+        hide_env_values = true
+    )]
     pub auth_token: Option<Secret<String>>,
 
     /// An optional arg to use a custom ca for useful for testing with self signed certs

--- a/influxdb3/src/commands/delete.rs
+++ b/influxdb3/src/commands/delete.rs
@@ -109,7 +109,7 @@ pub struct DatabaseConfig {
     pub host_url: Url,
 
     /// The token for authentication with the InfluxDB 3 Core server
-    #[clap(long = "token", env = "INFLUXDB3_AUTH_TOKEN")]
+    #[clap(long = "token", env = "INFLUXDB3_AUTH_TOKEN", hide_env_values = true)]
     pub auth_token: Option<Secret<String>>,
 
     /// The name of the database to be deleted
@@ -210,7 +210,7 @@ pub struct TokenConfig {
     pub host_url: Url,
 
     /// The token for authentication with the InfluxDB 3 Core server
-    #[clap(long = "token", env = "INFLUXDB3_AUTH_TOKEN")]
+    #[clap(long = "token", env = "INFLUXDB3_AUTH_TOKEN", hide_env_values = true)]
     pub auth_token: Option<Secret<String>>,
 
     /// The name of the token to be deleted

--- a/influxdb3/src/commands/install.rs
+++ b/influxdb3/src/commands/install.rs
@@ -37,7 +37,7 @@ pub struct PackageConfig {
     )]
     host_url: Url,
     /// The token for authentication with the InfluxDB 3 Core server
-    #[clap(long = "token", env = "INFLUXDB3_AUTH_TOKEN")]
+    #[clap(long = "token", env = "INFLUXDB3_AUTH_TOKEN", hide_env_values = true)]
     auth_token: Option<Secret<String>>,
 
     /// The processing engine config.

--- a/influxdb3/src/commands/show.rs
+++ b/influxdb3/src/commands/show.rs
@@ -38,7 +38,7 @@ pub struct ShowTokensConfig {
     host_url: Url,
 
     /// The token for authentication with the InfluxDB 3 Enterprise server
-    #[clap(long = "token", env = "INFLUXDB3_AUTH_TOKEN")]
+    #[clap(long = "token", env = "INFLUXDB3_AUTH_TOKEN", hide_env_values = true)]
     auth_token: Option<Secret<String>>,
 
     /// The format in which to output the list of databases
@@ -62,7 +62,7 @@ pub struct DatabaseConfig {
     host_url: Url,
 
     /// The token for authentication with the InfluxDB 3 Core server
-    #[clap(long = "token", env = "INFLUXDB3_AUTH_TOKEN")]
+    #[clap(long = "token", env = "INFLUXDB3_AUTH_TOKEN", hide_env_values = true)]
     auth_token: Option<Secret<String>>,
 
     /// Include databases that were marked as deleted in the output

--- a/influxdb3_load_generator/src/commands/common.rs
+++ b/influxdb3_load_generator/src/commands/common.rs
@@ -33,7 +33,7 @@ pub(crate) struct InfluxDb3Config {
     pub(crate) database_name: String,
 
     /// The token for authentication with the InfluxDB 3 Core server
-    #[clap(long = "token", env = "INFLUXDB3_AUTH_TOKEN")]
+    #[clap(long = "token", env = "INFLUXDB3_AUTH_TOKEN", hide_env_values = true)]
     pub(crate) auth_token: Option<Secret<String>>,
 
     /// The name of the builtin spec to run. Use this instead of spec_path if you want to run

--- a/influxdb3_load_generator/src/commands/write_fixed.rs
+++ b/influxdb3_load_generator/src/commands/write_fixed.rs
@@ -31,7 +31,7 @@ pub struct WriteFixedConfig {
     pub(crate) host_url: Url,
 
     /// The token for authentication with the InfluxDB 3 Enterprise server
-    #[clap(long = "token", env = "INFLUXDB3_AUTH_TOKEN")]
+    #[clap(long = "token", env = "INFLUXDB3_AUTH_TOKEN", hide_env_values = true)]
     pub(crate) auth_token: Option<Secret<String>>,
 
     /// Write-specific config:


### PR DESCRIPTION
Use clap crate's "hide_env_values" option to suppress displaying the current value of the env var of the db token INFLUXDB3_AUTH_TOKEN when displaying cli help. The default behavior of clap is to display env var values for arguments when displaying the generated help messages. Showing the token disrupts formatting of the help because it is often long and in a way leaks the token's value.

* closes #26713