### PR TITLE
chore(CI): add "influxdata-archive-keyring" package (main)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -516,7 +516,7 @@ jobs:
 
   build-packages:
     docker:
-      - image: us-east1-docker.pkg.dev/influxdata-team-edge/ci-support/ci-packager-next@sha256:8223348466129205be30413c597e573114949be4190e66e45eb3e2ff8af4cc25
+      - image: us-east1-docker.pkg.dev/influxdata-team-edge/ci-support/ci-packager-next@sha256:c92ea43b5529b9c4f93478c26d128b3a5aa811559e1fa634cdb476241f8d7620
         auth:
           username: _json_key
           password: $CISUPPORT_GCS_AUTHORIZATION

--- a/.circleci/packages/config.yaml
+++ b/.circleci/packages/config.yaml
@@ -114,3 +114,9 @@ packages:
       - source: LICENSE-MIT
         target: usr/share/influxdb3/LICENSE-MIT
     source: .circleci/packages/influxdb3
+    deb:
+      recommends:
+        - influxdata-archive-keyring
+    rpm:
+      recommends:
+        - influxdata-archive-keyring


### PR DESCRIPTION
This adds the "influxdata-archive-keyring" package as a "recommended" package:

```sh
$ dpkg -I influxdb3-core_3.0.0+snapshot-deadbeef_arm64.deb
 new Debian package, version 2.0.
 size 115259320 bytes: control archive=88272 bytes.
     299 bytes,    10 lines      control
  429873 bytes,  4725 lines      md5sums
      12 bytes,     1 lines   *  postinst             #!/bin/bash
     434 bytes,    22 lines   *  preinst              #!/bin/bash
 Package: influxdb3-core
 Version: 3.0.0+snapshot-deadbeef
 Architecture: arm64
 Maintainer: support <support@influxdata.com>
 Installed-Size: 848384
 Recommends: influxdata-archive-keyring
 Section: default
 Priority: optional
 Homepage: https://influxdata.com
 Description: Monolithic time-series database.
```

```sh
$ rpm -q --recommends influxdb3-core-3.0.0+snapshot-deadbeef.aarch64.rpm
influxdata-archive-keyring
```