### PR TITLE
feat: Add offline token creation test

### DIFF
--- a/influxdb3/tests/cli/mod.rs
+++ b/influxdb3/tests/cli/mod.rs
@@ -1,6 +1,7 @@
 mod admin_token;
 mod api;
 mod db_retention;
+mod offline_tokens;
 
 use crate::server::{ConfigProvider, TestServer};
 use assert_cmd::Command as AssertCmd;

--- a/influxdb3/tests/cli/offline_tokens.rs
+++ b/influxdb3/tests/cli/offline_tokens.rs
@@ -1,0 +1,93 @@
+use tempfile::TempDir;
+use test_helpers::assert_contains;
+
+use crate::cli::api::run_cmd_with_result;
+use crate::server::{ConfigProvider, TestServer};
+use reqwest::StatusCode;
+use serde_json::Value;
+
+#[test_log::test(tokio::test)]
+async fn test_offline_token_creation_flow() {
+    // Create temporary directory for token files
+    let temp_dir = TempDir::new().unwrap();
+    let admin_token_file = temp_dir.path().join("admin_token.json");
+
+    // Step 1: Create offline admin token using CLI
+    println!("Creating offline admin token...");
+    let result = run_cmd_with_result(
+        &[],
+        None,
+        vec![
+            "create",
+            "token",
+            "--admin",
+            "--offline",
+            "--output-file",
+            admin_token_file.to_str().unwrap(),
+        ],
+    )
+    .unwrap();
+    println!("Admin token creation result: {}", result);
+    assert_contains!(&result, "Token saved to:");
+
+    // Parse admin token from file
+    let admin_token_content = std::fs::read_to_string(&admin_token_file).unwrap();
+    let admin_token_json: Value = serde_json::from_str(&admin_token_content).unwrap();
+    let admin_token = admin_token_json["token"].as_str().unwrap().to_string();
+
+    // Step 2: Start server with token files
+    let mut server = TestServer::configure()
+        .with_auth()
+        .with_no_admin_token()
+        .with_admin_token_file(admin_token_file.to_str().unwrap())
+        .spawn()
+        .await;
+
+    // Set the admin token for further operations
+    server.set_token(Some(admin_token.clone()));
+
+    // Step 4: Verify tokens exist
+    let result = server
+        .run(
+            vec!["show", "tokens"],
+            &["--tls-ca", "../testing-certs/rootCA.pem"],
+        )
+        .unwrap();
+    assert_contains!(&result, "_admin");
+
+    // Step 4: Verify database creation
+    let result = server
+        .run(
+            vec!["show", "databases"],
+            &["--tls-ca", "../testing-certs/rootCA.pem"],
+        )
+        .unwrap();
+    assert_contains!(&result, "_internal");
+
+    // Step 5: Test admin token privileges
+    let client = server.http_client();
+    let base = server.client_addr();
+
+    // Admin can query _internal database
+    let query_sql_url = format!("{base}/api/v3/query_sql");
+    let response = client
+        .get(&query_sql_url)
+        .query(&[
+            ("db", "_internal"),
+            ("q", "SELECT * FROM system.tables LIMIT 1"),
+        ])
+        .bearer_auth(&admin_token)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    // Admin can create a new database
+    let result = server
+        .run(
+            vec!["create", "database", "admin_test_db"],
+            &["--tls-ca", "../testing-certs/rootCA.pem"],
+        )
+        .unwrap();
+    assert_contains!(&result, "Database \"admin_test_db\" created successfully");
+}

--- a/influxdb3/tests/server/mod.rs
+++ b/influxdb3/tests/server/mod.rs
@@ -97,6 +97,8 @@ pub struct TestConfig {
     gen1_duration: Option<String>,
     capture_logs: bool,
     enable_recovery_endpoint: bool,
+    admin_token_file: Option<String>,
+    permission_tokens_file: Option<String>,
 }
 
 impl TestConfig {
@@ -184,6 +186,18 @@ impl TestConfig {
         self.capture_logs = true;
         self
     }
+
+    /// Set the admin token file path for this [`TestServer`]
+    pub fn with_admin_token_file<S: Into<String>>(mut self, path: S) -> Self {
+        self.admin_token_file = Some(path.into());
+        self
+    }
+
+    /// Set the permission tokens file path for this [`TestServer`]
+    pub fn with_permission_tokens_file<S: Into<String>>(mut self, path: S) -> Self {
+        self.permission_tokens_file = Some(path.into());
+        self
+    }
 }
 
 impl ConfigProvider for TestConfig {
@@ -239,6 +253,20 @@ impl ConfigProvider for TestConfig {
             args.append(&mut vec![
                 "--gen1-duration".to_string(),
                 gen1_duration.to_owned(),
+            ])
+        }
+
+        if let Some(admin_token_file) = &self.admin_token_file {
+            args.append(&mut vec![
+                "--admin-token-file".to_string(),
+                admin_token_file.to_owned(),
+            ])
+        }
+
+        if let Some(permission_tokens_file) = &self.permission_tokens_file {
+            args.append(&mut vec![
+                "--permission-tokens-file".to_string(),
+                permission_tokens_file.to_owned(),
             ])
         }
 


### PR DESCRIPTION
This commit adds an offline token creation test. We did not have this as
part of the 3.4 test in the interest of time. This adds automated
testing to make sure the flow we expect happens which includes:

- Ability to create admin tokens via the CLI
- Token creation on startup
- Database creation on start

With this we can be more confident that the feature works as expected
and that other changes that might affect it have regression coverage.
