### PR TITLE
feat: port from enterprise to core

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -231,6 +231,7 @@ inherits = "release"
 codegen-units = 16
 lto = false
 incremental = true
+debug = "line-tables-only"
 
 # This profile extends the `quick-release` profile with debuginfo turned on in order to
 # produce more human friendly symbols for profiling tools

--- a/influxdb3/src/commands/serve.rs
+++ b/influxdb3/src/commands/serve.rs
@@ -147,6 +147,13 @@ pub enum Error {
 
     #[error("Must set INFLUXDB3_NODE_IDENTIFIER_PREFIX to a valid string value")]
     NodeIdEnvVarMissing,
+
+    #[error(
+        "Python environment initialization failed: {0}\nPlease ensure Python and either pip or uv package manager is installed"
+    )]
+    PythonEnvironmentInitialization(
+        #[source] influxdb3_processing_engine::environment::PluginEnvironmentError,
+    ),
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
@@ -1104,7 +1111,8 @@ pub async fn command(config: Config, user_params: HashMap<String, String>) -> Re
         Arc::clone(&time_provider) as _,
         sys_events_store,
     )
-    .await;
+    .await
+    .map_err(Error::PythonEnvironmentInitialization)?;
 
     // Update query executor with processing engine reference
     query_executor.set_processing_engine(Arc::clone(&processing_engine));

--- a/influxdb3_authz/src/lib.rs
+++ b/influxdb3_authz/src/lib.rs
@@ -36,10 +36,13 @@ pub enum AccessRequest {
     Admin,
 }
 
-#[derive(Debug, Clone, Copy, thiserror::Error)]
+#[derive(Debug, Clone, thiserror::Error)]
 pub enum ResourceAuthorizationError {
     #[error("unauthorized to perform requested action with the token")]
     Unauthorized,
+
+    #[error("resource type not supported, {0}")]
+    ResourceNotSupported(String),
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/influxdb3_cache/src/distinct_cache/mod.rs
+++ b/influxdb3_cache/src/distinct_cache/mod.rs
@@ -3,7 +3,7 @@
 mod cache;
 pub use cache::{CacheError, CreateDistinctCacheArgs};
 mod provider;
-pub use provider::{DistinctCacheProvider, ProviderError};
+pub use provider::{DistinctCacheProvider, ProviderError, background_catalog_update};
 mod table_function;
 pub use table_function::DISTINCT_CACHE_UDTF_NAME;
 pub use table_function::DistinctCacheFunction;

--- a/influxdb3_cache/src/distinct_cache/provider.rs
+++ b/influxdb3_cache/src/distinct_cache/provider.rs
@@ -271,7 +271,9 @@ impl DistinctCacheProvider {
     }
 }
 
