### PR TITLE
chore: backport object store TLS configuration from PR #1243

### DIFF
--- a/influxdb3/src/commands/serve/cli_params.rs
+++ b/influxdb3/src/commands/serve/cli_params.rs
@@ -97,6 +97,8 @@ const NON_SENSITIVE_PARAMS: &[&str] = &[
     "object-store-http2-max-frame-size",
     "object-store-max-retries",
     "object-store-retry-timeout",
+    "object-store-tls-allow-insecure",
+    "object-store-tls-ca",
     // Feature flags and modes
     "disable-authz",
     // Telemetry

--- a/influxdb3/src/help/serve_all.txt
+++ b/influxdb3/src/help/serve_all.txt
@@ -125,6 +125,13 @@ Examples:
                                   Max retry timeout [env: OBJECT_STORE_RETRY_TIMEOUT=]
   --object-store-cache-endpoint <ENDPOINT>
                                   S3 compatible cache endpoint [env: OBJECT_STORE_CACHE_ENDPOINT=]
+  --object-store-tls-allow-insecure
+                                  Skip TLS certificate verification for object storage.
+                                  WARNING: This is insecure and should only be used for testing
+                                  [env: OBJECT_STORE_TLS_ALLOW_INSECURE=]
+  --object-store-tls-ca <PATH>   Path to custom CA certificate file (PEM format) for object storage.
+                                  Use when your object store uses a certificate signed by a private CA
+                                  [env: OBJECT_STORE_TLS_CA=]
 
 {}
   --max-http-request-size <SIZE>   Maximum size of HTTP requests [default: 10485760]

--- a/influxdb3/tests/server/mod.rs
+++ b/influxdb3/tests/server/mod.rs
@@ -99,6 +99,8 @@ pub struct TestConfig {
     enable_recovery_endpoint: bool,
     admin_token_file: Option<String>,
     permission_tokens_file: Option<String>,
+    object_store_tls_allow_insecure: bool,
+    object_store_tls_ca_path: Option<String>,
 }
 
 impl TestConfig {
@@ -198,6 +200,18 @@ impl TestConfig {
         self.permission_tokens_file = Some(path.into());
         self
     }
+
+    /// Allow insecure TLS connections for object store
+    pub fn with_object_store_tls_allow_insecure(mut self) -> Self {
+        self.object_store_tls_allow_insecure = true;
+        self
+    }
+
+    /// Set custom CA certificate path for object store TLS
+    pub fn with_object_store_tls_ca_path<S: Into<String>>(mut self, path: S) -> Self {
+        self.object_store_tls_ca_path = Some(path.into());
+        self
+    }
 }
 
 impl ConfigProvider for TestConfig {
@@ -239,6 +253,17 @@ impl ConfigProvider for TestConfig {
             args.append(&mut vec![
                 "--object-store".to_string(),
                 "memory".to_string(),
+            ]);
+        }
+
+        // Add TLS configuration for object store
+        if self.object_store_tls_allow_insecure {
+            args.push("--object-store-tls-allow-insecure".to_string());
+        }
+        if let Some(ca_path) = &self.object_store_tls_ca_path {
+            args.append(&mut vec![
+                "--object-store-tls-ca".to_string(),
+                ca_path.to_owned(),
             ]);
         }
 


### PR DESCRIPTION

  ## Summary
  Backports TLS configuration options for object storage from influxdb_pro PR #1243 to allow:
  - Custom CA certificates for object stores using private certificate authorities
  - Option to skip TLS verification for testing environments

  ## Changes
  - Added `--object-store-tls-allow-insecure` flag to skip TLS certificate verification (testing only)
  - Added `--object-store-tls-ca` option to specify custom CA certificate file path
  - Updated CLI parameter handling and help documentation
  - Added TLS configuration support to test infrastructure

  ## Test plan
  - [x] Code compiles successfully
  - [x] Tests pass for influxdb3_clap_blocks package
  - [x] Manual testing with MinIO using self-signed certificates (see tests in https://github.com/influxdata/influxdb_pro/pull/1243)

  ## Reference
  Backported from influxdb_pro PR: https://github.com/influxdata/influxdb_pro/pull/1243
