### PR TITLE
chore(write): truncate original lp line in error serialization

### DIFF
--- a/influxdb3_server/src/lib.rs
+++ b/influxdb3_server/src/lib.rs
@@ -761,9 +761,9 @@ mod tests {
             "{\
                 \"error\":\"parsing failed for write_lp endpoint\",\
                 \"data\":{\
-                    \"original_line\":\"cpu,host=a val= 123\",\
+                    \"error_message\":\"No fields were provided\",\
                     \"line_number\":1,\
-                    \"error_message\":\"No fields were provided\"\
+                    \"original_line\":\"cpu,host=a val= 123\"\
                 }\
             }"
         );
@@ -788,9 +788,9 @@ mod tests {
             "{\
                 \"error\":\"partial write of line protocol occurred\",\
                 \"data\":[{\
-                    \"original_line\":\"cpu,host=a val= 123\",\
+                    \"error_message\":\"No fields were provided\",\
                     \"line_number\":2,\
-                    \"error_message\":\"No fields were provided\"\
+                    \"original_line\":\"cpu,host=a val= 123\"\
                 }]\
             }"
         );


### PR DESCRIPTION
Returning the full line of lp that error'd could be very expensive if the original line is very long.

* port of https://github.com/influxdata/influxdb/pull/26935 to 3.6 branch