### PR TITLE
fix: flipped count/sum when tracking observations

### DIFF
--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -263,8 +263,8 @@ type twoCounterObserver struct {
 }
 
 func (t twoCounterObserver) Observe(f float64) {
-	t.sum.Inc()
-	t.count.Add(f)
+	t.count.Inc()
+	t.sum.Add(f)
 }
 
 var _ prometheus.Observer = twoCounterObserver{}


### PR DESCRIPTION
Closes #25056.

Fix oversight when counting error events: every observation should increment the count, and add the sum. The current code does the opposite (i.e. increment the sum, add the count)

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
