### PR TITLE
fix(packaging): init.sh should run buildtsi as influxdb user (#26699)

### DIFF
--- a/.circleci/packages/influxdb/fs/usr/lib/influxdb/scripts/init.sh
+++ b/.circleci/packages/influxdb/fs/usr/lib/influxdb/scripts/init.sh
@@ -155,11 +155,12 @@ function start() {
     WAL_DIR="$(  influxd_config data wal-dir )"
     if [[ ( -d "${DATA_DIR}" ) && ( -d "${WAL_DIR}" ) ]]
     then
-        # If this daemon is configured to run as root, influx_inspect hangs
-        # waiting for confirmation before executing. Supplying "yes" allows
-        # the service to continue without interruption.
-        yes | /usr/bin/influx_inspect buildtsi -compact-series-file \
-            -datadir "${DATA_DIR}"                                  \
+        # buildtsi prompts with a warning if it is run as root as the files it creates will be owned by root which
+        # influxd won't be able to read. Best to run it as the influxdb user instead. sudo and su are options but
+        # difficult to use; setpriv is more direct and available in the util-linux package
+        echo "Building tsi with influxd_inspect buildtsi."
+        setpriv --reuid influxdb --regid influxdb --clear-groups /usr/bin/influx_inspect buildtsi -compact-series-file \
+            -datadir "${DATA_DIR}"                                                   \
             -waldir  "${WAL_DIR}"
     fi
 


### PR DESCRIPTION
* fix(packaging): init.sh should run buildtsi as influxdb user

The init.sh script assumes that it being run as root so thus we can use sudo to switch user to the influxdb user to run buildtsi; otherwise the files are owned by root and influxdb can't start.

* fixes #26698

* chore: switch from sudo to su; update comment

* chore: switch to runuser as the su syntax and debugging is difficult

* chore: switch to setpriv to avoid PAM

We want to run a command as another user but su has a frustrating syntax for calling a command and escaping, runuser is simpiler but delegates to su so both use PAM which is not needed in this case. It was recommended to use setpriv which a full toolkit for setting privilege bits and can mimic su/runuser by setting privilege to a specific user for running a command. It seems to work and be easy to use in a script.

* chore: update comment to reflect setpriv usage

(cherry picked from commit 7ca78d1342c46a26759c62af6e86f237b4d3734a)