### PR TITLE
fix: add EOF marker to end of metrics scrape

### DIFF
--- a/influxdb3_server/src/http.rs
+++ b/influxdb3_server/src/http.rs
@@ -1104,10 +1104,8 @@ impl HttpApi {
         let mut reporter = metric_exporters::PrometheusTextEncoder::new(&mut body);
         self.common_state.metrics.report(&mut reporter);
 
-        // Ensure the response ends with a newline (EOF marker)
-        if !body.ends_with(b"\n") {
-            body.extend(b"\n");
-        }
+        // Add required OpenMetrics EOF marker
+        body.extend_from_slice(b"# EOF\n");
 
         Ok(ResponseBuilder::new()
             .status(StatusCode::OK)


### PR DESCRIPTION
backport of:  https://github.com/influxdata/influxdb_pro/pull/2061
addresses:  https://github.com/influxdata/influxdb_pro/issues/1995

We currently claim Prometheus version=0.0.4, for which an EOF (newline) at the end of the metrics response is optional. However, some tooling expects this EOF. This PR ensures a newline is always appended to the metrics response to satisfy such tooling.

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
