### PR TITLE
chore(1.11): upgrade go toolchain to 1.23.12

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/influxdata/influxdb
 
 go 1.23.0
 
-toolchain go1.23.8
+toolchain go1.23.12
 
 require (
 	collectd.org v0.3.0


### PR DESCRIPTION
Continuation of PR #26706
Upgrading also toolchain from 1.23.8 to 1.23.12
