### PR TITLE
fix: ignore empty index error deleting last measurement (#25037)

### DIFF
--- a/cmd/influxd/inspect/delete_tsm/delete_tsm.go
+++ b/cmd/influxd/inspect/delete_tsm/delete_tsm.go
@@ -149,7 +149,8 @@ func (a *args) process(cmd *cobra.Command, path string) (retErr error) {
 
 		// Write index & close.
 		// It is okay to have no index values if no block was written
-		if err := w.WriteIndex(); err != nil && !(hasData || errors.Is(err, tsm1.ErrNoValues)) {
+
+		if err := w.WriteIndex(); err != nil && !(errors.Is(err, tsm1.ErrNoValues) && !hasData) {
 			return 0, fmt.Errorf("failed to write index to TSM file: %w", err)
 		}
 		return w.Size(), nil


### PR DESCRIPTION
An empty index is appropriate when deleting the last measurement.  Also clean up error handling, avoid
duplicate calls to Close.

closes https://github.com/influxdata/influxdb/issues/9929

(cherry picked from commit b09e4b751f9ac24e53558764df64b74e9b06fc3d)

Fixes https://github.com/influxdata/influxdb/issues/27037

