### PR TITLE
feat: add retention to show output

### DIFF
--- a/influxdb3/src/commands/show.rs
+++ b/influxdb3/src/commands/show.rs
@@ -27,6 +27,9 @@ pub enum SubCommand {
 
     /// Display system table data.
     System(SystemConfig),
+
+    /// Show retention policies with effective retention for each table
+    Retention(RetentionConfig),
 }
 
 #[derive(Debug, Parser)]
@@ -73,6 +76,38 @@ pub struct PluginsConfig {
     auth_token: Option<Secret<String>>,
 
     /// The format in which to output the list of plugins
+    #[clap(value_enum, long = "format", default_value = "pretty")]
+    output_format: Format,
+
+    /// An optional arg to use a custom ca for useful for testing with self signed certs
+    #[clap(long = "tls-ca", env = "INFLUXDB3_TLS_CA")]
+    ca_cert: Option<PathBuf>,
+
+    /// Disable TLS certificate verification
+    #[clap(long = "tls-no-verify", env = "INFLUXDB3_TLS_NO_VERIFY")]
+    tls_no_verify: bool,
+}
+
+#[derive(Debug, Parser)]
+pub struct RetentionConfig {
+    /// The host URL of the running InfluxDB 3 server
+    #[clap(
+        short = 'H',
+        long = "host",
+        env = "INFLUXDB3_HOST_URL",
+        default_value = "http://127.0.0.1:8181"
+    )]
+    host_url: Url,
+
+    /// The token for authentication with the InfluxDB 3 server
+    #[clap(long = "token", env = "INFLUXDB3_AUTH_TOKEN", hide_env_values = true)]
+    auth_token: Option<Secret<String>>,
+
+    /// Optional database name to filter results
+    #[clap(long = "database")]
+    database: Option<String>,
+
+    /// The format in which to output the retention policies
     #[clap(value_enum, long = "format", default_value = "pretty")]
     output_format: Format,
 
@@ -181,7 +216,71 @@ pub(crate) async fn command(config: Config) -> Result<(), Box<dyn Error>> {
                 .await?;
             println!("{}", std::str::from_utf8(&resp_bytes)?);
         }
+        SubCommand::Retention(retention_config) => {
+            show_retention_policies(retention_config).await?;
+        }
     }
 
+    Ok(())
+}
+
+/// Show retention policies for databases.
+/// This queries system.databases to show database-level retention periods.
+async fn show_retention_policies(config: RetentionConfig) -> Result<(), Box<dyn Error>> {
+    let mut client = influxdb3_client::Client::new(
+        config.host_url.clone(),
+        config.ca_cert,
+        config.tls_no_verify,
+    )?;
+
+    if let Some(t) = config.auth_token {
+        client = client.with_auth_token(t.expose_secret());
+    }
+
+    // Build the SQL query to show database retention policies
+    let query = if let Some(db) = &config.database {
+        format!(
+            "SELECT \
+                database_name, \
+                CASE \
+                    WHEN retention_period_ns IS NULL THEN 'infinite' \
+                    WHEN retention_period_ns % 86400000000000 = 0 THEN \
+                        CAST(retention_period_ns / 86400000000000 AS VARCHAR) || 'd' \
+                    WHEN retention_period_ns % 3600000000000 = 0 THEN \
+                        CAST(retention_period_ns / 3600000000000 AS VARCHAR) || 'h' \
+                    WHEN retention_period_ns % 60000000000 = 0 THEN \
+                        CAST(retention_period_ns / 60000000000 AS VARCHAR) || 'm' \
+                    ELSE CAST(retention_period_ns / 1000000000 AS VARCHAR) || 's' \
+                END as retention_period \
+            FROM system.databases \
+            WHERE database_name = '{}' \
+            ORDER BY database_name",
+            db.replace('\'', "''") // Escape single quotes
+        )
+    } else {
+        "SELECT \
+            database_name, \
+            CASE \
+                WHEN retention_period_ns IS NULL THEN 'infinite' \
+                WHEN retention_period_ns % 86400000000000 = 0 THEN \
+                    CAST(retention_period_ns / 86400000000000 AS VARCHAR) || 'd' \
+                WHEN retention_period_ns % 3600000000000 = 0 THEN \
+                    CAST(retention_period_ns / 3600000000000 AS VARCHAR) || 'h' \
+                WHEN retention_period_ns % 60000000000 = 0 THEN \
+                    CAST(retention_period_ns / 60000000000 AS VARCHAR) || 'm' \
+                ELSE CAST(retention_period_ns / 1000000000 AS VARCHAR) || 's' \
+            END as retention_period \
+        FROM system.databases \
+        ORDER BY database_name"
+            .to_string()
+    };
+
+    let resp_bytes = client
+        .api_v3_query_sql("_internal", query)
+        .format(config.output_format.into())
+        .send()
+        .await?;
+
+    println!("{}", std::str::from_utf8(&resp_bytes)?);
     Ok(())
 }

--- a/influxdb3_server/src/http.rs
+++ b/influxdb3_server/src/http.rs
@@ -1865,6 +1865,11 @@ impl HttpApi {
         let catalog = self.write_buffer.catalog();
         let delete_req = serde_urlencoded::from_str::<ClearRetentionPeriod>(query)?;
 
+        info!(
+            database = %delete_req.db,
+            "clearing retention period for database"
+        );
+
         catalog
             .clear_retention_period_for_database(delete_req.db.as_str())
             .await?;


### PR DESCRIPTION
This PR ports the `show retention` command.

### Usage

```
# show with no policies set

➜  influxdb3 show retention --host http://localhost:8181 --format pretty
+---------------+------------------+
| database_name | retention_period |
+---------------+------------------+
| _internal     | 7.0000d          |
| test_db       | infinite         |
+---------------+------------------+

# set on the db
➜  influxdb3 update database \
  --host http://localhost:8181 \
  --database test_db \
  --retention-period 7d
Database "test_db" updated successfully

# show they get policy from the db
➜  influxdb3 show retention --host http://localhost:8181 --format pretty
+---------------+------------------+
| database_name | retention_period |
+---------------+------------------+
| _internal     | 7.0000d          |
| test_db       | 7.0000d          |
+---------------+------------------+

# output can also be formatted as json, and a database can be specified to filter output:
influxdb3 show retention --host http://localhost:8181 --format json --database test_db
[{"database_name":"test_db","retention_period":"7.0000d"}]
```

https://docs.influxdata.com/influxdb3/core/reference/cli/influxdb3/show/retention/

* closes https://github.com/influxdata/influxdb/issues/27082
