### PR TITLE
chore: set package version to 3.8.1-nightly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3067,7 +3067,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3"
-version = "3.8.0"
+version = "3.8.1-nightly"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3155,7 +3155,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_authz"
-version = "3.8.0"
+version = "3.8.1-nightly"
 dependencies = [
  "async-trait",
  "authz",
@@ -3172,7 +3172,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_cache"
-version = "3.8.0"
+version = "3.8.1-nightly"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3207,7 +3207,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_catalog"
-version = "3.8.0"
+version = "3.8.1-nightly"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3259,7 +3259,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_clap_blocks"
-version = "3.8.0"
+version = "3.8.1-nightly"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3294,7 +3294,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_client"
-version = "3.8.0"
+version = "3.8.1-nightly"
 dependencies = [
  "bytes",
  "hashbrown 0.15.5",
@@ -3314,7 +3314,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_id"
-version = "3.8.0"
+version = "3.8.1-nightly"
 dependencies = [
  "indexmap 2.12.0",
  "serde",
@@ -3324,7 +3324,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_internal_api"
-version = "3.8.0"
+version = "3.8.1-nightly"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3346,7 +3346,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_load_generator"
-version = "3.8.0"
+version = "3.8.1-nightly"
 dependencies = [
  "anyhow",
  "bytes",
@@ -3375,7 +3375,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_process"
-version = "3.8.0"
+version = "3.8.1-nightly"
 dependencies = [
  "cargo_metadata",
  "iox_time",
@@ -3384,7 +3384,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_processing_engine"
-version = "3.8.0"
+version = "3.8.1-nightly"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3428,7 +3428,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_py_api"
-version = "3.8.0"
+version = "3.8.1-nightly"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -3455,7 +3455,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_query_executor"
-version = "3.8.0"
+version = "3.8.1-nightly"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3483,7 +3483,7 @@ dependencies = [
  "insta",
  "iox_query",
  "iox_query_influxql",
- "iox_query_influxql_rewrite 3.8.0",
+ "iox_query_influxql_rewrite 3.8.1-nightly",
  "iox_query_params",
  "iox_time",
  "itertools 0.13.0",
@@ -3505,7 +3505,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_server"
-version = "3.8.0"
+version = "3.8.1-nightly"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3552,7 +3552,7 @@ dependencies = [
  "iox_http",
  "iox_http_util",
  "iox_query",
- "iox_query_influxql_rewrite 3.8.0",
+ "iox_query_influxql_rewrite 3.8.1-nightly",
  "iox_query_params",
  "iox_time",
  "iox_v1_query_api",
@@ -3588,7 +3588,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_shutdown"
-version = "3.8.0"
+version = "3.8.1-nightly"
 dependencies = [
  "futures",
  "futures-util",
@@ -3603,7 +3603,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_sys_events"
-version = "3.8.0"
+version = "3.8.1-nightly"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3622,7 +3622,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_system_tables"
-version = "3.8.0"
+version = "3.8.1-nightly"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -3654,7 +3654,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_telemetry"
-version = "3.8.0"
+version = "3.8.1-nightly"
 dependencies = [
  "futures",
  "futures-util",
@@ -3675,7 +3675,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_test_helpers"
-version = "3.8.0"
+version = "3.8.1-nightly"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3688,7 +3688,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_types"
-version = "3.8.0"
+version = "3.8.1-nightly"
 dependencies = [
  "anyhow",
  "chrono",
@@ -3708,7 +3708,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_wal"
-version = "3.8.0"
+version = "3.8.1-nightly"
 dependencies = [
  "async-trait",
  "bitcode",
@@ -3736,7 +3736,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_write"
-version = "3.8.0"
+version = "3.8.1-nightly"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3976,7 +3976,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query_influxql_rewrite"
-version = "3.8.0"
+version = "3.8.1-nightly"
 dependencies = [
  "influxdb_influxql_parser",
  "thiserror 1.0.69",
@@ -4834,7 +4834,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_utils"
-version = "3.8.0"
+version = "3.8.1-nightly"
 dependencies = [
  "async-trait",
  "backon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ exclude = [
 # then this will be `3.1.0-nightly`. Once `3.1.0` is released, this will be bumped to `3.2.0-nightly`,
 # and will remain that regardless of how many `3.1.x` patch releases are done prior to the `3.2.0`
 # release.
-version = "3.8.0"
+version = "3.8.1-nightly"
 authors = ["InfluxData OSS Developers"]
 edition = "2024"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
This probably isn't strictly necessary, but may be helpful if we need to work on a 3.8.1 release.
