### PR TITLE
fix(py): update to python 3.13.12-20260211 for pip security fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,7 +146,7 @@ parameters:
   # Consistent environment setup for Python Build Standalone
   PBS_DATE:
     type: string
-    default: "20260203"
+    default: "20260211"
   PBS_VERSION:
     type: string
     default: "3.13.12"


### PR DESCRIPTION
Update PBS_DATE to 20260211 to pull in pip 26.0.1: https://github.com/astral-sh/python-build-standalone/releases/tag/20260211

Testing in x86_64 linux (ubuntu 24.04):

<details>

```
$ ./python/bin/python --version
Python 3.13.12

$ ./influxdb3 --version
influxdb3 3.10.0-nightly, revision 3c69b91badd4bfc1849b74574f25ccf063a6fec1

$ mkdir plugins

$ cat > plugins/test-sched.py << 'EOF'
import importlib.util

def _tst_log(influxdb3_local):
    influxdb3_local.info("_tst_log(): success")

def _tst_sys(influxdb3_local):
    try:
        import sys
        influxdb3_local.info("_tst_sys(): sys.prefix = %s" % sys.prefix)
        influxdb3_local.info("_tst_sys(): sys.exec_prefix = %s" % sys.exec_prefix)
        influxdb3_local.info("_tst_sys(): sys.base_prefix = %s" % sys.base_prefix)
        influxdb3_local.info("_tst_sys(): sys.base_exec_prefix = %s" % sys.base_exec_prefix)
        influxdb3_local.info("_tst_sys(): sys.path = %s" % sys.path)
    except Exception as e:
        influxdb3_local.error("_tst_sys(): %s" % e)
        return

def _tst_wheel(influxdb3_local):
    spec = importlib.util.find_spec("requests")
    if spec is not None:
        try:
            influxdb3_local.info("_tst_sys(): 'requests' location = %s" % spec.origin)
            import requests
            influxdb3_local.info("_tst_wheel(): requests = %s" % requests.__version__)
        except Exception as e:
            influxdb3_local.error("_tst_wheel(): %s" % e)
            return
    else:
        influxdb3_local.warn("_tst_sys(): 'requests' not found")

def _tst_libssl(influxdb3_local):
    spec = importlib.util.find_spec("ssl")
    if spec is not None:
        try:
            influxdb3_local.info("_tst_libssl(): 'ssl' location = %s" % spec.origin)
            import socket
            import ssl
            hn = 'www.python.org'
            ctx = ssl.create_default_context()
            with socket.create_connection((hn, 443)) as sock:
                with ctx.wrap_socket(sock, server_hostname=hn) as ssock:
                    influxdb3_local.info("_tst_libssl: connecting to: %s" % hn)
                    influxdb3_local.info("_tst_libssl: sock version: %s" % ssock.version())
        except Exception as e:
            influxdb3_local.error("_tst_libssl(): %s" % e)
            return
    else:
        influxdb3_local.error("_tst_libssl(): 'ssl' not found")

def _tst_datetime(influxdb3_local):
    spec = importlib.util.find_spec("datetime")
    if spec is not None:
        try:
            influxdb3_local.info("_tst_datetime(): 'datetime' location = %s" % spec.origin)
            import datetime
            influxdb3_local.info("_tst_datetime(): datetime.datetime.now() = %s" % datetime.datetime.now())
            influxdb3_local.info("_tst_datetime(): datetime.datetime.now().strftime() = %s" % datetime.datetime.now().strftime('%Y%m%d%H%M%S'))
        except Exception as e:
            influxdb3_local.error("_tst_datetime(): %s" % e)
            return
    else:
        influxdb3_local.error("_tst_datetime(): 'ssl' not found")

def process_scheduled_call(influxdb3_local, call_time, args=None):
    _tst_log(influxdb3_local)
    _tst_sys(influxdb3_local)
    _tst_wheel(influxdb3_local)
    _tst_libssl(influxdb3_local)
    _tst_datetime(influxdb3_local)

def _tst_query_basic(influxdb3_local):
    influxdb3_local.info("_tst_query_basic(): query = 'SELECT * FROM telegraf LIMIT 1'")
    try:
        res = influxdb3_local.query("SELECT * FROM telegraf LIMIT 1")
    except Exception as e:
        influxdb3_local.error("_tst_query_basic(): %s" % e)
        return
    influxdb3_local.info("_tst_query_basic(): result = %s" % str(res))

def _tst_query_args(influxdb3_local, args):
    if args is None:
        influxdb3_local.warn("_tst_query_args(): Could not find 'args'")
        return
    elif "host" not in args:
        influxdb3_local.warn("_tst_query_args(): Could not find 'host' in 'args': %s" % args)
        return
    influxdb3_local.info("_tst_query_args(): args = '%s'" % args)
    influxdb3_local.info("_tst_query_args(): parameterized query = 'SELECT * FROM telegraf WHERE host = $host LIMIT 1'")
    query_params = {"host": args["host"]}
    try:
        query_result = influxdb3_local.query("SELECT * FROM telegraf WHERE host = $host LIMIT 1", query_params)
    except Exception as e:
        influxdb3_local.error("_tst_query_args(): %s" % e)
        return
    influxdb3_local.info("_tst_query_args(): parameterized query result = %s" % str(query_result))

def _tst_table_batches(influxdb3_local, table_batches):
    if table_batches is None:
        influxdb3_local.error("_tst_table_batches(): table_batches is None")
        return
    for table_batch in table_batches:
        if "table_name" not in table_batch:
            influxdb3_local.error("_tst_table_batches(): 'table_name' missing from batch: %s" % str(table_batch))
        else:
            influxdb3_local.info("_tst_table_batches(): table = %s" % table_batch["table_name"])
            if "rows" not in table_batch:
                influxdb3_local.error("_tst_table_batches(): 'rows' missing from batch: %s" % str(table_batch))
            else:
                for row in table_batch["rows"]:
                    influxdb3_local.info("_tst_table_batches(): row = %s" % str(row))

def _tst_write_table(influxdb3_local):
    try:
        line = LineBuilder("test_table").tag("tag1", "tag1_value").tag("tag2", "tag2_value").int64_field("field1", 1).float64_field("field2", 2.0).string_field("field3", "number three")
        influxdb3_local.info("_tst_write_table(): line = %s" % line.build())
        influxdb3_local.write(line)
    except Exception as e:
        influxdb3_local.error("_tst_write_table(): %s" % e)
        return

def _tst_write_db(influxdb3_local):
    import time
    now = time.time_ns()
    try:
        other_line = LineBuilder("other_table")
        other_line.int64_field("other_field", 1)
        other_line.float64_field("other_field2", 3.14)
        other_line.time_ns(now)
        influxdb3_local.info("_tst_write_db(): line = %s" % other_line.build())
        influxdb3_local.write_to_db("mydb02", other_line)
    except Exception as e:
        influxdb3_local.error("_tst_write_db(): %s" % e)
        return

def process_writes(influxdb3_local, table_batches, args=None):
    _tst_query_basic(influxdb3_local)
    _tst_query_args(influxdb3_local, args)
    _tst_table_batches(influxdb3_local, table_batches)
    _tst_write_table(influxdb3_local)
    _tst_write_db(influxdb3_local)
EOF

$ ./influxdb3 serve --without-auth --node-id node0 --object-store memory --plugin-dir ./plugins &
startup time: 2241ms address=0.0.0.0:8181

$ ./influxdb3 create database mydb01
Database "mydb01" created successfully

$ ./influxdb3 create database mydb02
Database "mydb02" created successfully

$ ./influxdb3 write --database mydb01 'telegraf,host=server01 cpu=0.5,mem=1024i'
success

$ ./influxdb3 query --database mydb01 'SELECT * FROM telegraf'
+-----+----------+------+-------------------------------+
| cpu | host     | mem  | time                          |
+-----+----------+------+-------------------------------+
| 0.5 | server01 | 1024 | 2026-02-12T20:59:05.754570547 |
+-----+----------+------+-------------------------------+

$ ./plugins/.venv/bin/pip install requests
Successfully installed certifi-2026.1.4 charset_normalizer-3.4.4 idna-3.11 requests-2.32.5 urllib3-2.6.3

$ ./influxdb3 test schedule_plugin -d mydb01 test-sched.py
{
  "trigger_time": "2026-02-12T20:59:24Z",
  "log_lines": [
    "INFO: starting execution with scheduled time 2026-02-12 20:59:24 UTC",
    "INFO: _tst_log(): success",
    "INFO: _tst_sys(): sys.prefix = /home/ai-agent/plugins/.venv",
    "INFO: _tst_sys(): sys.exec_prefix = /home/ai-agent/plugins/.venv",
    "INFO: _tst_sys(): sys.base_prefix = /home/ai-agent/python",
    "INFO: _tst_sys(): sys.base_exec_prefix = /home/ai-agent/python",
    "INFO: _tst_sys(): sys.path = ['/home/ai-agent/python/lib/python313.zip', '/home/ai-agent/python/lib/python3.13', '/home/ai-agent/python/lib/python3.13/lib-dynload', '/home/ai-agent/plugins/.venv/lib/python3.13/site-packages']",
    "INFO: _tst_sys(): 'requests' location = /home/ai-agent/plugins/.venv/lib/python3.13/site-packages/requests/__init__.py",
    "INFO: _tst_wheel(): requests = 2.32.5",
    "INFO: _tst_libssl(): 'ssl' location = /home/ai-agent/python/lib/python3.13/ssl.py",
    "INFO: _tst_libssl: connecting to: www.python.org",
    "INFO: _tst_libssl: sock version: TLSv1.3",
    "INFO: _tst_datetime(): 'datetime' location = /home/ai-agent/python/lib/python3.13/datetime.py",
    "INFO: _tst_datetime(): datetime.datetime.now() = 2026-02-12 20:59:24.136996",
    "INFO: _tst_datetime(): datetime.datetime.now().strftime() = 20260212205924",
    "INFO: finished execution in 150ms 329us 930ns"
  ],
  "database_writes": {},
  "errors": []
}

$ ./influxdb3 test wal_plugin -d mydb01 --lp 'telegraf,host=server02 cpu=0.75,mem=2048i' --input-arguments 'host=server01' test-sched.py
{
  "log_lines": [
    "INFO: starting execution of wal plugin.",
    "INFO: _tst_query_basic(): query = 'SELECT * FROM telegraf LIMIT 1'",
    "INFO: _tst_query_basic(): result = [{'cpu': 0.5, 'host': 'server01', 'mem': 1024, 'time': 1770929945754570547}]",
    "INFO: _tst_query_args(): args = '{'host': 'server01'}'",
    "INFO: _tst_query_args(): parameterized query = 'SELECT * FROM telegraf WHERE host = $host LIMIT 1'",
    "INFO: _tst_query_args(): parameterized query result = [{'cpu': 0.5, 'host': 'server01', 'mem': 1024, 'time': 1770929945754570547}]",
    "INFO: _tst_table_batches(): table = telegraf",
    "INFO: _tst_table_batches(): row = {'host': 'server02', 'cpu': 0.75, 'mem': 2048, 'time': 1770929970578003144}",
    "INFO: _tst_write_table(): line = test_table,tag1=tag1_value,tag2=tag2_value field1=1i,field2=2.0,field3=\"number three\"",
    "INFO: _tst_write_db(): line = other_table other_field=1i,other_field2=3.14 1770929970623001339",
    "INFO: finished execution in 44ms 46us 750ns"
  ],
  "database_writes": {
    "mydb01": [
      "test_table,tag1=tag1_value,tag2=tag2_value field1=1i,field2=2.0,field3=\"number three\""
    ],
    "mydb02": [
      "other_table other_field=1i,other_field2=3.14 1770929970623001339"
    ]
  },
  "errors": []
}
```

</details>