### PR TITLE
feat: Add show plugins command

### DIFF
--- a/influxdb3/src/commands/show.rs
+++ b/influxdb3/src/commands/show.rs
@@ -22,6 +22,9 @@ pub enum SubCommand {
     /// List tokens
     Tokens(ShowTokensConfig),
 
+    /// List plugins
+    Plugins(PluginsConfig),
+
     /// Display system table data.
     System(SystemConfig),
 }
@@ -42,6 +45,30 @@ pub struct ShowTokensConfig {
     auth_token: Option<Secret<String>>,
 
     /// The format in which to output the list of databases
+    #[clap(value_enum, long = "format", default_value = "pretty")]
+    output_format: Format,
+
+    /// An optional arg to use a custom ca for useful for testing with self signed certs
+    #[clap(long = "tls-ca", env = "INFLUXDB3_TLS_CA")]
+    ca_cert: Option<PathBuf>,
+}
+
+#[derive(Debug, Parser)]
+pub struct PluginsConfig {
+    /// The host URL of the running InfluxDB 3 Core server
+    #[clap(
+        short = 'H',
+        long = "host",
+        env = "INFLUXDB3_HOST_URL",
+        default_value = "http://127.0.0.1:8181"
+    )]
+    host_url: Url,
+
+    /// The token for authentication with the InfluxDB 3 Core server
+    #[clap(long = "token", env = "INFLUXDB3_AUTH_TOKEN", hide_env_values = true)]
+    auth_token: Option<Secret<String>>,
+
+    /// The format in which to output the list of plugins
     #[clap(value_enum, long = "format", default_value = "pretty")]
     output_format: Format,
 
@@ -97,6 +124,26 @@ pub(crate) async fn command(config: Config) -> Result<(), Box<dyn Error>> {
                 .api_v3_configure_db_show()
                 .with_format(output_format.into())
                 .with_show_deleted(show_deleted)
+                .send()
+                .await?;
+
+            println!("{}", std::str::from_utf8(&resp_bytes)?);
+        }
+        SubCommand::Plugins(PluginsConfig {
+            host_url,
+            auth_token,
+            output_format,
+            ca_cert,
+        }) => {
+            let mut client = influxdb3_client::Client::new(host_url, ca_cert)?;
+
+            if let Some(t) = auth_token {
+                client = client.with_auth_token(t.expose_secret());
+            }
+
+            let resp_bytes = client
+                .api_v3_query_sql("_internal", "SELECT * FROM system.plugin_files")
+                .format(output_format.into())
                 .send()
                 .await?;
 

--- a/influxdb3/tests/cli/api.rs
+++ b/influxdb3/tests/cli/api.rs
@@ -261,6 +261,43 @@ impl ShowDatabasesQuery<'_> {
     }
 }
 
+// Builder for the 'show plugins' command
+#[derive(Debug)]
+pub struct ShowPluginsQuery<'a> {
+    server: &'a TestServer,
+    format: Option<String>,
+}
+
+impl TestServer {
+    pub fn show_plugins(&self) -> ShowPluginsQuery<'_> {
+        ShowPluginsQuery {
+            server: self,
+            format: None,
+        }
+    }
+}
+
+impl ShowPluginsQuery<'_> {
+    pub fn with_format(mut self, format: impl Into<String>) -> Self {
+        self.format = Some(format.into());
+        self
+    }
+
+    pub fn run(self) -> Result<String> {
+        let mut args = Vec::new();
+
+        if let Some(format) = self.format.as_ref() {
+            args.push("--format");
+            args.push(format);
+        }
+
+        args.push("--tls-ca");
+        args.push("../testing-certs/rootCA.pem");
+
+        self.server.run(vec!["show", "plugins"], &args)
+    }
+}
+
 // Builder for the 'delete database' command
 #[derive(Debug)]
 pub struct DeleteDatabaseQuery<'a> {

