### PR TITLE
chore: ignore Authorization header when building request plugin headers

### DIFF
--- a/influxdb3_server/src/http.rs
+++ b/influxdb3_server/src/http.rs
@@ -1645,10 +1645,12 @@ impl HttpApi {
             .map(|(k, v)| (k.to_string(), v.to_string()))
             .collect();
 
-        // pull out the request headers into a hashmap
+        // pull out the request headers into a hashmap, excluding the authorization header
+        // to prevent credentials from being passed to plugins
         let headers = req
             .headers()
             .iter()
+            .filter(|(k, _)| *k != AUTHORIZATION)
             .map(|(k, v)| (k.to_string(), v.to_str().unwrap().to_string()))
             .collect();
 


### PR DESCRIPTION
While authenticate_request() already removes the Authorization header, explicitly skip adding the Authorization header when building up the request plugin's 'request_headers' headers that is passed into the 'process_request()' python API. This hardens the codebase from accidentally adding it back and allowing the request plugin to use the Authorization header to hit the HTTP API through the front door, bypassing it's intended API.

Clean cherry-pick from influxdb_pro