### PR TITLE
feat: TagValueIterator holds RLock for too long (#26369) (#26372)

### DIFF
--- a/tsdb/index/tsi1/log_file.go
+++ b/tsdb/index/tsi1/log_file.go
@@ -421,17 +421,19 @@ func (f *LogFile) TagValue(name, key, value []byte) TagValueElem {
 // TagValueIterator returns a value iterator for a tag key.
 func (f *LogFile) TagValueIterator(name, key []byte) TagValueIterator {
 	f.mu.RLock()
-	defer f.mu.RUnlock()
 
 	mm, ok := f.mms[string(name)]
 	if !ok {
+		f.mu.RUnlock()
 		return nil
 	}
 
 	tk, ok := mm.tagSet[string(key)]
 	if !ok {
+		f.mu.RUnlock()
 		return nil
 	}
+	f.mu.RUnlock()
 	return tk.TagValueIterator()
 }
 


### PR DESCRIPTION
(cherry picked from commit 016d77fbba6c3ed6c9aaa3a138451b72f81b3129)