### PR TITLE
chore: Update assert_cmd and remove deprecations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3564,7 +3564,6 @@ dependencies = [
  "parquet_file",
  "pretty_assertions",
  "regex",
- "rustls-pemfile",
  "schema",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ arrow-flight = { version = "55", features = ["flight-sql-experimental"] }
 arrow-ipc = { version = "55" }
 arrow-json = "55"
 arrow-schema = { version = "55" }
-assert_cmd = "2.0.14"
+assert_cmd = "2.1.1"
 async-trait = "0.1"
 backon = { version = "1.5.0", features = ["tokio"] }
 backtrace = "0.3"
@@ -133,7 +133,6 @@ reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"
 rstest = "0.26"
 rustls = { version = "0.23", default-features = false, features = ["logging", "ring", "std", "tls12"] }
 rustls-webpki = { version = "0.103", default-features = false, features = ["ring", "std"] }
-rustls-pemfile = "2.2.0"
 secrecy = "0.8.0"
 serde = { version = "1.0", features = ["derive"] }
 # serde_json is set to 1.0.127 to prevent a conflict with core, if that gets updated upstream, this

--- a/deny.toml
+++ b/deny.toml
@@ -9,6 +9,10 @@ ignore = [
     # Keep this here until our transisent dependencies no longer
     # need it
     "RUSTSEC-2024-0436",
+    # rustls-pemfile is unmaintained but still used as a transitive dependency
+    # from object_store. We've removed our direct dependency and migrated to
+    # rustls-pki-types. Remove once object_store updates.
+    "RUSTSEC-2025-0134",
 ]
 git-fetch-with-cli = true
 

--- a/influxdb3/tests/cli/api.rs
+++ b/influxdb3/tests/cli/api.rs
@@ -1,6 +1,5 @@
 use crate::server::TestServer;
 use anyhow::{Result, bail};
-use assert_cmd::cargo::CommandCargoExt;
 use influxdb3_types::http::FieldType;
 use serde_json::Value;
 use std::io::Write;
@@ -53,9 +52,7 @@ pub(super) fn run_cmd_with_result(
     input: Option<&str>,
     command_args: Vec<&str>,
 ) -> std::result::Result<String, anyhow::Error> {
-    // See https://github.com/influxdata/influxdb/issues/26975
-    #[allow(deprecated)]
-    let mut child_process = Command::cargo_bin("influxdb3")?
+    let mut child_process = Command::new(assert_cmd::cargo_bin!("influxdb3"))
         .args(&command_args)
         .args(args)
         .stdin(Stdio::piped())

--- a/influxdb3/tests/cli/mod.rs
+++ b/influxdb3/tests/cli/mod.rs
@@ -5,7 +5,7 @@ mod offline_tokens;
 mod system_tables;
 
 use crate::server::{ConfigProvider, TestServer};
-use assert_cmd::Command as AssertCmd;
+use assert_cmd::cargo::cargo_bin_cmd;
 use observability_deps::tracing::debug;
 use pretty_assertions::assert_eq;
 use reqwest::StatusCode;
@@ -72,10 +72,7 @@ fn test_telemetry_disabled_with_debug_msg() {
     let expected_disabled: &str = "Initializing TelemetryStore with upload disabled.";
 
     // validate we get a debug message indicating upload disabled
-    // See https://github.com/influxdata/influxdb/issues/26975
-    #[allow(deprecated)]
-    let output = AssertCmd::cargo_bin("influxdb3")
-        .unwrap()
+    let output = cargo_bin_cmd!("influxdb3")
         .args(serve_args)
         .arg("-vv")
         .arg("--disable-telemetry-upload")
@@ -103,10 +100,7 @@ fn test_telemetry_disabled() {
 
     let expected_disabled: &str = "Initializing TelemetryStore with upload disabled.";
     // validate no message when debug output disabled
-    // See https://github.com/influxdata/influxdb/issues/26975
-    #[allow(deprecated)]
-    let output = AssertCmd::cargo_bin("influxdb3")
-        .unwrap()
+    let output = cargo_bin_cmd!("influxdb3")
         .args(serve_args)
         .arg("-v")
         .arg("--disable-telemetry-upload")
@@ -136,10 +130,7 @@ fn test_telemetry_enabled_with_debug_msg() {
         "Initializing TelemetryStore with upload enabled for http://localhost:9999.";
 
     // validate debug output shows which endpoint we are hitting when telemetry enabled
-    // See https://github.com/influxdata/influxdb/issues/26975
-    #[allow(deprecated)]
-    let output = AssertCmd::cargo_bin("influxdb3")
-        .unwrap()
+    let output = cargo_bin_cmd!("influxdb3")
         .args(serve_args)
         .arg("-vv")
         .arg("--telemetry-endpoint")
@@ -170,10 +161,7 @@ fn test_telementry_enabled() {
         "Initializing TelemetryStore with upload enabled for http://localhost:9999.";
 
     // validate no telemetry endpoint reported when debug output not enabled
-    // See https://github.com/influxdata/influxdb/issues/26975
-    #[allow(deprecated)]
-    let output = AssertCmd::cargo_bin("influxdb3")
-        .unwrap()
+    let output = cargo_bin_cmd!("influxdb3")
         .args(serve_args)
         .arg("-v")
         .arg("--telemetry-endpoint")
@@ -3981,10 +3969,7 @@ async fn test_db_name_cannot_start_with_underscore_on_create_table() {
 #[test_log::test]
 fn test_create_token_requires_subcommand() {
     // Test that 'create token' command shows help instead of panicking when no subcommand is provided
-    // See https://github.com/influxdata/influxdb/issues/26975
-    #[allow(deprecated)]
-    let output = assert_cmd::Command::cargo_bin("influxdb3")
-        .unwrap()
+    let output = cargo_bin_cmd!("influxdb3")
         .args(["create", "token"])
         .output()
         .unwrap();
@@ -4000,10 +3985,7 @@ fn test_create_token_requires_subcommand() {
     assert_not_contains!(&stderr, "thread 'main' panicked");
 
     // Test that --name alone also shows the error
-    // See https://github.com/influxdata/influxdb/issues/26975
-    #[allow(deprecated)]
-    let output_name_only = assert_cmd::Command::cargo_bin("influxdb3")
-        .unwrap()
+    let output_name_only = cargo_bin_cmd!("influxdb3")
         .args(["create", "token", "--name", "test"])
         .output()
         .unwrap();
@@ -4016,10 +3998,7 @@ fn test_create_token_requires_subcommand() {
     );
 
     // Test that --help works properly (help goes to stdout when explicitly requested)
-    // See https://github.com/influxdata/influxdb/issues/26975
-    #[allow(deprecated)]
-    let output_help = assert_cmd::Command::cargo_bin("influxdb3")
-        .unwrap()
+    let output_help = cargo_bin_cmd!("influxdb3")
         .args(["create", "token", "--help"])
         .output()
         .unwrap();

--- a/influxdb3/tests/server/mod.rs
+++ b/influxdb3/tests/server/mod.rs
@@ -7,7 +7,6 @@ use std::{
 
 use arrow::record_batch::RecordBatch;
 use arrow_flight::{FlightClient, decode::FlightRecordBatchStream};
-use assert_cmd::cargo::CommandCargoExt;
 use futures::TryStreamExt;
 use influxdb_iox_client::flightsql::FlightSqlClient;
 use influxdb3_client::Precision;
@@ -403,9 +402,7 @@ impl TestServer {
         let admin_token_recover_tmp_dir_path = admin_token_recover_tmp_dir.keep();
         let tcp_addr_file_2 = admin_token_recover_tmp_dir_path.join("tcp-listener");
 
-        // See https://github.com/influxdata/influxdb/issues/26975x
-        #[allow(deprecated)]
-        let mut command = Command::cargo_bin("influxdb3").expect("create the influxdb3 command");
+        let mut command = Command::new(assert_cmd::cargo_bin!("influxdb3"));
         let mut command = command
             .arg("serve")
             .arg("--disable-telemetry-upload")

--- a/influxdb3_server/Cargo.toml
+++ b/influxdb3_server/Cargo.toml
@@ -69,7 +69,6 @@ humantime.workspace = true
 mime.workspace = true
 object_store.workspace = true
 regex.workspace = true
-rustls-pemfile.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serde_urlencoded.workspace = true


### PR DESCRIPTION
This updates our usage of Command::cargo_bin and AssertCmd::cargo_bin with the cargo_bin_cmd and cargo_bin macros to replace them as they were deprecated.

Closes #26975