### PR TITLE
feat: add TLS certificate reloading on SIGHUP

### DIFF
--- a/cmd/influxd/run/command.go
+++ b/cmd/influxd/run/command.go
@@ -65,27 +65,39 @@ func NewCommand() *Command {
 	}
 }
 
-// Run parses the config from args and runs the server.
-func (cmd *Command) Run(args ...string) error {
+func (cmd *Command) LoadConfig(args ...string) (Options, *Config, error) {
+	fail := func(err error) (Options, *Config, error) { return Options{}, nil, err }
+
 	// Parse the command line flags.
 	options, err := cmd.ParseFlags(args...)
 	if err != nil {
-		return err
+		return fail(fmt.Errorf("error parsing command line: %w", err))
 	}
 
-	config, err := cmd.ParseConfig(options.GetConfigPath())
+	configPath := options.GetConfigPath()
+	config, err := cmd.ParseConfig(configPath)
 	if err != nil {
-		return fmt.Errorf("parse config: %s", err)
+		return fail(fmt.Errorf("error parsing config file (%q): %s", configPath, err))
 	}
 
 	// Apply any environment variables on top of the parsed config
 	if err := config.ApplyEnvOverrides(cmd.Getenv); err != nil {
-		return fmt.Errorf("apply env config: %v", err)
+		return fail(fmt.Errorf("error applying env config: %v", err))
 	}
 
 	// Validate the configuration.
 	if err := config.Validate(); err != nil {
-		return fmt.Errorf("%s. To generate a valid configuration file run `influxd config > influxdb.generated.conf`", err)
+		return fail(fmt.Errorf("%s. To generate a valid configuration file run `influxd config > influxdb.generated.conf`", err))
+	}
+
+	return options, config, nil
+}
+
+// Run parses the config from args and runs the server.
+func (cmd *Command) Run(args ...string) error {
+	options, config, err := cmd.LoadConfig(args...)
+	if err != nil {
+		return err
 	}
 
 	var logErr error
@@ -177,6 +189,22 @@ func (cmd *Command) Close() error {
 		return cmd.Server.Close()
 	}
 	return nil
+}
+
+// ReloadConfig reloads the configuration and applies select configuration values to the running server.
+func (cmd *Command) ReloadConfig(args ...string) {
+	log, logEnd := logger.NewOperation(cmd.Logger, "Reloading select configuration settings", "config_reload")
+	defer logEnd()
+
+	_, reloadedConfig, err := cmd.LoadConfig(args...)
+	if err != nil {
+		log.Error("error reloading config", zap.Error(err))
+		return
+	}
+
+	if err := cmd.Server.ApplyReloadedConfig(reloadedConfig, log); err != nil {
+		log.Error("error applying reloaded config; some config values may have been applied", zap.Error(err))
+	}
 }
 
 func (cmd *Command) monitorServerErrors() {

--- a/pkg/file/file.go
+++ b/pkg/file/file.go
@@ -1,11 +1,17 @@
 package file
 
 import (
+	goerrors "errors"
 	"fmt"
 	"io"
 	"os"
 
 	"github.com/influxdata/influxdb/pkg/errors"
+)
+
+var (
+	ErrPermissionsTooOpen = goerrors.New("file permissions are too open")
+	ErrNilParam           = goerrors.New("got nil parameter")
 )
 
 func copyFile(src, dst string) (err error) {
@@ -41,4 +47,42 @@ func MoveFileWithReplacement(src, dst string) error {
 	}
 
 	return os.Remove(src)
+}
+
+// VerifyFilePermissivenessF checks if permissions on f are as restrictive
+// or more restrictive than maxPerms. if not, then an error is returned.
+// For security reasons, there is no VerifyFilePermissiveness function
+// that allows passing a path. This is to prevent TOCTOU (Time-of-Check-Time-of-Use)
+// issues because of race conditions on checking file permissions versus
+// opening the file.
+func VerifyFilePermissivenessF(f *os.File, maxPerms os.FileMode) error {
+	if f == nil {
+		return fmt.Errorf("VerifyFilePermissivenessF: %w", ErrNilParam)
+	}
+
+	info, err := f.Stat()
+	if err != nil {
+		return fmt.Errorf("stat failed for %q: %w", f.Name(), err)
+	}
+	return VerifyFileInfoPermissiveness(info, maxPerms, f.Name())
+}
+
+// VerifyFileInfoPermissiveness checks if permissions on info are as restrictive
+// or more restrictive than maxPerms. If not, then an error is returned. path is
+// only used to provide better messages. If path is empty, then info.Name() is used
+// for error messages.
+func VerifyFileInfoPermissiveness(info os.FileInfo, maxPerms os.FileMode, path string) error {
+	if info == nil {
+		return fmt.Errorf("VerifyFileInfoPermissiveness: %w", ErrNilParam)
+	}
+	perms := info.Mode().Perm()
+	extraPerms := perms & ^maxPerms
+	if extraPerms != 0 {
+		if len(path) == 0 {
+			path = info.Name()
+		}
+		return fmt.Errorf("%w: for %q, maximum is %04o (%s) but found %04o (%s); extra permissions: %04o (%s)",
+			ErrPermissionsTooOpen, path, maxPerms, maxPerms, perms, perms, extraPerms, extraPerms)
+	}
+	return nil
 }

--- a/pkg/file/file_test.go
+++ b/pkg/file/file_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/influxdata/influxdb/pkg/file"
+	"github.com/stretchr/testify/require"
 )
 
 func TestRenameFileWithReplacement(t *testing.T) {
@@ -139,4 +140,221 @@ func MustReadAllFile(path string) string {
 		panic(err)
 	}
 	return string(data)
+}
+
+func TestVerifyFilePermissivenessF(t *testing.T) {
+	t.Run("nil file pointer", func(t *testing.T) {
+		err := file.VerifyFilePermissivenessF(nil, 0644)
+		require.Error(t, err)
+		require.ErrorIs(t, err, file.ErrNilParam)
+	})
+
+	t.Run("valid file with acceptable permissions", func(t *testing.T) {
+		tmpFile := MustCreateTempFile(t, "test data")
+		defer MustRemoveAll(tmpFile)
+
+		require.NoError(t, os.Chmod(tmpFile, 0644))
+
+		f, err := os.Open(tmpFile)
+		require.NoError(t, err)
+		defer func() {
+			require.NoError(t, f.Close())
+		}()
+
+		err = file.VerifyFilePermissivenessF(f, 0644)
+		require.NoError(t, err)
+	})
+
+	t.Run("valid file with too open permissions", func(t *testing.T) {
+		tmpFile := MustCreateTempFile(t, "test data")
+		defer MustRemoveAll(tmpFile)
+
+		require.NoError(t, os.Chmod(tmpFile, 0666))
+
+		f, err := os.Open(tmpFile)
+		require.NoError(t, err)
+		defer func() {
+			require.NoError(t, f.Close())
+		}()
+
+		err = file.VerifyFilePermissivenessF(f, 0644)
+		require.Error(t, err)
+		require.ErrorIs(t, err, file.ErrPermissionsTooOpen)
+		require.Contains(t, err.Error(), "maximum is 0644")
+		require.Contains(t, err.Error(), "but found 0666")
+		require.Contains(t, err.Error(), "extra permissions: 0022")
+	})
+
+	t.Run("valid file with restrictive permissions", func(t *testing.T) {
+		tmpFile := MustCreateTempFile(t, "test data")
+		defer MustRemoveAll(tmpFile)
+
+		require.NoError(t, os.Chmod(tmpFile, 0400))
+
+		f, err := os.Open(tmpFile)
+		require.NoError(t, err)
+		defer func() {
+			require.NoError(t, f.Close())
+		}()
+
+		err = file.VerifyFilePermissivenessF(f, 0644)
+		require.NoError(t, err)
+	})
+
+	t.Run("check exact permission boundary 0600", func(t *testing.T) {
+		tmpFile := MustCreateTempFile(t, "test data")
+		defer MustRemoveAll(tmpFile)
+
+		require.NoError(t, os.Chmod(tmpFile, 0600))
+
+		f, err := os.Open(tmpFile)
+		require.NoError(t, err)
+		defer func() {
+			require.NoError(t, f.Close())
+		}()
+
+		// Should pass with 0600 max
+		err = file.VerifyFilePermissivenessF(f, 0600)
+		require.NoError(t, err)
+
+		// Should fail with 0400 max
+		err = file.VerifyFilePermissivenessF(f, 0400)
+		require.Error(t, err)
+		require.ErrorIs(t, err, file.ErrPermissionsTooOpen)
+		require.Contains(t, err.Error(), "maximum is 0400")
+		require.Contains(t, err.Error(), "but found 0600")
+		require.Contains(t, err.Error(), "extra permissions: 0200")
+	})
+}
+
+func TestVerifyFileInfoPermissiveness(t *testing.T) {
+	t.Run("nil FileInfo", func(t *testing.T) {
+		err := file.VerifyFileInfoPermissiveness(nil, 0644, "/some/path")
+		require.Error(t, err)
+		require.ErrorIs(t, err, file.ErrNilParam)
+	})
+
+	t.Run("permissions exactly at maximum", func(t *testing.T) {
+		tmpFile := MustCreateTempFile(t, "test data")
+		defer MustRemoveAll(tmpFile)
+
+		require.NoError(t, os.Chmod(tmpFile, 0644))
+
+		info, err := os.Stat(tmpFile)
+		require.NoError(t, err)
+
+		err = file.VerifyFileInfoPermissiveness(info, 0644, tmpFile)
+		require.NoError(t, err)
+	})
+
+	t.Run("permissions more restrictive", func(t *testing.T) {
+		tmpFile := MustCreateTempFile(t, "test data")
+		defer MustRemoveAll(tmpFile)
+
+		require.NoError(t, os.Chmod(tmpFile, 0400))
+
+		info, err := os.Stat(tmpFile)
+		require.NoError(t, err)
+
+		err = file.VerifyFileInfoPermissiveness(info, 0644, tmpFile)
+		require.NoError(t, err)
+	})
+
+	t.Run("permissions too open", func(t *testing.T) {
+		tmpFile := MustCreateTempFile(t, "test data")
+		defer MustRemoveAll(tmpFile)
+
+		require.NoError(t, os.Chmod(tmpFile, 0777))
+
+		info, err := os.Stat(tmpFile)
+		require.NoError(t, err)
+
+		err = file.VerifyFileInfoPermissiveness(info, 0644, tmpFile)
+		require.Error(t, err)
+		require.ErrorIs(t, err, file.ErrPermissionsTooOpen)
+		require.Contains(t, err.Error(), `for "`+tmpFile+`"`)
+		require.Contains(t, err.Error(), "maximum is 0644")
+		require.Contains(t, err.Error(), "but found 0777")
+		// Extra permissions: 0777 & ^0644 = 0133
+		require.Contains(t, err.Error(), "extra permissions: 0133")
+	})
+
+	t.Run("various permission scenarios", func(t *testing.T) {
+		testCases := []struct {
+			name        string
+			filePerms   os.FileMode
+			maxPerms    os.FileMode
+			shouldError bool
+		}{
+			{"0600 vs 0600", 0600, 0600, false},
+			{"0600 vs 0644", 0600, 0644, false},
+			{"0644 vs 0600", 0644, 0600, true},
+			{"0400 vs 0600", 0400, 0600, false},
+			{"0000 vs 0644", 0000, 0644, false},
+			{"0755 vs 0644", 0755, 0644, true},
+			{"0444 vs 0644", 0444, 0644, false},
+			{"0666 vs 0644", 0666, 0644, true},
+			{"0640 vs 0644", 0640, 0644, false},
+			{"0660 vs 0644", 0660, 0644, true},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				tmpFile := MustCreateTempFile(t, "test data")
+				defer MustRemoveAll(tmpFile)
+
+				require.NoError(t, os.Chmod(tmpFile, tc.filePerms))
+
+				info, err := os.Stat(tmpFile)
+				require.NoError(t, err)
+
+				err = file.VerifyFileInfoPermissiveness(info, tc.maxPerms, tmpFile)
+				if tc.shouldError {
+					require.Error(t, err, "expected error for %04o vs max %04o", tc.filePerms, tc.maxPerms)
+				} else {
+					require.NoError(t, err, "expected no error for %04o vs max %04o", tc.filePerms, tc.maxPerms)
+				}
+			})
+		}
+	})
+
+	t.Run("error message format", func(t *testing.T) {
+		tmpFile := MustCreateTempFile(t, "test data")
+		defer MustRemoveAll(tmpFile)
+
+		require.NoError(t, os.Chmod(tmpFile, 0666))
+
+		info, err := os.Stat(tmpFile)
+		require.NoError(t, err)
+
+		err = file.VerifyFileInfoPermissiveness(info, 0644, tmpFile)
+		require.Error(t, err)
+		require.ErrorIs(t, err, file.ErrPermissionsTooOpen)
+
+		errStr := err.Error()
+		// Error should contain full path with quotes
+		require.Contains(t, errStr, `for "`+tmpFile+`"`)
+		// Error should contain properly formatted permission messages
+		require.Contains(t, errStr, "maximum is 0644")
+		require.Contains(t, errStr, "but found 0666")
+		require.Contains(t, errStr, "extra permissions: 0022")
+		// Error should contain both numeric and symbolic representations
+		require.Contains(t, errStr, "rw-")
+	})
+
+	t.Run("empty path falls back to basename", func(t *testing.T) {
+		tmpFile := MustCreateTempFile(t, "test data")
+		defer MustRemoveAll(tmpFile)
+
+		require.NoError(t, os.Chmod(tmpFile, 0666))
+
+		info, err := os.Stat(tmpFile)
+		require.NoError(t, err)
+
+		// Pass empty path to test fallback to info.Name()
+		err = file.VerifyFileInfoPermissiveness(info, 0644, "")
+		require.Error(t, err)
+		require.ErrorIs(t, err, file.ErrPermissionsTooOpen)
+		require.Contains(t, err.Error(), `for "`+filepath.Base(info.Name())+`"`)
+	})
 }

