### PR TITLE
fix: use 'release' profile for tagged builds of docker images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -681,7 +681,7 @@ jobs:
       - run:
           name: "Set Cargo profile based on branch"
           command: |
-            if [ "$CIRCLE_BRANCH" = "main" ]; then
+            if [ "$CIRCLE_BRANCH" = "main" ] || [ -z "${CIRCLE_TAG+x}" ]; then
               echo "export DOCKER_PROFILE=release" >> "$BASH_ENV"
             else
               echo "export DOCKER_PROFILE=quick-release" >> "$BASH_ENV"


### PR DESCRIPTION
Cherry-pick of #27065
