### PR TITLE
fix: full compactions not scheduled under some circumstances

### DIFF
--- a/tsdb/engine/tsm1/compact.go
+++ b/tsdb/engine/tsm1/compact.go
@@ -776,6 +776,14 @@ func (c *DefaultPlanner) Release(groups []CompactionGroup) {
 	}
 }
 
+// InUseCount returns the number of files currently locked as in-use.
+// This method is primarily useful for test validation.
+func (c *DefaultPlanner) InUseCount() int {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	return len(c.filesInUse)
+}
+
 // Compactor merges multiple TSM files into new files or
 // writes a Cache into 1 or more TSM files.
 type Compactor struct {

--- a/tsdb/engine/tsm1/compact_test.go
+++ b/tsdb/engine/tsm1/compact_test.go
@@ -2912,7 +2912,7 @@ func TestEnginePlanCompactions(t *testing.T) {
 		// so we can simulate the passage of time in tests
 		testShardTime time.Duration
 		// Each result is for the different plantypes
-		getResultByPlanType func(planType tsm1.PlanType) testLevelResults
+		expectedResult func() testLevelResults
 	}
 
 	tests := []testEnginePlanCompactionsRunner{
@@ -2949,8 +2949,8 @@ func TestEnginePlanCompactions(t *testing.T) {
 				},
 			},
 			testShardTime: -1,
-			getResultByPlanType: func(planType tsm1.PlanType) testLevelResults {
-				common := testLevelResults{
+			expectedResult: func() testLevelResults {
+				return testLevelResults{
 					level5Groups: []tsm1.PlannedCompactionGroup{
 						{
 							tsm1.CompactionGroup{"01-05.tsm", "02-05.tsm", "03-05.tsm", "04-04.tsm"},
@@ -2958,13 +2958,6 @@ func TestEnginePlanCompactions(t *testing.T) {
 						},
 					},
 				}
-				switch planType {
-				case tsm1.PT_Standard, tsm1.PT_SmartOptimize:
-					return common
-				case tsm1.PT_NoOptimize:
-					return testLevelResults{}
-				}
-				return testLevelResults{}
 			},
 		},
 		{
@@ -3042,8 +3035,8 @@ func TestEnginePlanCompactions(t *testing.T) {
 				},
 			},
 			testShardTime: -1,
-			getResultByPlanType: func(planType tsm1.PlanType) testLevelResults {
-				common := testLevelResults{
+			expectedResult: func() testLevelResults {
+				return testLevelResults{
 					level5Groups: []tsm1.PlannedCompactionGroup{
 						{
 							tsm1.CompactionGroup{"01-05.tsm1", "01-06.tsm1", "01-07.tsm1", "01-08.tsm1", "02-05.tsm1", "02-06.tsm1", "02-07.tsm1", "02-08.tsm1", "03-04.tsm1", "03-05.tsm1"},
@@ -3051,14 +3044,6 @@ func TestEnginePlanCompactions(t *testing.T) {
 						},
 					},
 				}
-
-				switch planType {
-				case tsm1.PT_Standard, tsm1.PT_SmartOptimize:
-					return common
-				case tsm1.PT_NoOptimize:
-					return testLevelResults{}
-				}
-				return testLevelResults{}
 			},
 		},
 		{
@@ -3091,8 +3076,8 @@ func TestEnginePlanCompactions(t *testing.T) {
 				},
 			},
 			testShardTime: -1,
-			getResultByPlanType: func(planType tsm1.PlanType) testLevelResults {
-				common := testLevelResults{
+			expectedResult: func() testLevelResults {
+				return testLevelResults{
 					level5Groups: []tsm1.PlannedCompactionGroup{
 						{
 							tsm1.CompactionGroup{"01-05.tsm1",
@@ -3104,14 +3089,6 @@ func TestEnginePlanCompactions(t *testing.T) {
 						},
 					},
 				}
-
-				switch planType {
-				case tsm1.PT_Standard, tsm1.PT_SmartOptimize:
-					return common
-				case tsm1.PT_NoOptimize:
-					return testLevelResults{}
-				}
-				return testLevelResults{}
 			},
 		},
 		{
@@ -3132,8 +3109,8 @@ func TestEnginePlanCompactions(t *testing.T) {
 				},
 			}.ToExtFileStats(),
 			testShardTime: -1,
-			getResultByPlanType: func(planType tsm1.PlanType) testLevelResults {
-				common := testLevelResults{
+			expectedResult: func() testLevelResults {
+				return testLevelResults{
 					level5Groups: []tsm1.PlannedCompactionGroup{
 						{
 							tsm1.CompactionGroup{"01-02.tsm1",
@@ -3144,14 +3121,6 @@ func TestEnginePlanCompactions(t *testing.T) {
 						},
 					},
 				}
-
-				switch planType {
-				case tsm1.PT_Standard, tsm1.PT_SmartOptimize:
-					return common
-				case tsm1.PT_NoOptimize:
-					return testLevelResults{}
-				}
-				return testLevelResults{}
 			},
 		},
 		{
@@ -3176,8 +3145,8 @@ func TestEnginePlanCompactions(t *testing.T) {
 			}.ToExtFileStats(),
 			defaultBlockCount: tsdb.DefaultMaxPointsPerBlock,
 			testShardTime:     -1,
-			getResultByPlanType: func(planType tsm1.PlanType) testLevelResults {
-				common := testLevelResults{
+			expectedResult: func() testLevelResults {
+				return testLevelResults{
 					level5Groups: []tsm1.PlannedCompactionGroup{
 						{
 							tsm1.CompactionGroup{"01-05.tsm1",
@@ -3189,14 +3158,6 @@ func TestEnginePlanCompactions(t *testing.T) {
 						},
 					},
 				}
-
-				switch planType {
-				case tsm1.PT_Standard, tsm1.PT_SmartOptimize:
-					return common
-				case tsm1.PT_NoOptimize:
-					return testLevelResults{}
-				}
-				return testLevelResults{}
 			},
 		},
 		{
@@ -3260,8 +3221,8 @@ func TestEnginePlanCompactions(t *testing.T) {
 				},
 			},
 			testShardTime: -1,
-			getResultByPlanType: func(planType tsm1.PlanType) testLevelResults {
-				common := testLevelResults{
+			expectedResult: func() testLevelResults {
+				return testLevelResults{
 					level5Groups: []tsm1.PlannedCompactionGroup{
 						{
 							tsm1.CompactionGroup{"01-05.tsm1",
@@ -3277,14 +3238,6 @@ func TestEnginePlanCompactions(t *testing.T) {
 						},
 					},
 				}
-
-				switch planType {
-				case tsm1.PT_Standard, tsm1.PT_SmartOptimize:
-					return common
-				case tsm1.PT_NoOptimize:
-					return testLevelResults{}
-				}
-				return testLevelResults{}
 			},
 		},
 		{
@@ -3314,8 +3267,8 @@ func TestEnginePlanCompactions(t *testing.T) {
 			},
 
 			testShardTime: -1,
-			getResultByPlanType: func(planType tsm1.PlanType) testLevelResults {
-				common := testLevelResults{
+			expectedResult: func() testLevelResults {
+				return testLevelResults{
 					level5Groups: []tsm1.PlannedCompactionGroup{
 						{
 							tsm1.CompactionGroup{"01-13.tsm1",
@@ -3326,14 +3279,6 @@ func TestEnginePlanCompactions(t *testing.T) {
 						},
 					},
 				}
-
-				switch planType {
-				case tsm1.PT_Standard, tsm1.PT_SmartOptimize:
-					return common
-				case tsm1.PT_NoOptimize:
-					return testLevelResults{}
-				}
-				return testLevelResults{}
 			},
 		},
 		{
@@ -3349,7 +3294,7 @@ func TestEnginePlanCompactions(t *testing.T) {
 				},
 			}.ToExtFileStats(),
 			testShardTime: -1,
-			getResultByPlanType: func(planType tsm1.PlanType) testLevelResults {
+			expectedResult: func() testLevelResults {
 				return testLevelResults{}
 			},
 		},
@@ -3370,7 +3315,7 @@ func TestEnginePlanCompactions(t *testing.T) {
 			}.ToExtFileStats(),
 			defaultBlockCount: tsdb.DefaultAggressiveMaxPointsPerBlock,
 			testShardTime:     -1,
-			getResultByPlanType: func(planType tsm1.PlanType) testLevelResults {
+			expectedResult: func() testLevelResults {
 				return testLevelResults{}
 			},
 		},
@@ -3397,7 +3342,7 @@ func TestEnginePlanCompactions(t *testing.T) {
 				},
 			},
 			testShardTime: -1,
-			getResultByPlanType: func(planType tsm1.PlanType) testLevelResults {
+			expectedResult: func() testLevelResults {
 				return testLevelResults{}
 			},
 		},
@@ -3421,7 +3366,7 @@ func TestEnginePlanCompactions(t *testing.T) {
 			}.ToExtFileStats(),
 			defaultBlockCount: tsdb.DefaultAggressiveMaxPointsPerBlock,
 			testShardTime:     -1,
-			getResultByPlanType: func(planType tsm1.PlanType) testLevelResults {
+			expectedResult: func() testLevelResults {
 				return testLevelResults{}
 			},
 		},
@@ -3479,8 +3424,8 @@ func TestEnginePlanCompactions(t *testing.T) {
 				},
 			}.ToExtFileStats(),
 			testShardTime: -1,
-			getResultByPlanType: func(planType tsm1.PlanType) testLevelResults {
-				common := testLevelResults{
+			expectedResult: func() testLevelResults {
+				return testLevelResults{
 					level5Groups: []tsm1.PlannedCompactionGroup{
 						{
 							tsm1.CompactionGroup{"01-05.tsm1",
@@ -3499,14 +3444,6 @@ func TestEnginePlanCompactions(t *testing.T) {
 						},
 					},
 				}
-
-				switch planType {
-				case tsm1.PT_Standard, tsm1.PT_SmartOptimize:
-					return common
-				case tsm1.PT_NoOptimize:
-					return testLevelResults{}
-				}
-				return testLevelResults{}
 			},
 		},
 		{
@@ -3602,8 +3539,8 @@ func TestEnginePlanCompactions(t *testing.T) {
 				},
 			},
 			testShardTime: -1,
-			getResultByPlanType: func(planType tsm1.PlanType) testLevelResults {
-				common := testLevelResults{
+			expectedResult: func() testLevelResults {
+				return testLevelResults{
 					level5Groups: []tsm1.PlannedCompactionGroup{
 						{
 							tsm1.CompactionGroup{
@@ -3622,14 +3559,6 @@ func TestEnginePlanCompactions(t *testing.T) {
 							}, tsdb.DefaultAggressiveMaxPointsPerBlock},
 					},
 				}
-
-				switch planType {
-				case tsm1.PT_Standard, tsm1.PT_SmartOptimize:
-					return common
-				case tsm1.PT_NoOptimize:
-					return testLevelResults{}
-				}
-				return testLevelResults{}
 			},
 		},
 		{
@@ -4123,8 +4052,8 @@ func TestEnginePlanCompactions(t *testing.T) {
 			},
 			defaultBlockCount: tsdb.DefaultMaxPointsPerBlock,
 			testShardTime:     -1,
-			getResultByPlanType: func(planType tsm1.PlanType) testLevelResults {
-				common := testLevelResults{
+			expectedResult: func() testLevelResults {
+				return testLevelResults{
 					level5Groups: []tsm1.PlannedCompactionGroup{
 						{
 							tsm1.CompactionGroup{
@@ -4213,14 +4142,6 @@ func TestEnginePlanCompactions(t *testing.T) {
 						},
 					},
 				}
-
-				switch planType {
-				case tsm1.PT_Standard, tsm1.PT_SmartOptimize:
-					return common
-				case tsm1.PT_NoOptimize:
-					return testLevelResults{}
-				}
-				return testLevelResults{}
 			},
 		},
 		{
@@ -4326,8 +4247,8 @@ func TestEnginePlanCompactions(t *testing.T) {
 				},
 			},
 			testShardTime: -1,
-			getResultByPlanType: func(planType tsm1.PlanType) testLevelResults {
-				standard := testLevelResults{
+			expectedResult: func() testLevelResults {
+				return testLevelResults{
 					level1Groups: []tsm1.PlannedCompactionGroup{
 						{
 							tsm1.CompactionGroup{"05-01.tsm", "06-01.tsm", "07-01.tsm", "08-01.tsm", "09-01.tsm", "10-01.tsm", "11-01.tsm", "12-01.tsm"},
@@ -4341,23 +4262,6 @@ func TestEnginePlanCompactions(t *testing.T) {
 						},
 					},
 				}
-
-				common := testLevelResults{
-					level1Groups: []tsm1.PlannedCompactionGroup{
-						{
-							tsm1.CompactionGroup{"05-01.tsm", "06-01.tsm", "07-01.tsm", "08-01.tsm", "09-01.tsm", "10-01.tsm", "11-01.tsm", "12-01.tsm"},
-							tsdb.DefaultMaxPointsPerBlock,
-						},
-					},
-				}
-
-				switch planType {
-				case tsm1.PT_Standard:
-					return standard
-				case tsm1.PT_SmartOptimize, tsm1.PT_NoOptimize:
-					return common
-				}
-				return testLevelResults{}
 			},
 		},
 		{
@@ -4463,8 +4367,8 @@ func TestEnginePlanCompactions(t *testing.T) {
 				},
 			},
 			testShardTime: -1,
-			getResultByPlanType: func(planType tsm1.PlanType) testLevelResults {
-				standard := testLevelResults{
+			expectedResult: func() testLevelResults {
+				return testLevelResults{
 					level1Groups: []tsm1.PlannedCompactionGroup{
 						{
 							tsm1.CompactionGroup{"05-01.tsm", "06-01.tsm", "07-01.tsm", "08-01.tsm", "09-01.tsm", "10-01.tsm", "11-01.tsm", "12-01.tsm"},
@@ -4478,23 +4382,6 @@ func TestEnginePlanCompactions(t *testing.T) {
 						},
 					},
 				}
-
-				common := testLevelResults{
-					level1Groups: []tsm1.PlannedCompactionGroup{
-						{
-							tsm1.CompactionGroup{"05-01.tsm", "06-01.tsm", "07-01.tsm", "08-01.tsm", "09-01.tsm", "10-01.tsm", "11-01.tsm", "12-01.tsm"},
-							tsdb.DefaultMaxPointsPerBlock,
-						},
-					},
-				}
-
-				switch planType {
-				case tsm1.PT_Standard:
-					return standard
-				case tsm1.PT_SmartOptimize, tsm1.PT_NoOptimize:
-					return common
-				}
-				return testLevelResults{}
 			},
 		},
 		{
@@ -4601,8 +4488,8 @@ func TestEnginePlanCompactions(t *testing.T) {
 				},
 			},
 			testShardTime: -1,
-			getResultByPlanType: func(planType tsm1.PlanType) testLevelResults {
-				standard := testLevelResults{
+			expectedResult: func() testLevelResults {
+				return testLevelResults{
 					level1Groups: []tsm1.PlannedCompactionGroup{
 						{
 							tsm1.CompactionGroup{"05-01.tsm", "06-01.tsm", "07-01.tsm", "08-01.tsm", "09-01.tsm", "10-01.tsm", "11-01.tsm", "12-01.tsm"},
@@ -4616,23 +4503,6 @@ func TestEnginePlanCompactions(t *testing.T) {
 						},
 					},
 				}
-
-				common := testLevelResults{
-					level1Groups: []tsm1.PlannedCompactionGroup{
-						{
-							tsm1.CompactionGroup{"05-01.tsm", "06-01.tsm", "07-01.tsm", "08-01.tsm", "09-01.tsm", "10-01.tsm", "11-01.tsm", "12-01.tsm"},
-							tsdb.DefaultMaxPointsPerBlock,
-						},
-					},
-				}
-
-				switch planType {
-				case tsm1.PT_Standard:
-					return standard
-				case tsm1.PT_SmartOptimize, tsm1.PT_NoOptimize:
-					return common
-				}
-				return testLevelResults{}
 			},
 		},
 	}
@@ -4644,49 +4514,41 @@ func TestEnginePlanCompactions(t *testing.T) {
 	e.Compactor = tsm1.NewCompactor()
 	defer e.Compactor.Close()
 
-	for i := 0; i < 3; i++ {
-		for _, test := range tests {
-			var testName string
-			switch i {
-			case 0:
-				testName = test.name + "_PT_Standard"
-			case 1:
-				testName = test.name + "_PT_SmartOptimize"
-			case 2:
-				testName = test.name + "_PT_NoOptimize"
-			}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ffs := newFakeFileStore(withExtFileStats(test.files), withDefaultBlockCount(test.defaultBlockCount))
+			cp := tsm1.NewDefaultPlanner(ffs, test.testShardTime)
 
-			t.Run(testName, func(t *testing.T) {
-				ffs := newFakeFileStore(withExtFileStats(test.files), withDefaultBlockCount(test.defaultBlockCount))
-				cp := tsm1.NewDefaultPlanner(ffs, test.testShardTime)
+			e.MaxPointsPerBlock = tsdb.DefaultMaxPointsPerBlock
+			e.CompactionPlan = cp
+			e.Compactor.FileStore = ffs
 
-				e.MaxPointsPerBlock = tsdb.DefaultMaxPointsPerBlock
-				e.CompactionPlan = cp
-				e.Compactor.FileStore = ffs
-
-				// Arbitrary group length to use in Scheduler.SetDepth
-				mockGroupLen := 5
-				// Set the scheduler depth for our lower level groups.
-				// During PT_Standard this should still plan a level5 compaction group
-				// but during PT_SmartOptimize this should not.
-				e.Scheduler.SetDepth(1, mockGroupLen)
-				e.Scheduler.SetDepth(2, mockGroupLen)
+			// Arbitrary group length to use in Scheduler.SetDepth
+			mockGroupLen := 5
+			// Set the scheduler depth for our lower level groups.
+			e.Scheduler.SetDepth(1, mockGroupLen)
+			e.Scheduler.SetDepth(2, mockGroupLen)
 
 				// Normally this is called within PlanCompactions but because we want to simulate already running
 				// some compactions we will set them manually here.
 				e.Scheduler.SetActive(1, int64(mockGroupLen))
 				e.Scheduler.SetActive(2, int64(mockGroupLen))
 
-				// Should use PlanType 0 (PT_Standard), 1(PT_SmartOptimize), 2(PT_NoOptimize)
-				planType := tsm1.PlanType(i)
-				level1Groups, level2Groups, Level3Groups, Level4Groups, Level5Groups := e.PlanCompactions(planType)
-				compareLevelGroups(t, test.getResultByPlanType(planType).level1Groups, level1Groups, "unexpected level 1 Group")
-				compareLevelGroups(t, test.getResultByPlanType(planType).level2Groups, level2Groups, "unexpected level 2 Group")
-				compareLevelGroups(t, test.getResultByPlanType(planType).level3Groups, Level3Groups, "unexpected level 3 Group")
-				compareLevelGroups(t, test.getResultByPlanType(planType).level4Groups, Level4Groups, "unexpected level 4 Group")
-				compareLevelGroups(t, test.getResultByPlanType(planType).level5Groups, Level5Groups, "unexpected level 5 Group")
-			})
-		}
+			// Plan and check results.
+			level1Groups, level2Groups, Level3Groups, Level4Groups, Level5Groups := e.PlanCompactions()
+			results := test.expectedResult()
+			compareLevelGroups(t, results.level1Groups, level1Groups, "unexpected level 1 Group")
+			compareLevelGroups(t, results.level2Groups, level2Groups, "unexpected level 2 Group")
+			compareLevelGroups(t, results.level3Groups, Level3Groups, "unexpected level 3 Group")
+			compareLevelGroups(t, results.level4Groups, Level4Groups, "unexpected level 4 Group")
+			compareLevelGroups(t, results.level5Groups, Level5Groups, "unexpected level 5 Group")
+
+			// Remove all the returned compaction levels and verify that no TSM files are marked as in-use.
+			// Calling e.PlanCompactions followed by e.ReleaseCompactionPlans replicates the code structure
+			// of the e.compact loop.
+			e.ReleaseCompactionPlans(level1Groups, level2Groups, Level3Groups, Level4Groups, Level5Groups)
+			require.Zero(t, cp.InUseCount(), "some TSM files were not released properly")
+		})
 	}
 }
 

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -2123,14 +2123,6 @@ const optimizationHoldoff = 5 * time.Minute
 // tickPeriod is the interval between successive compaction loops.
 const tickPeriod = time.Second
 
-func (e *Engine) GetPlanTypeBasedOnHoldOff(start time.Time, dur time.Duration) PlanType {
-	planType := PT_SmartOptimize
-	if time.Since(start) < dur {
-		planType = PT_NoOptimize
-	}
-	return planType
-}
-
 func (e *Engine) compact(wg *sync.WaitGroup) {
 	t := time.NewTicker(tickPeriod)
 	defer t.Stop()
@@ -2154,18 +2146,26 @@ func (e *Engine) compact(wg *sync.WaitGroup) {
 
 		case <-t.C:
 
-			// Determine if we should do a smart optimized plan or skip optimizations in the plan.
-			planType := e.GetPlanTypeBasedOnHoldOff(optHoldoffStart, optHoldoffDuration)
+			level1Groups, level2Groups, level3Groups, level4Groups, level5Groups := e.PlanCompactions()
 
-			level1Groups, level2Groups, level3Groups, level4Groups, level5Groups := e.PlanCompactions(planType)
 			// Set the queue depths on the scheduler
 			// Use the real queue depth, dependent on acquiring
 			// the file locks.
+
+			// If we are in the optimize holdoff period, do not look at anything in level 5.
+			// Using 0 for the level 5 depth will make Scheduler.next() not pick level 5.
+			// level5Groups will still be available for cleanup later to avoid blocking TSM
+			// files from compaction.
+			var l5GroupCount int
+			if time.Since(optHoldoffStart) >= optHoldoffDuration {
+				l5GroupCount = len(level5Groups)
+			}
+
 			e.Scheduler.SetDepth(1, len(level1Groups))
 			e.Scheduler.SetDepth(2, len(level2Groups))
 			e.Scheduler.SetDepth(3, len(level3Groups))
 			e.Scheduler.SetDepth(4, len(level4Groups))
-			e.Scheduler.SetDepth(5, len(level5Groups))
+			e.Scheduler.SetDepth(5, l5GroupCount)
 
 			// Find the next compaction that can run and try to kick it off
 			if level, runnable := e.Scheduler.next(); runnable {
@@ -2217,12 +2217,12 @@ func (e *Engine) compact(wg *sync.WaitGroup) {
 			}
 
 			// Release all the plans we didn't start.
-			e.releaseCompactionPlans(level1Groups, level2Groups, level3Groups, level4Groups, level5Groups)
+			e.ReleaseCompactionPlans(level1Groups, level2Groups, level3Groups, level4Groups, level5Groups)
 		}
 	}
 }
 
-func (e *Engine) releaseCompactionPlans(
+func (e *Engine) ReleaseCompactionPlans(
 	level1Groups []PlannedCompactionGroup,
 	level2Groups []PlannedCompactionGroup,
 	level3Groups []PlannedCompactionGroup,
@@ -2273,18 +2273,6 @@ type PlannedCompactionGroup struct {
 // PlanType modifies how PlanCompactions operates.
 type PlanType int
 
-const (
-	// PT_Standard indicates the classic planner that plans all levels all the the time.
-	PT_Standard PlanType = iota
-
-	// PT_SmartOptimize follows a few basic rules to avoid planning optimized compactions unless
-	// they will be used.
-	PT_SmartOptimize
-
-	// PT_NotOptimized indicates that optimized compactions should not planned.
-	PT_NoOptimize
-)
-
 func makePlannedCompactionGroup(groups []CompactionGroup, pointsPerBlock int) []PlannedCompactionGroup {
 	planned := make([]PlannedCompactionGroup, 0, len(groups))
 	for _, g := range groups {
@@ -2301,34 +2289,22 @@ func (e *Engine) planCompactionsLevel(level int) []PlannedCompactionGroup {
 	return makePlannedCompactionGroup(groups, tsdb.DefaultMaxPointsPerBlock)
 }
 
-func (e *Engine) planCompactionsInner(planType PlanType) ([]PlannedCompactionGroup, []PlannedCompactionGroup, []PlannedCompactionGroup, []PlannedCompactionGroup, []PlannedCompactionGroup) {
+func (e *Engine) planCompactionsInner() ([]PlannedCompactionGroup, []PlannedCompactionGroup, []PlannedCompactionGroup, []PlannedCompactionGroup, []PlannedCompactionGroup) {
 	// Find our compaction plans
 	level1Groups := e.planCompactionsLevel(1)
 	level2Groups := e.planCompactionsLevel(2)
 	level3Groups := e.planCompactionsLevel(3)
 	l4Groups, _ := e.CompactionPlan.Plan(e.LastModified())
-
-	if planType == PT_SmartOptimize {
-		level, runnable := e.Scheduler.nextByQueueDepths([TotalCompactionLevels]int{len(level1Groups), len(level2Groups), len(level3Groups), len(l4Groups), 0})
-		// We don't stop if level 4 is runnable because we need to continue on and check for group 4 to group 5 promotions if
-		// group 4 is the runnable group.
-		if runnable && level <= 3 {
-			// We know that the compaction loop will pull a compaction group from levels 1-4, so no need to plan level 5.
-			return level1Groups, level2Groups, level3Groups, nil, nil
-		}
-	}
+	l5Groups, _, l5GenCount := e.CompactionPlan.PlanOptimize(e.LastModified())
 
 	// Some groups in level 4 may contain already optimized files. In these cases, it is
 	// desireable to maintain optimization for the entire group to avoid "going backwards" on the
 	// optimization level. For instance, if an optimized cold shard had back-fill data
 	// added to it, we should maintain the optimization to avoid unoptimizing the bulk of
 	// the shards only to need to reoptimize them later.
-	// However, the work to promote level4's to level 5's created issues in 1.12.1rc0, so the promotion logic
-	// has been removed. Re-enabling the promotion logic efficiently probably requires some caching of whether a
-	// compaction group is already optimized so we don't have to determine that every time through the compaction loop.
 	// In an ideal world, CompactionPlan.Plan and CompactionPlan.PlanOptimize might handle this.
 	level4Groups := make([]PlannedCompactionGroup, 0, len(l4Groups))
-	level5Groups := make([]PlannedCompactionGroup, 0, len(l4Groups)) // All level 4 groups could be promoted to level 5.
+	level5Groups := make([]PlannedCompactionGroup, 0, len(l4Groups)+len(l5Groups)) // All level 4 groups could be promoted to level 5.
 	for _, group := range l4Groups {
 		if isOpt, filename, heur := e.IsGroupOptimized(group); isOpt {
 			// Info level logging would be too noisy.
@@ -2351,28 +2327,11 @@ func (e *Engine) planCompactionsInner(planType PlanType) ([]PlannedCompactionGro
 		}
 	}
 
-	if planType == PT_NoOptimize {
-		// For PT_NoOptimize, throw away any promoted level 5 groups and return what we have for level 1 through 4.
-		// Our behavior changes depending what the plan type is.
-		return level1Groups, level2Groups, level3Groups, level4Groups, nil
-	} else if planType == PT_SmartOptimize {
-		level, runnable := e.Scheduler.nextByQueueDepths([TotalCompactionLevels]int{len(level1Groups), len(level2Groups), len(level3Groups), len(level4Groups), len(level5Groups)})
-		if runnable && level <= 5 {
-			// We know that the compaction loop will pull from something already planned, no need to go any further for smart optimize.
-			return level1Groups, level2Groups, level3Groups, level4Groups, level5Groups
-		}
-	}
-
-	// At this point, we are either planning PT_Standard or we are planning PT_SmartOptimize and haven't found anything to run yet. Look
-	// for level 5s using PlanOptimize.
-	// There is potential to limit the number of compaction groups returned by PlanOptimize when planType == PT_SmartOptimized, but
-	// the win is probably small compared to other optimizations that have already been added for PT_SmartOptimize.
-	plannedLevel5Groups, _, genCount := e.CompactionPlan.PlanOptimize(e.LastModified())
-
-	for _, group := range plannedLevel5Groups {
+	// Now append all the groups that started as level 5 so they will get picked after promoted level 4 groups. Also determine they're points-per-block.
+	for _, group := range l5Groups {
 		// If a level5 optimized compaction group is a single generation. We will need to rewrite
 		// the files at a higher points per block count in order to fully compact them in to a single TSM file.
-		if genCount == 1 {
+		if l5GenCount == 1 {
 			e.logger.Debug("Planned optimized level 5 compactions belong to single generation. All groups will use aggressive points per block.")
 			level5Groups = append(level5Groups, PlannedCompactionGroup{
 				Group:          group,
@@ -2397,19 +2356,14 @@ func (e *Engine) planCompactionsInner(planType PlanType) ([]PlannedCompactionGro
 				})
 
 			}
-
-			if planType == PT_SmartOptimize && len(level5Groups) >= 1 {
-				// We know the optimization loop will only look at 1 compaction group in level 5.
-				break
-			}
 		}
 	}
 
 	return level1Groups, level2Groups, level3Groups, level4Groups, level5Groups
 }
 
-func (e *Engine) PlanCompactions(planType PlanType) ([]PlannedCompactionGroup, []PlannedCompactionGroup, []PlannedCompactionGroup, []PlannedCompactionGroup, []PlannedCompactionGroup) {
-	l1, l2, l3, l4, l5 := e.planCompactionsInner(planType)
+func (e *Engine) PlanCompactions() ([]PlannedCompactionGroup, []PlannedCompactionGroup, []PlannedCompactionGroup, []PlannedCompactionGroup, []PlannedCompactionGroup) {
+	l1, l2, l3, l4, l5 := e.planCompactionsInner()
 
 	// Update the level plan queue stats
 	// For stats, use the length needed, even if the lock was


### PR DESCRIPTION
Fix issue introduced with 1.12.1 that caused some TSM files to not be scheduled for full compaction when they should be. The user visible symptom was an unbounded increase in disk space for impacted shards.

This simplifies the compaction planning code by removing the PT_SmartOptimize and PT_NoOptimize special cases. These are no longer needed for performance thanks to the first block caching code that was also added in #26432. Issues with the PT_SmartOptimize and PT_NoOptimize cases could cause TSM files to be locked by the compaction planner as in-use, preventing them from being compacted.

The optimized compaction hold-off is now handled entirely in Engine.compact rather than by the compaction planner.

Update test cases as necessary for changes, plus add checks for issue that caused #26667.

Closes: #26667
(cherry picked from commit 22bec4f046a28e3f1fa815705362767151407e1b)