### PR TITLE
chore: make `test_load_from_catalog_checkpoint` not flake

### DIFF
--- a/influxdb3_catalog/src/catalog/versions/v2.rs
+++ b/influxdb3_catalog/src/catalog/versions/v2.rs
@@ -4634,10 +4634,11 @@ mod tests {
         });
     }
 
+    // NOTE(tjh): this test was reported as flaky but has since been re-enabled:
+    // https://github.com/influxdata/influxdb_pro/issues/1827
     #[test_log::test(tokio::test(start_paused = true))]
     async fn test_load_from_catalog_checkpoint() {
-        let obj_store =
-            Arc::new(LocalFileSystem::new_with_prefix(test_helpers::tmp_dir().unwrap()).unwrap());
+        let obj_store = Arc::new(InMemory::new());
         let time_provider = Arc::new(MockProvider::new(Time::from_timestamp_nanos(0)));
 
         let init = async || {


### PR DESCRIPTION
- Back-port of https://github.com/influxdata/influxdb_pro/pull/1835

---

### How this fixes the flake

* I changed the test from using a file-based object store to using an in-memory object store. My hypothesis is that, in CI, use of a file-based object store may lead to different behaviour depending external factors in the CI environment. Using an in-memory store isolates the test from such factors.
* The type of object store is irrelevant to what this test is asserting.
* This makes the test run ~5ms faster on my local machine.