### PR TITLE
feat: Allow updating plugin files for a trigger

### DIFF
--- a/influxdb3_client/src/lib.rs
+++ b/influxdb3_client/src/lib.rs
@@ -689,6 +689,28 @@ impl Client {
         Ok(())
     }
 
+    /// Update a plugin file
+    pub async fn api_v3_update_plugin_file(
+        &self,
+        db: impl Into<String> + Send,
+        trigger_name: impl Into<String> + Send,
+        content: impl Into<String> + Send,
+    ) -> Result<()> {
+        let _bytes = self
+            .send_json_get_bytes(
+                Method::PUT,
+                &format!("/api/v3/plugins/files?db={}", &db.into()),
+                Some(UpdatePluginFileRequest {
+                    plugin_name: trigger_name.into(),
+                    content: content.into(),
+                }),
+                None::<()>,
+                None,
+            )
+            .await?;
+        Ok(())
+    }
+
     /// Make a request to the `POST /api/v3/plugin_test/wal` API
     pub async fn wal_plugin_test(
         &self,

--- a/influxdb3_server/src/all_paths.rs
+++ b/influxdb3_server/src/all_paths.rs
@@ -32,3 +32,4 @@ pub(crate) const API_V3_CONFIGURE_ADMIN_TOKEN_REGENERATE: &str =
 pub(crate) const API_V3_CONFIGURE_NAMED_ADMIN_TOKEN: &str = "/api/v3/configure/token/named_admin";
 pub(crate) const API_V3_TEST_WAL_ROUTE: &str = "/api/v3/plugin_test/wal";
 pub(crate) const API_V3_TEST_PLUGIN_ROUTE: &str = "/api/v3/plugin_test/schedule";
+pub(crate) const API_V3_PLUGINS_FILES: &str = "/api/v3/plugins/files";

--- a/influxdb3_types/src/http.rs
+++ b/influxdb3_types/src/http.rs
@@ -201,6 +201,13 @@ pub struct ProcessingEngineTriggerDeleteRequest {
     pub force: bool,
 }
 
+/// Request definition for the `PUT /api/v3/plugins/files` API
+#[derive(Debug, Deserialize, Serialize)]
+pub struct UpdatePluginFileRequest {
+    pub plugin_name: String,
+    pub content: String,
+}
+
 /// Request definition for the `POST /api/v3/configure/plugin_environment/install_packages` API
 #[derive(Debug, Deserialize, Serialize)]
 pub struct ProcessingEngineInstallPackagesRequest {


### PR DESCRIPTION
This commit adds the ability to update the files for a given trigger at runtime by uploading new code to the server. This is done via an admin only command so that not just anyone can upload code to the server. We look for the file associated with the plugin and update it on the server side with the content sent to it via an HTTP request.