--- a/pkg/testing/selfsigned/selfsigned.go
+++ b/pkg/testing/selfsigned/selfsigned.go
@@ -1,0 +1,244 @@
+package selfsigned
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+type Cert struct {
+	// Path to the SSL certificates.
+	CACertPath, CertPath string
+
+	// Path to the private keys for the SSL certificates.
+	CAKeyPath, KeyPath string
+}
+
+type CertOptions struct {
+	// DNSNames for cert
+	DNSNames []string
+
+	// IP Addresses for cert
+	IPAddrs []net.IP
+
+	// SkipDefaultIPAddrs indicates if the default IPAddrs should be skipped if IPAddrs is not set.
+	SkipDefaultIPAddrs bool
+
+	// NotBefore for certificate
+	NotBefore time.Time
+
+	// NotAfter for certificate
+	NotAfter time.Time
+
+	// CombinedFile indicates if the certificate and key should be combined into a single file
+	CombinedFile bool
+}
+
+type CertOpt func(*CertOptions)
+
+func WithDNSName(dnsName string) CertOpt {
+	return func(o *CertOptions) {
+		o.DNSNames = append(o.DNSNames, dnsName)
+	}
+}
+
+func WithIPAddr(ipAddr net.IP) CertOpt {
+	return func(o *CertOptions) {
+		o.IPAddrs = append(o.IPAddrs, ipAddr)
+	}
+}
+
+func WithNoDefaultIPAddrs() CertOpt {
+	return func(o *CertOptions) {
+		o.SkipDefaultIPAddrs = true
+	}
+}
+
+func WithNotBefore(notBefore time.Time) CertOpt {
+	return func(o *CertOptions) {
+		o.NotBefore = notBefore
+	}
+}
+
+func WithNotAfter(notAfter time.Time) CertOpt {
+	return func(o *CertOptions) {
+		o.NotAfter = notAfter
+	}
+}
+
+func WithCombinedFile() CertOpt {
+	return func(o *CertOptions) {
+		o.CombinedFile = true
+	}
+}
+
+func NewSelfSignedCert(t *testing.T, opts ...CertOpt) *Cert {
+	t.Helper()
+	tmpdir := t.TempDir()
+
+	// Get options for self-signed certificate and set defaults if needed.
+	options := CertOptions{}
+	for _, o := range opts {
+		o(&options)
+	}
+
+	if len(options.DNSNames) == 0 {
+		options.DNSNames = []string{"localhost"}
+	}
+
+	if len(options.IPAddrs) == 0 && !options.SkipDefaultIPAddrs {
+		options.IPAddrs = []net.IP{net.IPv4(127, 0, 0, 1)}
+	}
+
+	if options.NotBefore.IsZero() {
+		options.NotBefore = time.Now()
+	}
+
+	if options.NotAfter.IsZero() {
+		options.NotAfter = time.Now().Add(7 * 24 * time.Hour)
+	}
+
+	// Sanity check options.
+	require.NotEmpty(t, options.DNSNames)
+
+	// Now generate the certificate.
+	capk, err := rsa.GenerateKey(rand.Reader, 1024)
+	require.NoError(t, err)
+
+	caSerial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	require.NoError(t, err)
+
+	caTemplate := x509.Certificate{
+		SerialNumber: caSerial,
+		NotBefore:    options.NotBefore,
+		NotAfter:     options.NotAfter,
+
+		KeyUsage:    x509.KeyUsageCertSign,
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+
+		BasicConstraintsValid: true,
+
+		Subject: pkix.Name{
+			Organization: []string{"my_test_ca"},
+			CommonName:   "My Test CA",
+		},
+
+		IsCA: true,
+	}
+
+	caCert, err := x509.CreateCertificate(rand.Reader, &caTemplate, &caTemplate, capk.Public(), capk)
+	require.NoError(t, err)
+	caCertPEM := &pem.Block{Type: "CERTIFICATE", Bytes: caCert}
+	caCertFile, err := os.CreateTemp(tmpdir, "cacert-*.pem")
+	require.NoError(t, err)
+	require.NoError(t, pem.Encode(caCertFile, caCertPEM))
+	require.NoError(t, caCertFile.Close())
+
+	caKeyFile, err := os.CreateTemp(tmpdir, "cakey-*.pem")
+	require.NoError(t, err)
+	require.NoError(t, pem.Encode(caKeyFile, &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(capk)}))
+	require.NoError(t, caKeyFile.Close())
+
+	serial, err := rand.Int(rand.Reader, new(big.Int).Lsh(big.NewInt(1), 128))
+	require.NoError(t, err)
+	// Basically the same as the CA template, but its own serial, and with ip addresses and dns names.
+	template := x509.Certificate{
+		SerialNumber: serial,
+		NotBefore:    options.NotBefore,
+		NotAfter:     options.NotAfter,
+
+		KeyUsage:    x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature,
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth},
+
+		BasicConstraintsValid: true,
+
+		Subject: pkix.Name{
+			CommonName: options.DNSNames[0],
+		},
+
+		IPAddresses: options.IPAddrs,
+		DNSNames:    options.DNSNames,
+	}
+
+	pk, err := rsa.GenerateKey(rand.Reader, 1024)
+	require.NoError(t, err)
+	cert, err := x509.CreateCertificate(rand.Reader, &template, &caTemplate, pk.Public(), capk)
+	require.NoError(t, err)
+	certPEM := &pem.Block{Type: "CERTIFICATE", Bytes: cert}
+	keyPEM := &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(pk)}
+
+	var certPath, keyPath string
+	if options.CombinedFile {
+		// Create a single file containing both certificate and key
+		combinedFile, err := os.CreateTemp(tmpdir, "combined-*.pem")
+		require.NoError(t, err)
+		require.NoError(t, pem.Encode(combinedFile, certPEM))
+		require.NoError(t, pem.Encode(combinedFile, keyPEM))
+		require.NoError(t, combinedFile.Close())
+		certPath = combinedFile.Name()
+		keyPath = combinedFile.Name()
+	} else {
+		// Create separate certificate and key files
+		certFile, err := os.CreateTemp(tmpdir, "sslcert-*.pem")
+		require.NoError(t, err)
+		require.NoError(t, pem.Encode(certFile, certPEM))
+		require.NoError(t, certFile.Close())
+
+		keyFile, err := os.CreateTemp(tmpdir, "key-*.pem")
+		require.NoError(t, err)
+		require.NoError(t, pem.Encode(keyFile, keyPEM))
+		require.NoError(t, keyFile.Close())
+
+		certPath = certFile.Name()
+		keyPath = keyFile.Name()
+	}
+
+	return &Cert{
+		CACertPath: caCertFile.Name(),
+		CAKeyPath:  caKeyFile.Name(),
+		CertPath:   certPath,
+		KeyPath:    keyPath,
+	}
+}
+
+func (c *Cert) ClientTLSConfig(t *testing.T, insecure, addCert bool) *tls.Config {
+	t.Helper()
+	cert, err := os.ReadFile(c.CACertPath)
+	require.NoError(t, err)
+
+	// Return a TLS config that trusts our self-generated CA.
+	var pool *x509.CertPool
+	if !insecure {
+		pool = x509.NewCertPool()
+		require.True(t, pool.AppendCertsFromPEM(cert), "failed to append certificate")
+	}
+	conf := &tls.Config{
+		RootCAs:            pool,
+		InsecureSkipVerify: insecure,
+	}
+	if addCert {
+		clientPair, err := tls.LoadX509KeyPair(c.CertPath, c.KeyPath)
+		require.NoError(t, err)
+		conf.Certificates = []tls.Certificate{clientPair}
+	}
+	return conf
+}
+
+func (c *Cert) ServerTLSConfig(t *testing.T) *tls.Config {
+	cert, err := tls.LoadX509KeyPair(c.CertPath, c.KeyPath)
+	require.NoError(t, err)
+	return &tls.Config{
+		ServerName:   "localhost",
+		Certificates: []tls.Certificate{cert},
+	}
+}

