### PR TITLE
feat(http,write): support v1 db/rp style names in all write apis

### DIFF
--- a/influxdb3/tests/server/write.rs
+++ b/influxdb3/tests/server/write.rs
@@ -340,7 +340,7 @@ async fn writes_with_different_schema_should_fail() {
                 message: _
             }
         ),
-        "the request should hae failed with an API Error"
+        "the request should have failed with an API Error"
     );
 }
 

--- a/influxdb3_server/src/lib.rs
+++ b/influxdb3_server/src/lib.rs
@@ -815,7 +815,7 @@ mod tests {
         // Check that invalid database names are rejected
         let resp = write_lp(
             &server,
-            "this/_is_fine",
+            "this#_is_fine",
             "cpu,host=b val=2 155\n",
             None,
             true,
@@ -831,7 +831,7 @@ mod tests {
         assert_eq!(
             body,
             "{\
-                \"error\":\"invalid character in database name: must be ASCII, containing only letters, numbers, underscores, or hyphens\"\
+                \"error\":\"invalid character in database or rp name: must be ASCII, containing only letters, numbers, underscores, or hyphens\"\
             }"
         );
 
@@ -1853,10 +1853,11 @@ mod tests {
     ) -> Response {
         let server = server.into();
         let client = Client::builder(TokioExecutor::new()).build(HttpConnector::new());
+        let database = urlencoding::encode(database.into().as_ref());
         let url = format!(
             "{}/api/v3/write_lp?db={}&accept_partial={accept_partial}&precision={}",
             server,
-            database.into(),
+            database,
             precision.into(),
         );
         println!("{url}");


### PR DESCRIPTION
This changes the validation of database names to support v1 db/rp style names in all apis. Only one forward slash is allowed. Tests, errors, and logging are updated. Validation of db name length is pulled into monolith code so we can return a 400 instead of a 500 which the iox NamespaceName validation was causing.

* this is a port of influxdata/influxdb_pro#1516
