### PR TITLE
fix: reduce unnecessary purger operations and logging (#26762)

### DIFF
--- a/tsdb/engine/tsm1/file_store.go
+++ b/tsdb/engine/tsm1/file_store.go
@@ -1595,6 +1595,10 @@ type purger struct {
 
 func (p *purger) add(files []TSMFile) {
 	var fileNames []string
+
+	if len(files) == 0 {
+		return
+	}
 	p.mu.Lock()
 	for _, f := range files {
 		fileName := f.Path()


### PR DESCRIPTION
Skip purger call if no TSM files are held open
during a replace operation. Reduce useless
log entries.

(cherry picked from commit b64789222a85a199a956eb322844496f200c7dad)
