### PR TITLE
chore: improve logging on compaction failures (#26545)

### DIFF
--- a/tsdb/engine/tsm1/compact.go
+++ b/tsdb/engine/tsm1/compact.go
@@ -69,6 +69,11 @@ func (e errCompactionInProgress) Unwrap() error {
 	return e.err
 }
 
+func (e errCompactionInProgress) Is(target error) bool {
+	_, ok := target.(errCompactionInProgress)
+	return ok
+}
+
 type errCompactionAborted struct {
 	err error
 }
@@ -78,6 +83,15 @@ func (e errCompactionAborted) Error() string {
 		return fmt.Sprintf("compaction aborted: %s", e.err)
 	}
 	return "compaction aborted"
+}
+
+func (e errCompactionAborted) Unwrap() error {
+	return e.err
+}
+
+func (e errCompactionAborted) Is(target error) bool {
+	_, ok := target.(errCompactionAborted)
+	return ok
 }
 
 type errBlockRead struct {
@@ -1048,7 +1062,7 @@ func (c *Compactor) CompactFull(tsmFiles []string, logger *zap.Logger, pointsPer
 	c.mu.RUnlock()
 
 	if !enabled {
-		if err := c.RemoveTmpFiles(files); err != nil {
+		if err := removeTmpFiles(files); err != nil {
 			return nil, err
 		}
 		return nil, errCompactionsDisabled
@@ -1080,7 +1094,7 @@ func (c *Compactor) CompactFast(tsmFiles []string, logger *zap.Logger, pointsPer
 	c.mu.RUnlock()
 
 	if !enabled {
-		if err := c.RemoveTmpFiles(files); err != nil {
+		if err := removeTmpFiles(files); err != nil {
 			return nil, err
 		}
 		return nil, errCompactionsDisabled
@@ -1090,9 +1104,9 @@ func (c *Compactor) CompactFast(tsmFiles []string, logger *zap.Logger, pointsPer
 
 }
 
-// RemoveTmpFiles is responsible for cleaning up a compaction that
+// removeTmpFiles is responsible for cleaning up a compaction that
 // was started, but then abandoned before the temporary files were dealt with.
-func (c *Compactor) RemoveTmpFiles(files []string) error {
+func removeTmpFiles(files []string) error {
 	var errs []error
 	for _, f := range files {
 		if err := os.Remove(f); err != nil {
@@ -1102,8 +1116,8 @@ func (c *Compactor) RemoveTmpFiles(files []string) error {
 	return errors.Join(errs...)
 }
 
-func (c *Compactor) RemoveTmpFilesOnErr(files []string, originalErrs ...error) error {
-	removeErr := c.RemoveTmpFiles(files)
+func removeTmpFilesOnErr(files []string, originalErrs ...error) error {
+	removeErr := removeTmpFiles(files)
 	if removeErr == nil {
 		if len(originalErrs) == 1 {
 			return originalErrs[0]
@@ -1146,7 +1160,7 @@ func (c *Compactor) writeNewFiles(generation, sequence int, src []string, iter K
 			// file that we can drop.
 			if err := os.RemoveAll(fileName); err != nil {
 				// Only return an error if we couldn't remove the temp files
-				return nil, c.RemoveTmpFilesOnErr(files, err)
+				return nil, removeTmpFilesOnErr(files, err)
 			}
 			break
 		} else if errors.As(err, &eInProgress) {
@@ -1159,12 +1173,12 @@ func (c *Compactor) writeNewFiles(generation, sequence int, src []string, iter K
 			}
 			// We hit an error and didn't finish the compaction.  Abort.
 			// Remove any tmp files we already completed
-			return nil, c.RemoveTmpFilesOnErr(files, err)
+			return nil, removeTmpFilesOnErr(files, err)
 		} else if err != nil {
 			// We hit an error and didn't finish the compaction.  Abort.
 			// Remove any tmp files we already completed, as well as the current
 			// file we were writing to.
-			return nil, c.RemoveTmpFilesOnErr(files, err, os.RemoveAll(fileName))
+			return nil, removeTmpFilesOnErr(files, err, os.RemoveAll(fileName))
 		}
 
 		files = append(files, fileName)

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -2604,21 +2604,21 @@ func (s *compactionStrategy) compactGroup() {
 
 	if err != nil {
 		defer func(fs []string) {
-			if removeErr := s.compactor.RemoveTmpFiles(fs); removeErr != nil {
-				log.Warn("Unable to remove temporary file(s)", zap.Error(removeErr))
+			if removeErr := removeTmpFiles(fs); removeErr != nil {
+				log.Error("Unable to remove temporary file(s)", zap.Error(removeErr), zap.Strings("files", fs))
 			}
 		}(files)
-		_, inProgress := err.(errCompactionInProgress)
-		if err == errCompactionsDisabled || inProgress {
+		inProgress := errors.Is(err, errCompactionInProgress{})
+		if errors.Is(err, errCompactionsDisabled) || inProgress {
 			log.Info("Aborted compaction", zap.Error(err))
 
-			if _, ok := err.(errCompactionInProgress); ok {
+			if inProgress {
 				time.Sleep(time.Second)
 			}
 			return
 		}
 
-		log.Warn("Error compacting TSM files", zap.Error(err))
+		log.Error("Error compacting TSM files", zap.Error(err))
 
 		MoveTsmOnReadErr(err, log, s.fileStore.Replace)
 
@@ -2644,8 +2644,7 @@ func (s *compactionStrategy) compactGroup() {
 	for i, f := range files {
 		log.Info("Compacted file", zap.Int("tsm1_index", i), zap.String("tsm1_file", f))
 	}
-	log.Info("Finished compacting files",
-		zap.Int("tsm1_files_n", len(files)))
+	log.Info("Finished compacting and renaming files", zap.Int("count", len(files)), zap.Strings("files", files))
 }
 
 func MoveTsmOnReadErr(err error, log *zap.Logger, replaceFn func([]string, []string) error) {
@@ -2655,9 +2654,9 @@ func MoveTsmOnReadErr(err error, log *zap.Logger, replaceFn func([]string, []str
 		path := blockReadErr.file
 		log.Info("Renaming a corrupt TSM file due to compaction error", zap.String("file", path), zap.Error(err))
 		if err := replaceFn([]string{path}, nil); err != nil {
-			log.Info("Error removing bad TSM file", zap.String("file", path), zap.Error(err))
+			log.Error("Failed removing bad TSM file", zap.String("file", path), zap.Error(err))
 		} else if e := os.Rename(path, path+"."+BadTSMFileExtension); e != nil {
-			log.Info("Error renaming corrupt TSM file", zap.String("file", path), zap.Error(err))
+			log.Error("Failed renaming corrupt TSM file", zap.String("file", path), zap.Error(err))
 		}
 	}
 }


### PR DESCRIPTION
Streamline compaction logging, while
providing more information to debug
remnant temporary files.

(cherry picked from commit ea36c5ff479fcaf14dd123dde4014039cf2d38ee)

