### PR TITLE
feat: Check if shards len is less than or equal to 1

### DIFF
--- a/v1/services/meta/data.go
+++ b/v1/services/meta/data.go
@@ -291,7 +291,7 @@ func (data *Data) DropShard(id uint64) {
 					shards := sg.Shards
 					data.Databases[dbidx].RetentionPolicies[rpidx].ShardGroups[sgidx].Shards = append(shards[:found], shards[found+1:]...)
 
-					if len(shards) == 1 {
+					if len(shards) <= 1 {
 						// We just deleted the last shard in the shard group, but make sure we don't overwrite the timestamp if it
 						// was already deleted.
 						if !data.Databases[dbidx].RetentionPolicies[rpidx].ShardGroups[sgidx].Deleted() {


### PR DESCRIPTION
Might be related to bug we are seeing where we end up with ShardGroups that have null shards without a DeleteAt time like the following, but very unlikely. 0 as an invariant is not possible afaik: 

```
            {
              "ID": 789,
              "StartTime": "2025-12-01T00:00:00Z",
              "EndTime": "2025-12-08T00:00:00Z",
              "DeletedAt": "0001-01-01T00:00:00Z",
              "Shards": null,
              "TruncatedAt": "0001-01-01T00:00:00Z"
            },
```

Related logging PR: https://github.com/influxdata/influxdb/pull/27035
