### PR TITLE
chore: CI improvements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,9 +30,9 @@ executors:
       image: ubuntu-2204:current
       resource_class: arm.large
   darwin:
-    resource_class: macos.m1.medium.gen1
+    resource_class: m4pro.medium
     macos:
-      xcode: 15.0.0
+      xcode: 26.2.0
     shell: /bin/bash -eo pipefail
   windows:
     machine:

--- a/scripts/ci/run-monitor-ci-tests.bash
+++ b/scripts/ci/run-monitor-ci-tests.bash
@@ -211,7 +211,7 @@ fi
 # poll the status of the monitor-ci pipeline
 is_failure=0
 attempts=0
-max_attempts=30 # minutes
+max_attempts=40 # minutes
 while [ $attempts -le $max_attempts ];
 do
 


### PR DESCRIPTION
- Move away from deprecated MacOS runners.
- Increase e2e-monitor-ci timeout to 40 minutes. This should prevent CI pipeline failures due to the e2e-monitor-ci pipeline sometimes taking an extra minute or two.

Clean cherry-pick from main-2.x.

(cherry picked from commit d89cf61cd6ae28bef8f54d6aa1d2f032c9d52b19)

Closes: #27163