### PR TITLE
chore: update install_influxdb.sh to default to 3.8.4 for Enterprise

### DIFF
--- a/install_influxdb.sh
+++ b/install_influxdb.sh
@@ -166,9 +166,13 @@ PORT=8181
 
 # Set the default (latest) version here. Users may specify a version using the
 # --version arg (handled below)
-INFLUXDB_VERSION="3.8.0"
+INFLUXDB_VERSION_FLAG_SET="0"
+INFLUXDB_OSS_VERSION="3.8.3"
+INFLUXDB_ENT_VERSION="3.8.4"
+
 EDITION="Core"
 EDITION_TAG="core"
+INFLUXDB_VERSION="${INFLUXDB_OSS_VERSION}"
 
 # ==============================================================================
 # SECTION 2: COMMAND LINE ARGUMENT PARSING
@@ -178,11 +182,15 @@ while [ $# -gt 0 ]; do
     case "$1" in
         --version)
             INFLUXDB_VERSION="$2"
+            INFLUXDB_VERSION_FLAG_SET=1
             shift 2
             ;;
         enterprise)
             EDITION="Enterprise"
             EDITION_TAG="enterprise"
+            if [ "${INFLUXDB_VERSION_FLAG_SET}" == "0" ]; then
+                INFLUXDB_VERSION="${INFLUXDB_ENT_VERSION}"
+            fi
             shift 1
             ;;
         *)


### PR DESCRIPTION
This PR updates the `oss/install_influxdb.sh` script to default to version `3.8.4` for InfluxDB 3 Enterprise while sticking with `3.8.3` for InfluxDB 3 OSS.

Here's the initial script output when running `./oss/install_influxdb.sh enterprise`:

```
┌───────────────────────────────────────────────────┐                                                                                                                                                                                                                                                            14:12 [54/5│ Welcome to InfluxDB! We'll make this quick.       │
└───────────────────────────────────────────────────┘

Select Installation Type

1) Docker Compose  (Installs InfluxDB 3 Enterprise + Explorer UI)
2) Simple Download (Binary installation, no dependencies)

Enter your choice (1-2): 2


Downloading InfluxDB 3 Enterprise to /home/wayne/.influxdb
├─ mkdir -p '/home/wayne/.influxdb'
└─ curl -sSL 'https://dl.influxdata.com/influxdb/releases/influxdb3-enterprise-3.8.4_linux_amd64.tar.gz' -o '/home/wayne/.influxdb/influxdb3-enterprise.tar.gz'
```

Here's the initial script output when running `./oss/install_influxdb.sh` (defaults to OSS):
```
┌───────────────────────────────────────────────────┐
│ Welcome to InfluxDB! We'll make this quick.       │
└───────────────────────────────────────────────────┘

Select Installation Type

1) Docker Compose  (Installs InfluxDB 3 Core + Explorer UI)
2) Simple Download (Binary installation, no dependencies)

Enter your choice (1-2): 2


Downloading InfluxDB 3 Core to /home/wayne/.influxdb
├─ mkdir -p '/home/wayne/.influxdb'
└─ curl -sSL 'https://dl.influxdata.com/influxdb/releases/influxdb3-core-3.8.3_linux_amd64.tar.gz' -o '/home/wayne/.influxdb/influxdb3-core.tar.gz'
```
