### PR TITLE
feat: Add offline generation for admin tokens

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3037,6 +3037,7 @@ dependencies = [
  "authz",
  "backtrace",
  "base64 0.21.7",
+ "chrono",
  "clap",
  "console-subscriber",
  "datafusion_util",

--- a/influxdb3/Cargo.toml
+++ b/influxdb3/Cargo.toml
@@ -54,6 +54,7 @@ influxdb3_write = { path = "../influxdb3_write" }
 anyhow.workspace = true
 backtrace.workspace = true
 base64.workspace = true
+chrono.workspace = true
 clap.workspace = true
 owo-colors.workspace = true
 dotenvy.workspace = true

--- a/influxdb3/src/help/serve.txt
+++ b/influxdb3/src/help/serve.txt
@@ -38,6 +38,8 @@ Examples
                                    list of resources. Valid values are health, ping, and metrics.
                                    To disable auth for multiple resources pass in a list, eg.
                                    `--disable-authz health,ping`
+  --admin-token-file <FILE>        File containing offline admin tokens
+                                  [env: INFLUXDB3_ADMIN_TOKEN_FILE=]
 
 {}
   --data-dir <DIR>                 Location to store files locally [env: INFLUXDB3_DB_DIR=]

--- a/influxdb3/src/help/serve_all.txt
+++ b/influxdb3/src/help/serve_all.txt
@@ -47,6 +47,9 @@ Examples:
                                    Address for HTTP API for admin token recovery requests [default: 127.0.0.1:8182]
                                    WARNING: This endpoint allows unauthenticated admin token regeneration - use with caution!
                                    [env: INFLUXDB3_ADMIN_TOKEN_RECOVERY_HTTP_BIND_ADDR]
+  --admin-token-file <FILE>        File containing offline admin tokens. Used for automated
+                                   deployments where the admin token is pre-generated and loaded at startup.
+                                   [env: INFLUXDB3_ADMIN_TOKEN_FILE=]
 
 
 {}

--- a/influxdb3_catalog/src/catalog.rs
+++ b/influxdb3_catalog/src/catalog.rs
@@ -402,7 +402,13 @@ impl CatalogResource for TokenInfo {
     }
 }
 
-fn create_token_and_hash() -> (String, Vec<u8>) {
+/// Compute the SHA512 hash of a token string
+/// This is the canonical way to hash tokens across the codebase
+pub fn compute_token_hash(token: &str) -> Vec<u8> {
+    Sha512::digest(token).to_vec()
+}
+
+pub fn create_token_and_hash() -> (String, Vec<u8>) {
     let token = {
         let mut token = String::from("apiv3_");
         let mut key = [0u8; 64];
@@ -410,5 +416,5 @@ fn create_token_and_hash() -> (String, Vec<u8>) {
         token.push_str(&B64.encode(key));
         token
     };
-    (token.clone(), Sha512::digest(&token).to_vec())
+    (token.clone(), compute_token_hash(&token))
 }


### PR DESCRIPTION
This commit adds the ability to generate authentication tokens offline that can then be loaded up by the database at runtime if the tokens do not already exist. This is perfect for automated deployments and containerized environments. This is the implementation for Core which only has admin tokens. The Enterprise counterpart to this change also includes permissions based tokens.

CLI Usage

```bash
# Generate offline admin token
influxdb3 create token --admin --offline --output-file ./config/admin_token.txt
```

Server Configuration

The server can load tokens from files on startup:
- Admin token: `--admin-token-file ./config/admin_token.txt`

Closes #26437

Note the Enterprise PR is here: https://github.com/influxdata/influxdb_pro/pull/977