### PR TITLE
fix: [httpd] https-insecure-certificate not handled properly

### DIFF
--- a/services/httpd/service.go
+++ b/services/httpd/service.go
@@ -160,7 +160,7 @@ func (s *Service) Open() error {
 
 	// Open listener.
 	tm, err := tlsconfig.NewTLSConfigManager(s.https, s.tlsConfig, s.cert, s.key, false,
-		tlsconfig.WithAllowInsecure(s.insecureCert),
+		tlsconfig.WithIgnoreFilePermissions(s.insecureCert),
 		tlsconfig.WithLogger(s.Logger))
 	if err != nil {
 		return fmt.Errorf("httpd: error creating TLS manager: %w", err)


### PR DESCRIPTION
Fix issue with [httpd] https-insecure-certificate not properly ignoring certificate file permissions. Added tests for verifying the httpd service's TLSConfigManager is properly configured from the configuration.