### PR TITLE
chore: add cli_params test to verify influxdb3-core.conf; adjust options

### DIFF
--- a/.circleci/packages/influxdb3/fs/usr/lib/influxdb3/influxdb3-launcher
+++ b/.circleci/packages/influxdb3/fs/usr/lib/influxdb3/influxdb3-launcher
@@ -50,6 +50,10 @@ TOML_KEY_ENVVAR: Dict[str, Dict[str, str]] = {
         "admin-token-recovery-http-bind": "INFLUXDB3_ADMIN_TOKEN_RECOVERY_HTTP_BIND_ADDR",
         # Authorization
         "without-auth": "INFLUXDB3_START_WITHOUT_AUTH",
+        # Datafusion
+        "num-datafusion-threads": "INFLUXDB3_DATAFUSION_NUM_THREADS",
+        # IO
+        "num-io-threads": "INFLUXDB3_IO_NUM_THREADS",
         # Object storage
         "data-dir": "INFLUXDB3_DB_DIR",
         # AWS (AWS_ prefix, not INFLUXDB3_)
@@ -58,6 +62,7 @@ TOML_KEY_ENVVAR: Dict[str, Dict[str, str]] = {
         "aws-credentials-file": "AWS_CREDENTIALS_FILE",
         "aws-default-region": "AWS_DEFAULT_REGION",
         "aws-endpoint": "AWS_ENDPOINT",
+        "aws-s3-custom-backend": "AWS_S3_CUSTOM_BACKEND",
         "aws-secret-access-key": "AWS_SECRET_ACCESS_KEY",
         "aws-session-token": "AWS_SESSION_TOKEN",
         "aws-skip-signature": "AWS_SKIP_SIGNATURE",
@@ -74,6 +79,7 @@ TOML_KEY_ENVVAR: Dict[str, Dict[str, str]] = {
         "object-store-http2-only": "OBJECT_STORE_HTTP2_ONLY",
         "object-store-http2-max-frame-size": "OBJECT_STORE_HTTP2_MAX_FRAME_SIZE",
         "object-store-max-retries": "OBJECT_STORE_MAX_RETRIES",
+        "object-store-request-timeout": "OBJECT_STORE_REQUEST_TIMEOUT",
         "object-store-retry-timeout": "OBJECT_STORE_RETRY_TIMEOUT",
         "object-store-tls-allow-insecure": "OBJECT_STORE_TLS_ALLOW_INSECURE",
         "object-store-tls-ca": "OBJECT_STORE_TLS_CA",
@@ -81,6 +87,10 @@ TOML_KEY_ENVVAR: Dict[str, Dict[str, str]] = {
         "virtual-env-location": "VIRTUAL_ENV",
         # WAL
         "snapshotted-wal-files-to-keep": "INFLUXDB3_NUM_WAL_FILES_TO_KEEP",
+        # Tokio console (TOKIO_CONSOLE_ prefix, not INFLUXDB3_)
+        "tokio-console-enabled": "TOKIO_CONSOLE_ENABLED",
+        "tokio-console-client-buffer-capacity": "TOKIO_CONSOLE_CLIENT_BUFFER_CAPACITY",
+        "tokio-console-event-buffer-capacity": "TOKIO_CONSOLE_EVENT_BUFFER_CAPACITY",
         # Tracing (TRACES_ prefix, not INFLUXDB3_)
         "traces-exporter": "TRACES_EXPORTER",
         "traces-exporter-jaeger-agent-host": "TRACES_EXPORTER_JAEGER_AGENT_HOST",
@@ -98,17 +108,32 @@ TOML_KEY_ENVVAR: Dict[str, Dict[str, str]] = {
     "enterprise": {
         # Enterprise cluster configuration
         "cluster-id": "INFLUXDB3_ENTERPRISE_CLUSTER_ID",
+        "conn-info": "INFLUXDB3_ENTERPRISE_CONN_INFO",
         "mode": "INFLUXDB3_ENTERPRISE_MODE",
         "num-cores": "INFLUXDB3_ENTERPRISE_NUM_CORES",
-        # Resource limits
-        "max-columns": "INFLUXDB3_ENTERPRISE_PACHA_TREE_MAX_COLUMNS",
-        "num-database-limit": "INFLUXDB3_ENTERPRISE_NUM_DATABASE_LIMIT",
-        "num-table-limit": "INFLUXDB3_ENTERPRISE_NUM_TABLE_LIMIT",
-        "num-total-columns-per-table-limit": "INFLUXDB3_ENTERPRISE_NUM_TOTAL_COLUMNS_PER_TABLE_LIMIT",
+        # Compaction
+        "compaction-check-interval": "INFLUXDB3_ENTERPRISE_COMPACTION_CHECK_INTERVAL",
+        "compaction-cleanup-wait": "INFLUXDB3_ENTERPRISE_COMPACTION_CLEANUP_WAIT",
+        "compaction-gen2-duration": "INFLUXDB3_ENTERPRISE_COMPACTION_GEN2_DURATION",
+        "compaction-max-num-files-per-plan": "INFLUXDB3_ENTERPRISE_COMPACTION_MAX_NUM_FILES_PER_PLAN",
+        "compaction-multipliers": "INFLUXDB3_ENTERPRISE_COMPACTION_MULTIPLIERS",
+        "compaction-row-limit": "INFLUXDB3_ENTERPRISE_COMPACTION_ROW_LIMIT",
+        "max-compact-destination": "INFLUXDB3_ENTERPRISE_MAX_COMPACT_DESTINATION",
+        # Last Value & Distinct Value Caches
+        "preemptive-cache-age": "INFLUXDB3_ENTERPRISE_PREEMPTIVE_CACHE_AGE",
         # Licensing
         "license-email": "INFLUXDB3_ENTERPRISE_LICENSE_EMAIL",
         "license-file": "INFLUXDB3_ENTERPRISE_LICENSE_FILE",
         "license-type": "INFLUXDB3_ENTERPRISE_LICENSE_TYPE",
+        # Resource limits
+        "catalog-sync-interval": "INFLUXDB3_ENTERPRISE_CATALOG_SYNC_INTERVAL",
+        "database-split-level": "INFLUXDB3_ENTERPRISE_DATABASE_SPLIT_LEVEL",
+        "max-columns": "INFLUXDB3_ENTERPRISE_PACHA_TREE_MAX_COLUMNS",
+        "num-database-limit": "INFLUXDB3_ENTERPRISE_NUM_DATABASE_LIMIT",
+        "num-table-limit": "INFLUXDB3_ENTERPRISE_NUM_TABLE_LIMIT",
+        "num-total-columns-per-table-limit": "INFLUXDB3_ENTERPRISE_NUM_TOTAL_COLUMNS_PER_TABLE_LIMIT",
+        "replication-interval": "INFLUXDB3_ENTERPRISE_REPLICATION_INTERVAL",
+        "table-split-level": "INFLUXDB3_ENTERPRISE_TABLE_SPLIT_LEVEL",
     },
 }
 

--- a/.circleci/packages/influxdb3/fs/usr/share/influxdb3/influxdb3-core.conf
+++ b/.circleci/packages/influxdb3/fs/usr/share/influxdb3/influxdb3-core.conf
@@ -66,12 +66,6 @@
 # (env: INFLUXDB3_ADMIN_TOKEN_FILE)
 #admin-token-file="<FILE>"
 
-# File containing offline permission tokens for automated deployments. Multiple
-# tokens with database-level permissions can be defined (env: INFLUXDB3_PERMISSION_TOKENS_FILE).
-# Generate the file using:
-#  $ influxdb3 create token --permission <SPEC> --offline --create-databases foo,bar,baz
-#permission-tokens-file="<FILE>"
-
 # Disables authentication for all server actions (CLI commands and API
 # requests). The server processes all requests without requiring tokens or
 # authentication. (env: INFLUXDB3_START_WITHOUT_AUTH)
@@ -176,6 +170,10 @@
 # Default: 16 (env: OBJECT_STORE_CONNECTION_LIMIT)
 #object-store-connection-limit="16"
 
+# HTTP request timeout for object store operations
+# Default: 30s (env: OBJECT_STORE_REQUEST_TIMEOUT)
+#object-store-request-timeout="30s"
+
 # Force HTTP/2 for object stores (env: OBJECT_STORE_HTTP2_ONLY)
 #object-store-http2-only="false"
 
@@ -269,6 +267,10 @@
 # Note: setting this too high can lead to OOM
 #wal-replay-concurrency-limit="<N>"
 
+# Fail server startup if WAL replay encounters errors
+# Default: false (env: INFLUXDB3_WAL_REPLAY_FAIL_ON_ERROR)
+#wal-replay-fail-on-error="false"
+
 # Number of snapshotted WAL files to retain
 # Default: 300 (env: INFLUXDB3_NUM_WAL_FILES_TO_KEEP)
 #snapshotted-wal-files-to-keep="300"
@@ -280,16 +282,6 @@
 # Last-N-Value cache eviction interval
 # Default: 10s (env: INFLUXDB3_LAST_CACHE_EVICTION_INTERVAL)
 #last-cache-eviction-interval="10s"
-
-# Disable populating the Last-N-Value cache from historical data. When
-# disabled, the cache will still be populated with data from the WAL
-# (env: INFLUXDB3_LAST_VALUE_CACHE_DISABLE_FROM_HISTORY)
-#last-value-cache-disable-from-history="false"
-
-# Disable populating the Distinct Value cache from historical data. When
-# disabled, the cache will still be populated with data from the WAL
-# (env: INFLUXDB3_DISTINCT_VALUE_CACHE_DISABLE_FROM_HISTORY)
-#distinct-value-cache-disable-from-history="false"
 
 # Distinct Value cache eviction interval
 # Default: 10s (env: INFLUXDB3_DISTINCT_CACHE_EVICTION_INTERVAL)
@@ -350,8 +342,13 @@
 # DataFusion Configuration
 # =============================================================================
 
-# Max DataFusion runtime threads
-# Default: Auto-determined based on available cores minus IO threads (env: INFLUXDB3_DATAFUSION_NUM_THREADS)
+# Number of DataFusion runtime threads
+# Default: Auto-determined based on available cores minus IO threads
+# (env: INFLUXDB3_DATAFUSION_NUM_THREADS)
+#num-datafusion-threads="<N>"
+
+# Legacy alias for num-datafusion-threads (deprecated)
+# (env: INFLUXDB3_DATAFUSION_NUM_THREADS)
 #datafusion-num-threads="<N>"
 
 # DataFusion runtime type. Possible values: current-thread, multi-thread,
@@ -391,6 +388,39 @@
 # Thread priority
 # Default: 10 (env: INFLUXDB3_DATAFUSION_RUNTIME_THREAD_PRIORITY)
 #datafusion-runtime-thread-priority="10"
+
+# =============================================================================
+# IO Runtime Configuration
+# =============================================================================
+
+# Number of IO runtime threads
+# Default: Auto-determined (env: INFLUXDB3_IO_NUM_THREADS)
+#num-io-threads="<N>"
+
+# IO runtime type. Possible values: current-thread, multi-thread, multi-thread-alt
+# Default: multi-thread (env: INFLUXDB3_IO_RUNTIME_TYPE)
+#io-runtime-type="multi-thread"
+
+# Disable LIFO slot for IO runtime (env: INFLUXDB3_IO_RUNTIME_DISABLE_LIFO_SLOT)
+#io-runtime-disable-lifo-slot="false"
+
+# IO runtime scheduler event interval (env: INFLUXDB3_IO_RUNTIME_EVENT_INTERVAL)
+#io-runtime-event-interval="<N>"
+
+# IO runtime global queue interval (env: INFLUXDB3_IO_RUNTIME_GLOBAL_QUEUE_INTERVAL)
+#io-runtime-global-queue-interval="<N>"
+
+# Max blocking threads for IO runtime (env: INFLUXDB3_IO_RUNTIME_MAX_BLOCKING_THREADS)
+#io-runtime-max-blocking-threads="<N>"
+
+# Max IO events per tick (env: INFLUXDB3_IO_RUNTIME_MAX_IO_EVENTS_PER_TICK)
+#io-runtime-max-io-events-per-tick="<N>"
+
+# IO runtime thread keep alive duration (env: INFLUXDB3_IO_RUNTIME_THREAD_KEEP_ALIVE)
+#io-runtime-thread-keep-alive="<DURATION>"
+
+# IO runtime thread priority (env: INFLUXDB3_IO_RUNTIME_THREAD_PRIORITY)
+#io-runtime-thread-priority="<N>"
 
 # =============================================================================
 # Logging and Tracing
@@ -434,3 +464,22 @@
 # Max messages per second
 # Default: 1000 (env: TRACES_JAEGER_MAX_MSGS_PER_SECOND)
 #traces-jaeger-max-msgs-per-second="1000"
+
+# -----------------------------------------------------------------------------
+# Tokio Console
+# -----------------------------------------------------------------------------
+
+# Enable tokio console for runtime debugging
+# This comes with a certain runtime overhead
+# Default: false (env: TOKIO_CONSOLE_ENABLED)
+#tokio-console-enabled="false"
+
+# Maximum capacity for the channel of events sent from subscriber layers to the
+# aggregator task. When this channel is at capacity, additional events will be
+# dropped. (env: TOKIO_CONSOLE_EVENT_BUFFER_CAPACITY)
+#tokio-console-event-buffer-capacity="<SIZE>"
+
+# Maximum capacity of updates to buffer for each subscribed client, if that
+# client is not reading from the RPC stream. When this channel is at capacity,
+# the client may be disconnected. (env: TOKIO_CONSOLE_CLIENT_BUFFER_CAPACITY)
+#tokio-console-client-buffer-capacity="<SIZE>"

--- a/influxdb3/src/commands/serve/cli_params.rs
+++ b/influxdb3/src/commands/serve/cli_params.rs
@@ -291,4 +291,184 @@ mod tests {
             );
         }
     }
+
+    /// Extract all public (non-hidden) argument long names from a Command recursively.
+    /// Returns a HashSet of option names (without the leading "--").
+    fn extract_public_cli_options(cmd: &clap::Command, args: &mut HashSet<String>) {
+        for arg in cmd.get_arguments() {
+            // Skip help and version which are always present
+            let id = arg.get_id().as_str();
+            if id == "help" || id == "version" || id == "help-all" {
+                continue;
+            }
+
+            // Skip hidden arguments - these are internal/test-only and shouldn't
+            // be in the config file
+            if arg.is_hide_set() {
+                continue;
+            }
+
+            // Only include arguments that have a long form (these are the ones
+            // that can be configured via TOML config)
+            if let Some(long) = arg.get_long() {
+                args.insert(long.to_string());
+            }
+        }
+
+        // Recursively process subcommands
+        for subcmd in cmd.get_subcommands() {
+            if subcmd.get_name() != "help" {
+                extract_public_cli_options(subcmd, args);
+            }
+        }
+    }
+
+    /// Parse the core config file and extract all documented option names.
+    /// Options are in the format: #option-name="value" or #option-name=value
+    fn extract_config_file_options(config_content: &str) -> HashSet<String> {
+        let mut options = HashSet::new();
+
+        for line in config_content.lines() {
+            let line = line.trim();
+
+            // Skip empty lines and comment-only lines (lines starting with # followed
+            // by space or that don't contain '=')
+            if line.is_empty() || !line.contains('=') {
+                continue;
+            }
+
+            // Match lines like: #option-name="value" or option-name="value"
+            // The '#' prefix indicates a commented-out (default) option
+            let line = line.strip_prefix('#').unwrap_or(line);
+
+            // Extract the option name (everything before the '=')
+            if let Some(eq_pos) = line.find('=') {
+                let option_name = line[..eq_pos].trim();
+
+                // Only include valid option names (kebab-case identifiers)
+                if !option_name.is_empty()
+                    && option_name
+                        .chars()
+                        .all(|c| c.is_ascii_alphanumeric() || c == '-')
+                {
+                    options.insert(option_name.to_string());
+                }
+            }
+        }
+
+        options
+    }
+
+    /// Options (long form) that are intentionally excluded from the config file.
+    /// These are either:
+    /// - Deprecated and will be removed
+    /// - Have special handling that doesn't fit the config file model
+    /// - Are handled by the launcher itself (not passed to influxdb3)
+    /// - CLI-only debugging/interactive flags
+    const CONFIG_EXCLUDED_OPTIONS: &[&str] = &[
+        // Verbose flag - typically used only on command line for debugging
+        "verbose",
+        // Enterprise-only option that errors when used with Core OSS
+        "cluster-id",
+    ];
+
+    /// Options that exist in the config file but not in CLI.
+    /// These are typically options that are:
+    /// - Renamed in CLI (old name kept in config for backwards compatibility)
+    /// - Translated by the launcher to a different CLI option
+    /// - Other runtime options not part of serve subcommand's Config
+    const CLI_EXCLUDED_OPTIONS: &[&str] = &[
+        // Renamed to num-datafusion-threads in CLI
+        "datafusion-num-threads",
+        // Top-level IO runtime options - these are valid CLI options but
+        // defined using the tokio_rt_config! macro outside of serve::Config.
+        // The test only introspects serve::Config, so these appear as
+        // "missing" from CLI.
+        "io-runtime-type",
+        "io-runtime-disable-lifo-slot",
+        "io-runtime-event-interval",
+        "io-runtime-global-queue-interval",
+        "io-runtime-max-blocking-threads",
+        "io-runtime-max-io-events-per-tick",
+        "io-runtime-thread-keep-alive",
+        "io-runtime-thread-priority",
+        "num-io-threads",
+    ];
+
+    #[test]
+    fn test_config_file_cli_option_drift() {
+        use crate::commands::serve::Config;
+
+        // Path to the core config file (relative to workspace root)
+        let config_path = concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../.circleci/packages/influxdb3/fs/usr/share/influxdb3/influxdb3-core.conf"
+        );
+
+        // Read the config file
+        let config_content = std::fs::read_to_string(config_path).unwrap_or_else(|e| {
+            panic!(
+                "Failed to read config file at {}: {}\n\
+                 This test verifies that CLI options match the config file template.",
+                config_path, e
+            )
+        });
+
+        // Extract options from CLI (using clap introspection)
+        let cmd = Config::command();
+        let mut cli_options = HashSet::new();
+        extract_public_cli_options(&cmd, &mut cli_options);
+
+        // Extract options from config file
+        let config_options = extract_config_file_options(&config_content);
+
+        // Find options in CLI but not in config file
+        let mut missing_from_config: Vec<_> = cli_options
+            .iter()
+            .filter(|opt| {
+                !config_options.contains(*opt) && !CONFIG_EXCLUDED_OPTIONS.contains(&opt.as_str())
+            })
+            .cloned()
+            .collect();
+        missing_from_config.sort();
+
+        // Find options in config file but not in CLI
+        let mut missing_from_cli: Vec<_> = config_options
+            .iter()
+            .filter(|opt| {
+                !cli_options.contains(*opt) && !CLI_EXCLUDED_OPTIONS.contains(&opt.as_str())
+            })
+            .cloned()
+            .collect();
+        missing_from_cli.sort();
+
+        // Build error message if there's drift
+        let mut error_msg = String::new();
+
+        if !missing_from_config.is_empty() {
+            error_msg.push_str(&format!(
+                "\n\nCLI options missing from config file ({}):\n",
+                config_path
+            ));
+            for opt in &missing_from_config {
+                error_msg.push_str(&format!("  - {}\n", opt));
+            }
+            error_msg.push_str("\nTo fix: Add these options to the config file template, or add them to\nCONFIG_EXCLUDED_OPTIONS if they should be excluded. Until influxdb3 supports\nTOML configuration natively, when adding to the config file template, you\nmust also consider that the launcher maps options to the corresponding\nenvironment variable for the option by using this pattern:\n`INFLUXDB3_ + key.replace('-', '_').upper()`. If the new option doesn't\nfollow this pattern (ie, all 'INFLUXDB3_ENTERPRISE_...' env vars), update\nTOML_KEY_ENVVAR in `influxdb3-launcher` to include your new mapping.");
+        }
+
+        if !missing_from_cli.is_empty() {
+            error_msg.push_str(&format!(
+                "\n\nConfig file options not found in CLI ({}):\n",
+                config_path
+            ));
+            for opt in &missing_from_cli {
+                error_msg.push_str(&format!("  - {}\n", opt));
+            }
+            error_msg.push_str("\nTo fix: Remove these options from the config file, or add them to\nCLI_EXCLUDED_OPTIONS if they're handled specially.");
+        }
+
+        if !error_msg.is_empty() {
+            panic!("Config file and CLI options are out of sync!{}", error_msg);
+        }
+    }
 }


### PR DESCRIPTION
* add cli_params test to verify influxdb3-core.conf
* add missing options to launcher and config template
* remove unimplemented options from config template

Note, this is based on https://github.com/influxdata/influxdb_pro/commit/e82eda1bce4a027464d96ca4180b65e0c2376f28 but necessarily updated for Core's config file name and options.