### PR TITLE
feat(http): add cluster uuid as header to responses

### DIFF
--- a/influxdb3_server/src/all_paths.rs
+++ b/influxdb3_server/src/all_paths.rs
@@ -34,3 +34,6 @@ pub(crate) const API_V3_TEST_WAL_ROUTE: &str = "/api/v3/plugin_test/wal";
 pub(crate) const API_V3_TEST_PLUGIN_ROUTE: &str = "/api/v3/plugin_test/schedule";
 pub(crate) const API_V3_PLUGINS_FILES: &str = "/api/v3/plugins/files";
 pub(crate) const API_V3_PLUGINS_DIRECTORY: &str = "/api/v3/plugins/directory";
+
+/****** headers ********/
+pub(crate) const API_HEADER_CLUSTER_UUID: &str = "cluster-uuid";


### PR DESCRIPTION
Adds the cluster uuid string under the header name of "cluster-uuid" to most responses; some failure/error responses won't have the header, until a larger refactor is ported from enterprise.

* partial port of https://github.com/influxdata/influxdb_pro/pull/1683