### PR TITLE
feat: Adds detection for orphaned TSM files while running PlanOptimize

### DIFF
--- a/tsdb/engine/tsm1/compact.go
+++ b/tsdb/engine/tsm1/compact.go
@@ -476,7 +476,8 @@ func (c *DefaultPlanner) PlanOptimize(lastWrite time.Time) (compactGroup []Compa
 		levelGroups = append(levelGroups, groups...)
 	} else {
 		for _, cur := range groups {
-			if cur.level() == 4 {
+			// We need to account for potentially orphaned lower level TSM files
+			if cur.level() == 4 || cur.Len() < 2 {
 				levelGroups = append(levelGroups, cur)
 			}
 		}

--- a/tsdb/engine/tsm1/compact_test.go
+++ b/tsdb/engine/tsm1/compact_test.go
@@ -4492,6 +4492,103 @@ func TestEnginePlanCompactions(t *testing.T) {
 				}
 			},
 		},
+		{
+			name: "Mixed generations with varying file sizes",
+			files: []tsm1.ExtFileStat{
+				{
+					FileStat: tsm1.FileStat{
+						Path: "000016684-000000007.tsm",
+						Size: 2147483648, // 2.1GB
+					},
+					FirstBlockCount: tsdb.DefaultMaxPointsPerBlock,
+				},
+				{
+					FileStat: tsm1.FileStat{
+						Path: "000016684-000000008.tsm",
+						Size: 2147483648, // 2.1GB
+					},
+					FirstBlockCount: tsdb.DefaultMaxPointsPerBlock,
+				},
+				{
+					FileStat: tsm1.FileStat{
+						Path: "000016684-000000009.tsm",
+						Size: 2147483648, // 2.1GB
+					},
+					FirstBlockCount: tsdb.DefaultMaxPointsPerBlock,
+				},
+				{
+					FileStat: tsm1.FileStat{
+						Path: "000016684-000000010.tsm",
+						Size: 394264576, // 376MB
+					},
+					FirstBlockCount: tsdb.DefaultMaxPointsPerBlock,
+				},
+				{
+					FileStat: tsm1.FileStat{
+						Path: "000016812-000000004.tsm",
+						Size: 2147483648, // 2.1GB
+					},
+					FirstBlockCount: tsdb.DefaultMaxPointsPerBlock,
+				},
+				{
+					FileStat: tsm1.FileStat{
+						Path: "000016812-000000005.tsm",
+						Size: 1503238553, // 1.4GB
+					},
+					FirstBlockCount: tsdb.DefaultMaxPointsPerBlock,
+				},
+				{
+					FileStat: tsm1.FileStat{
+						Path: "000016844-000000002.tsm",
+						Size: 1395864371, // 1.3GB
+					},
+					FirstBlockCount: tsdb.DefaultMaxPointsPerBlock,
+				},
+				{
+					FileStat: tsm1.FileStat{
+						Path: "000016948-000000004.tsm",
+						Size: 2147483648, // 2.1GB
+					},
+					FirstBlockCount: tsdb.DefaultMaxPointsPerBlock,
+				},
+				{
+					FileStat: tsm1.FileStat{
+						Path: "000016948-000000005.tsm",
+						Size: 1503238553, // 1.4GB
+					},
+					FirstBlockCount: tsdb.DefaultMaxPointsPerBlock,
+				},
+				{
+					FileStat: tsm1.FileStat{
+						Path: "000017076-000000004.tsm",
+						Size: 2147483648, // 2.1GB
+					},
+					FirstBlockCount: tsdb.DefaultMaxPointsPerBlock,
+				},
+			},
+			testShardTime: -1,
+			expectedResult: func() testLevelResults {
+				return testLevelResults{
+					level5Groups: []tsm1.PlannedCompactionGroup{
+						{
+							tsm1.CompactionGroup{
+								"000016684-000000007.tsm",
+								"000016684-000000008.tsm",
+								"000016684-000000009.tsm",
+								"000016684-000000010.tsm",
+								"000016812-000000004.tsm",
+								"000016812-000000005.tsm",
+								"000016844-000000002.tsm",
+								"000016948-000000004.tsm",
+								"000016948-000000005.tsm",
+								"000017076-000000004.tsm",
+							},
+							tsdb.DefaultMaxPointsPerBlock,
+						},
+					},
+				}
+			},
+		},
 	}
 
 	e, err := NewEngine(tsdb.InmemIndexName)


### PR DESCRIPTION
We were seeing a state in which a shard would not perform full compactions leading to a build up of level 4 TSM files.

File state:

```
-rw-r--r--.  1 root root 2.1G Aug  5 20:59 000016684-000000007.tsm
-rw-r--r--.  1 root root 2.1G Aug  5 21:02 000016684-000000008.tsm
-rw-r--r--.  1 root root 2.1G Aug  5 21:04 000016684-000000009.tsm
-rw-r--r--.  1 root root 376M Aug  5 21:05 000016684-000000010.tsm
-rw-r--r--.  1 root root 2.1G Aug  5 18:00 000016812-000000004.tsm
-rw-r--r--.  1 root root 1.4G Aug  5 18:00 000016812-000000005.tsm
-rw-r--r--.  1 root root 1.3G Aug  5 21:21 000016844-000000002.tsm
-rw-r--r--.  1 root root 2.1G Aug  5 18:00 000016948-000000004.tsm
-rw-r--r--.  1 root root 1.4G Aug  5 18:00 000016948-000000005.tsm
-rw-r--r--.  1 root root 2.1G Aug  5 18:00 000017076-000000004.tsm
```

There is a rouge level 2 file packed within fully compacted files

```
-rw-r--r--.  1 root root 2.1G Aug  5 20:59 000016684-000000007.tsm
-rw-r--r--.  1 root root 2.1G Aug  5 21:02 000016684-000000008.tsm
-rw-r--r--.  1 root root 2.1G Aug  5 21:04 000016684-000000009.tsm
-rw-r--r--.  1 root root 376M Aug  5 21:05 000016684-000000010.tsm
```

and level 4 files

```
-rw-r--r--.  1 root root 2.1G Aug  5 18:00 000016948-000000004.tsm
-rw-r--r--.  1 root root 1.4G Aug  5 18:00 000016948-000000005.tsm
-rw-r--r--.  1 root root 2.1G Aug  5 18:00 000017076-000000004.tsm
```

The area of our code that would cause this state to be skipped would be here

https://github.com/influxdata/influxdb/blob/22bec4f046a28e3f1fa815705362767151407e1b/tsdb/engine/tsm1/compact.go#L620-L670

We need to add some sort of escape mechanism that would allow for compactions to occur or simplify this logic.

This PR adds a test for the bugged file listing where we experience the issue. I'm still trying to find the way files get in to this state, but, this should resolve the issue if and when it occurs. I've added the check in PlanOptimize() as to not change any of the core logic in Plan().

(cherry picked from commit cabcdd1adfd9a391a48fd211642784721ee9d96a)

Closes #

Describe your proposed changes here.

- [ ] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb/blob/main/README.md).
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
