### PR TITLE
fix: improve various error messages

### DIFF
--- a/influxdb3_write/src/write_buffer/mod.rs
+++ b/influxdb3_write/src/write_buffer/mod.rs
@@ -62,7 +62,7 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub enum Error {
-    #[error("parsing for line protocol failed")]
+    #[error("line protocol parse failed: {}", .0.error_message)]
     ParseError(WriteLineError),
 
     #[error("incoming write was empty")]


### PR DESCRIPTION
In the course of working with a customer I've noticed several opaque error messages where we have been missing out on opportunities to provide more detail that may enable customers to address issues without or input.

This PR address two such cases:

* Line protocol parsing errors where the error message says no more than that there was a line protocol parsing error.
  * This masked a line protocol issue in which the user was trying to write data that contained a field and a tag with the same name.
* `influxdb3_client` (eg used in `influxdb3 write ...`) errors only show opaque `reqwest::Error` `Display` implementation which hides details of the underlying error (eg, customer may be using `http://` when they should be using `https://` which would have resulted in an "error sending request" message.
  * See https://users.rust-lang.org/t/reqwest-post-call-gives-client-connect-error-before-giving-response-how-to-get-more-descriptive-error/115633
