### PR TITLE
fix: stop noisy logging about phantom shards that do not belong to no…

### DIFF
--- a/cmd/influxd/run/server.go
+++ b/cmd/influxd/run/server.go
@@ -299,7 +299,7 @@ func (s *Server) appendRetentionPolicyService(c retention.Config) {
 		return
 	}
 	srv := retention.NewService(c)
-	srv.MetaClient = s.MetaClient
+	srv.SetOSSMetaClient(s.MetaClient)
 	srv.TSDBStore = s.TSDBStore
 	srv.DropShardMetaRef = retention.OSSDropShardMetaRef(s.MetaClient)
 	s.Services = append(s.Services, srv)

--- a/services/retention/service.go
+++ b/services/retention/service.go
@@ -4,6 +4,8 @@ package retention // import "github.com/influxdata/influxdb/services/retention"
 import (
 	"errors"
 	"fmt"
+	"math"
+	"slices"
 	"sync"
 	"time"
 
@@ -13,11 +15,35 @@ import (
 	"go.uber.org/zap"
 )
 
-type MetaClient interface {
+type OSSMetaClient interface {
 	Databases() []meta.DatabaseInfo
 	DeleteShardGroup(database, policy string, id uint64) error
 	DropShard(id uint64) error
 	PruneShardGroups() error
+}
+
+type MetaClient interface {
+	OSSMetaClient
+	NodeID() uint64
+}
+
+const (
+	// ossNodeID is a special node ID for OSS nodes. No enterprise node will ever have this node ID.
+	// 0 can not be used because there is a brief period on startup before meta-client initialization
+	// and before joining a cluster that NodeID() == 0.
+	ossNodeID uint64 = math.MaxUint64
+)
+
+// ossMetaClientAdapter adds methods the retention service needs to the OSS meta.Client implementation.
+// OSSMetaClient is decorated with methods needed for the Enterprise retention service instead of adding
+// them to the OSS MetaClient to avoid polluting the OSS MetaClient namespace.
+type ossMetaClientAdapter struct {
+	OSSMetaClient
+}
+
+// NodeID returns the magic ossNodeID identifier.
+func (c *ossMetaClientAdapter) NodeID() uint64 {
+	return ossNodeID
 }
 
 // Service represents the retention policy enforcement service.
@@ -58,10 +84,18 @@ func NewService(c Config) *Service {
 }
 
 // OSSDropShardMetaRef creates a closure appropriate for OSS to use as DropShardMetaRef.
-func OSSDropShardMetaRef(mc MetaClient) func(uint64, []uint64) error {
+func OSSDropShardMetaRef(mc OSSMetaClient) func(uint64, []uint64) error {
 	return func(shardID uint64, owners []uint64) error {
 		return mc.DropShard(shardID)
 	}
+}
+
+func (s *Service) SetMetaClient(c MetaClient) {
+	s.MetaClient = c
+}
+
+func (s *Service) SetOSSMetaClient(c OSSMetaClient) {
+	s.SetMetaClient(&ossMetaClientAdapter{OSSMetaClient: c})
 }
 
 // Open starts retention policy enforcement.
@@ -114,6 +148,10 @@ func (s *Service) run() {
 			s.DeletionCheck()
 		}
 	}
+}
+
+func (s *Service) isOSS() bool {
+	return s.NodeID() == ossNodeID
 }
 
 func (s *Service) DeletionCheck() {
@@ -244,16 +282,21 @@ func (s *Service) DeletionCheck() {
 
 	// Check for expired phantom shards that exist in the metadata but not in the store.
 	for id, info := range deletedShardIDs {
-		func() {
-			log, logEnd := logger.NewOperation(log, "Drop phantom shard references", "retention_drop_phantom_refs",
-				logger.Database(info.db), logger.Shard(id), logger.RetentionPolicy(info.rp), zap.Uint64s("owners", info.owners))
-			defer logEnd()
-			log.Warn("Expired phantom shard detected during retention check, removing from metadata")
-			if err := s.DropShardMetaRef(id, info.owners); err != nil {
-				log.Error("Error dropping shard meta reference for phantom shard", zap.Error(err))
-				retryNeeded = true
-			}
-		}()
+		// Enterprise tracks shard ownership while OSS does not because it is single node. A shard not in the
+		// TSDB but in the metadata is always a phantom shard for OSS. For enterprise, it is only a phantom shard
+		// if this node is supposed to own the shard according to the metadata.
+		if s.isOSS() || slices.Contains(info.owners, s.NodeID()) {
+			func() {
+				log, logEnd := logger.NewOperation(log, "Drop phantom shard references", "retention_drop_phantom_refs",
+					logger.Database(info.db), logger.Shard(id), logger.RetentionPolicy(info.rp), zap.Uint64s("owners", info.owners))
+				defer logEnd()
+				log.Warn("Expired phantom shard detected during retention check, removing from metadata")
+				if err := s.DropShardMetaRef(id, info.owners); err != nil {
+					log.Error("Error dropping shard meta reference for phantom shard", zap.Error(err))
+					retryNeeded = true
+				}
+			}()
+		}
 	}
 
 	func() {

--- a/services/retention/service_test.go
+++ b/services/retention/service_test.go
@@ -266,7 +266,7 @@ func TestRetention_DeletionCheck(t *testing.T) {
 	}
 
 	s := retention.NewService(cfg)
-	s.MetaClient = mc
+	s.SetOSSMetaClient(mc)
 	s.TSDBStore = store
 	s.DropShardMetaRef = retention.OSSDropShardMetaRef(s.MetaClient)
 	require.NoError(t, s.Open())
@@ -721,7 +721,7 @@ func NewService(c retention.Config) *Service {
 	l := logger.New(&s.LogBuf)
 	s.WithLogger(l)
 
-	s.Service.MetaClient = s.MetaClient
+	s.Service.SetOSSMetaClient(s.MetaClient)
 	s.Service.TSDBStore = s.TSDBStore
 	s.Service.DropShardMetaRef = retention.OSSDropShardMetaRef(s.Service.MetaClient)
 	return s


### PR DESCRIPTION
…de (#26527)

Stop noisy logging about phantom shards that do not belong to the current node by checking the shard ownership before logging about the phantom shard. Note that only the logging was inaccurate. This did not accidentally remove shards from the metadata that weren't really phantom shards due to checks in `DropShardMetaRef` implementations.

closes: #26525
(cherry picked from commit 8ef2aca1ca70622a01c3f47f38018a918b98a032)