--- a/pkg/tlsconfig/certconfig.go
+++ b/pkg/tlsconfig/certconfig.go
@@ -1,0 +1,452 @@
+package tlsconfig
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/influxdata/influxdb/logger"
+	"github.com/influxdata/influxdb/pkg/file"
+	"go.uber.org/zap"
+)
+
+const (
+	// CertMaxPermissions is the maximum permissions allowed for the certificate file.
+	CertMaxPermissions = 0644
+
+	// KeyMaxPermissions is the maximum permissions allowed for the key file.
+	KeyMaxPermissions = 0600
+
+	// DefaultExpirationWarnTime is the default advanced warning to give for expiring certificates.
+	DefaultExpirationWarnTime = 5 * (24 * time.Hour)
+
+	// DefaultCertificateCheckTime is the default duration between certificate checks.
+	DefaultCertificateCheckTime = time.Hour
+)
+
+var (
+	ErrCertificateNil           = errors.New("TLS certificate is nil")
+	ErrCertificateEmpty         = errors.New("TLS certificate is empty")
+	ErrLoadedCertificateInvalid = errors.New("LoadedCertificate is invalid")
+	ErrPathEmpty                = errors.New("empty path")
+)
+
+// LoadedCertificate encapsulates information about a loaded certificate.
+type LoadedCertificate struct {
+	// valid indicates if this object is valid.
+	valid bool
+
+	// CertPath is the path the certificate was loaded from.
+	CertificatePath string
+
+	// KeyPath is the path the private key was loaded from.
+	KeyPath string
+
+	// Certificate is the certificate that was loaded.
+	Certificate *tls.Certificate
+
+	// Leaf is the parsed x509 certificate of Certificate's leaf certificate.
+	Leaf *x509.Certificate
+}
+
+func (lc *LoadedCertificate) IsValid() bool {
+	return lc.valid
+}
+
+// LoadCertificate loads a key pair from certPath and keyPath, performing several checks
+// along the way. If any checks fail or an error occurs loading the files, then an error is returned.
+// If keyPath is empty, then certPath is assumed to contain both the certificate and the private key.
+// Only trusted input (standard configuration files) should be used for certPath and keyPath.
+func LoadCertificate(certPath, keyPath string) (LoadedCertificate, error) {
+	fail := func(err error) (LoadedCertificate, error) { return LoadedCertificate{valid: false}, err }
+
+	if certPath == "" {
+		return fail(fmt.Errorf("LoadCertificate: certificate: %w", ErrPathEmpty))
+	}
+
+	if keyPath == "" {
+		// Assume key is combined with certificate.
+		keyPath = certPath
+	}
+
+	wipeData := func(d []byte) {
+		for i := range d {
+			d[i] = 0
+		}
+	}
+
+	// Load the certificate and private key from their files.
+	loadFile := func(path string, maxPerms os.FileMode) (rData []byte, rErr error) {
+		f, err := os.Open(path)
+		if err != nil {
+			return nil, fmt.Errorf("LoadCertificate: error opening %q for reading: %w", path, err)
+		}
+		defer func() {
+			if err := f.Close(); err != nil {
+				wipeData(rData)
+				rData = nil
+				rErr = errors.Join(rErr, fmt.Errorf("LoadCertificate: error closing file %q: %w", path, err))
+			}
+		}()
+
+		if err := file.VerifyFilePermissivenessF(f, maxPerms); err != nil {
+			// VerifyFilePermissivenessF includes a lot context in its errors. No need to add duplicate here.
+			return nil, fmt.Errorf("LoadCertificate: %w", err)
+		}
+		data, err := io.ReadAll(f)
+		if err != nil {
+			return nil, fmt.Errorf("LoadCertificate: error data from %q: %w", path, err)
+		}
+		return data, nil
+	}
+	certData, err := loadFile(certPath, CertMaxPermissions)
+	defer wipeData(certData)
+	if err != nil {
+		return fail(err)
+	}
+
+	keyData, err := loadFile(keyPath, KeyMaxPermissions)
+	defer wipeData(keyData)
+	if err != nil {
+		return fail(err)
+	}
+
+	// Create key pair from loaded data
+	cert, err := tls.X509KeyPair(certData, keyData)
+	if err != nil {
+		return fail(fmt.Errorf("error loading x509 key pair: %w", err))
+	}
+
+	// Parse the first X509 certificate in cert's chain.
+	// X509KeyPair() guarantees that cert.Certificate is not empty.
+	leaf, err := x509.ParseCertificate(cert.Certificate[0])
+	if err != nil {
+		// This should be impossible to reach because `tls.X509KeyPair` will fail
+		// if the leaf certificate can't be parsed.
+		return fail(fmt.Errorf("error parsing leaf certificate: %w", err))
+	}
+	if leaf == nil {
+		// This shouldn't happen, but we should be extra careful with TLS certs.
+		return fail(fmt.Errorf("error parsing leaf certificate: %w", ErrCertificateNil))
+	}
+
+	return LoadedCertificate{
+		valid:           true,
+		CertificatePath: certPath,
+		KeyPath:         keyPath,
+		Certificate:     &cert,
+		Leaf:            leaf,
+	}, nil
+}
+
+// TLSCertLoader handles loading TLS certificates, providing them to a tls.Config, and
+// monitoring the certificate for expiration.
+type TLSCertLoader struct {
+	// logger is the logger used for logging status.
+	logger *zap.Logger
+
+	// expirationAdvanced determines how long before a certificate expires a warning is issued.
+	expirationAdvanced time.Duration
+
+	// certificateCheckInterval determines the duration between each certificate check.
+	certificateCheckInterval time.Duration
+
+	// closeOnce is used to close closeCh exactly one time.
+	closeOnce sync.Once
+
+	// closeCh is used to trigger closing the monitor.
+	closeCh chan struct{}
+
+	// mu protects all members below.
+	mu sync.Mutex
+
+	// certPath is the path to the TLS certificate PEM file.
+	certPath string
+
+	// keyPath is the path to the TLS certificate key file.
+	keyPath string
+
+	// cert is the TLS certificate.
+	cert *tls.Certificate
+
+	// leaf is the parsed leaf certificate.
+	leaf *x509.Certificate
+}
+
+type TLSCertLoaderOpt func(*TLSCertLoader)
+
+// WithExpirationAdvanced sets the how far ahead a CertLoader will
+// warn about a certificate that is about to expire.
+func WithExpirationAdvanced(d time.Duration) TLSCertLoaderOpt {
+	return func(cl *TLSCertLoader) {
+		cl.expirationAdvanced = d
+	}
+}
+
+// WithCertificateCheckInterval sets how often to check for certificate expiration.
+func WithCertificateCheckInterval(d time.Duration) TLSCertLoaderOpt {
+	return func(cl *TLSCertLoader) {
+		cl.certificateCheckInterval = d
+	}
+}
+
+// WithLogger assigns a logger for to use.
+func WithLogger(logger *zap.Logger) TLSCertLoaderOpt {
+	return func(cl *TLSCertLoader) {
+		cl.logger = logger
+	}
+}
+
+// NewTLSCertLoader creates a TLSCertLoader loaded with the certifcate found in certPath and keyPath.
+// Only trusted input (standard configuration files) should be used for certPath and keyPath.
+// If the certificate can not be loaded, an error is returned. On success, a monitor is setup to
+// periodically check the certificate for expiration.
+func NewTLSCertLoader(certPath, keyPath string, opts ...TLSCertLoaderOpt) (rCertLoader *TLSCertLoader, rErr error) {
+	cl := &TLSCertLoader{
+		expirationAdvanced:       DefaultExpirationWarnTime,
+		certificateCheckInterval: DefaultCertificateCheckTime,
+		closeCh:                  make(chan struct{}),
+	}
+
+	// Configure options.
+	for _, o := range opts {
+		o(cl)
+	}
+
+	// Make sure there is a valid logger.
+	if cl.logger == nil {
+		cl.logger = zap.NewNop()
+	}
+
+	// Perform initial certificate load.
+	if err := cl.Load(certPath, keyPath); err != nil {
+		return nil, err
+	}
+
+	// Start monitoring certificate.
+	var monitorWg sync.WaitGroup
+	monitorWg.Add(1)
+	go cl.monitorCert(&monitorWg)
+	monitorWg.Wait()
+
+	return cl, nil
+}
+
+// SetCertificate sets the currently loaded certificate from a LoadedCertificate.
+// Will also log any warnings about certificate (e.g. expired, about to expire, etc.).
+func (cl *TLSCertLoader) SetCertificate(l LoadedCertificate) error {
+	err := func() error {
+		cl.mu.Lock()
+		defer cl.mu.Unlock()
+		return cl.setCertificate(l)
+	}()
+	if err != nil {
+		return err
+	}
+
+	cl.checkCurrentCert()
+	return nil
+}
+
+// setCertificate is an internal method used to set the current certificate information
+// from a LoadedCertficate. cl.mu must be held when calling.
+func (cl *TLSCertLoader) setCertificate(l LoadedCertificate) error {
+	if !l.valid {
+		return fmt.Errorf("setCertificate: %w", ErrLoadedCertificateInvalid)
+	}
+
+	cl.certPath = l.CertificatePath
+	cl.keyPath = l.KeyPath
+	cl.cert = l.Certificate
+	cl.leaf = l.Leaf
+
+	return nil
+}
+
+// Certificate returns the currently loaded certificate, which may be nil.
+func (cl *TLSCertLoader) Certificate() *tls.Certificate {
+	cl.mu.Lock()
+	defer cl.mu.Unlock()
+	return cl.cert
+}
+
+// GetCertificate is for use with a tls.Config's GetCertificate member. This allows a
+// tls.Config to dynamically update its certificate when Load changes the active
+// certificate.
+func (cl *TLSCertLoader) GetCertificate(*tls.ClientHelloInfo) (*tls.Certificate, error) {
+	cert := cl.Certificate()
+	if cert != nil {
+		return cert, nil
+	} else {
+		// It should be impossible to get here. If we can't load a certificate in
+		// NewTLSCertLoader then we don't return the CertLoader. If we fail during Load,
+		// then we keep using the currently loaded certificate.
+		return nil, ErrCertificateNil
+	}
+}
+
+// Leaf returns the parsed x509 certificate of the currently loaded certificate.
+// If no certificate is loaded then nil is returned.
+func (cl *TLSCertLoader) Leaf() *x509.Certificate {
+	cl.mu.Lock()
+	defer cl.mu.Unlock()
+	return cl.leaf
+}
+
+// Load loads the certificate at the given certificate path and private keyfile path.
+// Only trusted input (standard configuration files) should be used for certPath and keyPath.
+func (cl *TLSCertLoader) Load(certPath, keyPath string) (rErr error) {
+	log, logEnd := logger.NewOperation(cl.logger, "Loading TLS certificate", "tls_load_cert", zap.String("cert", certPath), zap.String("key", keyPath))
+	defer logEnd()
+
+	loadedCert, err := LoadCertificate(certPath, keyPath)
+
+	cl.mu.Lock()
+	defer cl.mu.Unlock()
+	if err == nil {
+		if err := cl.setCertificate(loadedCert); err != nil {
+			// There shouldn't be a way to get here.
+			log.Error("error setting certificate after load", zap.Error(err))
+			return err
+		}
+		cl.logX509CertIssues(log, loadedCert.Leaf)
+		log.Info("Successfully loaded TLS certificate", zap.String("cert", certPath), zap.String("key", keyPath))
+	} else if cl.cert != nil {
+		// This case shouldn't be possible, but we can't be too careful with TLS certificates.
+		log.Error("Error loading TLS certificate, continuing to use previously loaded certificate",
+			zap.Error(err),
+			zap.String("failedCert", certPath), zap.String("failedKey", keyPath),
+			zap.String("activeCert", cl.certPath), zap.String("activeKey", cl.keyPath))
+	} else {
+		log.Error("Error loading TLS certificate, no previously loaded TLS certificate is available",
+			zap.Error(err),
+			zap.String("failedCert", certPath), zap.String("failedKey", keyPath))
+	}
+
+	return err
+}
+
+// PrepareLoad verifies that the certificate at certPath and keyPath will load without error.
+// If the certificate can be loaded, a function that will apply the certificate reload is
+// returned. Otherwise, an error is returned.
+func (cl *TLSCertLoader) PrepareLoad(certPath, keyPath string) (func() error, error) {
+	loadedCert, err := LoadCertificate(certPath, keyPath)
+	if err != nil {
+		return nil, err
+	}
+	return func() error {
+		if err := cl.SetCertificate(loadedCert); err != nil {
+			cl.logger.Error("error applying new certificate after VerifyLoad success", zap.Error(err))
+			return err
+		}
+		return nil
+	}, nil
+}
+
+// Close shuts down the goroutine monitoring certificate expiration.
+// Even after the monitoring goroutine is shutdown, Load and GetCertificate
+// will continue to work normally.
+func (cl *TLSCertLoader) Close() error {
+	cl.closeOnce.Do(func() {
+		close(cl.closeCh)
+	})
+
+	return nil
+}
+
+// isCertPremature determines if an x509 cert is premature (not valid yet).
+// Returns true if certificate is premature, false otherwise. cert must not be nil.
+func (cl *TLSCertLoader) isCertPremature(cert *x509.Certificate) bool {
+	return time.Now().Before(cert.NotBefore)
+}
+
+// isCertExpired determines if an x509 cert is expired. Returns if true if certificate
+// is expired, false otherwise. cert must not be nil.
+func (cl *TLSCertLoader) isCertExpired(cert *x509.Certificate) bool {
+	return time.Now().After(cert.NotAfter)
+}
+
+// certExpiresSoon determines if an x509 cert is about to expire, as well as returning
+// how long until the cert expires if we are within the expiration warn window.
+// cert must not be nil.
+func (cl *TLSCertLoader) certExpiresSoon(cert *x509.Certificate) (bool, time.Duration) {
+	untilExpires := time.Until(cert.NotAfter)
+	if untilExpires < cl.expirationAdvanced {
+		return true, untilExpires
+	}
+	return false, 0
+}
+
+// logX509CertIssues logs issues with an x509.Certificate to log. Included issues are:
+// - expired certificate
+// - certificates that are about to expire
+// - certificate that is not valid yet
+func (cl *TLSCertLoader) logX509CertIssues(log *zap.Logger, x509Cert *x509.Certificate) {
+	if log == nil || x509Cert == nil {
+		return
+	}
+
+	if cl.isCertExpired(x509Cert) {
+		log.Warn("Certificate is expired", zap.Time("NotAfter", x509Cert.NotAfter))
+	} else if cl.isCertPremature(x509Cert) {
+		log.Warn("Certificate is not valid yet", zap.Time("NotBefore", x509Cert.NotBefore))
+	} else if expiresSoon, timeUntilExpires := cl.certExpiresSoon(x509Cert); expiresSoon {
+		log.Warn("Certificate will expire soon", zap.Time("NotAfter", x509Cert.NotAfter), zap.Duration("untilExpires", timeUntilExpires))
+	}
+}
+
+// Paths returns the path of the currently loaded certificate and private key.
+// The keyPath will be the file containing the private key, even if no keyPath
+// was provided to NewTLSCertLoader / Load.
+func (cl *TLSCertLoader) Paths() (certPath, keyPath string) {
+	cl.mu.Lock()
+	defer cl.mu.Unlock()
+	return cl.certPath, cl.keyPath
+}
+
+// checkCurrentCert logs errors with the currently loaded leaf certificate.
+func (cl *TLSCertLoader) checkCurrentCert() {
+	leaf, log := func() (*x509.Certificate, *zap.Logger) {
+		cl.mu.Lock()
+		defer cl.mu.Unlock()
+		log := cl.logger.With(zap.String("cert", cl.certPath), zap.String("key", cl.keyPath))
+		return cl.leaf, log
+	}()
+	if leaf != nil {
+		cl.logX509CertIssues(log, leaf)
+	} else {
+		// There shouldn't be a way to get here because we don't return the CertLoader if the
+		// initial certificate load fails, and we also don't replace the certificate if Load
+		// fails.
+		log.Error("No certificate loaded when TLS certificate check performed", zap.Error(ErrCertificateNil))
+	}
+}
+
+// monitorCert periodically logs errors with the currently loaded certificate.
+func (cl *TLSCertLoader) monitorCert(wg *sync.WaitGroup) {
+	cl.logger.Info("Starting TLS certificate monitor")
+
+	ticker := time.NewTicker(cl.certificateCheckInterval)
+	defer ticker.Stop()
+
+	if wg != nil {
+		wg.Done()
+	}
+
+	for {
+		select {
+		case <-ticker.C:
+			cl.checkCurrentCert()
+
+		case <-cl.closeCh:
+			certPath, keyPath := cl.Paths()
+			cl.logger.Info("Closing TLS certificate monitor", zap.String("cert", certPath), zap.String("key", keyPath))
+			return
+		}
+	}
+}

