### PR TITLE
chore: port influxdb_pro#1163 to Core

### DIFF
--- a/influxdb3/src/commands/serve.rs
+++ b/influxdb3/src/commands/serve.rs
@@ -56,6 +56,7 @@ use object_store_metrics::ObjectStoreMetrics;
 use observability_deps::tracing::*;
 use panic_logging::SendPanicsToTracing;
 use parquet_file::storage::{ParquetStorage, StorageId};
+use std::collections::HashMap;
 use std::{env, num::NonZeroUsize, sync::Arc, time::Duration};
 use std::{path::Path, str::FromStr};
 use std::{path::PathBuf, process::Command};
@@ -86,6 +87,8 @@ pub const DEFAULT_HTTP_BIND_ADDR: &str = "0.0.0.0:8181";
 pub const DEFAULT_ADMIN_TOKEN_RECOVERY_BIND_ADDR: &str = "127.0.0.1:8182";
 
 pub const DEFAULT_TELEMETRY_ENDPOINT: &str = "https://telemetry.v3.influxdata.com";
+
+mod cli_params;
 
 #[derive(Debug, Error)]
 pub enum Error {
@@ -648,7 +651,7 @@ fn ensure_directory_exists(p: &Path) {
     }
 }
 
-pub async fn command(config: Config) -> Result<()> {
+pub async fn command(config: Config, user_params: HashMap<String, String>) -> Result<()> {
     // Check that both a cert file and key file are present if TLS is being set up
     match (&config.cert_file, &config.key_file) {
         (Some(_), None) | (None, Some(_)) => {
@@ -870,12 +873,16 @@ pub async fn command(config: Config) -> Result<()> {
             .await
     });
 
+    // Capture and filter CLI parameters
+    let cli_params = cli_params::capture_cli_params(user_params);
+
     let _ = catalog
         .register_node(
             &config.node_identifier_prefix,
             num_cpus as u64,
             vec![influxdb3_catalog::log::NodeMode::Core],
             process_uuid_getter,
+            Some(cli_params),
         )
         .await?;
     let node_def = catalog

--- a/influxdb3/src/commands/serve/cli_params.rs
+++ b/influxdb3/src/commands/serve/cli_params.rs
@@ -1,0 +1,283 @@
+//! CLI parameter capture for storing user-provided configuration, filtering out sensitive parameters.
+
+use std::collections::HashMap;
+
+/// List of all known sensitive CLI parameters
+const SENSITIVE_PARAMS: &[&str] = &[
+    "aws-access-key-id",
+    "aws-secret-access-key",
+    "aws-session-token",
+    "aws-credentials-file",
+    "aws-endpoint",
+    "aws-allow-http",
+    "aws-default-region",
+    "aws-skip-signature",
+    "azure-endpoint",
+    "azure-allow-http",
+    "azure-storage-account",
+    "azure-storage-access-key",
+    "google-service-account",
+    "tls-key",
+    "tls-cert",
+    "without-auth",
+];
+
+/// List of all known non-sensitive CLI parameters - only used in test but declared at module level
+/// for visibility
+#[allow(dead_code)]
+const NON_SENSITIVE_PARAMS: &[&str] = &[
+    // Core parameters
+    "node-id",
+    "http-bind",
+    "max-http-request-size",
+    "object-store",
+    "data-dir",
+    "verbose",
+    "bucket",
+    // Memory and performance parameters
+    "exec-mem-pool-bytes",
+    "num-datafusion-threads",
+    "query-file-limit",
+    "force-snapshot-mem-threshold",
+    // WAL parameters
+    "wal-flush-interval",
+    "wal-snapshot-size",
+    "wal-max-write-buffer-size",
+    "wal-replay-fail-on-error",
+    "wal-replay-concurrency-limit",
+    "snapshotted-wal-files-to-keep",
+    // Cache parameters
+    "parquet-mem-cache-size",
+    "parquet-mem-cache-prune-percentage",
+    "parquet-mem-cache-prune-interval",
+    "parquet-mem-cache-query-path-duration",
+    "disable-parquet-mem-cache",
+    "table-index-cache-max-entries",
+    "table-index-cache-concurrency-limit",
+    // Distinct cache parameters
+    "distinct-cache-eviction-interval",
+    // Last cache parameters
+    "last-cache-eviction-interval",
+    // Retention and deletion parameters
+    "retention-check-interval",
+    "delete-grace-period",
+    "hard-delete-default-duration",
+    // Generation configuration
+    "gen1-duration",
+    "gen1-lookback-duration",
+    // Logging and tracing parameters
+    "log-filter",
+    "log-destination",
+    "log-format",
+    "query-log-size",
+    "traces-exporter",
+    "traces-exporter-jaeger-agent-host",
+    "traces-exporter-jaeger-agent-port",
+    "traces-exporter-jaeger-service-name",
+    "traces-exporter-jaeger-trace-context-header-name",
+    "traces-jaeger-debug-name",
+    "traces-jaeger-tags",
+    "traces-jaeger-max-msgs-per-second",
+    // DataFusion parameters
+    "datafusion-config",
+    "datafusion-use-cached-parquet-loader",
+    "datafusion-max-parquet-fanout",
+    "datafusion-runtime-type",
+    "datafusion-runtime-thread-priority",
+    "datafusion-runtime-thread-keep-alive",
+    "datafusion-runtime-disable-lifo-slot",
+    "datafusion-runtime-event-interval",
+    "datafusion-runtime-global-queue-interval",
+    "datafusion-runtime-max-io-events-per-tick",
+    "datafusion-runtime-max-blocking-threads",
+    // Object store parameters
+    "object-store-cache-endpoint",
+    "object-store-connection-limit",
+    "object-store-http2-only",
+    "object-store-http2-max-frame-size",
+    "object-store-max-retries",
+    "object-store-retry-timeout",
+    // Feature flags and modes
+    "disable-authz",
+    // Telemetry
+    "telemetry-endpoint",
+    "disable-telemetry-upload",
+    // TLS parameters
+    "tls-minimum-version",
+    // Python integration
+    "plugin-dir",
+    "virtual-env-location",
+    "package-manager",
+    // Other parameters
+    "tcp-listener-file-path",
+];
+
+const REDACTED_STR: &str = "*******";
+
+/// Capture user-provided CLI parameters with sensitive values redacted
+///
+/// This function takes user-provided parameters extracted from ArgMatches
+/// and returns a JSON string where sensitive parameters show as "*******"
+/// while non-sensitive parameters show their actual values.
+pub(super) fn capture_cli_params(user_params: HashMap<String, String>) -> String {
+    let mut params = HashMap::new();
+
+    for (key, value) in user_params {
+        if is_sensitive(&key) {
+            // Sensitive params show as asterisks
+            params.insert(key, REDACTED_STR.to_string());
+        } else {
+            // Non-sensitive params show actual value
+            params.insert(key, value);
+        }
+    }
+
+    serde_json::to_string(&params).unwrap_or_else(|_| "{}".to_string())
+}
+
+/// Check if a parameter name contains sensitive information
+fn is_sensitive(param: &str) -> bool {
+    // First check against our known sensitive parameters list
+    if SENSITIVE_PARAMS.contains(&param) {
+        return true;
+    }
+
+    // Additional substring matches for parameter patterns (safety net)
+    const SENSITIVE_PATTERNS: &[&str] =
+        &["password", "secret", "token", "credential", "auth", "key"];
+
+    let param_lower = param.to_lowercase();
+
+    // Check substring matches for extra safety
+    for pattern in SENSITIVE_PATTERNS {
+        if param_lower.contains(pattern) {
+            return true;
+        }
+    }
+
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::CommandFactory;
+    use hashbrown::HashSet;
+
+    use crate::commands::serve::Config;
+
+    use super::*;
+
+    #[test]
+    fn test_sensitive_params_are_redacted() {
+        let mut params = HashMap::new();
+        for sensitive in SENSITIVE_PARAMS {
+            params.insert(sensitive.to_string(), "un-redacted".to_string());
+        }
+        let result = capture_cli_params(params);
+        let parsed = serde_json::from_str::<HashMap<String, String>>(&result).unwrap();
+        assert_eq!(
+            parsed.len(),
+            SENSITIVE_PARAMS.len(),
+            "expected there to be {n} parsed entries",
+            n = SENSITIVE_PARAMS.len()
+        );
+        for sensitive in SENSITIVE_PARAMS {
+            assert_eq!(
+                parsed.get(*sensitive).unwrap(),
+                REDACTED_STR,
+                "expected {REDACTED_STR} for '{sensitive}' argument"
+            );
+        }
+    }
+
+    /// Extract all argument IDs from a Command recursively
+    fn extract_all_arg_ids(cmd: &clap::Command, args: &mut HashSet<String>) {
+        for arg in cmd.get_arguments() {
+            let id = arg.get_id().as_str();
+
+            // Skip help and version which are always present
+            if id == "help" || id == "version" || id == "help-all" {
+                continue;
+            }
+
+            // Get the display name (long form or short form or id)
+            let display_name = if let Some(long) = arg.get_long() {
+                long.to_string()
+            } else if let Some(short) = arg.get_short() {
+                format!("{}", short)
+            } else {
+                id.to_string()
+            };
+
+            args.insert(display_name);
+        }
+
+        // Recursively process subcommands
+        for subcmd in cmd.get_subcommands() {
+            if subcmd.get_name() != "help" {
+                extract_all_arg_ids(subcmd, args);
+            }
+        }
+    }
+
+    #[test]
+    fn test_all_config_params_categorized() {
+        // Use the module-level constants - no need to redefine them here
+        // Get all arguments from the Config command
+        let cmd = Config::command();
+        let mut discovered_args = HashSet::new();
+        extract_all_arg_ids(
+            cmd.get_subcommands()
+                .find(|c| c.get_name() == "serve")
+                .unwrap_or(&cmd),
+            &mut discovered_args,
+        );
+
+        // If there are no serve subcommand, check the root
+        if discovered_args.is_empty() {
+            extract_all_arg_ids(&cmd, &mut discovered_args);
+        }
+
+        let mut uncategorized = Vec::new();
+
+        for arg in &discovered_args {
+            let is_in_non_sensitive_list = NON_SENSITIVE_PARAMS.contains(&arg.as_str());
+            let is_in_sensitive_list = SENSITIVE_PARAMS.contains(&arg.as_str());
+
+            if !is_in_non_sensitive_list && !is_in_sensitive_list {
+                // Check if it might be caught by substring matching in is_sensitive function
+                if !is_sensitive(arg) {
+                    uncategorized.push(arg.clone());
+                }
+            }
+        }
+
+        if !uncategorized.is_empty() {
+            panic!(
+                "The following CLI parameters are not categorized as either sensitive or \
+                non-sensitive:\n{}\n\n\
+                Please add them to either NON_SENSITIVE_PARAMS or SENSITIVE_PARAMS constants \
+                at the module level.",
+                uncategorized.join("\n")
+            );
+        }
+
+        let mut needlessly_categorized = Vec::new();
+
+        for arg in NON_SENSITIVE_PARAMS.iter().chain(SENSITIVE_PARAMS) {
+            let is_discovered = discovered_args.contains(*arg);
+            if !is_discovered {
+                needlessly_categorized.push(arg.to_owned());
+            }
+        }
+
+        if !needlessly_categorized.is_empty() {
+            panic!(
+                "The following CLI parameters were set as either sensitive or non-sensitive \
+                but were not discovered in the actual command:\n{}\n\n\
+                Please remove them from the NON_SENSITIVE_PARAMS or SENSITIVE_PARAMS constants.",
+                needlessly_categorized.join("\n")
+            );
+        }
+    }
+}

--- a/influxdb3_catalog/src/catalog/migrations/snapshots/influxdb3_catalog__catalog__migrations__v2__tests__catalog_snapshot__verify snapshot.snap
+++ b/influxdb3_catalog/src/catalog/migrations/snapshots/influxdb3_catalog__catalog__migrations__v2__tests__catalog_snapshot__verify snapshot.snap
@@ -22,7 +22,8 @@ expression: v2_catalog.snapshot()
               "registered_time_ns": 1000
             }
           },
-          "core_count": 1
+          "core_count": 1,
+          "cli_params": null
         }
       ]
     ],

