### PR TITLE
feat: Adds 'cq' diagnostics to /debug/vars (#26874)

### DIFF
--- a/cmd/influxd/run/server.go
+++ b/cmd/influxd/run/server.go
@@ -416,6 +416,9 @@ func (s *Server) appendContinuousQueryService(c continuous_querier.Config) {
 	srv.QueryExecutor = s.QueryExecutor
 	srv.Monitor = s.Monitor
 	s.Services = append(s.Services, srv)
+	if s.Monitor != nil {
+		s.Monitor.RegisterDiagnosticsClient("cq", srv)
+	}
 }
 
 // Err returns an error channel that multiplexes all out of band errors received from all services.

--- a/monitor/service.go
+++ b/monitor/service.go
@@ -241,6 +241,7 @@ func (m *Monitor) Close() error {
 	m.DeregisterDiagnosticsClient("system")
 	m.DeregisterDiagnosticsClient("stats")
 	m.DeregisterDiagnosticsClient("config")
+	m.DeregisterDiagnosticsClient("cq")
 	return nil
 }
 

--- a/services/continuous_querier/service.go
+++ b/services/continuous_querier/service.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/influxdata/influxdb/logger"
 	"github.com/influxdata/influxdb/models"
+	"github.com/influxdata/influxdb/monitor/diagnostics"
 	"github.com/influxdata/influxdb/query"
 	"github.com/influxdata/influxdb/services/meta"
 	"github.com/influxdata/influxql"
@@ -167,6 +168,12 @@ func (s *Service) Statistics(tags map[string]string) []models.Statistic {
 			statQueryFail: atomic.LoadInt64(&s.stats.QueryFail),
 		},
 	}}
+}
+
+// Required for Monitor interface. Currently does not return any
+// diagnostic values.
+func (s *Service) Diagnostics() (*diagnostics.Diagnostics, error) {
+	return &diagnostics.Diagnostics{}, nil
 }
 
 // Run runs the specified continuous query, or all CQs if none is specified.


### PR DESCRIPTION
This PR adds continuous query diags to our /debug/vars endpoint

Example
```
  "cq": {
    "queryFail": 0,
    "queryOk": 2
  },
```

(cherry picked from commit 63498cab4e5b9f310b4e98dc0f782d1080da25dd)
