### PR TITLE
feat: Defer cleanup for log/index compactions, add debug log (#26511)

### DIFF
--- a/tsdb/index/tsi1/partition.go
+++ b/tsdb/index/tsi1/partition.go
@@ -368,19 +368,18 @@ func (p *Partition) Wait() {
 		if p.CurrentCompactionN() == 0 {
 			return
 		}
-		select {
-		case <-ticker.C:
-			elapsed := time.Since(startTime)
-			if elapsed >= timeoutDuration {
-				files := make([]string, 0)
-				for _, v := range p.fileSet.Files() {
-					files = append(files, v.Path())
-				}
-				p.logger.Warn("Partition.Wait() timed out waiting for compactions to complete",
-					zap.Int32("stuck_compactions", p.CurrentCompactionN()), zap.Duration("timeout", timeoutDuration),
-					zap.Strings("files", files))
-				startTime = time.Now()
+
+		<-ticker.C
+		elapsed := time.Since(startTime)
+		if elapsed >= timeoutDuration {
+			files := make([]string, 0)
+			for _, v := range p.fileSet.Files() {
+				files = append(files, v.Path())
 			}
+			p.logger.Warn("Partition.Wait() timed out waiting for compactions to complete",
+				zap.Int32("stuck_compactions", p.CurrentCompactionN()), zap.Duration("timeout", timeoutDuration),
+				zap.Strings("files", files))
+			startTime = time.Now()
 		}
 	}
 }


### PR DESCRIPTION
I believe that there is something happening which causes CurrentCompactionN() to always be greater than 0. Thus making Partition.Wait() hang forever.

Taking a look at some profiles where this issue occurs. I'm seeing a consistent one where we're stuck on Partition.Wait()
```
-----------+-------------------------------------------------------
         1   runtime.gopark
             runtime.chanrecv
             runtime.chanrecv1
             github.com/influxdata/influxdb/tsdb/index/tsi1.(*Partition).Wait
             github.com/influxdata/influxdb/tsdb/index/tsi1.(*Partition).Close
             github.com/influxdata/influxdb/tsdb/index/tsi1.(*Index).close
             github.com/influxdata/influxdb/tsdb/index/tsi1.(*Index).Close
             github.com/influxdata/influxdb/tsdb.(*Shard).closeNoLock
             github.com/influxdata/influxdb/tsdb.(*Shard).Close
             github.com/influxdata/influxdb/tsdb.(*Store).DeleteShard
             github.com/influxdata/influxdb/services/retention.(*Service).DeletionCheck.func3
             github.com/influxdata/influxdb/services/retention.(*Service).DeletionCheck
             github.com/influxdata/influxdb/services/retention.(*Service).run
             github.com/influxdata/influxdb/services/retention.(*Service).Open.func1
-----------+-------------------------------------------------------
```

Defer'ing compaction count cleanup inside goroutines should help with any hanging current compaction counts.

Modify currentCompactionN to be a sync atomic.

Adding a debug level log within Compaction.Wait() should aid in debugging.

(cherry picked from commit 149fb4759750d01e6347834b6aec93b20fb986eb)

