### PR TITLE
feat: add --tls-no-verify option to CLI subcommand

### DIFF
--- a/influxdb3/src/commands/create/token.rs
+++ b/influxdb3/src/commands/create/token.rs
@@ -201,6 +201,14 @@ pub struct InfluxDb3ServerConfig {
     /// An optional arg to use a custom ca for useful for testing with self signed certs
     #[clap(name = "tls-ca", long = "tls-ca")]
     pub ca_cert: Option<PathBuf>,
+
+    /// Disable TLS certificate verification
+    #[clap(
+        name = "tls-no-verify",
+        long = "tls-no-verify",
+        env = "INFLUXDB3_TLS_NO_VERIFY"
+    )]
+    pub tls_no_verify: bool,
 }
 
 #[derive(Parser, Debug)]

--- a/influxdb3/src/commands/delete.rs
+++ b/influxdb3/src/commands/delete.rs
@@ -16,15 +16,17 @@ pub struct Config {
 
 impl Config {
     fn get_client(&self) -> Result<Client, Box<dyn Error>> {
-        match &self.cmd {
+        let (host_url, auth_token, ca_cert, tls_no_verify) = match &self.cmd {
             SubCommand::Database(DatabaseConfig {
                 host_url,
                 auth_token,
                 ca_cert,
+                tls_no_verify,
                 ..
             })
             | SubCommand::LastCache(LastCacheConfig {
                 ca_cert,
+                tls_no_verify,
                 influxdb3_config:
                     InfluxDb3Config {
                         host_url,
@@ -35,6 +37,7 @@ impl Config {
             })
             | SubCommand::DistinctCache(DistinctCacheConfig {
                 ca_cert,
+                tls_no_verify,
                 influxdb3_config:
                     InfluxDb3Config {
                         host_url,
@@ -45,6 +48,7 @@ impl Config {
             })
             | SubCommand::Table(TableConfig {
                 ca_cert,
+                tls_no_verify,
                 influxdb3_config:
                     InfluxDb3Config {
                         host_url,
@@ -55,6 +59,7 @@ impl Config {
             })
             | SubCommand::Trigger(TriggerConfig {
                 ca_cert,
+                tls_no_verify,
                 influxdb3_config:
                     InfluxDb3Config {
                         host_url,
@@ -65,17 +70,17 @@ impl Config {
             })
             | SubCommand::Token(TokenConfig {
                 ca_cert,
+                tls_no_verify,
                 host_url,
                 auth_token,
                 ..
-            }) => {
-                let mut client = Client::new(host_url.clone(), ca_cert.clone())?;
-                if let Some(token) = &auth_token {
-                    client = client.with_auth_token(token.expose_secret());
-                }
-                Ok(client)
-            }
+            }) => (host_url, auth_token, ca_cert, tls_no_verify),
+        };
+        let mut client = Client::new(host_url.clone(), ca_cert.clone(), *tls_no_verify)?;
+        if let Some(token) = &auth_token {
+            client = client.with_auth_token(token.expose_secret());
         }
+        Ok(client)
     }
 }
 
@@ -124,6 +129,10 @@ pub struct DatabaseConfig {
     /// An optional arg to use a custom ca for useful for testing with self signed certs
     #[clap(long = "tls-ca", env = "INFLUXDB3_TLS_CA")]
     ca_cert: Option<PathBuf>,
+
+    /// Disable TLS certificate verification
+    #[clap(long = "tls-no-verify", env = "INFLUXDB3_TLS_NO_VERIFY")]
+    tls_no_verify: bool,
 }
 
 #[derive(Debug, clap::Args)]
@@ -142,6 +151,10 @@ pub struct LastCacheConfig {
     /// An optional arg to use a custom ca for useful for testing with self signed certs
     #[clap(long = "tls-ca", env = "INFLUXDB3_TLS_CA")]
     ca_cert: Option<PathBuf>,
+
+    /// Disable TLS certificate verification
+    #[clap(long = "tls-no-verify", env = "INFLUXDB3_TLS_NO_VERIFY")]
+    tls_no_verify: bool,
 }
 
 #[derive(Debug, clap::Args)]
@@ -160,6 +173,10 @@ pub struct DistinctCacheConfig {
     /// An optional arg to use a custom ca for useful for testing with self signed certs
     #[clap(long = "tls-ca", env = "INFLUXDB3_TLS_CA")]
     ca_cert: Option<PathBuf>,
+
+    /// Disable TLS certificate verification
+    #[clap(long = "tls-no-verify", env = "INFLUXDB3_TLS_NO_VERIFY")]
+    tls_no_verify: bool,
 }
 
 #[derive(Debug, clap::Args)]
@@ -178,6 +195,10 @@ pub struct TableConfig {
     /// An optional arg to use a custom ca for useful for testing with self signed certs
     #[clap(long = "tls-ca", env = "INFLUXDB3_TLS_CA")]
     ca_cert: Option<PathBuf>,
+
+    /// Disable TLS certificate verification
+    #[clap(long = "tls-no-verify", env = "INFLUXDB3_TLS_NO_VERIFY")]
+    tls_no_verify: bool,
 }
 
 #[derive(Debug, clap::Parser)]
@@ -196,6 +217,10 @@ pub struct TriggerConfig {
     /// An optional arg to use a custom ca for useful for testing with self signed certs
     #[clap(long = "tls-ca", env = "INFLUXDB3_TLS_CA")]
     ca_cert: Option<PathBuf>,
+
+    /// Disable TLS certificate verification
+    #[clap(long = "tls-no-verify", env = "INFLUXDB3_TLS_NO_VERIFY")]
+    tls_no_verify: bool,
 }
 
 #[derive(Debug, clap::Args)]
@@ -220,6 +245,10 @@ pub struct TokenConfig {
     /// An optional arg to use a custom ca for useful for testing with self signed certs
     #[clap(long = "tls-ca", env = "INFLUXDB3_TLS_CA")]
     ca_cert: Option<PathBuf>,
+
+    /// Disable TLS certificate verification
+    #[clap(long = "tls-no-verify", env = "INFLUXDB3_TLS_NO_VERIFY")]
+    tls_no_verify: bool,
 }
 
 fn parse_hard_delete_time(value: Option<String>) -> Option<HardDeletionTime> {

--- a/influxdb3/src/commands/disable.rs
+++ b/influxdb3/src/commands/disable.rs
@@ -11,9 +11,10 @@ pub struct Config {
 
 impl Config {
     fn get_client(&self) -> Result<Client, Box<dyn Error>> {
-        let (host_url, auth_token, ca_cert) = match &self.cmd {
+        let (host_url, auth_token, ca_cert, tls_no_verify) = match &self.cmd {
             SubCommand::Trigger(TriggerConfig {
                 ca_cert,
+                tls_no_verify,
                 influxdb3_config:
                     InfluxDb3Config {
                         host_url,
@@ -21,9 +22,9 @@ impl Config {
                         ..
                     },
                 ..
-            }) => (host_url, auth_token, ca_cert),
+            }) => (host_url, auth_token, ca_cert, tls_no_verify),
         };
-        let mut client = Client::new(host_url.clone(), ca_cert.clone())?;
+        let mut client = Client::new(host_url.clone(), ca_cert.clone(), *tls_no_verify)?;
         if let Some(token) = &auth_token {
             client = client.with_auth_token(token.expose_secret());
         }
@@ -49,6 +50,10 @@ struct TriggerConfig {
     /// An optional arg to use a custom ca for useful for testing with self signed certs
     #[clap(long = "tls-ca", env = "INFLUXDB3_TLS_CA")]
     pub ca_cert: Option<PathBuf>,
+
+    /// Disable TLS certificate verification
+    #[clap(long = "tls-no-verify", env = "INFLUXDB3_TLS_NO_VERIFY")]
+    pub tls_no_verify: bool,
 }
 
 pub async fn command(config: Config) -> Result<(), Box<dyn Error>> {

--- a/influxdb3/src/commands/enable.rs
+++ b/influxdb3/src/commands/enable.rs
@@ -11,9 +11,10 @@ pub struct Config {
 
 impl Config {
     fn get_client(&self) -> Result<Client, Box<dyn Error>> {
-        let (host_url, auth_token, ca_cert) = match &self.cmd {
+        let (host_url, auth_token, ca_cert, tls_no_verify) = match &self.cmd {
             SubCommand::Trigger(TriggerConfig {
                 ca_cert,
+                tls_no_verify,
                 influxdb3_config:
                     InfluxDb3Config {
                         host_url,
@@ -21,9 +22,9 @@ impl Config {
                         ..
                     },
                 ..
-            }) => (host_url, auth_token, ca_cert),
+            }) => (host_url, auth_token, ca_cert, tls_no_verify),
         };
-        let mut client = Client::new(host_url.clone(), ca_cert.clone())?;
+        let mut client = Client::new(host_url.clone(), ca_cert.clone(), *tls_no_verify)?;
         if let Some(token) = &auth_token {
             client = client.with_auth_token(token.expose_secret());
         }
@@ -49,6 +50,10 @@ struct TriggerConfig {
     /// An optional arg to use a custom ca for useful for testing with self signed certs
     #[clap(long = "tls-ca", env = "INFLUXDB3_TLS_CA")]
     pub ca_cert: Option<PathBuf>,
+
+    /// Disable TLS certificate verification
+    #[clap(long = "tls-no-verify", env = "INFLUXDB3_TLS_NO_VERIFY")]
+    pub tls_no_verify: bool,
 }
 
 pub async fn command(config: Config) -> Result<(), Box<dyn Error>> {

--- a/influxdb3/src/commands/install.rs
+++ b/influxdb3/src/commands/install.rs
@@ -55,11 +55,19 @@ pub struct PackageConfig {
     /// An optional arg to use a custom ca for useful for testing with self signed certs
     #[clap(long = "tls-ca", env = "INFLUXDB3_TLS_CA")]
     ca_cert: Option<PathBuf>,
+
+    /// Disable TLS certificate verification
+    #[clap(long = "tls-no-verify", env = "INFLUXDB3_TLS_NO_VERIFY")]
+    tls_no_verify: bool,
 }
 
 impl PackageConfig {
     async fn run_command(&self) -> Result<(), anyhow::Error> {
-        let mut client = Client::new(self.host_url.clone(), self.ca_cert.clone())?;
+        let mut client = Client::new(
+            self.host_url.clone(),
+            self.ca_cert.clone(),
+            self.tls_no_verify,
+        )?;
         if let Some(token) = &self.auth_token {
             client = client.with_auth_token(token.expose_secret());
         }

--- a/influxdb3/src/commands/query.rs
+++ b/influxdb3/src/commands/query.rs
@@ -76,6 +76,10 @@ pub struct Config {
     /// An optional arg to use a custom ca for useful for testing with self signed certs
     #[clap(long = "tls-ca", env = "INFLUXDB3_TLS_CA")]
     ca_cert: Option<PathBuf>,
+
+    /// Disable TLS certificate verification
+    #[clap(long = "tls-no-verify", env = "INFLUXDB3_TLS_NO_VERIFY")]
+    tls_no_verify: bool,
 }
 
 #[derive(Debug, ValueEnum, Clone)]
@@ -90,7 +94,7 @@ pub(crate) async fn command(config: Config) -> Result<()> {
         database_name,
         auth_token,
     } = config.influxdb3_config;
-    let mut client = influxdb3_client::Client::new(host_url, config.ca_cert)?;
+    let mut client = influxdb3_client::Client::new(host_url, config.ca_cert, config.tls_no_verify)?;
     if let Some(t) = auth_token {
         client = client.with_auth_token(t.expose_secret());
     }

--- a/influxdb3/src/commands/show.rs
+++ b/influxdb3/src/commands/show.rs
@@ -51,6 +51,10 @@ pub struct ShowTokensConfig {
     /// An optional arg to use a custom ca for useful for testing with self signed certs
     #[clap(long = "tls-ca", env = "INFLUXDB3_TLS_CA")]
     ca_cert: Option<PathBuf>,
+
+    /// Disable TLS certificate verification
+    #[clap(long = "tls-no-verify", env = "INFLUXDB3_TLS_NO_VERIFY")]
+    tls_no_verify: bool,
 }
 
 #[derive(Debug, Parser)]
@@ -75,6 +79,10 @@ pub struct PluginsConfig {
     /// An optional arg to use a custom ca for useful for testing with self signed certs
     #[clap(long = "tls-ca", env = "INFLUXDB3_TLS_CA")]
     ca_cert: Option<PathBuf>,
+
+    /// Disable TLS certificate verification
+    #[clap(long = "tls-no-verify", env = "INFLUXDB3_TLS_NO_VERIFY")]
+    tls_no_verify: bool,
 }
 
 #[derive(Debug, Parser)]
@@ -103,6 +111,10 @@ pub struct DatabaseConfig {
     /// An optional arg to use a custom ca for useful for testing with self signed certs
     #[clap(long = "tls-ca", env = "INFLUXDB3_TLS_CA")]
     ca_cert: Option<PathBuf>,
+
+    /// Disable TLS certificate verification
+    #[clap(long = "tls-no-verify", env = "INFLUXDB3_TLS_NO_VERIFY")]
+    tls_no_verify: bool,
 }
 
 pub(crate) async fn command(config: Config) -> Result<(), Box<dyn Error>> {
@@ -113,8 +125,9 @@ pub(crate) async fn command(config: Config) -> Result<(), Box<dyn Error>> {
             show_deleted,
             output_format,
             ca_cert,
+            tls_no_verify,
         }) => {
-            let mut client = influxdb3_client::Client::new(host_url, ca_cert)?;
+            let mut client = influxdb3_client::Client::new(host_url, ca_cert, tls_no_verify)?;
 
             if let Some(t) = auth_token {
                 client = client.with_auth_token(t.expose_secret());
@@ -134,8 +147,9 @@ pub(crate) async fn command(config: Config) -> Result<(), Box<dyn Error>> {
             auth_token,
             output_format,
             ca_cert,
+            tls_no_verify,
         }) => {
-            let mut client = influxdb3_client::Client::new(host_url, ca_cert)?;
+            let mut client = influxdb3_client::Client::new(host_url, ca_cert, tls_no_verify)?;
 
             if let Some(t) = auth_token {
                 client = client.with_auth_token(t.expose_secret());
@@ -154,6 +168,7 @@ pub(crate) async fn command(config: Config) -> Result<(), Box<dyn Error>> {
             let mut client = influxdb3_client::Client::new(
                 show_tokens_config.host_url.clone(),
                 show_tokens_config.ca_cert,
+                show_tokens_config.tls_no_verify,
             )?;
 
             if let Some(t) = show_tokens_config.auth_token {

--- a/influxdb3/src/commands/update.rs
+++ b/influxdb3/src/commands/update.rs
@@ -33,6 +33,10 @@ pub struct UpdateDatabase {
     /// An optional arg to use a custom ca for useful for testing with self signed certs
     #[clap(long = "tls-ca", env = "INFLUXDB3_TLS_CA")]
     ca_cert: Option<PathBuf>,
+
+    /// Disable TLS certificate verification
+    #[clap(long = "tls-no-verify", env = "INFLUXDB3_TLS_NO_VERIFY")]
+    tls_no_verify: bool,
 }
 
 #[derive(Debug, clap::Args)]
@@ -51,6 +55,10 @@ pub struct UpdateTrigger {
     /// An optional arg to use a custom ca for useful for testing with self signed certs
     #[clap(long = "tls-ca", env = "INFLUXDB3_TLS_CA")]
     ca_cert: Option<PathBuf>,
+
+    /// Disable TLS certificate verification
+    #[clap(long = "tls-no-verify", env = "INFLUXDB3_TLS_NO_VERIFY")]
+    tls_no_verify: bool,
 }
 
 pub async fn command(config: Config) -> Result<(), Box<dyn Error>> {
@@ -65,8 +73,9 @@ pub async fn command(config: Config) -> Result<(), Box<dyn Error>> {
                 },
             retention_period,
             ca_cert,
+            tls_no_verify,
         }) => {
-            let mut client = Client::new(host_url, ca_cert)?;
+            let mut client = Client::new(host_url, ca_cert, tls_no_verify)?;
             if let Some(token) = &auth_token {
                 client = client.with_auth_token(token.expose_secret());
             }
@@ -97,8 +106,9 @@ pub async fn command(config: Config) -> Result<(), Box<dyn Error>> {
             trigger_name,
             path,
             ca_cert,
+            tls_no_verify,
         }) => {
-            let mut client = Client::new(host_url, ca_cert)?;
+            let mut client = Client::new(host_url, ca_cert, tls_no_verify)?;
             if let Some(token) = &auth_token {
                 client = client.with_auth_token(token.expose_secret());
             }

--- a/influxdb3/src/commands/write.rs
+++ b/influxdb3/src/commands/write.rs
@@ -69,6 +69,10 @@ pub struct Config {
     /// An optional arg to use a custom ca for useful for testing with self signed certs
     #[clap(long = "tls-ca", env = "INFLUXDB3_TLS_CA")]
     ca_cert: Option<PathBuf>,
+
+    /// Disable TLS certificate verification
+    #[clap(long = "tls-no-verify", env = "INFLUXDB3_TLS_NO_VERIFY")]
+    tls_no_verify: bool,
 }
 
 pub(crate) async fn command(config: Config) -> Result<()> {
@@ -77,7 +81,7 @@ pub(crate) async fn command(config: Config) -> Result<()> {
         database_name,
         auth_token,
     } = config.influxdb3_config;
-    let mut client = influxdb3_client::Client::new(host_url, config.ca_cert)?;
+    let mut client = influxdb3_client::Client::new(host_url, config.ca_cert, config.tls_no_verify)?;
     if let Some(t) = auth_token {
         client = client.with_auth_token(t.expose_secret());
     }

--- a/influxdb3/tests/cli/mod.rs
+++ b/influxdb3/tests/cli/mod.rs
@@ -3,6 +3,7 @@ mod api;
 mod db_retention;
 mod offline_tokens;
 mod system_tables;
+mod tls_no_verify;
 
 use crate::server::{ConfigProvider, TestServer};
 use assert_cmd::cargo::cargo_bin_cmd;

--- a/influxdb3/tests/cli/tls_no_verify.rs
+++ b/influxdb3/tests/cli/tls_no_verify.rs
@@ -1,0 +1,371 @@
+//! Integration tests for the `--tls-no-verify` CLI flag
+//!
+//! These tests verify that CLI commands work correctly when connecting to a server
+//! with invalid/expired TLS certificates when the `--tls-no-verify` flag is used.
+
+use crate::server::{ConfigProvider, TestServer};
+
+// =============================================================================
+// Simple commands (no database setup needed)
+// =============================================================================
+
+/// Test that `show databases` succeeds with `--tls-no-verify` against bad TLS server
+#[test_log::test(tokio::test)]
+async fn test_show_databases_with_tls_no_verify() {
+    let server = TestServer::configure().with_bad_tls(true).spawn().await;
+
+    let result = server
+        .run(vec!["show", "databases", "--tls-no-verify"], &[])
+        .unwrap();
+
+    assert!(!result.contains("certificate"));
+}
+
+/// Test that `show plugins` succeeds with `--tls-no-verify` against bad TLS server
+#[test_log::test(tokio::test)]
+async fn test_show_plugins_with_tls_no_verify() {
+    let server = TestServer::configure().with_bad_tls(true).spawn().await;
+
+    let result = server
+        .run(vec!["show", "plugins", "--tls-no-verify"], &[])
+        .unwrap();
+
+    assert!(!result.contains("certificate"));
+}
+
+// =============================================================================
+// Commands that need a database
+// =============================================================================
+
+/// Test query command with `--tls-no-verify`
+#[test_log::test(tokio::test)]
+async fn test_query_with_tls_no_verify() {
+    let server = TestServer::configure().with_bad_tls(true).spawn().await;
+
+    // Create database first
+    server
+        .run(vec!["create", "database", "--tls-no-verify"], &["testdb"])
+        .unwrap();
+
+    let result = server
+        .run(
+            vec!["query", "--tls-no-verify", "-d", "testdb"],
+            &["SELECT 1"],
+        )
+        .unwrap();
+
+    assert!(
+        !result.contains("certificate"),
+        "Unexpected output: {result}"
+    );
+}
+
+// =============================================================================
+// Commands that need a database and table
+// =============================================================================
+
+/// Test write command
+#[test_log::test(tokio::test)]
+async fn test_write_with_tls_no_verify() {
+    let server = TestServer::configure().with_bad_tls(true).spawn().await;
+
+    server
+        .run(vec!["create", "database", "--tls-no-verify"], &["writedb"])
+        .unwrap();
+
+    let result = server
+        .run(
+            vec!["write", "--tls-no-verify", "-d", "writedb"],
+            &["cpu,host=server01 value=0.64"],
+        )
+        .unwrap();
+
+    assert!(
+        !result.contains("certificate"),
+        "Unexpected output: {result}"
+    );
+}
+
+/// Test create table command
+#[test_log::test(tokio::test)]
+async fn test_create_table_with_tls_no_verify() {
+    let server = TestServer::configure().with_bad_tls(true).spawn().await;
+
+    server
+        .run(vec!["create", "database", "--tls-no-verify"], &["tabledb"])
+        .unwrap();
+
+    let result = server
+        .run(
+            vec![
+                "create",
+                "table",
+                "--tls-no-verify",
+                "-d",
+                "tabledb",
+                "--tags",
+                "host",
+                "--fields",
+                "value:float64",
+            ],
+            &["cpu"],
+        )
+        .unwrap();
+
+    assert!(
+        !result.contains("certificate"),
+        "Unexpected output: {result}"
+    );
+}
+
+/// Test delete table command
+#[test_log::test(tokio::test)]
+async fn test_delete_table_with_tls_no_verify() {
+    let server = TestServer::configure().with_bad_tls(true).spawn().await;
+
+    server
+        .run(
+            vec!["create", "database", "--tls-no-verify"],
+            &["deltabledb"],
+        )
+        .unwrap();
+
+    // Create table via write
+    server
+        .run(
+            vec!["write", "--tls-no-verify", "-d", "deltabledb"],
+            &["cpu,host=server01 value=0.64"],
+        )
+        .unwrap();
+
+    let result = server
+        .run_with_confirmation(
+            vec!["delete", "table", "--tls-no-verify", "-d", "deltabledb"],
+            &["cpu"],
+        )
+        .unwrap();
+
+    assert!(
+        !result.contains("certificate"),
+        "Unexpected output: {result}"
+    );
+}
+
+// =============================================================================
+// Cache commands (last_cache and distinct_cache)
+// =============================================================================
+
+/// Test create and delete last_cache commands
+#[test_log::test(tokio::test)]
+async fn test_last_cache_commands_with_tls_no_verify() {
+    let server = TestServer::configure().with_bad_tls(true).spawn().await;
+
+    server
+        .run(vec!["create", "database", "--tls-no-verify"], &["cachedb"])
+        .unwrap();
+
+    // Create table via write
+    server
+        .run(
+            vec!["write", "--tls-no-verify", "-d", "cachedb"],
+            &["cpu,host=server01 value=0.64"],
+        )
+        .unwrap();
+
+    // Create last cache
+    let result = server
+        .run(
+            vec![
+                "create",
+                "last_cache",
+                "--tls-no-verify",
+                "-d",
+                "cachedb",
+                "-t",
+                "cpu",
+            ],
+            &[],
+        )
+        .unwrap();
+    assert!(
+        !result.contains("certificate"),
+        "Create last_cache failed: {result}"
+    );
+
+    // Delete last cache
+    let result = server
+        .run_with_confirmation(
+            vec![
+                "delete",
+                "last_cache",
+                "--tls-no-verify",
+                "-d",
+                "cachedb",
+                "-t",
+                "cpu",
+            ],
+            &["cpu_host_last_cache"],
+        )
+        .unwrap();
+    assert!(
+        !result.contains("certificate"),
+        "Delete last_cache failed: {result}"
+    );
+}
+
+/// Test create and delete distinct_cache commands
+#[test_log::test(tokio::test)]
+async fn test_distinct_cache_commands_with_tls_no_verify() {
+    let server = TestServer::configure().with_bad_tls(true).spawn().await;
+
+    server
+        .run(
+            vec!["create", "database", "--tls-no-verify"],
+            &["dvcachedb"],
+        )
+        .unwrap();
+
+    // Create table via write
+    server
+        .run(
+            vec!["write", "--tls-no-verify", "-d", "dvcachedb"],
+            &["cpu,host=server01 value=0.64"],
+        )
+        .unwrap();
+
+    // Create distinct cache
+    let result = server
+        .run(
+            vec![
+                "create",
+                "distinct_cache",
+                "--tls-no-verify",
+                "-d",
+                "dvcachedb",
+                "-t",
+                "cpu",
+                "--columns",
+                "host",
+            ],
+            &[],
+        )
+        .unwrap();
+    assert!(
+        !result.contains("certificate"),
+        "Create distinct_cache failed: {result}"
+    );
+
+    // Delete distinct cache
+    let result = server
+        .run_with_confirmation(
+            vec![
+                "delete",
+                "distinct_cache",
+                "--tls-no-verify",
+                "-d",
+                "dvcachedb",
+                "-t",
+                "cpu",
+            ],
+            &["cpu_host_distinct_cache"],
+        )
+        .unwrap();
+    assert!(
+        !result.contains("certificate"),
+        "Delete distinct_cache failed: {result}"
+    );
+}
+
+// =============================================================================
+// Database create/delete commands
+// =============================================================================
+
+/// Test create database command
+#[test_log::test(tokio::test)]
+async fn test_create_database_with_tls_no_verify() {
+    let server = TestServer::configure().with_bad_tls(true).spawn().await;
+
+    let result = server
+        .run(vec!["create", "database", "--tls-no-verify"], &["newdb"])
+        .unwrap();
+
+    assert!(
+        !result.contains("certificate"),
+        "Unexpected output: {result}"
+    );
+}
+
+/// Test delete database command
+#[test_log::test(tokio::test)]
+async fn test_delete_database_with_tls_no_verify() {
+    let server = TestServer::configure().with_bad_tls(true).spawn().await;
+
+    server
+        .run(vec!["create", "database", "--tls-no-verify"], &["deletedb"])
+        .unwrap();
+
+    let result = server
+        .run_with_confirmation(vec!["delete", "database", "--tls-no-verify"], &["deletedb"])
+        .unwrap();
+
+    assert!(
+        !result.contains("certificate"),
+        "Unexpected output: {result}"
+    );
+}
+
+// =============================================================================
+// Update commands
+// =============================================================================
+
+/// Test update database command
+#[test_log::test(tokio::test)]
+async fn test_update_database_with_tls_no_verify() {
+    let server = TestServer::configure().with_bad_tls(true).spawn().await;
+
+    server
+        .run(vec!["create", "database", "--tls-no-verify"], &["updatedb"])
+        .unwrap();
+
+    // Update database with a retention period
+    let result = server
+        .run(
+            vec![
+                "update",
+                "database",
+                "--tls-no-verify",
+                "-d",
+                "updatedb",
+                "--retention-period",
+                "30d",
+            ],
+            &[],
+        )
+        .unwrap();
+
+    assert!(
+        !result.contains("certificate"),
+        "Unexpected output: {result}"
+    );
+}
+
+/// Test update table command
+#[test_log::test(tokio::test)]
+async fn test_update_table_with_tls_no_verify() {
+    let server = TestServer::configure().with_bad_tls(true).spawn().await;
+
+    server
+        .run(
+            vec!["create", "database", "--tls-no-verify"],
+            &["updatetabledb"],
+        )
+        .unwrap();
+
+    // Create table via write
+    server
+        .run(
+            vec!["write", "--tls-no-verify", "-d", "updatetabledb"],
+            &["cpu,host=server01 value=0.64"],
+        )
+        .unwrap();
+}

--- a/influxdb3/tests/server/client.rs
+++ b/influxdb3/tests/server/client.rs
@@ -15,6 +15,7 @@ async fn write_and_query() {
     let client = influxdb3_client::Client::new(
         server.client_addr(),
         Some("../testing-certs/rootCA.pem".into()),
+        false,
     )
     .unwrap();
     client
@@ -47,6 +48,7 @@ async fn configure_last_caches() {
     let client = influxdb3_client::Client::new(
         server.client_addr(),
         Some("../testing-certs/rootCA.pem".into()),
+        false,
     )
     .unwrap();
     client
@@ -106,6 +108,7 @@ async fn write_with_no_sync() {
     let client = influxdb3_client::Client::new(
         server.client_addr(),
         Some("../testing-certs/rootCA.pem".into()),
+        false,
     )
     .unwrap();
 

--- a/influxdb3_load_generator/src/commands/common.rs
+++ b/influxdb3_load_generator/src/commands/common.rs
@@ -453,7 +453,7 @@ pub(crate) fn create_client(
     host_url: Url,
     auth_token: Option<Secret<String>>,
 ) -> Result<Client, influxdb3_client::Error> {
-    let mut client = Client::new(host_url, None)?;
+    let mut client = Client::new(host_url, None, false)?;
     if let Some(t) = auth_token {
         client = client.with_auth_token(t.expose_secret());
     }


### PR DESCRIPTION
This PR ports a small quality-of-life improvement from enterprise that allows users to circumvent client side TLS validation when they don't have access to the CA root cert or don't understand the TLS setup well enough to figure it out and need to perform troubleshooting operations from their local dev machine.
