### PR TITLE
chore(CI): add "influxdata-archive-keyring" package (2.x)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -477,7 +477,7 @@ jobs:
 
   build-packages:
     docker:
-      - image: us-east1-docker.pkg.dev/influxdata-team-edge/ci-support/ci-packager:latest
+      - image: us-east1-docker.pkg.dev/influxdata-team-edge/ci-support/ci-packager-next@sha256:c92ea43b5529b9c4f93478c26d128b3a5aa811559e1fa634cdb476241f8d7620
         auth:
           username: _json_key
           password: $CISUPPORT_GCS_AUTHORIZATION

--- a/.circleci/packages/config.yaml
+++ b/.circleci/packages/config.yaml
@@ -1,9 +1,8 @@
 ---
 version:
-  release:
-    match: '^v[0-9]+.[0-9]+.[0-9]+'
+  - match: '^v[0-9]+.[0-9]+.[0-9]+'
     value: '{{env.CIRCLE_TAG[1:]}}'
-  default:
+  - match: '.*'
     value: '2.x-{{env.CIRCLE_SHA1[:8]}}'
 
 sources:
@@ -31,6 +30,11 @@ packages:
   - name:        influxdb2
     description: Distributed time-series database.
     license:     MIT
+    vendor:      InfluxData
+    homepage:    https://influxdata.com
+    maintainer:
+      name:  support
+      email: support@influxdata.com
     binaries:
       - influxd
       - influxd.exe
@@ -60,10 +64,15 @@ packages:
         group:  root
         perms:  0644
         target: lib/systemd/system/influxdb.service
-    deb_recommends:
-      - influxdb2-cli
-    conflicts:
-      - influxdb
-    depends:
-      - curl
     source: .circleci/packages/influxdb2
+    deb:
+      recommends:
+        - influxdata-archive-keyring
+        - influxdb2-cli
+      conflicts:
+        - influxdb
+      depends:
+        - curl
+    rpm:
+      recommends:
+        - influxdata-archive-keyring


### PR DESCRIPTION
This is the 2.X version of https://github.com/influxdata/influxdb/pull/26938.

```sh
$ rpm -q --recommends influxdb2-2.x-0dc46cef.aarch64.rpm
influxdata-archive-keyring
```
```sh
$ dpkg -I influxdb2_2.x-0dc46cef_amd64.deb
 new Debian package, version 2.0.
 size 41936144 bytes: control archive=2708 bytes.
      26 bytes,     1 lines      conffiles
     333 bytes,    12 lines      control
     615 bytes,     9 lines      md5sums
    3873 bytes,   143 lines   *  postinst             #!/bin/bash
    1428 bytes,    57 lines   *  postrm               #!/bin/bash
     428 bytes,    22 lines   *  preinst              #!/bin/bash
     253 bytes,     7 lines   *  prerm                #!/bin/sh
 Package: influxdb2
 Version: 2.x-0dc46cef
 Architecture: amd64
 Maintainer: support <support@influxdata.com>
 Installed-Size: 134289
 Depends: curl
 Recommends: influxdata-archive-keyring, influxdb2-cli
 Conflicts: influxdb
 Section: default
 Priority: optional
 Homepage: https://influxdata.com
 Description: Distributed time-series database.
```