### PR TITLE
feat: Adds property based testing framework for compaction (#26783)

### DIFF
--- a/tsdb/engine/tsm1/compact_common_test.go
+++ b/tsdb/engine/tsm1/compact_common_test.go
@@ -1,0 +1,25 @@
+package tsm1_test
+
+import (
+	"github.com/influxdata/influxdb/tsdb/engine/tsm1"
+	"time"
+)
+
+type TestLevelResults struct {
+	level1Groups []tsm1.PlannedCompactionGroup
+	level2Groups []tsm1.PlannedCompactionGroup
+	level3Groups []tsm1.PlannedCompactionGroup
+	level4Groups []tsm1.PlannedCompactionGroup
+	level5Groups []tsm1.PlannedCompactionGroup
+}
+
+type TestEnginePlanCompactionsRunner struct {
+	name              string
+	files             []tsm1.ExtFileStat
+	defaultBlockCount int // Default block count if member of files has FirstBlockCount of 0.
+	// This is specifically used to adjust the modification time
+	// so we can simulate the passage of time in tests
+	testShardTime time.Duration
+	// Each result is for the different plantypes
+	expectedResult func() TestLevelResults
+}

--- a/tsdb/engine/tsm1/compact_property_test.go
+++ b/tsdb/engine/tsm1/compact_property_test.go
@@ -1,0 +1,145 @@
+package tsm1_test
+
+import (
+	"errors"
+	"fmt"
+	"golang.org/x/exp/slices"
+
+	"github.com/influxdata/influxdb/tsdb/engine/tsm1"
+)
+
+// CompactionProperty represents a property that compaction groups should satisfy
+type CompactionProperty struct {
+	Name        string
+	Description string
+	Validator   func(allFiles []string, groups []tsm1.CompactionGroup) error
+}
+
+// AdjacentFileProperty validates that compaction groups don't create gaps
+var AdjacentFileProperty = CompactionProperty{
+	Name:        "Adjacency Rule",
+	Description: "Files should not have non-adjacent files within the same compaction level - if files A and C are in the same level group, any file B between them should also be in a group at the same level or higher",
+	Validator:   validateFileAdjacency,
+}
+
+type fileInfo struct {
+	filename   string
+	generation int
+	sequence   int
+	index      int
+}
+
+// validateFileAdjacency checks that there are no adjacency violations between TSM files
+// The following example will highlight an adjacency violation:
+// Given the following list of files [01-01.tsm, 02-02.tsm, 03-03.tsm] let's say we have the following compaction plans created
+// Group 1: [01-01.tsm, 03-03.tsm] & Group 2: [02-02.tsm]
+// This violates file adjacency as the first compaction group sees [01-01.tsm, X, 03-03.tsm] and the second group: [X, 02-02.tsm, X]
+// these are non-contiguous blocks, when the first group performs compaction we will have two files that are out of order compacted together.
+// This rule is important to maintain the ordering of files, with improper ordering we cannot determine which point is the newest point when overwrites occur.
+// We always want the newest write to win.
+func validateFileAdjacency(allFiles []string, groups []tsm1.CompactionGroup) error {
+	var fileInfos []fileInfo
+	for _, file := range allFiles {
+		gen, seq, err := tsm1.DefaultParseFileName(file)
+		if err != nil {
+			return fmt.Errorf("failed to parse file %s: %v", file, err)
+		}
+		fileInfos = append(fileInfos, fileInfo{
+			filename:   file,
+			generation: gen,
+			sequence:   seq,
+		})
+	}
+
+	slices.SortFunc(fileInfos, func(a, b fileInfo) int {
+		if a.generation != b.generation {
+			return a.generation - b.generation
+		}
+
+		return a.sequence - b.sequence
+	})
+
+	var fileMap = make(map[string]fileInfo, len(allFiles))
+	for i, file := range allFiles {
+		fileMap[file] = fileInfo{
+			index: i,
+		}
+	}
+
+	for groupIndex, group := range groups {
+		lastIndex := -1
+		for _, file := range group {
+			f, ok := fileMap[file]
+			if !ok {
+				return fmt.Errorf("file %s not found in group %d", file, groupIndex)
+			}
+
+			if lastIndex == -1 {
+				lastIndex = f.index
+			} else {
+				// Check lastIndex wrt f.index
+				if lastIndex+1 != f.index {
+					return fmt.Errorf("file %s in compaction group %d violates adjacency policy", file, groupIndex+1)
+				}
+				lastIndex = f.index
+			}
+		}
+	}
+
+	return nil
+}
+
+// ValidateCompactionProperties validates that compaction results satisfy all properties
+func ValidateCompactionProperties(allFiles []string, results TestLevelResults, properties ...CompactionProperty) error {
+	var errs []error
+
+	// Collect all compaction groups from results
+	var allGroups []tsm1.CompactionGroup
+	allGroups = append(allGroups, extractGroups(results.level1Groups)...)
+	allGroups = append(allGroups, extractGroups(results.level2Groups)...)
+	allGroups = append(allGroups, extractGroups(results.level3Groups)...)
+	allGroups = append(allGroups, extractGroups(results.level4Groups)...)
+	allGroups = append(allGroups, extractGroups(results.level5Groups)...)
+
+	// Validate each property
+	for _, property := range properties {
+		if err := property.Validator(allFiles, allGroups); err != nil {
+			errs = append(errs, fmt.Errorf("%s violation: %v", property.Name, err))
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+// extractGroups extracts CompactionGroup from PlannedCompactionGroup
+func extractGroups(plannedGroups []tsm1.PlannedCompactionGroup) []tsm1.CompactionGroup {
+	var groups []tsm1.CompactionGroup
+	for _, planned := range plannedGroups {
+		groups = append(groups, planned.Group)
+	}
+	return groups
+}
+
+// ValidateTestCase validates both expected results and actual planner output
+func ValidateTestCase(testCase TestEnginePlanCompactionsRunner, actualResults TestLevelResults) error {
+	var errs []error
+
+	// Extract all filenames from test case
+	var allFiles = make([]string, len(testCase.files))
+	for i, file := range testCase.files {
+		allFiles[i] = file.Path
+	}
+
+	// Validate expected results
+	expectedResults := testCase.expectedResult()
+	if expectedErr := ValidateCompactionProperties(allFiles, expectedResults, AdjacentFileProperty); expectedErr != nil {
+		errs = append(errs, fmt.Errorf("expected results: %v", expectedErr))
+	}
+
+	// Validate actual results
+	if actualErr := ValidateCompactionProperties(allFiles, actualResults, AdjacentFileProperty); actualErr != nil {
+		errs = append(errs, fmt.Errorf("actual results: %v", actualErr))
+	}
+
+	return errors.Join(errs...)
+}

--- a/tsdb/engine/tsm1/compact_test.go
+++ b/tsdb/engine/tsm1/compact_test.go
@@ -2883,26 +2883,7 @@ func TestIsGroupOptimized(t *testing.T) {
 }
 
 func TestEnginePlanCompactions(t *testing.T) {
-	type testLevelResults struct {
-		level1Groups []tsm1.PlannedCompactionGroup
-		level2Groups []tsm1.PlannedCompactionGroup
-		level3Groups []tsm1.PlannedCompactionGroup
-		level4Groups []tsm1.PlannedCompactionGroup
-		level5Groups []tsm1.PlannedCompactionGroup
-	}
-
-	type testEnginePlanCompactionsRunner struct {
-		name              string
-		files             []tsm1.ExtFileStat
-		defaultBlockCount int // Default block count if member of files has FirstBlockCount of 0.
-		// This is specifically used to adjust the modification time
-		// so we can simulate the passage of time in tests
-		testShardTime time.Duration
-		// Each result is for the different plantypes
-		expectedResult func() testLevelResults
-	}
-
-	tests := []testEnginePlanCompactionsRunner{
+	tests := []TestEnginePlanCompactionsRunner{
 		{
 			name: "many generations under 2GB",
 			files: []tsm1.ExtFileStat{
@@ -2936,8 +2917,8 @@ func TestEnginePlanCompactions(t *testing.T) {
 				},
 			},
 			testShardTime: -1,
-			expectedResult: func() testLevelResults {
-				return testLevelResults{
+			expectedResult: func() TestLevelResults {
+				return TestLevelResults{
 					level5Groups: []tsm1.PlannedCompactionGroup{
 						{
 							tsm1.CompactionGroup{"01-05.tsm", "02-05.tsm", "03-05.tsm", "04-04.tsm"},
@@ -3022,8 +3003,8 @@ func TestEnginePlanCompactions(t *testing.T) {
 				},
 			},
 			testShardTime: -1,
-			expectedResult: func() testLevelResults {
-				return testLevelResults{
+			expectedResult: func() TestLevelResults {
+				return TestLevelResults{
 					level5Groups: []tsm1.PlannedCompactionGroup{
 						{
 							tsm1.CompactionGroup{"01-05.tsm1", "01-06.tsm1", "01-07.tsm1", "01-08.tsm1", "02-05.tsm1", "02-06.tsm1", "02-07.tsm1", "02-08.tsm1", "03-04.tsm1", "03-05.tsm1"},
@@ -3063,8 +3044,8 @@ func TestEnginePlanCompactions(t *testing.T) {
 				},
 			},
 			testShardTime: -1,
-			expectedResult: func() testLevelResults {
-				return testLevelResults{
+			expectedResult: func() TestLevelResults {
+				return TestLevelResults{
 					level5Groups: []tsm1.PlannedCompactionGroup{
 						{
 							tsm1.CompactionGroup{"01-05.tsm1",
@@ -3096,8 +3077,8 @@ func TestEnginePlanCompactions(t *testing.T) {
 				},
 			}.ToExtFileStats(),
 			testShardTime: -1,
-			expectedResult: func() testLevelResults {
-				return testLevelResults{
+			expectedResult: func() TestLevelResults {
+				return TestLevelResults{
 					level5Groups: []tsm1.PlannedCompactionGroup{
 						{
 							tsm1.CompactionGroup{"01-02.tsm1",
@@ -3132,8 +3113,8 @@ func TestEnginePlanCompactions(t *testing.T) {
 			}.ToExtFileStats(),
 			defaultBlockCount: tsdb.DefaultMaxPointsPerBlock,
 			testShardTime:     -1,
-			expectedResult: func() testLevelResults {
-				return testLevelResults{
+			expectedResult: func() TestLevelResults {
+				return TestLevelResults{
 					level5Groups: []tsm1.PlannedCompactionGroup{
 						{
 							tsm1.CompactionGroup{"01-05.tsm1",
@@ -3208,8 +3189,8 @@ func TestEnginePlanCompactions(t *testing.T) {
 				},
 			},
 			testShardTime: -1,
-			expectedResult: func() testLevelResults {
-				return testLevelResults{
+			expectedResult: func() TestLevelResults {
+				return TestLevelResults{
 					level5Groups: []tsm1.PlannedCompactionGroup{
 						{
 							tsm1.CompactionGroup{"01-05.tsm1",
@@ -3254,8 +3235,8 @@ func TestEnginePlanCompactions(t *testing.T) {
 			},
 
 			testShardTime: -1,
-			expectedResult: func() testLevelResults {
-				return testLevelResults{
+			expectedResult: func() TestLevelResults {
+				return TestLevelResults{
 					level5Groups: []tsm1.PlannedCompactionGroup{
 						{
 							tsm1.CompactionGroup{"01-13.tsm1",
@@ -3281,8 +3262,8 @@ func TestEnginePlanCompactions(t *testing.T) {
 				},
 			}.ToExtFileStats(),
 			testShardTime: -1,
-			expectedResult: func() testLevelResults {
-				return testLevelResults{}
+			expectedResult: func() TestLevelResults {
+				return TestLevelResults{}
 			},
 		},
 		{
@@ -3302,8 +3283,8 @@ func TestEnginePlanCompactions(t *testing.T) {
 			}.ToExtFileStats(),
 			defaultBlockCount: tsdb.DefaultAggressiveMaxPointsPerBlock,
 			testShardTime:     -1,
-			expectedResult: func() testLevelResults {
-				return testLevelResults{}
+			expectedResult: func() TestLevelResults {
+				return TestLevelResults{}
 			},
 		},
 		{
@@ -3329,8 +3310,8 @@ func TestEnginePlanCompactions(t *testing.T) {
 				},
 			},
 			testShardTime: -1,
-			expectedResult: func() testLevelResults {
-				return testLevelResults{}
+			expectedResult: func() TestLevelResults {
+				return TestLevelResults{}
 			},
 		},
 		{
@@ -3353,8 +3334,8 @@ func TestEnginePlanCompactions(t *testing.T) {
 			}.ToExtFileStats(),
 			defaultBlockCount: tsdb.DefaultAggressiveMaxPointsPerBlock,
 			testShardTime:     -1,
-			expectedResult: func() testLevelResults {
-				return testLevelResults{}
+			expectedResult: func() TestLevelResults {
+				return TestLevelResults{}
 			},
 		},
 		{
@@ -3411,8 +3392,8 @@ func TestEnginePlanCompactions(t *testing.T) {
 				},
 			}.ToExtFileStats(),
 			testShardTime: -1,
-			expectedResult: func() testLevelResults {
-				return testLevelResults{
+			expectedResult: func() TestLevelResults {
+				return TestLevelResults{
 					level5Groups: []tsm1.PlannedCompactionGroup{
 						{
 							tsm1.CompactionGroup{"01-05.tsm1",
@@ -3519,15 +3500,15 @@ func TestEnginePlanCompactions(t *testing.T) {
 				},
 				{
 					FileStat: tsm1.FileStat{
-						Path: "03-03.tsm1",
+						Path: "04-03.tsm1",
 						Size: 400 * 1024 * 1024,
 					},
 					FirstBlockCount: 10,
 				},
 			},
 			testShardTime: -1,
-			expectedResult: func() testLevelResults {
-				return testLevelResults{
+			expectedResult: func() TestLevelResults {
+				return TestLevelResults{
 					level5Groups: []tsm1.PlannedCompactionGroup{
 						{
 							tsm1.CompactionGroup{
@@ -3540,9 +3521,9 @@ func TestEnginePlanCompactions(t *testing.T) {
 								"03-02.tsm1",
 								"03-03.tsm1",
 								"03-04.tsm1",
-								"03-03.tsm1",
 								"04-01.tsm1",
 								"04-02.tsm1",
+								"04-03.tsm1",
 							}, tsdb.DefaultAggressiveMaxPointsPerBlock},
 					},
 				}
@@ -4039,8 +4020,8 @@ func TestEnginePlanCompactions(t *testing.T) {
 			},
 			defaultBlockCount: tsdb.DefaultMaxPointsPerBlock,
 			testShardTime:     -1,
-			expectedResult: func() testLevelResults {
-				return testLevelResults{
+			expectedResult: func() TestLevelResults {
+				return TestLevelResults{
 					level5Groups: []tsm1.PlannedCompactionGroup{
 						{
 							tsm1.CompactionGroup{
@@ -4234,8 +4215,8 @@ func TestEnginePlanCompactions(t *testing.T) {
 				},
 			},
 			testShardTime: -1,
-			expectedResult: func() testLevelResults {
-				return testLevelResults{
+			expectedResult: func() TestLevelResults {
+				return TestLevelResults{
 					level1Groups: []tsm1.PlannedCompactionGroup{
 						{
 							tsm1.CompactionGroup{"05-01.tsm", "06-01.tsm", "07-01.tsm", "08-01.tsm", "09-01.tsm", "10-01.tsm", "11-01.tsm", "12-01.tsm"},
@@ -4252,8 +4233,36 @@ func TestEnginePlanCompactions(t *testing.T) {
 			},
 		},
 		{
-			name: "Mock another planned level inside scheduler aggress blocks middle",
+			name: "Write level 5 group using DefaultAggressiveMaxPointsPerBlock given we have a TSM file at that level",
 			files: []tsm1.ExtFileStat{
+				{
+					FileStat: tsm1.FileStat{
+						Path: "01-05.tsm",
+						Size: 256 * 1024 * 1024,
+					},
+					FirstBlockCount: tsdb.DefaultAggressiveMaxPointsPerBlock,
+				},
+				{
+					FileStat: tsm1.FileStat{
+						Path: "02-05.tsm",
+						Size: 256 * 1024 * 1024,
+					},
+					FirstBlockCount: tsdb.DefaultMaxPointsPerBlock,
+				},
+				{
+					FileStat: tsm1.FileStat{
+						Path: "03-05.tsm",
+						Size: 256 * 1024 * 1024,
+					},
+					FirstBlockCount: tsdb.DefaultMaxPointsPerBlock,
+				},
+				{
+					FileStat: tsm1.FileStat{
+						Path: "04-04.tsm",
+						Size: 256 * 1024 * 1024,
+					},
+					FirstBlockCount: tsdb.DefaultMaxPointsPerBlock,
+				},
 				{
 					FileStat: tsm1.FileStat{
 						Path: "05-01.tsm",
@@ -4305,34 +4314,6 @@ func TestEnginePlanCompactions(t *testing.T) {
 				},
 				{
 					FileStat: tsm1.FileStat{
-						Path: "01-05.tsm",
-						Size: 256 * 1024 * 1024,
-					},
-					FirstBlockCount: tsdb.DefaultAggressiveMaxPointsPerBlock,
-				},
-				{
-					FileStat: tsm1.FileStat{
-						Path: "02-05.tsm",
-						Size: 256 * 1024 * 1024,
-					},
-					FirstBlockCount: tsdb.DefaultMaxPointsPerBlock,
-				},
-				{
-					FileStat: tsm1.FileStat{
-						Path: "03-05.tsm",
-						Size: 256 * 1024 * 1024,
-					},
-					FirstBlockCount: tsdb.DefaultMaxPointsPerBlock,
-				},
-				{
-					FileStat: tsm1.FileStat{
-						Path: "04-04.tsm",
-						Size: 256 * 1024 * 1024,
-					},
-					FirstBlockCount: tsdb.DefaultMaxPointsPerBlock,
-				},
-				{
-					FileStat: tsm1.FileStat{
 						Path: "12-01.tsm",
 						Size: 256 * 1024 * 1024,
 					},
@@ -4354,8 +4335,8 @@ func TestEnginePlanCompactions(t *testing.T) {
 				},
 			},
 			testShardTime: -1,
-			expectedResult: func() testLevelResults {
-				return testLevelResults{
+			expectedResult: func() TestLevelResults {
+				return TestLevelResults{
 					level1Groups: []tsm1.PlannedCompactionGroup{
 						{
 							tsm1.CompactionGroup{"05-01.tsm", "06-01.tsm", "07-01.tsm", "08-01.tsm", "09-01.tsm", "10-01.tsm", "11-01.tsm", "12-01.tsm"},
@@ -4475,8 +4456,8 @@ func TestEnginePlanCompactions(t *testing.T) {
 				},
 			},
 			testShardTime: -1,
-			expectedResult: func() testLevelResults {
-				return testLevelResults{
+			expectedResult: func() TestLevelResults {
+				return TestLevelResults{
 					level1Groups: []tsm1.PlannedCompactionGroup{
 						{
 							tsm1.CompactionGroup{"05-01.tsm", "06-01.tsm", "07-01.tsm", "08-01.tsm", "09-01.tsm", "10-01.tsm", "11-01.tsm", "12-01.tsm"},
@@ -4525,6 +4506,17 @@ func TestEnginePlanCompactions(t *testing.T) {
 			// Plan and check results.
 			level1Groups, level2Groups, Level3Groups, Level4Groups, Level5Groups := e.PlanCompactions()
 			results := test.expectedResult()
+
+			// Validate our test case based on compact_property_test.go
+			validationErr := ValidateTestCase(test, TestLevelResults{
+				level1Groups: level1Groups,
+				level2Groups: level2Groups,
+				level3Groups: Level3Groups,
+				level4Groups: Level4Groups,
+				level5Groups: Level5Groups,
+			})
+			assert.NoError(t, validationErr, "test validation failed")
+
 			compareLevelGroups(t, results.level1Groups, level1Groups, "unexpected level 1 Group")
 			compareLevelGroups(t, results.level2Groups, level2Groups, "unexpected level 2 Group")
 			compareLevelGroups(t, results.level3Groups, Level3Groups, "unexpected level 3 Group")


### PR DESCRIPTION
Adds property based testing framework for our compaction testings. Current we support checking for "gaps" within adjacent compaction groups.

For example:
```
			expectedResult: func() TestLevelResults {
				return TestLevelResults{
					// Our rogue level 2 file should be picked up in the full compaction
					level4Groups: []tsm1.PlannedCompactionGroup{
						{
							tsm1.CompactionGroup{
								"000016844-000000002.tsm",
								"000016948-000000004.tsm",
								"000016948-000000005.tsm",
								"000017076-000000004.tsm",
								"000017094-000000004.tsm",
							},
							tsdb.DefaultMaxPointsPerBlock,
						},
					},
					// Other files should get picked up by optimize compaction
					level5Groups: []tsm1.PlannedCompactionGroup{
						{
							tsm1.CompactionGroup{
								"000016684-000000007.tsm",
								"000016684-000000008.tsm",
								"000016684-000000009.tsm",
								"000016684-000000010.tsm",
								"000016812-000000004.tsm",
								"000016812-000000005.tsm",
								"000017095-000000005.tsm",
							},
							tsdb.DefaultMaxPointsPerBlock,
						},
					},
				}
			},
		},
```

Would be invalid and cause our validator to fail due to the file `"000017095-000000005.tsm"` in `level5Groups`.

(cherry picked from commit 3f1f4a0dde111af47b45e2122e82083d5227639b)

