### PR TITLE
fix(tokio): futures::executor::block_on is not compatible with tokio

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,3 @@
+disallowed-methods = [
+    { path = "futures::executor::block_on", reason = "incompatible with tokio runtime", replacement = "use tokio::task::block_in_place with Handle::current().block_on" },
+]

--- a/influxdb3/src/help/influxdb3_all.txt
+++ b/influxdb3/src/help/influxdb3_all.txt
@@ -23,9 +23,10 @@ InfluxDB 3 Core Server and Command Line Tools
   {}      Test that Processing Engine plugins work the way you expect
 
 {}
-  --io-runtime-type <TYPE>          IO tokio runtime type [env: INFLUXDB3_IO_RUNTIME_TYPE=]
-                                    [default: multi-thread]
-                                    [possible values: current-thread, multi-thread, multi-thread-alt]
+  --io-runtime-type <TYPE>           IO tokio runtime type [env: INFLUXDB3_IO_RUNTIME_TYPE=]
+                                     [default: multi-thread]
+                                     [possible values: multi-thread, multi-thread-alt]
+
   --io-runtime-disable-lifo-slot <BOOL>
                                      Disable LIFO slot of IO runtime
                                      [env: INFLUXDB3_IO_RUNTIME_DISABLE_LIFO_SLOT=]

--- a/influxdb3/src/main.rs
+++ b/influxdb3/src/main.rs
@@ -1,5 +1,6 @@
 use influxdb3_lib::startup;
 
+#[deny(clippy::disallowed_methods)]
 fn main() -> Result<(), std::io::Error> {
     startup(std::env::args().collect())
 }

--- a/influxdb3_clap_blocks/src/tokio.rs
+++ b/influxdb3_clap_blocks/src/tokio.rs
@@ -14,9 +14,6 @@ use paste::paste;
 /// Tokio runtime type.
 #[derive(Debug, Clone, Copy, Default, clap::ValueEnum)]
 pub enum TokioRuntimeType {
-    /// Current-thread runtime.
-    CurrentThread,
-
     /// Multi-thread runtime.
     #[default]
     MultiThread,
@@ -164,7 +161,6 @@ macro_rules! tokio_rt_config {
                     // requires a running tokio runtime and is initialised after this function.
 
                     let mut builder = match self.runtime_type {
-                        TokioRuntimeType::CurrentThread => tokio::runtime::Builder::new_current_thread(),
                         TokioRuntimeType::MultiThread => tokio::runtime::Builder::new_multi_thread(),
                         TokioRuntimeType::MultiThreadAlt => {
                             #[cfg(tokio_unstable)]

--- a/influxdb3_server/src/http.rs
+++ b/influxdb3_server/src/http.rs
@@ -1037,7 +1037,11 @@ impl HttpApi {
             .authenticate(auth_token.clone())
             .await
             .map_err(|e| {
-                error!(?e, "cannot authenticate token");
+                error!(
+                    ?e,
+                    path = req.uri().path_and_query().map(|pq| pq.path()),
+                    "cannot authenticate token"
+                );
                 AuthenticationError::Unauthenticated
             })?;
 


### PR DESCRIPTION
This is a backport from the enterprise fork that addresses a bug in the
ReauthingObjectStore that would lead to tokio runtime deadlocks under certain
low thread count conditions.

* fix(tokio): futures::executor::block_on is not compatible with tokio

futures::executor::block_on takes over the thread that calls it with a
while loop expecting another thread or runtime to drive the contained
future to completion. This doesn't work with tokio's runtime thread
expectations where it expects to swap tasks off threads as it likes.
While it doesn't always cause an issue with tokio, the futures block_on
can stall the tokio runtime.

The method tokio::task::block_in_place runs the contained closure in a
blocking manner without blocking the runtime. Within it then, you can
use Handle::current().block_on to enter an async context to execute
futures correctly on tokio's runtime.

These tokio versions are not compatible with the "current_thread"
runtime option of tokio.

This commit also includes the uri path when an authentical request to
the server's http api fails. This is useful for understand the target of
the unauthorized request.

* fix: remove current thread tokio runtime type

It is not compatible with our execution model.
