### PR TITLE
fix: avoid panic when `--admin` is missing

### DIFF
--- a/influxdb3/src/commands/create/token.rs
+++ b/influxdb3/src/commands/create/token.rs
@@ -291,9 +291,12 @@ impl CreateTokenConfig {
 
 impl FromArgMatches for CreateTokenConfig {
     fn from_arg_matches(matches: &clap::ArgMatches) -> Result<Self, clap::Error> {
-        let admin_subcmd_matches = matches
-            .subcommand_matches("--admin")
-            .expect("--admin must be present");
+        let admin_subcmd_matches = matches.subcommand_matches("--admin").ok_or_else(|| {
+            ClapError::raw(
+                ErrorKind::MissingSubcommand,
+                "Missing required subcommand. Use: influxdb3 create token --admin [OPTIONS]\n",
+            )
+        })?;
         let name = admin_subcmd_matches.get_one::<String>("name");
         let regenerate = admin_subcmd_matches
             .get_one::<bool>("regenerate")


### PR DESCRIPTION
### Summary

This commit fixes panic when `influxdb3 create token` is called without `--admin`. Removed `expect` and switched to a clap::Error which is better than panicking

closes: https://github.com/influxdata/influxdb/issues/26730

### Tests

- Missing subcommand

```
❯ ./target/debug/influxdb3 create token
error: Missing required subcommand. Use: influxdb3 create token --admin [OPTIONS]


Usage: influxdb3 [OPTIONS] [COMMAND]

For more information, try '--help'.

```

- Help text

```
❯ ./target/debug/influxdb3 create token --help
Create a new auth token

Usage: influxdb3 create token [COMMAND]

Commands:
  --admin  Create or regenerate an admin token

Options:
  -h, --help      Print help information
      --help-all  Print more detailed help information

```