### PR TITLE
chore(inclusivity): ignore core/ directory

### DIFF
--- a/.langcheck.yml
+++ b/.langcheck.yml
@@ -1,6 +1,11 @@
 # https://github.com/jdstrand/language-checker/blob/main/docs/rules.md
 # https://github.com/jdstrand/language-checker/blob/main/pkg/rule/default.yaml
 
+ignore_files:
+  # NOTE(tjh): Ignore crates from IOx until inclusivity checks are enforced
+  # on them upstream
+  - core/
+
 rules:
   # exclude the 'dummy' rule
   - name: dummy


### PR DESCRIPTION
The core directory is maintained upstream and therefore we cannot enforce inclusivity checks on it here. That must be done at the source before it can be done here.

Helps:
- https://github.com/influxdata/influxdb_pro/issues/2453