--- a/pkg/tlsconfig/certconfig_test.go
+++ b/pkg/tlsconfig/certconfig_test.go
@@ -1,0 +1,490 @@
+package tlsconfig
+
+import (
+	"crypto/x509"
+	"fmt"
+	"math/big"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/influxdata/influxdb/pkg/testing/selfsigned"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+func TestTLSCertLoader_HappyPath(t *testing.T) {
+	const DNSName = "data1.influxdata.edge"
+	ss := selfsigned.NewSelfSignedCert(t, selfsigned.WithDNSName(DNSName))
+
+	core, logs := observer.New(zapcore.InfoLevel)
+	logger := zap.New(core)
+
+	// Start cert loader
+	cl, err := NewTLSCertLoader(ss.CertPath, ss.KeyPath, WithLogger(logger))
+	require.NoError(t, err)
+	require.NotNil(t, cl)
+	defer func() {
+		require.NoError(t, cl.Close())
+	}()
+
+	{
+		// Check for expected log output
+		require.Equal(t, 4, logs.Len())
+		logLines := logs.TakeAll()
+		require.Equal(t, "Loading TLS certificate (start)", logLines[0].Message)
+		require.Equal(t, "Successfully loaded TLS certificate", logLines[1].Message)
+		require.Equal(t, "Loading TLS certificate (end)", logLines[2].Message)
+		require.Equal(t, "Starting TLS certificate monitor", logLines[3].Message)
+		for _, l := range logLines[:3] { // "Starting TLS certificate monitor" doesn't include the cert name and key
+			cm := l.ContextMap()
+			require.Equal(t, ss.CertPath, cm["cert"])
+			require.Equal(t, ss.KeyPath, cm["key"])
+		}
+
+		// Get certificate and do some checks on it.
+		cp, kp := cl.Paths()
+		require.Equal(t, ss.CertPath, cp)
+		require.Equal(t, ss.KeyPath, kp)
+		require.NotNil(t, cl.Certificate())
+		cert, err := cl.GetCertificate(nil)
+		require.NoError(t, err)
+		require.NotNil(t, cert)
+		require.Equal(t, cl.Certificate(), cert)
+		require.NotEmpty(t, cert.Certificate, "expected at least 1 certificate")
+		require.NotNil(t, cl.Leaf())
+		x509Cert, err := x509.ParseCertificate(cert.Certificate[0])
+		require.NoError(t, err)
+		require.NotNil(t, x509Cert)
+		require.Equal(t, []string{DNSName}, x509Cert.DNSNames)
+		require.Equal(t, x509Cert, cl.Leaf())
+	}
+
+	{
+		// Create new certificate and reload
+		const DNSName2 = "data1-ultimate-form.influxdata.edge"
+		logs.TakeAll()
+		ss := selfsigned.NewSelfSignedCert(t, selfsigned.WithDNSName(DNSName2))
+		require.NoError(t, cl.Load(ss.CertPath, ss.KeyPath))
+
+		require.Equal(t, 3, logs.Len())
+		logLines := logs.TakeAll()
+		require.Equal(t, "Loading TLS certificate (start)", logLines[0].Message)
+		require.Equal(t, "Successfully loaded TLS certificate", logLines[1].Message)
+		require.Equal(t, "Loading TLS certificate (end)", logLines[2].Message)
+		for _, l := range logLines {
+			cm := l.ContextMap()
+			require.Equal(t, ss.CertPath, cm["cert"])
+			require.Equal(t, ss.KeyPath, cm["key"])
+		}
+
+		cp, kp := cl.Paths()
+		require.Equal(t, ss.CertPath, cp)
+		require.Equal(t, ss.KeyPath, kp)
+		require.NotNil(t, cl.Certificate())
+		cert, err := cl.GetCertificate(nil)
+		require.NoError(t, err)
+		require.NotNil(t, cert)
+		require.Equal(t, cl.Certificate(), cert)
+		require.NotEmpty(t, cert.Certificate, "expected at least 1 certificate")
+		require.NotNil(t, cl.Leaf())
+		x509Cert, err := x509.ParseCertificate(cert.Certificate[0])
+		require.NoError(t, err)
+		require.NotNil(t, x509Cert)
+		require.Equal(t, []string{DNSName2}, x509Cert.DNSNames)
+		require.Equal(t, x509Cert, cl.Leaf())
+	}
+}
+
+func TestTLSCertLoader_GoodCertPersists(t *testing.T) {
+	const DNSName = "data1.influxdata.edge"
+	ss := selfsigned.NewSelfSignedCert(t, selfsigned.WithDNSName(DNSName))
+
+	core, logs := observer.New(zapcore.InfoLevel)
+	logger := zap.New(core)
+
+	// Start cert loader
+	cl, err := NewTLSCertLoader(ss.CertPath, ss.KeyPath, WithLogger(logger))
+	require.NoError(t, err)
+	require.NotNil(t, cl)
+	defer func() {
+		require.NoError(t, cl.Close())
+	}()
+
+	var goodSerial big.Int
+	{
+		cp, kp := cl.Paths()
+		require.Equal(t, ss.CertPath, cp)
+		require.Equal(t, ss.KeyPath, kp)
+
+		cert, err := cl.GetCertificate(nil)
+		require.NoError(t, err)
+		require.NotNil(t, cert)
+		require.NotEmpty(t, cert.Certificate)
+		x509Cert, err := x509.ParseCertificate(cert.Certificate[0])
+		require.NoError(t, err)
+		require.NotNil(t, x509Cert)
+		require.NotNil(t, x509Cert.SerialNumber)
+		goodSerial = *x509Cert.SerialNumber
+
+		// Logs for happy case are checked in another test, just dump them here.
+		logs.TakeAll()
+	}
+
+	{
+		// Create and load bad cert / key (empty files)
+		tmpdir := t.TempDir()
+		emptyFile, err := os.CreateTemp(tmpdir, "badcert-*.pem")
+		require.NoError(t, err)
+		emptyPath := emptyFile.Name()
+		require.NoError(t, emptyFile.Close())
+
+		loadErr := cl.Load(emptyPath, emptyPath)
+		require.ErrorContains(t, loadErr, "error loading x509 key pair: tls: failed to find any PEM data in certificate input")
+
+		// Check that we are still using the previously loaded certificate
+		cp, kp := cl.Paths()
+		require.Equal(t, ss.CertPath, cp)
+		require.Equal(t, ss.KeyPath, kp)
+
+		cert, err := cl.GetCertificate(nil)
+		require.NoError(t, err)
+		require.NotNil(t, cert)
+		require.NotEmpty(t, cert.Certificate)
+		x509Cert, err := x509.ParseCertificate(cert.Certificate[0])
+		require.NoError(t, err)
+		require.NotNil(t, x509Cert)
+		require.NotNil(t, x509Cert.SerialNumber)
+		require.Equal(t, goodSerial, *x509Cert.SerialNumber)
+	}
+
+}
+
+func TestTLSCertLoader_EmptyPaths(t *testing.T) {
+	ss := selfsigned.NewSelfSignedCert(t)
+
+	cl, err := NewTLSCertLoader("", ss.KeyPath)
+	require.ErrorIs(t, err, ErrPathEmpty)
+	require.Nil(t, cl)
+
+	cl, err = NewTLSCertLoader("", "")
+	require.ErrorIs(t, err, ErrPathEmpty)
+	require.Nil(t, cl)
+
+	// For this case, the loader will assume CertPath also contains, which
+	// it does not, so this will fail.
+	cl, err = NewTLSCertLoader(ss.CertPath, "")
+	require.ErrorContains(t, err, "found a certificate rather than a key")
+	require.Nil(t, cl)
+}
+
+func TestTLSCertLoader_FileNotFound(t *testing.T) {
+	ss := selfsigned.NewSelfSignedCert(t)
+
+	// Non-existent certificate file
+	cl, err := NewTLSCertLoader("/nonexistent/path/to/cert.pem", ss.KeyPath)
+	require.ErrorContains(t, err, "no such file or directory")
+	require.Nil(t, cl)
+
+	// Non-existent key file
+	cl, err = NewTLSCertLoader(ss.CertPath, "/nonexistent/path/to/key.pem")
+	require.ErrorContains(t, err, "no such file or directory")
+	require.Nil(t, cl)
+
+	// Both files non-existent
+	cl, err = NewTLSCertLoader("/nonexistent/cert.pem", "/nonexistent/key.pem")
+	require.ErrorContains(t, err, "no such file or directory")
+	require.Nil(t, cl)
+}
+
+func TestTLSCertLoader_MismatchedCertAndKey(t *testing.T) {
+	// Create two different certificate/key pairs
+	ss1 := selfsigned.NewSelfSignedCert(t, selfsigned.WithDNSName("cert1.influxdata.edge"))
+	ss2 := selfsigned.NewSelfSignedCert(t, selfsigned.WithDNSName("cert2.influxdata.edge"))
+
+	// Try to load cert from first pair with key from second pair
+	cl, err := NewTLSCertLoader(ss1.CertPath, ss2.KeyPath)
+	require.ErrorContains(t, err, "error loading x509 key pair")
+	require.ErrorContains(t, err, "tls: private key does not match public key")
+	require.Nil(t, cl)
+
+	// Try to load cert from second pair with key from first pair
+	cl, err = NewTLSCertLoader(ss2.CertPath, ss1.KeyPath)
+	require.ErrorContains(t, err, "error loading x509 key pair")
+	require.ErrorContains(t, err, "tls: private key does not match public key")
+	require.Nil(t, cl)
+}
+
+func TestTLSCertLoader_CombinedFile(t *testing.T) {
+	const DNSName = "combined.influxdata.edge"
+	ss := selfsigned.NewSelfSignedCert(t, selfsigned.WithDNSName(DNSName), selfsigned.WithCombinedFile())
+
+	// Verify that CertPath and KeyPath point to the same file
+	require.Equal(t, ss.CertPath, ss.KeyPath, "expected CertPath and KeyPath to be the same for combined file")
+
+	// Start cert loader with the combined file. Let the cert loader infer that the key is combined with the cert.
+	cl, err := NewTLSCertLoader(ss.CertPath, "")
+	require.NoError(t, err)
+	require.NotNil(t, cl)
+	defer func() {
+		require.NoError(t, cl.Close())
+	}()
+
+	// Get certificate and verify it
+	cert, err := cl.GetCertificate(nil)
+	require.NoError(t, err)
+	require.NotNil(t, cert)
+	require.NotEmpty(t, cert.Certificate, "expected at least 1 certificate")
+	x509Cert, err := x509.ParseCertificate(cert.Certificate[0])
+	require.NoError(t, err)
+	require.NotNil(t, x509Cert)
+	require.Equal(t, []string{DNSName}, x509Cert.DNSNames)
+}
+
+func TestTLSLoader_CertPermissionsTooOpen(t *testing.T) {
+	ss := selfsigned.NewSelfSignedCert(t)
+
+	require.NoError(t, os.Chmod(ss.CertPath, 0660))
+	cl, err := NewTLSCertLoader(ss.CertPath, ss.KeyPath)
+	require.ErrorContains(t, err, fmt.Sprintf("LoadCertificate: file permissions are too open: for %q, maximum is 0644 (-rw-r--r--) but found 0660 (-rw-rw----); extra permissions: 0020 (-----w----)", ss.CertPath))
+	require.Nil(t, cl)
+}
+
+func TestTLSLoader_KeyPermissionsTooOpen(t *testing.T) {
+	ss := selfsigned.NewSelfSignedCert(t)
+
+	require.NoError(t, os.Chmod(ss.KeyPath, 0644))
+	cl, err := NewTLSCertLoader(ss.CertPath, ss.KeyPath)
+	require.ErrorContains(t, err, fmt.Sprintf("LoadCertificate: file permissions are too open: for %q, maximum is 0600 (-rw-------) but found 0644 (-rw-r--r--); extra permissions: 0044 (----r--r--)", ss.KeyPath))
+	require.Nil(t, cl)
+}
+
+const (
+	// testCheckTme is the TLS certificate check time in logging tests.
+	testCheckTime = 333 * time.Millisecond
+
+	// testCheckCapture time is how long to capture logs during logging tests. To prevent flaky tests,
+	// it should be more than testCheckTime, but less than 2 * testCheckTime. Furthermore, it should be at least
+	// 100 ms more than testCheckCapture time and more than 100 ms less than 2 * testCheckTime.
+	testCheckCapture = 500 * time.Millisecond
+)
+
+func TestTLSCertLoader_PrematureCertificateLogging(t *testing.T) {
+	notBefore := time.Now().UTC().Truncate(time.Hour).Add(7 * 24 * time.Hour)
+	notAfter := notBefore.Add(7 * 24 * time.Hour)
+	ss := selfsigned.NewSelfSignedCert(t, selfsigned.WithNotBefore(notBefore), selfsigned.WithNotAfter(notAfter))
+
+	core, logs := observer.New(zapcore.InfoLevel)
+	logger := zap.New(core)
+
+	cl, err := NewTLSCertLoader(ss.CertPath, ss.KeyPath, WithLogger(logger), WithCertificateCheckInterval(testCheckTime))
+	require.NoError(t, err)
+	require.NotNil(t, cl)
+	defer func() {
+		require.NoError(t, cl.Close())
+	}()
+
+	checkWarning := func(t *testing.T) {
+		warning := logs.FilterMessage("Certificate is not valid yet").TakeAll()
+		require.Len(t, warning, 1)
+		require.Equal(t, zap.WarnLevel, warning[0].Level)
+		require.Equal(t, ss.CertPath, warning[0].ContextMap()["cert"])
+		require.Equal(t, ss.KeyPath, warning[0].ContextMap()["key"])
+		require.Equal(t, notBefore, warning[0].ContextMap()["NotBefore"])
+		logs.TakeAll() // dump all logs
+	}
+	checkWarning(t)
+
+	// Check for warning during monitor
+	require.Zero(t, logs.Len(), "init logs not dumped properly")
+	time.Sleep(testCheckCapture)
+	checkWarning(t)
+}
+
+func TestTLSCertLoader_ExpiredCertificateLogging(t *testing.T) {
+	notAfter := time.Now().UTC().Truncate(time.Hour).Add(-7 * 24 * time.Hour)
+	notBefore := notAfter.Add(-7 * 24 * time.Hour)
+	ss := selfsigned.NewSelfSignedCert(t, selfsigned.WithNotBefore(notBefore), selfsigned.WithNotAfter(notAfter))
+
+	core, logs := observer.New(zapcore.InfoLevel)
+	logger := zap.New(core)
+
+	cl, err := NewTLSCertLoader(ss.CertPath, ss.KeyPath, WithLogger(logger), WithCertificateCheckInterval(testCheckTime))
+	require.NoError(t, err)
+	require.NotNil(t, cl)
+	defer func() {
+		require.NoError(t, cl.Close())
+	}()
+
+	checkWarning := func(t *testing.T) {
+		warning := logs.FilterMessage("Certificate is expired").TakeAll()
+		require.Len(t, warning, 1)
+		require.Equal(t, zap.WarnLevel, warning[0].Level)
+		require.Equal(t, ss.CertPath, warning[0].ContextMap()["cert"])
+		require.Equal(t, ss.KeyPath, warning[0].ContextMap()["key"])
+		require.Equal(t, notAfter, warning[0].ContextMap()["NotAfter"])
+		logs.TakeAll() // dump all logs
+	}
+	checkWarning(t)
+
+	// Check for warning during monitor
+	require.Zero(t, logs.Len(), "init logs not dumped properly")
+	time.Sleep(testCheckCapture)
+	checkWarning(t)
+}
+
+func TestTLSCertLoader_CertificateExpiresSoonLogging(t *testing.T) {
+	notBefore := time.Now().UTC().Truncate(time.Minute).Add(-7 * 24 * time.Hour)
+	notAfter := time.Now().UTC().Truncate(time.Hour).Add(24 * time.Hour)
+
+	ss := selfsigned.NewSelfSignedCert(t, selfsigned.WithNotBefore(notBefore), selfsigned.WithNotAfter(notAfter))
+
+	core, logs := observer.New(zapcore.InfoLevel)
+	logger := zap.New(core)
+
+	cl, err := NewTLSCertLoader(ss.CertPath, ss.KeyPath, WithLogger(logger), WithCertificateCheckInterval(testCheckTime), WithExpirationAdvanced(2*24*time.Hour))
+	require.NoError(t, err)
+	require.NotNil(t, cl)
+	defer func() {
+		require.NoError(t, cl.Close())
+	}()
+
+	checkWarning := func(t *testing.T) {
+		warning := logs.FilterMessage("Certificate will expire soon").TakeAll()
+		require.Len(t, warning, 1)
+		require.Equal(t, zap.WarnLevel, warning[0].Level)
+		require.Equal(t, ss.CertPath, warning[0].ContextMap()["cert"])
+		require.Equal(t, ss.KeyPath, warning[0].ContextMap()["key"])
+		require.Equal(t, notAfter, warning[0].ContextMap()["NotAfter"])
+		untilExpires, ok := warning[0].ContextMap()["untilExpires"].(time.Duration)
+		require.True(t, ok)
+		timeExpires := time.Now().Add(untilExpires)
+		require.WithinDuration(t, notAfter, timeExpires, 2*time.Minute, "untilExpires varies more than expected")
+		logs.TakeAll() // dump all logs
+	}
+	checkWarning(t)
+
+	// Check for warning during monitor
+	require.Zero(t, logs.Len(), "init logs not dumped properly")
+	time.Sleep(testCheckCapture)
+	checkWarning(t)
+}
+
+func TestTLSCertLoader_SetCertificate(t *testing.T) {
+	// Initial setup
+	ss := selfsigned.NewSelfSignedCert(t)
+
+	cl, err := NewTLSCertLoader(ss.CertPath, ss.KeyPath)
+	require.NoError(t, err)
+	require.NotNil(t, cl)
+	defer func() {
+		require.NoError(t, cl.Close())
+	}()
+
+	cert1, err := cl.GetCertificate(nil)
+	require.NoError(t, err)
+	require.NotNil(t, cert1)
+	leaf := cl.Leaf()
+	require.NotNil(t, leaf)
+
+	// Make sure that setting an invalid LoadedCertificate returns an error and doesn't
+	// change the currently loaded certificate.
+	{
+		require.ErrorIs(t, cl.SetCertificate(LoadedCertificate{}), ErrLoadedCertificateInvalid)
+		cp, kp := cl.Paths()
+		require.Equal(t, ss.CertPath, cp)
+		require.Equal(t, ss.KeyPath, kp)
+		actualCert, err := cl.GetCertificate(nil)
+		require.NoError(t, err)
+		require.Equal(t, cert1, actualCert)
+		require.Equal(t, leaf, cl.Leaf())
+	}
+
+	// Check that a valid LoadedCertificate works properly.
+	ss2 := selfsigned.NewSelfSignedCert(t)
+	{
+		lc2, err := LoadCertificate(ss2.CertPath, ss2.KeyPath)
+		require.NoError(t, err)
+		require.True(t, lc2.IsValid())
+		require.NoError(t, cl.SetCertificate(lc2))
+
+		cp, kp := cl.Paths()
+		require.Equal(t, ss2.CertPath, cp)
+		require.Equal(t, ss2.KeyPath, kp)
+		actualCert, err := cl.GetCertificate(nil)
+		require.NoError(t, err)
+		require.Equal(t, lc2.Certificate, actualCert)
+		require.Equal(t, lc2.Leaf, cl.Leaf())
+	}
+}
+
+func TestTLSCertLoader_VerifyLoad(t *testing.T) {
+	ss := selfsigned.NewSelfSignedCert(t)
+
+	cl, err := NewTLSCertLoader(ss.CertPath, ss.KeyPath)
+	require.NoError(t, err)
+	require.NotNil(t, cl)
+	defer func() {
+		require.NoError(t, cl.Close())
+	}()
+
+	cert1, err := cl.GetCertificate(nil)
+	require.NoError(t, err)
+	require.NotNil(t, cert1)
+	leaf1 := cl.Leaf()
+	require.NotNil(t, leaf1)
+	sn1 := leaf1.SerialNumber.String()
+	require.NotEmpty(t, sn1)
+
+	ss2 := selfsigned.NewSelfSignedCert(t)
+
+	// Test VerifyLoad with a cert pair that will not load properly.
+	{
+		apply, err := cl.PrepareLoad(ss2.CACertPath, ss2.KeyPath) // mismatched cert and key
+		require.ErrorContains(t, err, "private key does not match public key")
+		require.Nil(t, apply)
+
+		// Make sure nothing in cl changed.
+		cp, kp := cl.Paths()
+		require.Equal(t, ss.CertPath, cp)
+		require.Equal(t, ss.KeyPath, kp)
+		require.Equal(t, cert1, cl.Certificate())
+		require.Equal(t, leaf1, cl.Leaf())
+	}
+
+	// Test VerifyLoad with a proper cert pair.
+	{
+		// Get the certificate data to compare against the actual loaded certificate.
+		exp, err := LoadCertificate(ss2.CertPath, ss2.KeyPath)
+		require.NoError(t, err)
+		sn2 := exp.Leaf.SerialNumber.String()
+		require.NotEmpty(t, sn2)
+		require.NotEqual(t, sn1, sn2)
+
+		apply, err := cl.PrepareLoad(ss2.CertPath, ss2.KeyPath)
+		require.NoError(t, err)
+		require.NotNil(t, apply)
+
+		// Make sure nothing in cl changed yet.
+		cp, kp := cl.Paths()
+		require.Equal(t, ss.CertPath, cp)
+		require.Equal(t, ss.KeyPath, kp)
+		require.Equal(t, cert1, cl.Certificate())
+		require.Equal(t, leaf1, cl.Leaf())
+
+		// Call apply function and check for appropriate changes.
+		require.NoError(t, apply())
+		cp, kp = cl.Paths()
+		require.Equal(t, ss2.CertPath, cp)
+		require.Equal(t, ss2.KeyPath, kp)
+
+		// Verify cert and leaf are different now, then verify the serial on leaf.
+		require.NotNil(t, cl.Certificate())
+		require.NotNil(t, cl.Leaf())
+		require.NotEqual(t, cert1, cl.Certificate())
+		require.NotEqual(t, leaf1, cl.Leaf())
+		require.Equal(t, sn2, cl.Leaf().SerialNumber.String())
+	}
+}

