### PR TITLE
chore: cherry-pick recent enterprise bug fixes

### DIFF
--- a/influxdb3_clap_blocks/src/object_store.rs
+++ b/influxdb3_clap_blocks/src/object_store.rs
@@ -1200,7 +1200,7 @@ impl AwsCredentialReloader {
         let cloned = self.clone();
         tokio::spawn(async move {
             loop {
-                let next_check_in = cloned
+                let mut next_check_in = cloned
                     .check_and_update()
                     .await
                     .and_then(|next_check_ts| {
@@ -1208,11 +1208,17 @@ impl AwsCredentialReloader {
                         if next_check_ts < now {
                             None
                         } else {
-                            Some(Duration::from_secs(now - next_check_ts))
+                            Some(Duration::from_secs(next_check_ts - now))
                         }
                     })
                     .unwrap_or_else(default_check_in);
 
+                // avoid a tight loop when sleeping under a second
+                // this might happen if the expiry time wasn't updated or
+                // the process started up right on the expiry time
+                if next_check_in.as_secs() < 1 {
+                    next_check_in = Duration::from_secs(1);
+                }
                 cloned.time_provider.sleep(next_check_in).await;
             }
         });
@@ -1260,11 +1266,9 @@ impl AwsCredentialReloader {
         if do_update {
             let mut guard = self.current.write().await;
             *guard = Arc::new(credentials);
-
-            next_expiry
-        } else {
-            None
         }
+        // we assume the creds file is accurate even if we didn't update the creds themselves
+        next_expiry
     }
 }
 


### PR DESCRIPTION
This PR pulls in a couple key bug fixes from the enterprise fork.

## fix(reauthing object store): respect expiry in the file

This adjusts the background reloading task for object store credentials.
It would ignore the expiry in the file if the credentials weren't
changing but this might mean that a check at the expiry time is missed.

This pr also makes sure the temporary runtime is shutdown when building
with the no_license feature enabled, which is the standard build config
for our hosting partner.

## fix: reject lp lines containing duplicate fields

The main problem this PR resolves is that ingesters currently accept line
protocol containing duplicates of the same field. This results in the WAL
containing N times the number of values for the duplicated fields where N is
the number of duplicates.

This causes the server to crash after the WAL files are persisted to object
store during the gen1 file snapshotting process. Since the corrupted WAL is
persisted to object store, the server will again crash next time it attempts to
start up during WAL replay & snapshotting.

The fix here is to introduce a `HashSet<ColumnId>` that we use when qualifying
each line in a batch that lets us detect a duplicate field. If we detect a
duplicate field, we return a `WriteLineError` indicating the problematic field.
This solution slightly increases the memory usage in the `WriteValidator`, but
we make a best effort to avoid this by re-using the same allocation for all
lines in a batch. The upper bound on the extra memory allocated for this on a
per-batch basis is 2**16*16 = 1MB, but should typically be much smaller since
it scales with the number of fileds on a given line.