-fn background_catalog_update(
+/// Background task that listens for catalog updates and maintains distinct caches.
+/// This should be started explicitly after creating the provider.
+pub fn background_catalog_update(
     provider: Arc<DistinctCacheProvider>,
     mut subscription: CatalogUpdateReceiver,
 ) -> tokio::task::JoinHandle<()> {

--- a/influxdb3_cache/src/last_cache/mod.rs
+++ b/influxdb3_cache/src/last_cache/mod.rs
@@ -6,7 +6,7 @@ mod cache;
 pub use cache::CreateLastCacheArgs;
 mod metrics;
 mod provider;
-pub use provider::LastCacheProvider;
+pub use provider::{LastCacheProvider, background_catalog_update};
 mod table_function;
 use schema::InfluxColumnType;
 pub use table_function::{LAST_CACHE_UDTF_NAME, LastCacheFunction};

--- a/influxdb3_cache/src/last_cache/provider.rs
+++ b/influxdb3_cache/src/last_cache/provider.rs
@@ -354,7 +354,9 @@ impl LastCacheProvider {
     }
 }
 
-fn background_catalog_update(
+/// Background task that listens for catalog updates and maintains last value caches.
+/// This should be started explicitly after creating the provider.
+pub fn background_catalog_update(
     provider: Arc<LastCacheProvider>,
     mut subscription: CatalogUpdateReceiver,
 ) -> tokio::task::JoinHandle<()> {

--- a/influxdb3_catalog/src/catalog.rs
+++ b/influxdb3_catalog/src/catalog.rs
@@ -219,7 +219,7 @@ impl<I: CatalogId, R: CatalogResource> Repository<I, R> {
     pub(crate) fn update(&mut self, id: I, resource: impl Into<Arc<R>>) -> Result<()> {
         let resource = resource.into();
         if !self.id_exists(&id) {
-            return Err(CatalogError::NotFound);
+            return Err(CatalogError::NotFound(format!("catalog id: {}", id)));
         }
         self.id_name_map.insert(id, resource.name());
         self.repo.insert(id, resource);
@@ -383,7 +383,7 @@ impl TokenRepository {
         let token_id = self
             .repo
             .name_to_id(&token_name)
-            .ok_or_else(|| CatalogError::NotFound)?;
+            .ok_or_else(|| CatalogError::NotFound(token_name))?;
         self.repo.remove(&token_id);
         self.hash_lookup_map.remove_by_left(&token_id);
         Ok(())

--- a/influxdb3_catalog/src/catalog/versions/v2.rs
+++ b/influxdb3_catalog/src/catalog/versions/v2.rs
@@ -3959,13 +3959,13 @@ mod tests {
         let fake_db_id = DbId::from(999);
         let fake_table_id = TableId::from(123);
         let result = catalog.hard_delete_table(&fake_db_id, &fake_table_id).await;
-        assert!(matches!(result, Err(CatalogError::NotFound)));
+        assert!(matches!(result, Err(CatalogError::NotFound(_))));
 
         // Create database but try to delete non-existent table
         catalog.create_database("test").await.unwrap();
         let db_id = catalog.db_name_to_id("test").unwrap();
         let result = catalog.hard_delete_table(&db_id, &fake_table_id).await;
-        assert!(matches!(result, Err(CatalogError::NotFound)));
+        assert!(matches!(result, Err(CatalogError::NotFound(_))));
     }
 
     #[test_log::test(tokio::test)]
@@ -4149,7 +4149,7 @@ mod tests {
         // Try to delete non-existent database
         let fake_db_id = DbId::from(999);
         let result = catalog.hard_delete_database(&fake_db_id).await;
-        assert!(matches!(result, Err(CatalogError::NotFound)));
+        assert!(matches!(result, Err(CatalogError::NotFound(_))));
     }
 
     #[test_log::test(tokio::test)]

--- a/influxdb3_catalog/src/error.rs
+++ b/influxdb3_catalog/src/error.rs
@@ -14,8 +14,8 @@ pub enum CatalogError {
     #[error("attempted to create a resource that already exists")]
     AlreadyExists,
 
-    #[error("the requested resource was not found")]
-    NotFound,
+    #[error("the requested resource was not found: {0}")]
+    NotFound(String),
 
     #[error("attempted to delete resource that was already deleted")]
     AlreadyDeleted,

--- a/influxdb3_id/src/lib.rs
+++ b/influxdb3_id/src/lib.rs
@@ -10,7 +10,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 mod serialize;
 pub use serialize::{SerdeVecMap, SerdeVecSet};
 
-pub trait CatalogId: Default + Hash + Eq + Copy + Ord + Serialize {
+pub trait CatalogId: Default + Hash + Eq + Copy + Ord + Serialize + Display {
     type Integer;
 
     const MAX: Self;

--- a/influxdb3_processing_engine/src/environment.rs
+++ b/influxdb3_processing_engine/src/environment.rs
@@ -27,7 +27,7 @@ pub enum PluginEnvironmentError {
 pub trait PythonEnvironmentManager: Debug + Send + Sync + 'static {
     fn init_pyenv(
         &self,
-        plugin_dir: &Path,
+        plugin_dir: Option<&Path>,
         virtual_env_location: Option<&PathBuf>,
     ) -> Result<(), PluginEnvironmentError>;
     fn install_packages(&self, packages: Vec<String>) -> Result<(), PluginEnvironmentError>;
@@ -55,9 +55,10 @@ fn is_valid_venv(venv_path: &Path) -> bool {
 impl PythonEnvironmentManager for UVManager {
     fn init_pyenv(
         &self,
-        plugin_dir: &Path,
+        plugin_dir: Option<&Path>,
         virtual_env_location: Option<&PathBuf>,
     ) -> Result<(), PluginEnvironmentError> {
+        let plugin_dir = plugin_dir.expect("plugin dir is set if using uv");
         let venv_path = match virtual_env_location {
             Some(path) => path,
             None => &plugin_dir.join(".venv"),
@@ -93,9 +94,10 @@ impl PythonEnvironmentManager for UVManager {
 impl PythonEnvironmentManager for PipManager {
     fn init_pyenv(
         &self,
-        plugin_dir: &Path,
+        plugin_dir: Option<&Path>,
         virtual_env_location: Option<&PathBuf>,
     ) -> Result<(), PluginEnvironmentError> {
+        let plugin_dir = plugin_dir.expect("plugin dir is set if using pip");
         let venv_path = match virtual_env_location {
             Some(path) => path,
             None => &plugin_dir.join(".venv"),
@@ -142,7 +144,7 @@ impl PythonEnvironmentManager for PipManager {
 impl PythonEnvironmentManager for DisabledManager {
     fn init_pyenv(
         &self,
-        _plugin_dir: &Path,
+        _plugin_dir: Option<&Path>,
         _virtual_env_location: Option<&PathBuf>,
     ) -> Result<(), PluginEnvironmentError> {
         Ok(())
@@ -169,7 +171,7 @@ pub struct DisabledPackageManager;
 impl PythonEnvironmentManager for DisabledPackageManager {
     fn init_pyenv(
         &self,
-        _plugin_dir: &Path,
+        _plugin_dir: Option<&Path>,
         _virtual_env_location: Option<&PathBuf>,
     ) -> Result<(), PluginEnvironmentError> {
         // Allow normal initialization - the processing engine should still work

--- a/influxdb3_py_api/src/system_py.rs
+++ b/influxdb3_py_api/src/system_py.rs
@@ -731,7 +731,10 @@ pub fn execute_schedule_trigger(
 
         let py_datetime = PyDateTime::from_timestamp(py, schedule_time.timestamp() as f64, None)
             .map_err(|e| {
-                anyhow::Error::new(e).context("error converting the schedule time to Python time")
+                anyhow::Error::new(e).context(format!(
+                    "error converting the schedule time {schedule_time} to Python time: \
+                likely python build or libpython issue"
+                ))
             })?;
 
         py.run(&CString::new(LINE_BUILDER_CODE).unwrap(), None, None)

--- a/influxdb3_types/src/lib.rs
+++ b/influxdb3_types/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod http;
+pub mod logging;
 pub mod write;

--- a/influxdb3_types/src/logging.rs
+++ b/influxdb3_types/src/logging.rs
@@ -1,0 +1,40 @@
+//! Utilities for structured logging
+
+/// Helper to format anyhow error chains on a single line for structured logging.
+///
+/// This wrapper formats an error and all its causes as a single-line string using
+/// anyhow's alternate format (`{:#}`), which is useful for structured logging systems
+/// that split on newlines.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use influxdb3_types::logging::ErrorOneLine;
+/// use tracing::error;
+///
+/// let error: anyhow::Error = /* ... */;
+/// error!(error = %ErrorOneLine(&error), "operation failed");
+/// ```
+///
+/// This produces a single-line log entry like:
+/// ```text
+/// error="outer error: middle error: root cause"
+/// ```
+///
+/// instead of the default multiline format:
+/// ```text
+/// error=outer error
+///
+/// Caused by:
+///     middle error
+///     root cause
+/// ```
+#[derive(Debug)]
+pub struct ErrorOneLine<'a>(pub &'a anyhow::Error);
+
+impl<'a> std::fmt::Display for ErrorOneLine<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Use anyhow's alternate format which joins the error chain with ": "
+        write!(f, "{:#}", self.0)
+    }
+}

--- a/influxdb3_write/src/deleter.rs
+++ b/influxdb3_write/src/deleter.rs
@@ -192,7 +192,7 @@ impl Task {
             Task::DeleteDatabase { db_id, catalog } => {
                 info!(?db_id, "Processing delete database task.");
                 match catalog.hard_delete_database(&db_id).await {
-                    Err(CatalogError::NotFound) | Ok(_) => {}
+                    Err(CatalogError::NotFound(_)) | Ok(_) => {}
                     Err(CatalogError::CannotDeleteInternalDatabase) => {
                         // This should not happen
                         error!("Rejected request to delete internal database")
@@ -209,7 +209,7 @@ impl Task {
             } => {
                 info!(?db_id, ?table_id, "Processing delete table task.");
                 match catalog.hard_delete_table(&db_id, &table_id).await {
-                    Err(CatalogError::NotFound) | Ok(_) => {}
+                    Err(CatalogError::NotFound(_)) | Ok(_) => {}
                     Err(err) => {
                         error!(%db_id, %table_id, ?err, "Unexpected error deleting table from catalog.");
                     }

--- a/influxdb3_write/src/write_buffer/mod.rs
+++ b/influxdb3_write/src/write_buffer/mod.rs
@@ -129,9 +129,6 @@ pub enum Error {
     #[error("error from wal: {0}")]
     WalError(#[from] influxdb3_wal::Error),
 
-    #[error("cannot write to a read-only server")]
-    NoWriteInReadOnly,
-
     #[error("error in distinct value cache: {0}")]
     DistinctCacheError(#[from] distinct_cache::ProviderError),
 


### PR DESCRIPTION
This brings several prs from enterprise into core. Most of volume is for improved error handling, but there are features:

* proper gzip multipayload support
* don't panic if there's an issue with the plugin dir
* improved resource not found messaging
* truncating user provided information in logging and errors
* cluster uuid header in all api responses

Ports most of or parts of
* https://github.com/influxdata/influxdb_pro/pull/1754 - `feat(http errors): improve error messages for not found`
* https://github.com/influxdata/influxdb_pro/pull/1684 - `refactor(http): centralize error handling through RoutingError enum`
* https://github.com/influxdata/influxdb_pro/pull/1683 - `feat(http): include cluster-uuid in response header for all requests`
* https://github.com/influxdata/influxdb_pro/pull/1670 - `chore(errors): refine errors and logging`
* https://github.com/influxdata/influxdb_pro/pull/1625 - `chore: improve error reporting for processing engine`
* https://github.com/influxdata/influxdb_pro/pull/1595 - `eat(server,http): accept multi-member gzip payloads`
* https://github.com/influxdata/influxdb_pro/pull/1371 - `feat: populate lvc dvc on creation`
* https://github.com/influxdata/influxdb_pro/pull/1100 - `fix: Error if plugin_dir is set with no pip/uv`
