### PR TITLE
fix: use correct path in open WAL error message

### DIFF
--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -787,7 +787,7 @@ func (e *Engine) Open() error {
 
 	if e.WALEnabled {
 		if err := e.WAL.Open(); err != nil {
-			return fmt.Errorf("error opening WAL for %q: %w", fieldPath, err)
+			return fmt.Errorf("error opening WAL for %q: %w", e.WAL.Path(), err)
 		}
 	}
 


### PR DESCRIPTION
(cherry picked from commit c87a451113915380b90c733d7e880d5e94b66865)

Closes #26928