--- a/influxdb3/tests/cli/system_tables.rs
+++ b/influxdb3/tests/cli/system_tables.rs
@@ -34,16 +34,13 @@ async fn test_system_plugins_table() -> Result<()> {
         .spawn()
         .await;
 
-    // Create database
     server.create_database("test_db").run()?;
 
-    // Create table
     server
         .create_table("test_db", "cpu")
         .with_fields([("usage", "float64")])
         .run()?;
 
-    // Create triggers for each plugin
     server
         .create_trigger("test_db", "trigger_alpha", "plugin_alpha.py", "all_tables")
         .run()?;
@@ -111,7 +108,6 @@ async fn test_system_plugins_table_empty() -> Result<()> {
     // Start server without any plugins
     let server = TestServer::spawn().await;
 
-    // Create database
     server.create_database("test_db").run()?;
 
     // Query system.plugin_files table when no triggers exist
@@ -134,7 +130,7 @@ async fn test_system_plugins_table_empty() -> Result<()> {
 
 #[test_log::test(tokio::test)]
 async fn test_system_plugins_table_after_delete() -> Result<()> {
-    // Setup: Create temp directory with a plugin file
+    // Create temp directory with a plugin file
     let plugin_dir = TempDir::new()?;
     let plugin_dir_path = plugin_dir.path();
 
@@ -146,14 +142,12 @@ async fn test_system_plugins_table_after_delete() -> Result<()> {
         .spawn()
         .await;
 
-    // Create database and table
     server.create_database("test_db").run()?;
     server
         .create_table("test_db", "cpu")
         .with_fields([("usage", "float64")])
         .run()?;
 
-    // Create a trigger
     server
         .create_trigger("test_db", "test_trigger", "test_plugin.py", "all_tables")
         .run()?;
@@ -168,7 +162,6 @@ async fn test_system_plugins_table_after_delete() -> Result<()> {
     assert_eq!(parsed.len(), 1, "Should have one plugin");
     assert_eq!(parsed[0]["plugin_name"], "test_trigger");
 
-    // Delete the trigger
     server
         .delete_trigger("test_db", "test_trigger")
         .force(true)
@@ -186,6 +179,323 @@ async fn test_system_plugins_table_after_delete() -> Result<()> {
         0,
         "Should have no plugins after trigger deletion"
     );
+
+    Ok(())
+}
+
+#[test_log::test(tokio::test)]
+async fn test_show_plugins_single_file() -> Result<()> {
+    let plugin_dir = TempDir::new()?;
+    let plugin_dir_path = plugin_dir.path();
+
+    fs::write(plugin_dir_path.join("plugin_alpha.py"), PLUGIN_ALPHA)?;
+    fs::write(plugin_dir_path.join("plugin_beta.py"), PLUGIN_BETA)?;
+
+    // Start server with plugin directory
+    let server = TestServer::configure()
+        .with_plugin_dir(plugin_dir_path.to_str().unwrap())
+        .spawn()
+        .await;
+
+    server.create_database("test_db").run()?;
+
+    // Create triggers with different trigger specifications
+    server
+        .create_trigger("test_db", "trigger_alpha", "plugin_alpha.py", "all_tables")
+        .run()?;
+
+    server
+        .create_trigger("test_db", "trigger_beta", "plugin_beta.py", "every:5s")
+        .run()?;
+
+    // Run show plugins command with JSON format
+    let output = server.show_plugins().with_format("json").run()?;
+
+    let parsed: serde_json::Value = serde_json::from_str(&output)?;
+    let triggers = parsed.as_array().expect("Expected array result");
+
+    // Verify we have exactly 2 plugins
+    assert_eq!(triggers.len(), 2, "Should have two plugins");
+
+    // Verify first plugin (trigger_alpha)
+    assert_eq!(triggers[0]["plugin_name"], "trigger_alpha");
+    assert_eq!(triggers[0]["file_name"], "plugin_alpha.py");
+    assert!(
+        triggers[0]["file_path"]
+            .as_str()
+            .unwrap()
+            .contains("plugin_alpha.py"),
+        "file_path should contain plugin_alpha.py"
+    );
+    assert!(triggers[0]["size_bytes"].as_i64().unwrap() > 0);
+    assert!(triggers[0]["last_modified"].as_i64().unwrap() > 0);
+
+    // Verify second plugin (trigger_beta)
+    assert_eq!(triggers[1]["plugin_name"], "trigger_beta");
+    assert_eq!(triggers[1]["file_name"], "plugin_beta.py");
+    assert!(
+        triggers[1]["file_path"]
+            .as_str()
+            .unwrap()
+            .contains("plugin_beta.py"),
+        "file_path should contain plugin_beta.py"
+    );
+    assert!(triggers[1]["size_bytes"].as_i64().unwrap() > 0);
+    assert!(triggers[1]["last_modified"].as_i64().unwrap() > 0);
+
+    Ok(())
+}
+
+#[test_log::test(tokio::test)]
+async fn test_show_plugins_multiple_databases() -> Result<()> {
+    let plugin_dir = TempDir::new()?;
+    let plugin_dir_path = plugin_dir.path();
+
+    fs::write(plugin_dir_path.join("plugin_alpha.py"), PLUGIN_ALPHA)?;
+    fs::write(plugin_dir_path.join("plugin_beta.py"), PLUGIN_BETA)?;
+
+    let server = TestServer::configure()
+        .with_plugin_dir(plugin_dir_path.to_str().unwrap())
+        .spawn()
+        .await;
+
+    server.create_database("test_db").run()?;
+    server.create_database("test_db2").run()?;
+
+    server
+        .create_trigger("test_db", "trigger_alpha", "plugin_alpha.py", "all_tables")
+        .run()?;
+
+    server
+        .create_trigger(
+            "test_db2",
+            "trigger_beta",
+            "plugin_beta.py",
+            "table:measurements",
+        )
+        .run()?;
+
+    // Show plugins - should see all plugins from all databases
+    let output = server.show_plugins().with_format("json").run()?;
+
+    let parsed: serde_json::Value = serde_json::from_str(&output)?;
+    let plugins = parsed.as_array().expect("Expected array result");
+
+    assert_eq!(plugins.len(), 2, "Should have two plugins total");
+
+    // Verify both plugins are present
+    let plugin_names: Vec<&str> = plugins
+        .iter()
+        .map(|p| p["plugin_name"].as_str().unwrap())
+        .collect();
+    assert!(
+        plugin_names.contains(&"trigger_alpha"),
+        "Should contain trigger_alpha"
+    );
+    assert!(
+        plugin_names.contains(&"trigger_beta"),
+        "Should contain trigger_beta"
+    );
+
+    Ok(())
+}
+
+#[test_log::test(tokio::test)]
+async fn test_show_plugins_empty() -> Result<()> {
+    // Start server without any plugins
+    let server = TestServer::spawn().await;
+
+    server.create_database("test_db").run()?;
+
+    // Run show plugins command when no triggers exist
+    let output = server.show_plugins().with_format("json").run()?;
+
+    let parsed: serde_json::Value = serde_json::from_str(&output)?;
+    let triggers = parsed.as_array().expect("Expected array result");
+
+    assert_eq!(
+        triggers.len(),
+        0,
+        "Should have no triggers when no triggers exist"
+    );
+
+    Ok(())
+}
+
+#[test_log::test(tokio::test)]
+async fn test_show_plugins_pretty_format() -> Result<()> {
+    let plugin_dir = TempDir::new()?;
+    let plugin_dir_path = plugin_dir.path();
+
+    fs::write(plugin_dir_path.join("plugin_alpha.py"), PLUGIN_ALPHA)?;
+    fs::write(plugin_dir_path.join("plugin_beta.py"), PLUGIN_BETA)?;
+
+    let server = TestServer::configure()
+        .with_plugin_dir(plugin_dir_path.to_str().unwrap())
+        .spawn()
+        .await;
+
+    server.create_database("test_db").run()?;
+
+    // Create triggers with different trigger specifications
+    server
+        .create_trigger("test_db", "trigger_alpha", "plugin_alpha.py", "all_tables")
+        .run()?;
+
+    server
+        .create_trigger("test_db", "trigger_beta", "plugin_beta.py", "every:5s")
+        .run()?;
+
+    // Run show plugins command with pretty format
+    let output = server.show_plugins().run()?;
+
+    assert!(
+        output.contains("plugin_name"),
+        "Should have plugin_name column"
+    );
+    assert!(output.contains("file_name"), "Should have file_name column");
+    assert!(output.contains("file_path"), "Should have file_path column");
+    assert!(
+        output.contains("size_bytes"),
+        "Should have size_bytes column"
+    );
+    assert!(
+        output.contains("last_modified"),
+        "Should have last_modified column"
+    );
+
+    // Verify the data rows
+    assert!(
+        output.contains("trigger_alpha"),
+        "Should contain trigger_alpha"
+    );
+    assert!(
+        output.contains("trigger_beta"),
+        "Should contain trigger_beta"
+    );
+    assert!(
+        output.contains("plugin_alpha.py"),
+        "Should contain plugin_alpha.py"
+    );
+    assert!(
+        output.contains("plugin_beta.py"),
+        "Should contain plugin_beta.py"
+    );
+
+    Ok(())
+}
+
+#[test_log::test(tokio::test)]
+async fn test_show_plugins_csv_format() -> Result<()> {
+    let plugin_dir = TempDir::new()?;
+    let plugin_dir_path = plugin_dir.path();
+
+    fs::write(plugin_dir_path.join("plugin_alpha.py"), PLUGIN_ALPHA)?;
+    fs::write(plugin_dir_path.join("plugin_beta.py"), PLUGIN_BETA)?;
+
+    let server = TestServer::configure()
+        .with_plugin_dir(plugin_dir_path.to_str().unwrap())
+        .spawn()
+        .await;
+
+    server.create_database("test_db").run()?;
+
+    // Create triggers with different trigger specifications
+    server
+        .create_trigger("test_db", "trigger_alpha", "plugin_alpha.py", "all_tables")
+        .run()?;
+
+    server
+        .create_trigger("test_db", "trigger_beta", "plugin_beta.py", "every:5s")
+        .run()?;
+
+    let output = server.show_plugins().with_format("csv").run()?;
+
+    // Parse CSV output
+    let lines: Vec<&str> = output.lines().collect();
+
+    // Verify CSV header
+    assert!(lines.len() >= 3, "Should have header + 2 data rows");
+    assert_eq!(
+        lines[0], "plugin_name,file_name,file_path,size_bytes,last_modified",
+        "CSV header should match expected columns"
+    );
+
+    // Verify trigger_alpha is in the output
+    let alpha_line = lines.iter().find(|line| line.contains("trigger_alpha"));
+    assert!(alpha_line.is_some(), "Should contain trigger_alpha in CSV");
+    let alpha_line = alpha_line.unwrap();
+    assert!(
+        alpha_line.contains("plugin_alpha.py"),
+        "Should contain plugin_alpha.py"
+    );
+
+    // Verify trigger_beta is in the output
+    let beta_line = lines.iter().find(|line| line.contains("trigger_beta"));
+    assert!(beta_line.is_some(), "Should contain trigger_beta in CSV");
+    let beta_line = beta_line.unwrap();
+    assert!(
+        beta_line.contains("plugin_beta.py"),
+        "Should contain plugin_beta.py"
+    );
+
+    Ok(())
+}
+
+#[test_log::test(tokio::test)]
+async fn test_show_plugins_pretty_format_empty() -> Result<()> {
+    // Start server without any plugins
+    let server = TestServer::spawn().await;
+
+    server.create_database("test_db").run()?;
+
+    // Run show plugins command with pretty format when no triggers exist
+    let output = server.show_plugins().run()?;
+
+    assert!(
+        !output.contains("trigger_alpha"),
+        "Should not contain any trigger data"
+    );
+    assert!(
+        !output.contains("trigger_beta"),
+        "Should not contain any trigger data"
+    );
+
+    Ok(())
+}
+
+#[test_log::test(tokio::test)]
+async fn test_show_plugins_csv_format_empty() -> Result<()> {
+    // Start server without any plugins
+    let server = TestServer::spawn().await;
+
+    server.create_database("test_db").run()?;
+
+    // Run show plugins command with CSV format when no triggers exist
+    let output = server.show_plugins().with_format("csv").run()?;
+
+    assert!(
+        !output.contains("trigger_alpha"),
+        "Should not contain any trigger data"
+    );
+    assert!(
+        !output.contains("trigger_beta"),
+        "Should not contain any trigger data"
+    );
+
+    // If output is present, verify it's valid CSV format
+    if !output.trim().is_empty() {
+        let lines: Vec<&str> = output.lines().collect();
+        // If there are lines, the first should be the header
+        if !lines.is_empty() {
+            assert_eq!(
+                lines[0], "plugin_name,file_name,file_path,size_bytes,last_modified",
+                "First line should be CSV header"
+            );
+            // And there should be no data rows when empty
+            assert_eq!(lines.len(), 1, "Should only have header line, no data rows");
+        }
+    }
 
     Ok(())
 }


### PR DESCRIPTION
This command exposes the ability to query the system table that was added in f7021ff6 via the CLI making it so that operators can easily see what files exist for plugins loaded into influxdb3. In the future this will list multiple files for plugins that are more than a singular file in size.

For now we expose the table in much the same way as we have done before. Since the table is an internal table this does require an admin token to view the table.

Tests were also included so as to avoid regressions with this command.