### PR TITLE
feat: Add multifile plugin support to InfluxDB 3 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3160,6 +3160,7 @@ dependencies = [
  "trogging",
  "url",
  "uuid",
+ "walkdir",
 ]
 
 [[package]]
@@ -3422,6 +3423,7 @@ dependencies = [
  "test-log",
  "thiserror 1.0.69",
  "tokio",
+ "walkdir",
 ]
 
 [[package]]

--- a/influxdb3/Cargo.toml
+++ b/influxdb3/Cargo.toml
@@ -81,6 +81,7 @@ tokio-rustls.workspace = true
 tokio-util.workspace = true
 url.workspace = true
 uuid.workspace = true
+walkdir = "2"
 
 # Optional Dependencies
 console-subscriber = { version = "0.1.10", optional = true, features = ["parking_lot"] }

--- a/influxdb3_client/src/lib.rs
+++ b/influxdb3_client/src/lib.rs
@@ -732,6 +732,35 @@ impl Client {
             .await
     }
 
+    /// Replace an entire plugin directory atomically
+    pub async fn api_v3_replace_plugin_directory(
+        &self,
+        db: impl Into<String> + Send,
+        trigger_name: impl Into<String> + Send,
+        files: Vec<(String, String)>,
+    ) -> Result<()> {
+        let file_entries = files
+            .into_iter()
+            .map(|(relative_path, content)| PluginFileEntry {
+                relative_path,
+                content,
+            })
+            .collect();
+
+        self.send_json_get_bytes(
+            Method::PUT,
+            &format!("/api/v3/plugins/directory?db={}", db.into()),
+            Some(ReplacePluginDirectoryRequest {
+                plugin_name: trigger_name.into(),
+                files: file_entries,
+            }),
+            None::<()>,
+            None,
+        )
+        .await?;
+        Ok(())
+    }
+
     /// Make a request to the `POST /api/v3/plugin_test/wal` API
     pub async fn wal_plugin_test(
         &self,

--- a/influxdb3_processing_engine/Cargo.toml
+++ b/influxdb3_processing_engine/Cargo.toml
@@ -34,6 +34,7 @@ reqwest.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
+walkdir = "2"
 
 [dev-dependencies]
 datafusion_util.workspace = true

--- a/influxdb3_server/src/all_paths.rs
+++ b/influxdb3_server/src/all_paths.rs
@@ -33,3 +33,4 @@ pub(crate) const API_V3_CONFIGURE_NAMED_ADMIN_TOKEN: &str = "/api/v3/configure/t
 pub(crate) const API_V3_TEST_WAL_ROUTE: &str = "/api/v3/plugin_test/wal";
 pub(crate) const API_V3_TEST_PLUGIN_ROUTE: &str = "/api/v3/plugin_test/schedule";
 pub(crate) const API_V3_PLUGINS_FILES: &str = "/api/v3/plugins/files";
+pub(crate) const API_V3_PLUGINS_DIRECTORY: &str = "/api/v3/plugins/directory";

--- a/influxdb3_types/src/http.rs
+++ b/influxdb3_types/src/http.rs
@@ -208,6 +208,21 @@ pub struct UpdatePluginFileRequest {
     pub content: String,
 }
 
+/// Request definition for the `PUT /api/v3/plugins/directory` API
+/// Replaces an entire plugin directory atomically
+#[derive(Debug, Deserialize, Serialize)]
+pub struct ReplacePluginDirectoryRequest {
+    pub plugin_name: String,
+    pub files: Vec<PluginFileEntry>,
+}
+
+/// Individual file entry for bulk plugin directory replacement
+#[derive(Debug, Deserialize, Serialize)]
+pub struct PluginFileEntry {
+    pub relative_path: String,
+    pub content: String,
+}
+
 /// Request definition for the `POST /api/v3/configure/plugin_environment/install_packages` API
 #[derive(Debug, Deserialize, Serialize)]
 pub struct ProcessingEngineInstallPackagesRequest {


### PR DESCRIPTION
This commit adds multifile plugin support for InfluxDB 3 and allows
users to write more complex plugins that have more than 1 file. The
following commit adds tests and the following abilities:

1. Multifile plugins can be created just like normal single file plugins
2. They can be uploaded as well just like single file plugins
3. The new path argument handles dirs and single files for update and
   creation of plugins

With this we expect users to be able to create more complex plugins and
to be able to update them easily!

Note you only need to look at 167dc80219112492d64aa45e8b720e1f8a8e56e1 as the other commit is part of #26895 which needs to be fixed up and merged first