--- a/influxdb3_catalog/src/catalog/migrations/v2.rs
+++ b/influxdb3_catalog/src/catalog/migrations/v2.rs
@@ -110,6 +110,7 @@ fn migrate_nodes(from: &v1::InnerCatalog, v2_inner: &mut InnerCatalog) {
                     v2::NodeState::Stopped { stopped_time_ns }
                 }
             },
+            cli_params: None, // v1 catalog doesn't have cli_params
         };
         v2_inner
             .nodes

--- a/influxdb3_catalog/src/catalog/versions/v2/metrics.rs
+++ b/influxdb3_catalog/src/catalog/versions/v2/metrics.rs
@@ -288,6 +288,7 @@ mod tests {
                 4,
                 vec![NodeMode::Core],
                 Arc::clone(&process_uuid_getter),
+                None,
             )
             .await
             .unwrap();

--- a/influxdb3_catalog/src/catalog/versions/v2/update.rs
+++ b/influxdb3_catalog/src/catalog/versions/v2/update.rs
@@ -206,8 +206,9 @@ impl Catalog {
         core_count: u64,
         mode: Vec<NodeMode>,
         process_uuid_getter: Arc<dyn ProcessUuidGetter>,
+        cli_params: Option<String>,
     ) -> Result<OrderedCatalogBatch> {
-        info!(node_id, core_count, mode = ?mode, "register node");
+        info!(node_id, core_count, mode = ?mode, cli_params = ?cli_params, "register node");
         let process_uuid = *process_uuid_getter.get_process_uuid();
         self.catalog_update_with_retry(|| {
             let time_ns = self.time_provider.now().timestamp_nanos();
@@ -251,6 +252,7 @@ impl Catalog {
                     core_count,
                     mode: mode.clone(),
                     process_uuid,
+                    cli_params: cli_params.clone(),
                 })],
             ))
         })

