### PR TITLE
chore: backport retention and deletion fixes from influxdb_pro

### DIFF
--- a/influxdb3_catalog/src/catalog.rs
+++ b/influxdb3_catalog/src/catalog.rs
@@ -30,6 +30,7 @@ use crate::{CatalogError, Result};
 const SOFT_DELETION_TIME_FORMAT: &str = "%Y%m%dT%H%M%S";
 
 pub const INTERNAL_DB_NAME: &str = "_internal";
+pub const INTERNAL_DB_RETENTION_PERIOD: Duration = Duration::from_secs(60 * 60 * 24 * 7); // Default to 7 days
 
 pub const TIME_COLUMN_NAME: &str = "time";
 pub const CHUNK_ORDER_COLUMN_NAME: &str = "__chunk_order";

--- a/influxdb3_catalog/src/catalog/versions/v1.rs
+++ b/influxdb3_catalog/src/catalog/versions/v1.rs
@@ -21,8 +21,8 @@ use uuid::Uuid;
 
 use crate::catalog::{
     CatalogSequenceNumber, DEFAULT_OPERATOR_TOKEN_NAME, DeletedSchema, INTERNAL_DB_NAME,
-    IfNotDeleted, Repository, TIME_COLUMN_NAME, TokenRepository, create_token_and_hash,
-    make_new_name_using_deleted_time,
+    INTERNAL_DB_RETENTION_PERIOD, IfNotDeleted, Repository, TIME_COLUMN_NAME, TokenRepository,
+    create_token_and_hash, make_new_name_using_deleted_time,
 };
 
 mod resource;
@@ -391,7 +391,14 @@ impl Catalog {
 }
 
 async fn create_internal_db(catalog: &Catalog) {
-    let result = catalog.create_database(INTERNAL_DB_NAME).await;
+    let result = catalog
+        .create_database_opts(
+            INTERNAL_DB_NAME,
+            CreateDatabaseOptions {
+                retention_period: Some(INTERNAL_DB_RETENTION_PERIOD),
+            },
+        )
+        .await;
     // what is the best outcome if "_internal" cannot be created?
     match result {
         Ok(_) => info!("created internal database"),

--- a/influxdb3_catalog/src/catalog/versions/v1/update.rs
+++ b/influxdb3_catalog/src/catalog/versions/v1/update.rs
@@ -281,7 +281,7 @@ impl Catalog {
 
             let hard_delete_changed = db.hard_delete_time != resolved_hard_delete_time;
             if db.deleted && !hard_delete_changed {
-                return Err(CatalogError::AlreadyDeleted);
+                return Err(CatalogError::AlreadyDeleted(db_name.to_string()));
             }
             let deletion_time = self.time_provider.now().timestamp_nanos();
             let database_id = db.id;
@@ -354,7 +354,7 @@ impl Catalog {
 
             let hard_delete_changed = tbl_def.hard_delete_time != resolved_hard_delete_time;
             if tbl_def.deleted && !hard_delete_changed {
-                return Err(CatalogError::AlreadyDeleted);
+                return Err(CatalogError::AlreadyDeleted(table_name.to_string()));
             }
             let deletion_time = self.time_provider.now().timestamp_nanos();
             Ok(CatalogBatch::database(

--- a/influxdb3_catalog/src/error.rs
+++ b/influxdb3_catalog/src/error.rs
@@ -17,8 +17,8 @@ pub enum CatalogError {
     #[error("the requested resource was not found: {0}")]
     NotFound(String),
 
-    #[error("attempted to delete resource that was already deleted")]
-    AlreadyDeleted,
+    #[error("attempted to modify resource that was already deleted: {0}")]
+    AlreadyDeleted(String),
 
     #[error("invalid configuration provided: {message}")]
     InvalidConfiguration { message: Box<str> },

--- a/influxdb3_server/src/http.rs
+++ b/influxdb3_server/src/http.rs
@@ -614,7 +614,7 @@ impl IntoResponse for CatalogError {
     fn into_response(self) -> Response {
         let resp_or_code: Either<Response, StatusCode> = match self {
             Self::NotFound(_) => Either::Right(StatusCode::NOT_FOUND),
-            Self::AlreadyExists | Self::AlreadyDeleted => Either::Right(StatusCode::CONFLICT),
+            Self::AlreadyExists | Self::AlreadyDeleted(_) => Either::Right(StatusCode::CONFLICT),
             Self::InvalidConfiguration { .. }
             | Self::InvalidDistinctCacheColumnType
             | Self::InvalidLastCacheKeyColumnType


### PR DESCRIPTION
This PR backports several bug fixes and improvements from the influxdb_pro repository:

- **influxdata/influxdb_pro#1986**: Fix catalog to prevent deleting tables from already deleted databases
- **influxdata/influxdb_pro#1991**: Update error message from "delete" to "modify" for AlreadyDeleted error
- **influxdata/influxdb_pro#2043**: Add resource name to AlreadyDeleted error for better error messages
- **influxdata/influxdb_pro#2046**: Set default retention period for _internal database to 7 days

Changes:
- Add check in soft_delete_table to return AlreadyDeleted error if database is already deleted
- Change CatalogError::AlreadyDeleted to include resource name
- Update all AlreadyDeleted error sites to include resource name
- Add INTERNAL_DB_RETENTION_PERIOD constant (7 days)
- Update create_internal_db to use retention period

References:
- influxdata/influxdb_pro#1986
- influxdata/influxdb_pro#1991
- influxdata/influxdb_pro#2043
- influxdata/influxdb_pro#2046

Closes #

Describe your proposed changes here.

- [ ] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb/blob/main/README.md).
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
