### PR TITLE
feat: use zap.AtomicLevel for dynamic logging levels (#26182)

### DIFF
--- a/cmd/influx_inspect/verify/seriesfile/command.go
+++ b/cmd/influx_inspect/verify/seriesfile/command.go
@@ -55,9 +55,9 @@ func (cmd *Command) Run(args ...string) error {
 	}
 
 	config := logger.NewConfig()
-	config.Level = zapcore.WarnLevel
+	config.Level.SetLevel(zapcore.WarnLevel)
 	if cmd.verbose {
-		config.Level = zapcore.InfoLevel
+		config.Level.SetLevel(zapcore.InfoLevel)
 	}
 	logger, err := config.New(cmd.Stderr)
 	if err != nil {

--- a/cmd/influx_tools/compact/command.go
+++ b/cmd/influx_tools/compact/command.go
@@ -59,7 +59,7 @@ func (cmd *Command) Run(args []string) (err error) {
 
 	var log = zap.NewNop()
 	if cmd.verbose {
-		cfg := logger.Config{Format: "logfmt", Level: zapcore.DebugLevel}
+		cfg := logger.Config{Format: "logfmt", Level: zap.NewAtomicLevelAt(zapcore.DebugLevel)}
 		log, err = cfg.New(os.Stdout)
 		if err != nil {
 			return err

--- a/cmd/influxd/run/config_test.go
+++ b/cmd/influxd/run/config_test.go
@@ -228,7 +228,7 @@ min-version = "tls1.0"
 		t.Fatalf("unexpected cache max memory size: %v", c.Data.CacheMaxMemorySize)
 	}
 
-	if c.Logging.Level != zapcore.WarnLevel {
+	if c.Logging.Level.Level() != zapcore.WarnLevel {
 		t.Fatalf("unexpected logging level: %v", c.Logging.Level)
 	}
 

--- a/logger/config.go
+++ b/logger/config.go
@@ -1,20 +1,20 @@
 package logger
 
 import (
-	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap"
 )
 
 // Config represents the configuration for creating a zap.Logger.
 type Config struct {
-	Format       string        `toml:"format"`
-	Level        zapcore.Level `toml:"level"`
-	SuppressLogo bool          `toml:"suppress-logo"`
+	Format       string          `toml:"format"`
+	Level        zap.AtomicLevel `toml:"level"`
+	SuppressLogo bool            `toml:"suppress-logo"`
 }
 
 // NewConfig returns a new instance of Config with defaults.
 func NewConfig() Config {
 	return Config{
 		Format: "auto",
-		Level:  zapcore.InfoLevel,
+		Level:  zap.NewAtomicLevel(),
 	}
 }

--- a/toml/toml_test.go
+++ b/toml/toml_test.go
@@ -141,10 +141,10 @@ func TestGroup_UnmarshalTOML(t *testing.T) {
 }
 
 func TestConfig_Encode(t *testing.T) {
-	var c run.Config
+	var c *run.Config = run.NewConfig()
 	c.Coordinator.WriteTimeout = itoml.Duration(time.Minute)
 	buf := new(bytes.Buffer)
-	if err := toml.NewEncoder(buf).Encode(&c); err != nil {
+	if err := toml.NewEncoder(buf).Encode(c); err != nil {
 		t.Fatal("Failed to encode: ", err)
 	}
 	got, search := buf.String(), `write-timeout = "1m0s"`


### PR DESCRIPTION
Use the zap.AtomicLevel struct for log levels
which allows the level to be changed dynamically.
Enterprise will use this feature.

(cherry picked from commit 53329a3ad34a6106c3058f62217b0ac85483d8af)
