### PR TITLE
feat: Bubble error up to writer if fields are dropped  (#26998)

### DIFF
--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -64,7 +64,6 @@ var (
 	// Ensure Engine implements the interface.
 	_ tsdb.Engine = &Engine{}
 	// Static objects to prevent small allocs.
-	timeBytes              = []byte("time")
 	keyFieldSeparatorBytes = []byte(keyFieldSeparator)
 	emptyBytes             = []byte{}
 )
@@ -1360,11 +1359,6 @@ func (e *Engine) WritePoints(points []models.Point, tracker tsdb.StatsTracker) e
 		npoints++
 		var nValuesForPoint int64
 		for iter.Next() {
-			// Skip fields name "time", they are illegal
-			if bytes.Equal(iter.FieldKey(), timeBytes) {
-				continue
-			}
-
 			keyBuf = append(keyBuf[:baseLen], iter.FieldKey()...)
 
 			if e.seriesTypeMap != nil {


### PR DESCRIPTION
Modify `WritePoints` to return an error if a user defined `time` field is inserted. Previously we would silently prune it, this PR will bubble an error up to the writer to inform that a field was dropped but not the entire point.

(cherry picked from commit 362217b3c142444ceaf115fbd7fec66215adbc0f)