--- a/influxdb3_catalog/src/log/versions/v4.rs
+++ b/influxdb3_catalog/src/log/versions/v4.rs
@@ -291,6 +291,8 @@ pub struct RegisterNodeLog {
     pub core_count: u64,
     pub mode: Vec<NodeMode>,
     pub process_uuid: Uuid,
+    #[serde(default)]
+    pub cli_params: Option<String>,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]

--- a/influxdb3_catalog/src/snapshot/versions/v4.rs
+++ b/influxdb3_catalog/src/snapshot/versions/v4.rs
@@ -106,6 +106,8 @@ pub(crate) struct NodeSnapshot {
     pub(crate) mode: Vec<NodeMode>,
     pub(crate) state: NodeStateSnapshot,
     pub(crate) core_count: u64,
+    #[serde(default)]
+    pub(crate) cli_params: Option<Arc<str>>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/influxdb3_server/src/system_tables/mod.rs
+++ b/influxdb3_server/src/system_tables/mod.rs
@@ -29,9 +29,14 @@ mod distinct_caches;
 mod generations;
 mod influxdb_schema;
 mod last_caches;
+mod nodes;
 mod parquet_files;
-use crate::system_tables::python_call::{
-    ProcessingEngineLogsTable, ProcessingEngineTriggerArgumentsTable, ProcessingEngineTriggerTable,
+use crate::system_tables::{
+    nodes::NodeSystemTable,
+    python_call::{
+        ProcessingEngineLogsTable, ProcessingEngineTriggerArgumentsTable,
+        ProcessingEngineTriggerTable,
+    },
 };
 mod python_call;
 mod queries;
@@ -48,6 +53,7 @@ pub(crate) const PARQUET_FILES_TABLE_NAME: &str = "parquet_files";
 pub(crate) const TOKENS_TABLE_NAME: &str = "tokens";
 pub(crate) const DATABASES_TABLE_NAME: &str = "databases";
 pub(crate) const TABLES_TABLE_NAME: &str = "tables";
+pub(crate) const NODES_TABLE_NAME: &str = "nodes";
 pub(crate) const GENERATION_DURATIONS_TABLE_NAME: &str = "generation_durations";
 pub(crate) const INFLUXDB_SCHEMA_TABLE_NAME: &str = "influxdb_schema";
 /// The default timezone used in the system schema.
@@ -169,6 +175,12 @@ impl AllSystemSchemaTablesProvider {
                 Arc::new(SystemTableProvider::new(Arc::new(TokenSystemTable::new(
                     Arc::clone(&catalog),
                     started_with_auth,
+                )))),
+            );
+            tables.insert(
+                NODES_TABLE_NAME,
+                Arc::new(SystemTableProvider::new(Arc::new(NodeSystemTable::new(
+                    Arc::clone(&catalog),
                 )))),
             );
             tables.insert(

--- a/influxdb3_server/src/system_tables/nodes.rs
+++ b/influxdb3_server/src/system_tables/nodes.rs
@@ -1,0 +1,117 @@
+use std::sync::Arc;
+
+use arrow::array::{
+    GenericListBuilder, StringViewBuilder, TimestampMillisecondBuilder, UInt32Builder,
+    UInt64Builder,
+};
+use arrow_array::RecordBatch;
+use arrow_schema::{DataType, Field, Schema, SchemaRef, TimeUnit};
+use datafusion::{error::DataFusionError, prelude::Expr};
+use influxdb3_catalog::catalog::{Catalog, NodeDefinition};
+use iox_system_tables::IoxSystemTable;
+use tonic::async_trait;
+
+#[derive(Debug)]
+pub(crate) struct NodeSystemTable {
+    catalog: Arc<Catalog>,
+    schema: SchemaRef,
+}
+
+impl NodeSystemTable {
+    pub(crate) fn new(catalog: Arc<Catalog>) -> Self {
+        Self {
+            catalog,
+            schema: table_schema(),
+        }
+    }
+}
+
+#[async_trait]
+impl IoxSystemTable for NodeSystemTable {
+    fn schema(&self) -> SchemaRef {
+        Arc::clone(&self.schema)
+    }
+
+    async fn scan(
+        &self,
+        _filters: Option<Vec<Expr>>,
+        _limit: Option<usize>,
+    ) -> Result<RecordBatch, DataFusionError> {
+        let nodes = self.catalog.list_nodes();
+        to_record_batch(&self.schema, nodes)
+    }
+}
+
+fn table_schema() -> SchemaRef {
+    let fields = vec![
+        Field::new("node_id", DataType::Utf8View, false),
+        Field::new("node_catalog_id", DataType::UInt32, false),
+        Field::new("instance_id", DataType::Utf8View, false),
+        Field::new(
+            "mode",
+            DataType::List(Arc::new(Field::new("item", DataType::Utf8View, true))),
+            false,
+        ),
+        Field::new("core_count", DataType::UInt64, false),
+        Field::new("state", DataType::Utf8View, false),
+        Field::new(
+            "updated_at",
+            DataType::Timestamp(TimeUnit::Millisecond, None),
+            true,
+        ),
+        Field::new("cli_params", DataType::Utf8View, true),
+    ];
+    Arc::new(Schema::new(fields))
+}
+
+fn to_record_batch(
+    schema: &SchemaRef,
+    nodes: Vec<Arc<NodeDefinition>>,
+) -> Result<RecordBatch, DataFusionError> {
+    let cap = nodes.len();
+    let mut node_id_builder = StringViewBuilder::with_capacity(cap);
+    let mut node_catalog_id_builder = UInt32Builder::with_capacity(cap);
+    let mut instance_id_builder = StringViewBuilder::with_capacity(cap);
+    let mode_builder = StringViewBuilder::new();
+    let mut mode_builder =
+        GenericListBuilder::<i32, StringViewBuilder>::with_capacity(mode_builder, cap);
+    let mut core_count_builder = UInt64Builder::with_capacity(cap);
+    let mut state_builder = StringViewBuilder::with_capacity(cap);
+    let mut updated_at_builder = TimestampMillisecondBuilder::with_capacity(cap);
+    let mut cli_params_builder = StringViewBuilder::with_capacity(cap);
+
+    for node in &nodes {
+        node_id_builder.append_value(node.node_id());
+        node_catalog_id_builder.append_value(node.node_catalog_id().get());
+        instance_id_builder.append_value(node.instance_id());
+        for mode in node.modes() {
+            mode_builder.values().append_value(mode.as_str());
+        }
+        mode_builder.append(true);
+        core_count_builder.append_value(node.core_count());
+        state_builder.append_value(node.state().as_str());
+        updated_at_builder.append_value(node.state().updated_at_ns() / (1_000 * 1_000));
+
+        // Add cli_params - handle None case
+        if let Some(params) = node.cli_params() {
+            cli_params_builder.append_value(params);
+        } else {
+            cli_params_builder.append_null();
+        }
+    }
+
+    RecordBatch::try_new(
+        Arc::clone(schema),
+        vec![
+            Arc::new(node_id_builder.finish()),
+            Arc::new(node_catalog_id_builder.finish()),
+            Arc::new(instance_id_builder.finish()),
+            Arc::new(mode_builder.finish()),
+            Arc::new(core_count_builder.finish()),
+            Arc::new(state_builder.finish()),
+            Arc::new(updated_at_builder.finish()),
+            Arc::new(cli_params_builder.finish()),
+        ],
+    )
+    .map_err(Into::into)
+}


### PR DESCRIPTION
See https://github.com/influxdata/influxdb_pro/issues/807

This back-port was non-trivial because the `system.nodes` table was not available in Core, only Enterprise. I therefore followed the implementation in the original PR, but did the following in addition:

* Added the `system.nodes` table to the `_internal` database using the same implementation as in Enterprise

* Modified the test that checks for newly added CLI arguments from the original PR to also check for "needlessly categorized" CLI arguments:
https://github.com/influxdata/influxdb/blob/9110fce4b8206eee58ac8962181e31487cb957ff/influxdb3/src/commands/serve/cli_params.rs#L265-L281
    This helped trim down some of the cruft in the `SENSITIVE`/`NON_SENSITIVE` lists that _I think_ were generated by Claude, and also revealed https://github.com/influxdata/influxdb_pro/issues/1204 and https://github.com/influxdata/influxdb_pro/issues/1203

* The [integration tests](https://github.com/influxdata/influxdb/blob/9110fce4b8206eee58ac8962181e31487cb957ff/influxdb3/tests/server/system_tables.rs#L544-L663) added in this PR are unique to tests added in Enterprise, but should capture the same functionality.


### Follow-on work

Based on the above, there is some work to be done to unify the code between Core and Enterprise, even though they have feature parity with this PR.

- [ ] Unify the code in the `influxdb3::commands::serve::cli_params` module between Core and Enterprise
- [ ] Make the `system.nodes` table a non-enterprise feature in the `influxdb_pro` repo by relocating the code to where it is implemented in Core by this PR
- [ ] Port the new integration tests added in this PR to Enterprise