### PR TITLE
Revert "chore: use CompactedData to reduce PersistedFiles initialization time (#2030)" (#2302)

### DIFF
--- a/influxdb3/src/commands/serve.rs
+++ b/influxdb3/src/commands/serve.rs
@@ -1015,7 +1015,6 @@ pub async fn command(config: Config, user_params: HashMap<String, String>) -> Re
         n_snapshots_to_load_on_start: n_snapshots_to_load_on_start as usize,
         shutdown: shutdown_manager.register(),
         wal_replay_concurrency_limit: config.wal_replay_concurrency_limit,
-        snapshot_markers: vec![],
     })
     .await
     .map_err(|e| Error::WriteBufferInit(e.into()))?;

--- a/influxdb3_processing_engine/src/lib.rs
+++ b/influxdb3_processing_engine/src/lib.rs
@@ -1508,7 +1508,6 @@ mod tests {
             shutdown: shutdown.register(),
             n_snapshots_to_load_on_start: N_SNAPSHOTS_TO_LOAD_ON_START,
             wal_replay_concurrency_limit: 1,
-            snapshot_markers: vec![],
         })
         .await
         .unwrap();
@@ -1697,7 +1696,6 @@ def helper_function():
             shutdown: shutdown.register(),
             n_snapshots_to_load_on_start: N_SNAPSHOTS_TO_LOAD_ON_START,
             wal_replay_concurrency_limit: 1,
-            snapshot_markers: vec![],
         })
         .await
         .unwrap();
@@ -1796,7 +1794,6 @@ def helper_function():
             shutdown: shutdown.register(),
             n_snapshots_to_load_on_start: N_SNAPSHOTS_TO_LOAD_ON_START,
             wal_replay_concurrency_limit: 1,
-            snapshot_markers: vec![],
         })
         .await
         .unwrap();
@@ -1963,7 +1960,6 @@ def helper_function():
             shutdown: shutdown.register(),
             n_snapshots_to_load_on_start: N_SNAPSHOTS_TO_LOAD_ON_START,
             wal_replay_concurrency_limit: 1,
-            snapshot_markers: vec![],
         })
         .await
         .unwrap();
@@ -2154,7 +2150,6 @@ def helper_function():
             shutdown: shutdown.register(),
             n_snapshots_to_load_on_start: N_SNAPSHOTS_TO_LOAD_ON_START,
             wal_replay_concurrency_limit: 1,
-            snapshot_markers: vec![],
         })
         .await
         .unwrap();
@@ -2246,7 +2241,6 @@ def helper_function():
             shutdown: shutdown.register(),
             n_snapshots_to_load_on_start: N_SNAPSHOTS_TO_LOAD_ON_START,
             wal_replay_concurrency_limit: 1,
-            snapshot_markers: vec![],
         })
         .await
         .unwrap();
@@ -2337,7 +2331,6 @@ def helper_function():
             shutdown: shutdown.register(),
             n_snapshots_to_load_on_start: N_SNAPSHOTS_TO_LOAD_ON_START,
             wal_replay_concurrency_limit: 1,
-            snapshot_markers: vec![],
         })
         .await
         .unwrap();
@@ -2428,7 +2421,6 @@ def helper_function():
             shutdown: shutdown.register(),
             n_snapshots_to_load_on_start: N_SNAPSHOTS_TO_LOAD_ON_START,
             wal_replay_concurrency_limit: 1,
-            snapshot_markers: vec![],
         })
         .await
         .unwrap();
@@ -2528,7 +2520,6 @@ def helper_function():
             shutdown: shutdown.register(),
             n_snapshots_to_load_on_start: N_SNAPSHOTS_TO_LOAD_ON_START,
             wal_replay_concurrency_limit: 1,
-            snapshot_markers: vec![],
         })
         .await
         .unwrap();
@@ -2667,7 +2658,6 @@ def helper_function():
             shutdown: shutdown.register(),
             n_snapshots_to_load_on_start: N_SNAPSHOTS_TO_LOAD_ON_START,
             wal_replay_concurrency_limit: 1,
-            snapshot_markers: vec![],
         })
         .await
         .unwrap();
@@ -2769,7 +2759,6 @@ def helper_function():
             shutdown: shutdown.register(),
             n_snapshots_to_load_on_start: N_SNAPSHOTS_TO_LOAD_ON_START,
             wal_replay_concurrency_limit: 1,
-            snapshot_markers: vec![],
         })
         .await
         .unwrap();

--- a/influxdb3_query_executor/src/lib.rs
+++ b/influxdb3_query_executor/src/lib.rs
@@ -937,7 +937,6 @@ mod tests {
             n_snapshots_to_load_on_start: N_SNAPSHOTS_TO_LOAD_ON_START,
             shutdown: shutdown.register(),
             wal_replay_concurrency_limit: 1,
-            snapshot_markers: vec![],
         })
         .await
         .unwrap();

--- a/influxdb3_server/src/lib.rs
+++ b/influxdb3_server/src/lib.rs
@@ -1940,7 +1940,6 @@ mod tests {
                 n_snapshots_to_load_on_start: N_SNAPSHOTS_TO_LOAD_ON_START,
                 shutdown: shutdown_manager.register(),
                 wal_replay_concurrency_limit: 1,
-                snapshot_markers: vec![],
             },
         )
         .await

--- a/influxdb3_server/tests/lib.rs
+++ b/influxdb3_server/tests/lib.rs
@@ -265,7 +265,6 @@ impl TestService {
             shutdown: ShutdownManager::new_testing().register(),
             n_snapshots_to_load_on_start: N_SNAPSHOTS_TO_LOAD_ON_START,
             wal_replay_concurrency_limit: 1,
-            snapshot_markers: vec![],
         })
         .await
         .unwrap();

--- a/influxdb3_write/src/lib.rs
+++ b/influxdb3_write/src/lib.rs
@@ -185,17 +185,6 @@ impl PersistedSnapshotVersion {
     }
 }
 
-/// Marker indicating which snapshots have been compacted for a given node.
-/// Used to filter out already-compacted snapshots during initialization.
-#[derive(Debug, Clone)]
-pub struct SnapshotMarker {
-    /// The node identifier this marker applies to
-    pub node_id: Arc<str>,
-    /// The last snapshot sequence number that was compacted for this node.
-    /// All snapshots with sequence numbers <= this have been compacted.
-    pub snapshot_sequence_number: SnapshotSequenceNumber,
-}
-
 /// The collection of Parquet files that were persisted in a snapshot
 #[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Clone)]
 pub struct PersistedSnapshot {

--- a/influxdb3_write/src/write_buffer/persisted_files.rs
+++ b/influxdb3_write/src/write_buffer/persisted_files.rs
@@ -282,9 +282,11 @@ impl PersistedFiles {
             }
         }
 
-        guard.parquet_files_count -= removed_paths.len() as u64;
+        guard.parquet_files_count = guard
+            .parquet_files_count
+            .saturating_sub(removed_paths.len() as u64);
         guard.parquet_files_size_mb -= as_mb(size);
-        guard.parquet_files_row_count -= row_count;
+        guard.parquet_files_row_count = guard.parquet_files_row_count.saturating_sub(row_count);
 
         // The deleted data has been processed.
         guard.deleted_data = HashMap::new();


### PR DESCRIPTION
This reverts part of the changes cherry-picked from Enterprise in https://github.com/influxdata/influxdb/pull/27160

* Revert "chore: use CompactedData to reduce PersistedFiles initialization time (#2030)"

This reverts commit be7bc354de04d667105a58157487f853144485aa.

* fix: use saturating subtraction
