### PR TITLE
feat: Logging and fsync delay for retention deletion (#27114)

### DIFF
--- a/cmd/influx_inspect/verify/seriesfile/verify_test.go
+++ b/cmd/influx_inspect/verify/seriesfile/verify_test.go
@@ -107,7 +107,7 @@ func NewTest(t *testing.T) *Test {
 		}
 
 		// delete one series
-		if err := seriesFile.DeleteSeriesID(ids[0]); err != nil {
+		if _, err := seriesFile.DeleteSeriesID(ids[0], tsdb.Flush); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
This area of the code is where we "hang" during retention policy deletion. It only occurs in very high cardinality dbs ~10 million+. DeleteSeriesID holds a mutex lock and does a fsync call. Running this millions of times + contention + disk I/O between various other writers/readers this could potentially go on for days.

This PR batches sync operations instead of running a sync during every series deletion op. It also adds additional logging to retention series deletion.

(cherry picked from commit c836ac271b7daf56019bb80393c7afda48b6cb6f)
