### PR TITLE
chore: Update Go to 1.24.13

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ orbs:
 parameters:
   cross-container-tag:
     type: string
-    default: go1.24.9-latest
+    default: go1.24.13-latest
 
   workflow:
     type: string

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/influxdata/influxdb/v2
 
 go 1.24.0
 
-toolchain go1.24.9
+toolchain go1.24.13
 
 require (
 	github.com/BurntSushi/toml v1.2.1


### PR DESCRIPTION
Fixes critical vulnerability CVE-2025-68121.

Closes #27226

Describe your proposed changes here.

- [X] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb/blob/main/README.md).
- [X] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
