### PR TITLE
fix: properly account request timeouts not as shard write errors

### DIFF
--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -698,8 +698,9 @@ func (s *Shard) WritePoints(ctx context.Context, points []models.Point) (rErr er
 	var writeError error
 	s.stats.writes.Observe(float64(len(points)))
 	defer func() {
-		if rErr != nil {
+		if rErr != nil && !errors.Is(rErr, context.DeadlineExceeded) && !errors.Is(rErr, context.Canceled) {
 			s.stats.writesErr.Observe(float64(len(points)))
+			s.logger.Error("writing points to engine failed", zap.Error(rErr))
 		}
 	}()
 

--- a/v1/coordinator/points_writer.go
+++ b/v1/coordinator/points_writer.go
@@ -17,9 +17,6 @@ import (
 )
 
 var (
-	// ErrTimeout is returned when a write times out.
-	ErrTimeout = errors.New("timeout")
-
 	// ErrWriteFailed is returned when no writes succeeded.
 	ErrWriteFailed = errors.New("write failed")
 )
@@ -459,6 +456,10 @@ func (w *PointsWriter) WritePointsPrivileged(
 		return err
 	}
 
+	// Set a timeout using the context object.
+	ctx, cancel := context.WithTimeout(ctx, w.WriteTimeout)
+	defer cancel()
+
 	// Write each shard in it's own goroutine and return as soon as one fails.
 	ch := make(chan error, len(shardMappings.Points))
 	for shardID, points := range shardMappings.Points {
@@ -466,18 +467,16 @@ func (w *PointsWriter) WritePointsPrivileged(
 			err := w.writeToShard(ctx, shard, database, retentionPolicy, points)
 			if err == nil {
 				w.stats.pointsWriteOk.Observe(float64(len(points)))
-			} else {
+			} else if !errors.Is(err, context.DeadlineExceeded) && !errors.Is(err, context.Canceled) {
 				w.stats.pointsWriteErr.Observe(float64(len(points)))
+				w.Logger.Error("writing points to shard failed", zap.Error(err))
 			}
-			if err == tsdb.ErrShardDeletion {
+			if errors.Is(err, tsdb.ErrShardDeletion) {
 				err = tsdb.PartialWriteError{Reason: fmt.Sprintf("shard %d is pending deletion", shard.ID), Dropped: len(points)}
 			}
 			ch <- err
 		}(shardMappings.Shards[shardID], database, retentionPolicy, points)
 	}
-
-	timeout := time.NewTimer(w.WriteTimeout)
-	defer timeout.Stop()
 
 	if err == nil && shardMappings.Dropped() > 0 {
 		w.stats.pointsWriteDropped.Observe(float64(shardMappings.Dropped()))
@@ -492,11 +491,10 @@ func (w *PointsWriter) WritePointsPrivileged(
 		select {
 		case <-w.closing:
 			return ErrWriteFailed
-		case <-timeout.C:
-			w.stats.timeout.Inc()
-			// return timeout error to caller
-			return ErrTimeout
 		case err := <-ch:
+			if errors.Is(err, context.Canceled) {
+				w.stats.timeout.Inc()
+			}
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Closes #26957.

Clean up the use of our own timeouts and use Context timeouts (which are tied to a request). This simplifies the code, and also no longer counts HTTP request timeouts as errors.

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
