### PR TITLE
fix(influxql): show retention policies returns duration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3329,7 +3329,6 @@ dependencies = [
  "async-trait",
  "datafusion",
  "futures",
- "humantime",
  "influxdb3_catalog",
  "influxdb_influxql_parser",
  "iox_query",

--- a/influxdb3/tests/server/query.rs
+++ b/influxdb3/tests/server/query.rs
@@ -366,9 +366,9 @@ async fn api_v3_query_influxql() {
             expected: "+---------------+---------+----------+\n\
                     | iox::database | name    | duration |\n\
                     +---------------+---------+----------+\n\
-                    | _internal     | autogen |          |\n\
-                    | bar           | autogen |          |\n\
-                    | foo           | autogen |          |\n\
+                    | _internal     | autogen | 168h0m0s |\n\
+                    | bar           | autogen | 0s       |\n\
+                    | foo           | autogen | 0s       |\n\
                     +---------------+---------+----------+",
         },
         TestCase {
@@ -377,7 +377,7 @@ async fn api_v3_query_influxql() {
             expected: "+---------------+---------+----------+\n\
                     | iox::database | name    | duration |\n\
                     +---------------+---------+----------+\n\
-                    | foo           | autogen |          |\n\
+                    | foo           | autogen | 0s       |\n\
                     +---------------+---------+----------+",
         },
         TestCase {
@@ -386,7 +386,7 @@ async fn api_v3_query_influxql() {
             expected: "+---------------+---------+----------+\n\
                     | iox::database | name    | duration |\n\
                     +---------------+---------+----------+\n\
-                    | foo           | autogen |          |\n\
+                    | foo           | autogen | 0s       |\n\
                     +---------------+---------+----------+",
         },
     ];
@@ -683,10 +683,12 @@ async fn api_v3_query_json_format() {
                 {
                   "iox::database": "_internal",
                   "name": "autogen",
+                  "duration": "168h0m0s",
                 },
                 {
                   "iox::database": "foo",
                   "name": "autogen",
+                  "duration": "0s",
                 },
             ]),
         },
@@ -791,8 +793,8 @@ async fn api_v3_query_jsonl_format() {
             database: None,
             query: "SHOW RETENTION POLICIES",
             expected:
-            "{\"iox::database\":\"_internal\",\"name\":\"autogen\"}\n\
-            {\"iox::database\":\"foo\",\"name\":\"autogen\"}\n".into(),
+            "{\"iox::database\":\"_internal\",\"name\":\"autogen\",\"duration\":\"168h0m0s\"}\n\
+            {\"iox::database\":\"foo\",\"name\":\"autogen\",\"duration\":\"0s\"}\n".into(),
         },
     ];
     for t in test_cases {

--- a/influxdb3/tests/server/snapshots/lib__server__query__api_v1_query_api_show_databases_and_retention_policies-2.snap
+++ b/influxdb3/tests/server/snapshots/lib__server__query__api_v1_query_api_show_databases_and_retention_policies-2.snap
@@ -3,4 +3,4 @@ source: influxdb3/tests/server/query.rs
 description: SHOW RETENTION POLICIES on foo db
 expression: response
 ---
-{"results":[{"statement_id":0,"series":[{"name":"retention_policies","columns":["name","duration","default"],"values":[["foo",null,true]]}]}]}
+{"results":[{"statement_id":0,"series":[{"name":"retention_policies","columns":["name","duration","default"],"values":[["foo","0s",true]]}]}]}

--- a/influxdb3/tests/server/snapshots/lib__server__query__api_v1_query_api_show_databases_and_retention_policies-3.snap
+++ b/influxdb3/tests/server/snapshots/lib__server__query__api_v1_query_api_show_databases_and_retention_policies-3.snap
@@ -3,4 +3,4 @@ source: influxdb3/tests/server/query.rs
 description: SHOW RETENTION POLICIES on bar db
 expression: response
 ---
-{"results":[{"statement_id":0,"series":[{"name":"retention_policies","columns":["name","duration","default"],"values":[["bar","30days",true]]}]}]}
+{"results":[{"statement_id":0,"series":[{"name":"retention_policies","columns":["name","duration","default"],"values":[["bar","720h0m0s",true]]}]}]}

--- a/influxdb3_internal_api/Cargo.toml
+++ b/influxdb3_internal_api/Cargo.toml
@@ -23,7 +23,6 @@ influxdb3_catalog = { path = "../influxdb3_catalog" }
 anyhow.workspace = true
 async-trait.workspace = true
 datafusion.workspace = true
-humantime.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]


### PR DESCRIPTION
`influxql SHOW RETENTION POLICIES` was returning empty duration column even when databases had retention periods configured.

This fix instead accesses retention_period directly from catalog.db_schema().

The format matches the InfluxDB v1 format (e.g. 336h0m0s, 0s, 1h0m0s, etc).

See docs on this from [v1](https://docs.influxdata.com/influxdb/v1/query_language/explore-schema/#show-retention-policies).


Describe your proposed changes here.

- [ ] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb/blob/main/README.md).
- [ ] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
