### PR TITLE
fix(pe): port to oss `main`- fix for sparse data for plugins

### DIFF
--- a/influxdb3_py_api/src/system_py.rs
+++ b/influxdb3_py_api/src/system_py.rs
@@ -234,6 +234,11 @@ impl PyPluginCallApi {
 
                         let array = batch.column(col_idx);
 
+                        if array.is_null(row_idx) {
+                            row.set_item(field_name, py.None())?;
+                            continue;
+                        }
+
                         match array.data_type() {
                             DataType::Int64 => {
                                 let array = array.as_any().downcast_ref::<Int64Array>().unwrap();


### PR DESCRIPTION
Ports influxdata/influxdb_pro#1925 which fixes issue with handling null values when passing data to python plugins.

* should fix influxdata/influxdb3_plugins#29
* port to `main` branch of https://github.com/influxdata/influxdb/pull/27023