### PR TITLE
feat: show user when displaying or logging queries (#26981)

### DIFF
--- a/query/executor.go
+++ b/query/executor.go
@@ -201,6 +201,9 @@ type ExecutionOptions struct {
 
 	// AbortCh is a channel that signals when results are no longer desired by the caller.
 	AbortCh <-chan struct{}
+
+	// UserID is the ID of the user executing the query.
+	UserID string
 }
 
 type (
@@ -470,6 +473,7 @@ func (e *Executor) recover(query *influxql.Query, results chan *Result) {
 type Task struct {
 	query     string
 	database  string
+	userID    string
 	status    TaskStatus
 	startTime time.Time
 	closing   chan struct{}

--- a/query/executor_test.go
+++ b/query/executor_test.go
@@ -318,6 +318,8 @@ func TestQueryExecutor_Abort(t *testing.T) {
 }
 
 func TestQueryExecutor_ShowQueries(t *testing.T) {
+	const testUser = "Fred"
+	const userColumn = 5
 	e := NewQueryExecutor()
 	e.StatementExecutor = &StatementExecutor{
 		ExecuteStatementFn: func(stmt influxql.Statement, ctx *query.ExecutionContext) error {
@@ -336,12 +338,16 @@ func TestQueryExecutor_ShowQueries(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	results := e.ExecuteQuery(q, query.ExecutionOptions{}, nil)
+	results := e.ExecuteQuery(q, query.ExecutionOptions{UserID: testUser}, nil)
 	result := <-results
 	if len(result.Series) != 1 {
 		t.Errorf("expected %d series, got %d", 1, len(result.Series))
 	} else if len(result.Series[0].Values) != 1 {
 		t.Errorf("expected %d row, got %d", 1, len(result.Series[0].Values))
+	} else if result.Series[0].Values[0][userColumn] != testUser {
+		t.Errorf("unexpected user: %s", result.Series[0].Values[0][0])
+	} else if result.Series[0].Columns[userColumn] != "user" {
+		t.Errorf("unexpected column: %s", result.Series[0].Columns[5])
 	}
 	if result.Err != nil {
 		t.Errorf("unexpected error: %s", result.Err)

--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -685,6 +685,11 @@ func (h *Handler) serveQuery(w http.ResponseWriter, r *http.Request, user meta.U
 	// Parse whether this is an async command.
 	async := r.FormValue("async") == "true"
 
+	var userName string
+
+	if user != nil {
+		userName = user.ID()
+	}
 	opts := query.ExecutionOptions{
 		Database:        db,
 		RetentionPolicy: r.FormValue("rp"),
@@ -692,6 +697,7 @@ func (h *Handler) serveQuery(w http.ResponseWriter, r *http.Request, user meta.U
 		ReadOnly:        r.Method == "GET",
 		NodeID:          nodeID,
 		Authorizer:      fineAuthorizer,
+		UserID:          userName,
 	}
 
 	if h.Config.AuthEnabled {


### PR DESCRIPTION
To assist customers in debugging long-running queries, display the user that submitted them in the following situations:

- SHOW QUERIES
- For log-queries-after > 0
- log-timedout-queries is true
- When termination-query-log is true

Fixes https://github.com/influxdata/influxdb/issues/26980

(cherry picked from commit 1f5c2b8422da876f01163edb01290b2266f92776)

Fixes https://github.com/influxdata/influxdb/issues/26984