### PR TITLE
feat: backport of custom plugin-repo functionality

### DIFF
--- a/influxdb3/src/commands/serve.rs
+++ b/influxdb3/src/commands/serve.rs
@@ -1270,6 +1270,7 @@ pub(crate) fn setup_processing_engine_env_manager(
         plugin_dir: config.plugin_dir.clone(),
         virtual_env_location: config.virtual_env_location.clone(),
         package_manager,
+        plugin_repo: config.plugin_repo.clone(),
     }
 }
 

--- a/influxdb3/src/commands/serve/cli_params.rs
+++ b/influxdb3/src/commands/serve/cli_params.rs
@@ -110,6 +110,7 @@ const NON_SENSITIVE_PARAMS: &[&str] = &[
     "plugin-dir",
     "virtual-env-location",
     "package-manager",
+    "plugin-repo",
     // Other parameters
     "tcp-listener-file-path",
 ];

--- a/influxdb3/tests/cli/mod.rs
+++ b/influxdb3/tests/cli/mod.rs
@@ -2719,7 +2719,7 @@ async fn test_trigger_create_validates_file_present() {
 
     assert!(result.is_err());
     let err = result.unwrap_err().to_string();
-    assert!(err.contains("error reading file from Github: 404 Not Found"));
+    assert!(err.contains("error fetching plugin from repository: 404 Not Found"));
 }
 
 fn check_logs(response: &Value, expected_logs: &[&str]) {

--- a/influxdb3_clap_blocks/src/plugins.rs
+++ b/influxdb3_clap_blocks/src/plugins.rs
@@ -12,6 +12,8 @@ pub struct ProcessingEngineConfig {
     pub virtual_env_location: Option<PathBuf>,
     #[clap(long = "package-manager", default_value = "discover")]
     pub package_manager: PackageManager,
+    #[clap(long = "plugin-repo", env = "INFLUXDB3_PLUGIN_REPO")]
+    pub plugin_repo: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, Default, clap::ValueEnum)]

--- a/influxdb3_processing_engine/src/plugins.rs
+++ b/influxdb3_processing_engine/src/plugins.rs
@@ -80,8 +80,8 @@ pub enum PluginError {
         trigger_type: String,
     },
 
-    #[error("error reading file from Github: {0} {1}")]
-    FetchingFromGithub(reqwest::StatusCode, String),
+    #[error("error fetching plugin from repository: {0} {1}")]
+    FetchingFromRepository(reqwest::StatusCode, String),
 
     #[error("Join error, please report: {0}")]
     JoinError(#[from] tokio::task::JoinError),
@@ -112,6 +112,7 @@ pub struct ProcessingEngineEnvironmentManager {
     pub plugin_dir: Option<PathBuf>,
     pub virtual_env_location: Option<PathBuf>,
     pub package_manager: Arc<dyn PythonEnvironmentManager>,
+    pub plugin_repo: Option<String>,
 }
 
 pub(crate) fn run_schedule_plugin(

--- a/influxdb3_server/src/lib.rs
+++ b/influxdb3_server/src/lib.rs
@@ -1780,6 +1780,7 @@ mod tests {
                 plugin_dir: None,
                 virtual_env_location: None,
                 package_manager: Arc::new(DisabledManager),
+                plugin_repo: None,
             },
             write_buffer.catalog(),
             node_identifier_prefix,


### PR DESCRIPTION
This backports the custom plugin-repo functionality included in Enterprise. 

## New Feature | Add Custom Plugin Repository
This commit enables the ability to define a custom plugin repo. This is needed for AWS to pass security requirements on the Processing Engine, and also opens up the ability for organizations to limit the plugins that can run.

I've changed the terminology from "GitHub" to "repository" to be more generic, depending on what format repository people are using. 

By default, the plugin-repo uses the standard InfluxData Plugins Repository. I have a custom, open repo at `https://raw.githubusercontent.com/peterbarnett03/influxdb3_plugins/refs/heads/main/`. 

### How to Test
Run the following commands:

```
influxdb3 serve 
  --node-id node0 
  --object-store memory 
  --plugin-repo="https://raw.githubusercontent.com/peterbarnett03/influxdb3_plugins/refs/heads/main/"
  --without-auth
```

2. `influxdb3 create database metrics`
3. `influxdb3 install package psutil`
4. 
```
influxdb3 create trigger \
  --trigger-spec "every:1s" \
  --plugin-filename "gh:influxdata/system_metrics/system_metrics.py" \
  --plugin-dir ~/.data \
  --database metrics \
  system_metrics
```
5. Confirm that metrics are written and that the logs show the `Written from custom repo!` output, as that is in the custom repo script.