### PR TITLE
feat: add client certificate support to TLSCertLoader

### DIFF
--- a/services/httpd/service.go
+++ b/services/httpd/service.go
@@ -158,7 +158,7 @@ func (s *Service) Open() error {
 		}
 
 		tlsConfig := s.tlsConfig.Clone()
-		tlsConfig.GetCertificate = s.certLoader.GetCertificate
+		s.certLoader.SetupTLSConfig(tlsConfig)
 
 		listener, err := tls.Listen("tcp", s.addr, tlsConfig)
 		if err != nil {

--- a/services/opentsdb/service.go
+++ b/services/opentsdb/service.go
@@ -141,7 +141,7 @@ func (s *Service) Open() error {
 		s.certLoader = certLoader
 
 		tlsConfig := s.tlsConfig.Clone()
-		tlsConfig.GetCertificate = s.certLoader.GetCertificate
+		s.certLoader.SetupTLSConfig(tlsConfig)
 
 		listener, err := tls.Listen("tcp", s.BindAddress, tlsConfig)
 		if err != nil {


### PR DESCRIPTION
Add support for client certificates to tlsconfig.TLSCertLoader. Also add TLSCertLoader.SetupTLSConfig to simplify using a TLSCertLoader with a tls.Config object.

Clean cherry-pick from master-1.x.

(cherry picked from commit 7050b3dd66230680516db3c21925588240ad4f8f)

Closes: #27089
