### PR TITLE
fix: add "rustlib" path (2.x)

### DIFF
--- a/scripts/ci/build-tests.sh
+++ b/scripts/ci/build-tests.sh
@@ -3,14 +3,17 @@ set -exo pipefail
 
 function build_linux () {
     local tags=osusergo,netgo,sqlite_foreign_keys,sqlite_json,static_build
+    local extld="-fno-PIC -static -Wl,-z,stack-size=8388608 "
     local cc
     case $(go env GOARCH) in
         amd64)
-            cc=$(xcc linux x86_64)
+            cc="$(xcc linux x86_64)"
+            extld+="-L$(find_rustlib_path x86_64-unknown-linux-musl) -Wl,-lunwind "
             ;;
         arm64)
-            cc=$(xcc linux aarch64)
+            cc="$(xcc linux aarch64)"
             tags="$tags,noasm"
+            extld+="-L$(find_rustlib_path aarch64-unknown-linux-musl) -Wl,-lunwind "
             ;;
         *)
             >&2 echo Error: Unknown arch $(go env GOARCH)
@@ -18,7 +21,6 @@ function build_linux () {
             ;;
     esac
 
-    local -r extld="-fno-PIC -static -Wl,-z,stack-size=8388608"
     CGO_ENABLED=1 PKG_CONFIG=$(which pkg-config) CC="${cc}" go-test-compile \
         -tags "$tags" -o "${1}/" -ldflags "-extldflags '$extld'" -x ./...
 }

--- a/scripts/ci/build.sh
+++ b/scripts/ci/build.sh
@@ -24,7 +24,7 @@ function main () {
             CGO_ENABLED=1 PKG_CONFIG=$(which pkg-config) go build \
                 -tags assets,sqlite_foreign_keys,sqlite_json,static_build,noasm \
                 -buildmode=pie \
-                -ldflags "-s -w -X main.version=${version} -X main.commit=${commit} -X main.date=${build_date} -linkmode=external -extld=${CC} -extldflags '${LINUX_EXTLD}'" \
+                -ldflags "-s -w -X main.version=${version} -X main.commit=${commit} -X main.date=${build_date} -linkmode=external -extld=${CC} -extldflags '${LINUX_EXTLD} -L$(find_rustlib_path x86_64-unknown-linux-musl) -Wl,-lunwind'" \
                 -o "$out_dir/" \
                 "$pkg"
             ;;
@@ -33,7 +33,7 @@ function main () {
             CGO_ENABLED=1 PKG_CONFIG=$(which pkg-config) go build \
                 -tags assets,sqlite_foreign_keys,sqlite_json,static_build,noasm \
                 -buildmode=pie \
-                -ldflags "-s -w -X main.version=${version} -X main.commit=${commit} -X main.date=${build_date} -linkmode=external -extld=${CC} -extldflags '${LINUX_EXTLD}'" \
+                -ldflags "-s -w -X main.version=${version} -X main.commit=${commit} -X main.date=${build_date} -linkmode=external -extld=${CC} -extldflags '${LINUX_EXTLD} -L$(find_rustlib_path aarch64-unknown-linux-musl) -Wl,-lunwind'" \
                 -o "$out_dir/" \
                 "$pkg"
             ;;


### PR DESCRIPTION
This adds "rustlib" to the library paths for `x86_64-unknown-linux-musl` and `aarch64-unknown-linux-musl` targets. These targets ship `libc` and `libunwind` static libraries. Since flux depends on `libunwind`, linking against at least `libunwind` is required.