--- a/pkg/tlsconfig/tls_config.go
+++ b/pkg/tlsconfig/tls_config.go
@@ -24,9 +24,7 @@ func (c Config) Validate() error {
 
 func (c Config) Parse() (out *tls.Config, err error) {
 	if len(c.Ciphers) > 0 {
-		if out == nil {
-			out = new(tls.Config)
-		}
+		out = new(tls.Config)
 
 		for _, name := range c.Ciphers {
 			cipher, ok := ciphersMap[strings.ToUpper(name)]

--- a/services/httpd/service.go
+++ b/services/httpd/service.go
@@ -4,6 +4,7 @@ package httpd // import "github.com/influxdata/influxdb/services/httpd"
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -11,10 +12,12 @@ import (
 	"path"
 	"runtime"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
 	"github.com/influxdata/influxdb/models"
+	"github.com/influxdata/influxdb/pkg/tlsconfig"
 	"go.uber.org/zap"
 )
 
@@ -22,11 +25,11 @@ import (
 const (
 	statRequest                          = "req"                    // Number of HTTP requests served.
 	statQueryRequest                     = "queryReq"               // Number of query requests served.
-	statWriteRequest                     = "writeReq"               // Number of write requests serverd.
+	statWriteRequest                     = "writeReq"               // Number of write requests served.
 	statPingRequest                      = "pingReq"                // Number of ping requests served.
 	statStatusRequest                    = "statusReq"              // Number of status requests served.
 	statWriteRequestBytesReceived        = "writeReqBytes"          // Sum of all bytes in write requests.
-	statQueryRequestBytesTransmitted     = "queryRespBytes"         // Sum of all bytes returned in query reponses.
+	statQueryRequestBytesTransmitted     = "queryRespBytes"         // Sum of all bytes returned in query responses.
 	statPointsWrittenOK                  = "pointsWrittenOK"        // Number of points written OK.
 	statValuesWrittenOK                  = "valuesWrittenOK"        // Number of values (fields) written OK.
 	statPointsWrittenDropped             = "pointsWrittenDropped"   // Number of points dropped by the storage engine.
@@ -44,32 +47,62 @@ const (
 	statPromReadRequest                  = "promReadReq"            // Number of read requests to the prometheus endpoint.
 	statFluxQueryRequests                = "fluxQueryReq"           // Number of flux query requests served.
 	statFluxQueryRequestDuration         = "fluxQueryReqDurationNs" // Number of (wall-time) nanoseconds spent executing Flux query requests.
-	statFluxQueryRequestBytesTransmitted = "fluxQueryRespBytes"     // Sum of all bytes returned in Flux query reponses.
+	statFluxQueryRequestBytesTransmitted = "fluxQueryRespBytes"     // Sum of all bytes returned in Flux query responses.
 
 )
 
 // Service manages the listener and handler for an HTTP endpoint.
 type Service struct {
-	ln        net.Listener
-	addr      string
-	https     bool
-	cert      string
-	key       string
+	// Fields above mu are not protected by mu and should be read-only after being
+	// set in NewService.
+
+	addr  string
+	https bool
+
+	unixSocket      bool
+	unixSocketPerm  uint32
+	unixSocketGroup int
+	bindSocket      string
+
+	// cert is the initial TLS certificate to load if https is true. This should not be
+	// exposed to client code because a different certificate might be loaded on a config reload.
+	cert string
+
+	// key is the initial TLS key to load if https is true. This should not be
+	// exposed to client code because a key certificate might be loaded on a config reload.
+	key string
+
 	limit     int
 	tlsConfig *tls.Config
 	err       chan error
 
+	closeFunc func() error
+
+	// Handler for httpd service. Handler is not protected by mu, and should only be modified
+	// before calling Open.
+	Handler    *Handler
 	httpServer http.Server
 
-	unixSocket         bool
-	unixSocketPerm     uint32
-	unixSocketGroup    int
-	bindSocket         string
-	unixSocketListener net.Listener
-
-	Handler *Handler
-
 	Logger *zap.Logger
+
+	// mu protects the fields that follow.
+	mu sync.RWMutex
+
+	ln                 net.Listener
+	unixSocketListener net.Listener
+	certLoader         *tlsconfig.TLSCertLoader
+
+	// tcpServerStarted indicates if httpServer is started for ln, which in turn indicates who is
+	// responsible for closing ln.
+	tcpServerStarted bool
+
+	// unixServerStarted indicates if httpServer is started unixSocketListener, which in turn
+	// indicates who is responsible for closing unixSocketListener.
+	unixServerStarted bool
+
+	// closed indicates if the Service has been closed. This is used to prevent opening the
+	// service after it has been shutdown.
+	closed bool
 }
 
 // NewService returns a new instance of Service.
@@ -82,7 +115,7 @@ func NewService(c Config) *Service {
 		key:            c.HTTPSPrivateKey,
 		limit:          c.MaxConnectionLimit,
 		tlsConfig:      c.TLS,
-		err:            make(chan error),
+		err:            make(chan error, 2), // There could be two serve calls that fail.
 		unixSocket:     c.UnixSocketEnabled,
 		unixSocketPerm: uint32(c.UnixSocketPermissions),
 		bindSocket:     c.BindSocket,
@@ -92,11 +125,9 @@ func NewService(c Config) *Service {
 		},
 		Logger: zap.NewNop(),
 	}
+	s.closeFunc = sync.OnceValue(s.doClose)
 	if s.tlsConfig == nil {
 		s.tlsConfig = new(tls.Config)
-	}
-	if s.key == "" {
-		s.key = s.cert
 	}
 	if c.UnixSocketGroup != nil {
 		s.unixSocketGroup = int(*c.UnixSocketGroup)
@@ -107,19 +138,27 @@ func NewService(c Config) *Service {
 
 // Open starts the service.
 func (s *Service) Open() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	s.Logger.Info("Starting HTTP service", zap.Bool("authentication", s.Handler.Config.AuthEnabled))
+
+	if s.closed {
+		return fmt.Errorf("attempt to Open http service after Close")
+	}
 
 	s.Handler.Open()
 
 	// Open listener.
 	if s.https {
-		cert, err := tls.LoadX509KeyPair(s.cert, s.key)
-		if err != nil {
+		if certLoader, err := tlsconfig.NewTLSCertLoader(s.cert, s.key, tlsconfig.WithLogger(s.Logger)); err == nil {
+			s.certLoader = certLoader
+		} else {
 			return err
 		}
 
 		tlsConfig := s.tlsConfig.Clone()
-		tlsConfig.Certificates = []tls.Certificate{cert}
+		tlsConfig.GetCertificate = s.certLoader.GetCertificate
 
 		listener, err := tls.Listen("tcp", s.addr, tlsConfig)
 		if err != nil {
@@ -170,7 +209,8 @@ func (s *Service) Open() error {
 			zap.Stringer("addr", listener.Addr()))
 		s.unixSocketListener = listener
 
-		go s.serveUnixSocket()
+		go s.serve(s.unixSocketListener)
+		s.unixServerStarted = true
 	}
 
 	// Enforce a connection limit if one has been given.
@@ -192,38 +232,95 @@ func (s *Service) Open() error {
 	}
 
 	// Begin listening for requests in a separate goroutine.
-	go s.serveTCP()
+	go s.serve(s.ln)
+	s.tcpServerStarted = true
 	return nil
 }
 
-// Close closes the underlying listener.
+// Close shuts down the httpd service, including closing the listeners.
 func (s *Service) Close() error {
+	return s.closeFunc()
+}
+
+// doClose performs the actual work of closing httpd service, including listeners.
+// Do not call doClose directly. Use the sync.OnceValue wrapped version created by
+// NewService in the closeFunc field.
+func (s *Service) doClose() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
 	s.Handler.Close()
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
+	s.closed = true
 	if err := s.httpServer.Shutdown(ctx); err != nil {
 		return err
 	}
 
-	if s.ln != nil {
-		if err := s.ln.Close(); err != nil {
+	// Close listeners, but only if the server hasn't started. Once the server starts,
+	// s.httpServer takes over management of the listener.
+	if !s.tcpServerStarted {
+		if s.ln != nil {
+			if err := s.ln.Close(); err != nil {
+				return err
+			}
+		}
+	}
+	if !s.unixServerStarted {
+		if s.unixSocketListener != nil {
+			if err := s.unixSocketListener.Close(); err != nil {
+				return err
+			}
+		}
+	}
+
+	if s.certLoader != nil {
+		// It is safe to call certLoader.Close multiple times.
+		if err := s.certLoader.Close(); err != nil {
 			return err
 		}
 	}
-	if s.unixSocketListener != nil {
-		if err := s.unixSocketListener.Close(); err != nil {
-			return err
-		}
-	}
+
 	return nil
 }
 
-// WithLogger sets the logger for the service.
+// WithLogger sets the logger for the service. WithLogger should only be called before Open.
 func (s *Service) WithLogger(log *zap.Logger) {
 	s.Logger = log.With(zap.String("service", "httpd"))
 	s.Handler.Logger = s.Logger
+}
+
+// PrepareReloadConfig checks if c can be applied. If it can be, a function
+// that will apply the reloaded configuration is returned. No function is
+// returned if no action is required.
+func (s *Service) PrepareReloadConfig(c Config) (func() error, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Let the user know that changing the https-enabled setting doesn't work.
+	if s.https != c.HTTPSEnabled {
+		return nil, fmt.Errorf("httpd: can not change https-enabled on a running server")
+	}
+
+	if s.https {
+		// Sanity check to make sure we have a certLoader. It's possible this could happen if a
+		// reload signal is sent to the process after NewService but before Open. By returning an
+		// error here the reload will fail and no changes will be made.
+		if s.certLoader == nil {
+			return nil, errors.New("httpd: no certLoader available")
+		}
+
+		// Make sure the specified certificate will load correctly and return an apply function.
+		if apply, err := s.certLoader.PrepareLoad(c.HTTPSCertificate, c.HTTPSPrivateKey); err == nil {
+			return apply, nil
+		} else {
+			return nil, fmt.Errorf("httpd: error loading certificate at (%q, %q): %w", c.HTTPSCertificate, c.HTTPSPrivateKey, err)
+		}
+	}
+
+	return nil, nil
 }
 
 // Err returns a channel for fatal errors that occur on the listener.
@@ -231,6 +328,9 @@ func (s *Service) Err() <-chan error { return s.err }
 
 // Addr returns the listener's address. Returns nil if listener is closed.
 func (s *Service) Addr() net.Addr {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
 	if s.ln != nil {
 		return s.ln.Addr()
 	}
@@ -245,24 +345,20 @@ func (s *Service) Statistics(tags map[string]string) []models.Statistic {
 // BoundHTTPAddr returns the string version of the address that the HTTP server is listening on.
 // This is useful if you start an ephemeral server in test with bind address localhost:0.
 func (s *Service) BoundHTTPAddr() string {
-	return s.ln.Addr().String()
-}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 
-// serveTCP serves the handler from the TCP listener.
-func (s *Service) serveTCP() {
-	s.serve(s.ln)
-}
-
-// serveUnixSocket serves the handler from the unix socket listener.
-func (s *Service) serveUnixSocket() {
-	s.serve(s.unixSocketListener)
+	if s.ln != nil {
+		return s.ln.Addr().String()
+	}
+	return "N/A"
 }
 
 // serve serves the handler from the listener.
-func (s *Service) serve(listener net.Listener) {
+func (s *Service) serve(ln net.Listener) {
 	// The listener was closed so exit
 	// See https://github.com/golang/go/issues/4373
-	if err := s.httpServer.Serve(listener); err != nil && !strings.Contains(err.Error(), "closed") {
-		s.err <- fmt.Errorf("listener failed: addr=%s, err=%s", s.Addr(), err)
+	if err := s.httpServer.Serve(ln); err != nil && !strings.Contains(err.Error(), "closed") {
+		s.err <- fmt.Errorf("listener failed: addr=%s, err=%s", ln.Addr(), err)
 	}
 }

--- a/services/httpd/service_test.go
+++ b/services/httpd/service_test.go
@@ -1,0 +1,257 @@
+package httpd_test
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/influxdata/influxdb/pkg/testing/selfsigned"
+	"github.com/influxdata/influxdb/pkg/tlsconfig"
+	"github.com/influxdata/influxdb/services/httpd"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+)
+
+func TestService_VerifyReloadedConfig(t *testing.T) {
+	t.Run("HTTPS disabled, no change", func(t *testing.T) {
+		// Create service with HTTPS disabled
+		config := httpd.Config{
+			HTTPSEnabled: false,
+		}
+		s := httpd.NewService(config)
+		s.WithLogger(zap.NewNop())
+
+		// Verify reload with HTTPS still disabled
+		newConfig := httpd.Config{
+			HTTPSEnabled: false,
+		}
+		applyFunc, err := s.PrepareReloadConfig(newConfig)
+		require.NoError(t, err)
+		require.Nil(t, applyFunc, "no apply function should be returned when HTTPS is disabled")
+	})
+
+	t.Run("HTTPS enabled to disabled returns error", func(t *testing.T) {
+		// Create certificates for initial service
+		ss := selfsigned.NewSelfSignedCert(t)
+
+		// Create service with HTTPS enabled
+		config := httpd.Config{
+			HTTPSEnabled:     true,
+			HTTPSCertificate: ss.CertPath,
+			HTTPSPrivateKey:  ss.KeyPath,
+		}
+		s := httpd.NewService(config)
+		s.WithLogger(zap.NewNop())
+
+		// Open service to initialize certLoader
+		require.NoError(t, s.Open())
+		defer func() {
+			require.NoError(t, s.Close())
+		}()
+
+		// Try to verify reload with HTTPS disabled
+		newConfig := httpd.Config{
+			HTTPSEnabled: false,
+		}
+		applyFunc, err := s.PrepareReloadConfig(newConfig)
+		require.ErrorContains(t, err, "can not change https-enabled on a running server")
+		require.Nil(t, applyFunc)
+	})
+
+	t.Run("HTTPS disabled to enabled returns error", func(t *testing.T) {
+		// Create service with HTTPS disabled
+		config := httpd.Config{
+			HTTPSEnabled: false,
+		}
+		s := httpd.NewService(config)
+		s.WithLogger(zap.NewNop())
+
+		// Create certificates for reload attempt
+		ss := selfsigned.NewSelfSignedCert(t)
+
+		// Try to verify reload with HTTPS enabled
+		newConfig := httpd.Config{
+			HTTPSEnabled:     true,
+			HTTPSCertificate: ss.CertPath,
+			HTTPSPrivateKey:  ss.KeyPath,
+		}
+		applyFunc, err := s.PrepareReloadConfig(newConfig)
+		require.ErrorContains(t, err, "can not change https-enabled on a running server")
+		require.Nil(t, applyFunc)
+	})
+
+	t.Run("HTTPS enabled, valid certificate reload", func(t *testing.T) {
+		// Create initial certificates
+		ss1 := selfsigned.NewSelfSignedCert(t, selfsigned.WithDNSName("initial.example.com"))
+
+		// Create service with HTTPS enabled
+		config := httpd.Config{
+			BindAddress:      "localhost:",
+			HTTPSEnabled:     true,
+			HTTPSCertificate: ss1.CertPath,
+			HTTPSPrivateKey:  ss1.KeyPath,
+			TLS:              new(tls.Config),
+		}
+		s := httpd.NewService(config)
+		s.WithLogger(zap.NewNop())
+
+		// Open service to initialize certLoader
+		require.NoError(t, s.Open())
+		defer func() {
+			require.NoError(t, s.Close())
+		}()
+
+		// Get the initial certificate serial number for comparison
+		initialCert, err := tlsconfig.LoadCertificate(ss1.CertPath, ss1.KeyPath)
+		require.NoError(t, err)
+		initialSerial := initialCert.Leaf.SerialNumber
+
+		// Verify the certificate is in use.
+		{
+			transport := &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			}
+			client := http.Client{Transport: transport}
+			pingURI := fmt.Sprintf("https://%s/ping", s.Addr())
+			resp, err := client.Get(pingURI)
+			require.NoError(t, err)
+			require.NotNil(t, resp.TLS)
+			require.NotEmpty(t, resp.TLS.PeerCertificates)
+			require.Equal(t, initialSerial, resp.TLS.PeerCertificates[0].SerialNumber)
+		}
+
+		// Create new certificates for reload
+		ss2 := selfsigned.NewSelfSignedCert(t, selfsigned.WithDNSName("reloaded.example.com"))
+
+		// Get the new certificate serial number
+		newCert, err := tlsconfig.LoadCertificate(ss2.CertPath, ss2.KeyPath)
+		require.NoError(t, err)
+		newSerial := newCert.Leaf.SerialNumber
+		require.NotEqual(t, initialSerial, newSerial, "test setup: certificates should have different serials")
+
+		// Verify reload with new certificate paths
+		newConfig := httpd.Config{
+			HTTPSEnabled:     true,
+			HTTPSCertificate: ss2.CertPath,
+			HTTPSPrivateKey:  ss2.KeyPath,
+		}
+		applyFunc, err := s.PrepareReloadConfig(newConfig)
+		require.NoError(t, err)
+		require.NotNil(t, applyFunc, "apply function should be returned for successful verification")
+
+		// Apply the certificate reload
+		require.NoError(t, applyFunc())
+
+		// Verify the new certificate is in use.
+		{
+			transport := &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			}
+			client := http.Client{Transport: transport}
+			pingURI := fmt.Sprintf("https://%s/ping", s.Addr())
+			resp, err := client.Get(pingURI)
+			require.NoError(t, err)
+			require.NotNil(t, resp.TLS)
+			require.NotEmpty(t, resp.TLS.PeerCertificates)
+			require.Equal(t, newSerial, resp.TLS.PeerCertificates[0].SerialNumber)
+		}
+	})
+
+	t.Run("HTTPS enabled, VerifyLoad fails", func(t *testing.T) {
+		// Create initial certificates
+		ss := selfsigned.NewSelfSignedCert(t)
+
+		// Create service with HTTPS enabled
+		config := httpd.Config{
+			HTTPSEnabled:     true,
+			HTTPSCertificate: ss.CertPath,
+			HTTPSPrivateKey:  ss.KeyPath,
+		}
+		s := httpd.NewService(config)
+		s.WithLogger(zap.NewNop())
+
+		// Open service to initialize certLoader
+		require.NoError(t, s.Open())
+		defer func() {
+			require.NoError(t, s.Close())
+		}()
+
+		// Try to verify reload with non-existent certificate (one example of VerifyLoad failure)
+		newConfig := httpd.Config{
+			HTTPSEnabled:     true,
+			HTTPSCertificate: "/nonexistent/path/cert.pem",
+			HTTPSPrivateKey:  "/nonexistent/path/key.pem",
+		}
+		applyFunc, err := s.PrepareReloadConfig(newConfig)
+		require.ErrorContains(t, err, "error loading certificate")
+		require.Nil(t, applyFunc)
+	})
+
+	t.Run("HTTPS enabled, no certificate change", func(t *testing.T) {
+		// Create initial certificates
+		ss := selfsigned.NewSelfSignedCert(t)
+
+		// Create service with HTTPS enabled
+		config := httpd.Config{
+			HTTPSEnabled:     true,
+			HTTPSCertificate: ss.CertPath,
+			HTTPSPrivateKey:  ss.KeyPath,
+			TLS:              new(tls.Config),
+		}
+		s := httpd.NewService(config)
+		s.WithLogger(zap.NewNop())
+
+		// Open service to initialize certLoader
+		require.NoError(t, s.Open())
+		defer func() {
+			require.NoError(t, s.Close())
+		}()
+
+		// Get the certificate serial number
+		cert, err := tlsconfig.LoadCertificate(ss.CertPath, ss.KeyPath)
+		require.NoError(t, err)
+		expectedSerial := cert.Leaf.SerialNumber
+
+		// Verify the certificate is in use.
+		{
+			transport := &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			}
+			client := http.Client{Transport: transport}
+			pingURI := fmt.Sprintf("https://%s/ping", s.Addr())
+			resp, err := client.Get(pingURI)
+			require.NoError(t, err)
+			require.NotNil(t, resp.TLS)
+			require.NotEmpty(t, resp.TLS.PeerCertificates)
+			require.Equal(t, expectedSerial, resp.TLS.PeerCertificates[0].SerialNumber)
+		}
+
+		// Verify reload with same certificate paths (common case for reloading updated files)
+		newConfig := httpd.Config{
+			HTTPSEnabled:     true,
+			HTTPSCertificate: ss.CertPath,
+			HTTPSPrivateKey:  ss.KeyPath,
+		}
+		applyFunc, err := s.PrepareReloadConfig(newConfig)
+		require.NoError(t, err)
+		require.NotNil(t, applyFunc, "apply function should be returned even for same paths")
+
+		// Apply should succeed
+		require.NoError(t, applyFunc())
+
+		// Verify the certificate is loaded correctly
+		{
+			transport := &http.Transport{
+				TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+			}
+			client := http.Client{Transport: transport}
+			pingURI := fmt.Sprintf("https://%s/ping", s.Addr())
+			resp, err := client.Get(pingURI)
+			require.NoError(t, err)
+			require.NotNil(t, resp.TLS)
+			require.NotEmpty(t, resp.TLS.PeerCertificates)
+			require.Equal(t, expectedSerial, resp.TLS.PeerCertificates[0].SerialNumber)
+		}
+	})
+}

--- a/services/opentsdb/config.go
+++ b/services/opentsdb/config.go
@@ -31,6 +31,7 @@ const (
 	DefaultBatchPending = 5
 
 	// DefaultCertificate is the default location of the certificate used when TLS is enabled.
+	// For defaults, we assume this also contains the private key.
 	DefaultCertificate = "/etc/ssl/influxdb.pem"
 )
 
@@ -43,6 +44,7 @@ type Config struct {
 	ConsistencyLevel string        `toml:"consistency-level"`
 	TLSEnabled       bool          `toml:"tls-enabled"`
 	Certificate      string        `toml:"certificate"`
+	PrivateKey       string        `toml:"private-key"`
 	BatchSize        int           `toml:"batch-size"`
 	BatchPending     int           `toml:"batch-pending"`
 	BatchTimeout     toml.Duration `toml:"batch-timeout"`
@@ -58,7 +60,7 @@ func NewConfig() Config {
 		RetentionPolicy:  DefaultRetentionPolicy,
 		ConsistencyLevel: DefaultConsistencyLevel,
 		TLSEnabled:       false,
-		Certificate:      DefaultCertificate,
+		Certificate:      DefaultCertificate, // TLSCertLoader will default PrivateKey if PrivateKey remains empty.
 		BatchSize:        DefaultBatchSize,
 		BatchPending:     DefaultBatchPending,
 		BatchTimeout:     toml.Duration(DefaultBatchTimeout),

--- a/services/opentsdb/service.go
+++ b/services/opentsdb/service.go
@@ -5,6 +5,8 @@ import (
 	"bufio"
 	"bytes"
 	"crypto/tls"
+	"errors"
+	"fmt"
 	"io"
 	"net"
 	"net/http"
@@ -17,6 +19,7 @@ import (
 
 	"github.com/influxdata/influxdb/logger"
 	"github.com/influxdata/influxdb/models"
+	"github.com/influxdata/influxdb/pkg/tlsconfig"
 	"github.com/influxdata/influxdb/services/meta"
 	"github.com/influxdata/influxdb/tsdb"
 	"go.uber.org/zap"
@@ -47,10 +50,12 @@ type Service struct {
 	ln     net.Listener  // main listener
 	httpln *chanListener // http channel-based listener
 
-	wg        sync.WaitGroup
-	tls       bool
-	tlsConfig *tls.Config
-	cert      string
+	wg         sync.WaitGroup
+	tls        bool
+	certLoader *tlsconfig.TLSCertLoader
+	tlsConfig  *tls.Config
+	cert       string
+	privateKey string
 
 	mu    sync.RWMutex
 	ready bool          // Has the required database been created?
@@ -89,6 +94,7 @@ func NewService(c Config) (*Service, error) {
 		tls:             d.TLSEnabled,
 		tlsConfig:       d.TLS,
 		cert:            d.Certificate,
+		privateKey:      d.PrivateKey,
 		BindAddress:     d.BindAddress,
 		Database:        d.Database,
 		RetentionPolicy: d.RetentionPolicy,
@@ -128,13 +134,14 @@ func (s *Service) Open() error {
 
 	// Open listener.
 	if s.tls {
-		cert, err := tls.LoadX509KeyPair(s.cert, s.cert)
+		certLoader, err := tlsconfig.NewTLSCertLoader(s.cert, s.privateKey, tlsconfig.WithLogger(s.Logger))
 		if err != nil {
 			return err
 		}
+		s.certLoader = certLoader
 
 		tlsConfig := s.tlsConfig.Clone()
-		tlsConfig.Certificates = []tls.Certificate{cert}
+		tlsConfig.GetCertificate = s.certLoader.GetCertificate
 
 		listener, err := tls.Listen("tcp", s.BindAddress, tlsConfig)
 		if err != nil {
@@ -181,6 +188,13 @@ func (s *Service) Close() error {
 		if err := s.httpln.Close(); err != nil {
 			return false, err
 		}
+		if s.certLoader != nil {
+			cl := s.certLoader
+			s.certLoader = nil
+			if err := cl.Close(); err != nil {
+				return false, err
+			}
+		}
 
 		if s.batcher != nil {
 			s.batcher.Stop()
@@ -198,6 +212,27 @@ func (s *Service) Close() error {
 	s.mu.Unlock()
 
 	return nil
+}
+
+// PrepareReloadTLSCertificates verifies that the configured TLS certificate can be reloaded.
+// If so, then a function that will apply the reloaded certificate is returned. If no reload
+// action is necessary, then nil is returned for the reload function.
+func (s *Service) PrepareReloadTLSCertificates() (func() error, error) {
+	if !s.tls {
+		return nil, nil
+	}
+
+	// Sanity check that we have a certLoader.
+	if s.certLoader == nil {
+		// This shouldn't happen.
+		return nil, errors.New("opentsdb: no certLoader available")
+	}
+
+	if apply, err := s.certLoader.PrepareLoad(s.cert, s.privateKey); err == nil {
+		return apply, nil
+	} else {
+		return nil, fmt.Errorf("opentsdb: TLS certificate reload failed (%q, %q): %w", s.cert, s.privateKey, err)
+	}
 }
 
 // Closed returns true if the service is currently closed.


### PR DESCRIPTION
Add TLS certificate reloading on SIGHUP. For httpd service certificates, the configuration is reloaded and certificate and key file locations are updated accordingly. For opentsdb service certificates, certificates and keys at the existing locations are reloaded. If reloading a certificate fails, the currently loaded certificate continues to be used.

Also adds file permission checking for TLS certificates and private keys.

Clean cherry-pick of #26994 to 1.12.

Closes: #27056

(cherry picked from commit 8c9b85043bffe3a337ae3d28346d99b29ab40a3a)

