### PR TITLE
chore: update Cargo.toml for 3.5.0-0.rc.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3078,7 +3078,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3"
-version = "3.5.0-nightly"
+version = "3.5.0-0.rc.1"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3161,7 +3161,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_authz"
-version = "3.5.0-nightly"
+version = "3.5.0-0.rc.1"
 dependencies = [
  "async-trait",
  "authz",
@@ -3178,7 +3178,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_cache"
-version = "3.5.0-nightly"
+version = "3.5.0-0.rc.1"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3213,7 +3213,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_catalog"
-version = "3.5.0-nightly"
+version = "3.5.0-0.rc.1"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3264,7 +3264,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_clap_blocks"
-version = "3.5.0-nightly"
+version = "3.5.0-0.rc.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3297,7 +3297,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_client"
-version = "3.5.0-nightly"
+version = "3.5.0-0.rc.1"
 dependencies = [
  "bytes",
  "hashbrown 0.15.5",
@@ -3317,7 +3317,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_id"
-version = "3.5.0-nightly"
+version = "3.5.0-0.rc.1"
 dependencies = [
  "indexmap 2.11.4",
  "serde",
@@ -3327,7 +3327,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_internal_api"
-version = "3.5.0-nightly"
+version = "3.5.0-0.rc.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3343,7 +3343,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_load_generator"
-version = "3.5.0-nightly"
+version = "3.5.0-0.rc.1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3372,7 +3372,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_process"
-version = "3.5.0-nightly"
+version = "3.5.0-0.rc.1"
 dependencies = [
  "cargo_metadata",
  "iox_time",
@@ -3381,7 +3381,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_processing_engine"
-version = "3.5.0-nightly"
+version = "3.5.0-0.rc.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3423,7 +3423,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_py_api"
-version = "3.5.0-nightly"
+version = "3.5.0-0.rc.1"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -3450,7 +3450,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_server"
-version = "3.5.0-nightly"
+version = "3.5.0-0.rc.1"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3547,7 +3547,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_shutdown"
-version = "3.5.0-nightly"
+version = "3.5.0-0.rc.1"
 dependencies = [
  "futures",
  "futures-util",
@@ -3562,7 +3562,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_sys_events"
-version = "3.5.0-nightly"
+version = "3.5.0-0.rc.1"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3581,7 +3581,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_telemetry"
-version = "3.5.0-nightly"
+version = "3.5.0-0.rc.1"
 dependencies = [
  "futures",
  "futures-util",
@@ -3602,7 +3602,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_test_helpers"
-version = "3.5.0-nightly"
+version = "3.5.0-0.rc.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3615,7 +3615,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_types"
-version = "3.5.0-nightly"
+version = "3.5.0-0.rc.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3635,7 +3635,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_wal"
-version = "3.5.0-nightly"
+version = "3.5.0-0.rc.1"
 dependencies = [
  "async-trait",
  "bitcode",
@@ -3663,7 +3663,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_write"
-version = "3.5.0-nightly"
+version = "3.5.0-0.rc.1"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3902,7 +3902,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query_influxql_rewrite"
-version = "3.5.0-nightly"
+version = "3.5.0-0.rc.1"
 dependencies = [
  "influxdb_influxql_parser",
  "thiserror 1.0.69",
@@ -4698,7 +4698,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_utils"
-version = "3.5.0-nightly"
+version = "3.5.0-0.rc.1"
 dependencies = [
  "async-trait",
  "backon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ exclude = [
 # then this will be `3.1.0-nightly`. Once `3.1.0` is released, this will be bumped to `3.2.0-nightly`,
 # and will remain that regardless of how many `3.1.x` patch releases are done prior to the `3.2.0`
 # release.
-version = "3.5.0-nightly"
+version = "3.5.0-0.rc.1"
 authors = ["InfluxData OSS Developers"]
 edition = "2024"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Version naming convention is based on: https://github.com/influxdata/influxdb/blob/0a9de807a608ce1c0ab9831d5acc4cef7ba1c1d4/.circleci/packages/config.yaml#L1-L65