### PR TITLE
feat: Adds 'cq' diagnostics to /debug/vars

### DIFF
--- a/cmd/influxd/run/server.go
+++ b/cmd/influxd/run/server.go
@@ -416,6 +416,9 @@ func (s *Server) appendContinuousQueryService(c continuous_querier.Config) {
 	srv.QueryExecutor = s.QueryExecutor
 	srv.Monitor = s.Monitor
 	s.Services = append(s.Services, srv)
+	if s.Monitor != nil {
+		s.Monitor.RegisterDiagnosticsClient("cq", srv)
+	}
 }
 
 // Err returns an error channel that multiplexes all out of band errors received from all services.

--- a/monitor/service.go
+++ b/monitor/service.go
@@ -222,6 +222,7 @@ func (m *Monitor) Close() error {
 	m.DeregisterDiagnosticsClient("runtime")
 	m.DeregisterDiagnosticsClient("network")
 	m.DeregisterDiagnosticsClient("system")
+	m.DeregisterDiagnosticsClient("cq")
 	return nil
 }
 

--- a/monitor/service_test.go
+++ b/monitor/service_test.go
@@ -416,21 +416,24 @@ func TestMonitor_QuickClose(t *testing.T) {
 	}
 }
 
-func TestMonitor_CQDiagnostics(t *testing.T) {
+func TestMonitor_CQStatistics(t *testing.T) {
 	s := monitor.New(nil, monitor.Config{}, &tsdb.Config{})
 	err := s.Open()
 	require.NoError(t, err, "monitor open")
 	defer s.Close()
 
 	s.RegisterDiagnosticsClient("cq", continuous_querier.NewService(continuous_querier.NewConfig()))
-	d, err := s.Diagnostics()
-	require.NoError(t, err, "cq diagnostics")
+	stats, err := s.Statistics(nil)
+	require.NoError(t, err, "cq statistics")
 
-	diags, ok := d["cq"]
-	require.True(t, ok, "no diagnostics found for 'cq'")
-
-	require.Equal(t, diags.Columns, []string{"queryFail", "queryOk"}, "diagnostics columns")
-	require.Equal(t, diags.Rows, [][]interface{}{{int64(0), int64(0)}}, "diagnostics rows")
+	for _, stat := range stats {
+		if stat.Name == "cq" {
+			require.Equal(t, stat.Values, map[string]interface{}{
+				"queryOk":   0,
+				"queryFail": 0,
+			}, "statistics")
+		}
+	}
 }
 
 func TestStatistic_ValueNames(t *testing.T) {

--- a/services/continuous_querier/service.go
+++ b/services/continuous_querier/service.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/influxdata/influxdb/logger"
 	"github.com/influxdata/influxdb/models"
+	"github.com/influxdata/influxdb/monitor/diagnostics"
 	"github.com/influxdata/influxdb/query"
 	"github.com/influxdata/influxdb/services/meta"
 	"github.com/influxdata/influxql"
@@ -167,6 +168,16 @@ func (s *Service) Statistics(tags map[string]string) []models.Statistic {
 			statQueryFail: atomic.LoadInt64(&s.stats.QueryFail),
 		},
 	}}
+}
+
+func (s *Service) Diagnostics() (*diagnostics.Diagnostics, error) {
+	d := map[string]interface{}{
+		statQueryOK:   atomic.LoadInt64(&s.stats.QueryOK),
+		statQueryFail: atomic.LoadInt64(&s.stats.QueryFail),
+	}
+
+	return diagnostics.RowFromMap(d), nil
+
 }
 
 // Run runs the specified continuous query, or all CQs if none is specified.

--- a/services/continuous_querier/service.go
+++ b/services/continuous_querier/service.go
@@ -170,14 +170,10 @@ func (s *Service) Statistics(tags map[string]string) []models.Statistic {
 	}}
 }
 
+// Required for Monitor interface. Currently does not return any
+// diagnostic values.
 func (s *Service) Diagnostics() (*diagnostics.Diagnostics, error) {
-	d := map[string]interface{}{
-		statQueryOK:   atomic.LoadInt64(&s.stats.QueryOK),
-		statQueryFail: atomic.LoadInt64(&s.stats.QueryFail),
-	}
-
-	return diagnostics.RowFromMap(d), nil
-
+	return &diagnostics.Diagnostics{}, nil
 }
 
 // Run runs the specified continuous query, or all CQs if none is specified.

--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -2397,7 +2397,16 @@ func (h *Handler) serveExpvar(w http.ResponseWriter, r *http.Request) {
 	for _, s := range stats {
 		if s.Name == "cq" {
 			jv, err := parseCQStatistics(&s.Statistic)
+			if err != nil {
+				h.httpError(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
 			data, err := json.Marshal(jv)
+			if err != nil {
+				h.httpError(w, err.Error(), http.StatusInternalServerError)
+				return
+			}
+
 			if !first {
 				_, err := fmt.Fprintln(w, ",")
 				if err != nil {


### PR DESCRIPTION
This PR adds continuous query diags to our /debug/vars endpoint

Example
```
  "cq": {
    "queryFail": 0,
    "queryOk": 2
  },
```

