### PR TITLE
chore(CI): add "influxdata-archive-keyring" package (1.12)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -180,7 +180,7 @@ jobs:
 
   build_packages:
     docker:
-      - image: us-east1-docker.pkg.dev/influxdata-team-edge/ci-support/ci-packager:latest
+      - image: us-east1-docker.pkg.dev/influxdata-team-edge/ci-support/ci-packager-next@sha256:c92ea43b5529b9c4f93478c26d128b3a5aa811559e1fa634cdb476241f8d7620
         auth:
           username: _json_key
           password: $CISUPPORT_GCS_AUTHORIZATION

--- a/.circleci/packages/config.yaml
+++ b/.circleci/packages/config.yaml
@@ -1,9 +1,8 @@
 ---
 version:
-  release:
-    match: '^v[0-9]+.[0-9]+.[0-9]+'
+  - match: '^v[0-9]+.[0-9]+.[0-9]+'
     value: '{{env.CIRCLE_TAG[1:]}}'
-  default:
+  - match: '.*'
     value: '1.x-{{env.CIRCLE_SHA1[:8]}}'
 
 sources:
@@ -31,6 +30,11 @@ packages:
   - name:        influxdb
     description: Distributed time-series database.
     license:     MIT
+    vendor:      InfluxData
+    homepage:    https://influxdata.com
+    maintainer:
+      name:  support
+      email: support@influxdata.com
     binaries:
       # linux, darwin
       - influx
@@ -86,3 +90,9 @@ packages:
       - 750,influxdb,influxdb:/var/log/influxdb
       - 750,influxdb,influxdb:/var/lib/influxdb
     source: .circleci/packages/influxdb
+    deb:
+      recommends:
+        - influxdata-archive-keyring
+    rpm:
+      recommends:
+        - influxdata-archive-keyring


### PR DESCRIPTION
This is the 1.12 version of https://github.com/influxdata/influxdb/pull/26938.

```sh
$ dpkg -I influxdb_1.x-cc218d5a_arm64.deb
 new Debian package, version 2.0.
 size 24746072 bytes: control archive=2304 bytes.
      28 bytes,     1 lines      conffiles
     283 bytes,    10 lines      control
    1089 bytes,    16 lines      md5sums
    1933 bytes,    75 lines   *  postinst             #!/bin/bash
    1428 bytes,    57 lines   *  postrm               #!/bin/bash
     761 bytes,    22 lines   *  preinst              #!/bin/bash
     253 bytes,     7 lines   *  prerm                #!/bin/sh
 Package: influxdb
 Version: 1.x-cc218d5a
 Architecture: arm64
 Maintainer: support <support@influxdata.com>
 Installed-Size: 118595
 Recommends: influxdata-archive-keyring
 Section: default
 Priority: optional
 Homepage: https://influxdata.com
 Description: Distributed time-series database.
```
```sh
$ rpm -q --recommends ./influxdb-1.x-cc218d5a.aarch64.rpm
influxdata-archive-keyring
```