### PR TITLE
chore: backport Enterprise fixes for TableIndexCache

### DIFF
--- a/influxdb3_processing_engine/src/lib.rs
+++ b/influxdb3_processing_engine/src/lib.rs
@@ -978,8 +978,8 @@ mod tests {
         let metric_registry = Arc::new(Registry::new());
         let persister = Arc::new(Persister::new(
             Arc::clone(&object_store),
-            "test_host",
-            Arc::clone(&time_provider) as _,
+            "test_host".to_string(),
+            Arc::clone(&time_provider),
         ));
         let catalog = Arc::new(
             Catalog::new(

--- a/influxdb3_write/src/lib.rs
+++ b/influxdb3_write/src/lib.rs
@@ -37,7 +37,7 @@ use iox_time::Time;
 use observability_deps::tracing::debug;
 use schema::TIME_COLUMN_NAME;
 use serde::{Deserialize, Serialize};
-use std::{fmt::Debug, sync::Arc};
+use std::{fmt::Debug, sync::Arc, time::Duration};
 use thiserror::Error;
 
 #[derive(Debug, Error)]
@@ -59,6 +59,22 @@ pub enum Error {
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
+
+/// Returns a standard retry configuration for ObjectStore operations.
+pub fn standard_retry_config() -> backon::ExponentialBuilder {
+    backon::ExponentialBuilder::default()
+        .with_min_delay(Duration::from_millis(50))
+        .with_max_delay(Duration::from_secs(2))
+        .with_max_times(5)
+}
+
+/// Returns a quick retry configuration for ObjectStore operations.
+pub fn quick_retry_config() -> backon::ExponentialBuilder {
+    backon::ExponentialBuilder::default()
+        .with_min_delay(Duration::from_millis(50))
+        .with_max_delay(Duration::from_secs(2))
+        .with_max_times(2)
+}
 
 pub trait WriteBuffer: Bufferer + ChunkContainer + DistinctCacheManager + LastCacheManager {}
 


### PR DESCRIPTION
Summary of backported changes:

fix: Persister doesn't actually need a TableIndexCache

* allow TableIndexCache initialization to gracefully fail

fix: TableIndexCache initialization and ObjectStore improvements

* By not exiting the process when the TableIndexCache fails to load, we allow it to continue starting up in a degraded state. We emit warning messages letting the user know that gen0 file retention policies and hard deletes may not be able to complete and that compaction and queries are unaffected.

* Add retries with exponential backoff to object store operations in the `influxdb3_write::table_index` and `influxdb3_write::table_index_cache` modules. Warning logs on retry let the user know what is failing when it happens, to assist with troubleshooting.
