### PR TITLE
fix: exclude soft-deleted databases from table count

### DIFF
--- a/influxdb3/tests/server/limits.rs
+++ b/influxdb3/tests/server/limits.rs
@@ -55,6 +55,33 @@ async fn limits() -> Result<(), Error> {
     };
     assert_eq!(code, StatusCode::UNPROCESSABLE_ENTITY);
 
+    // Test that soft-deleting a database frees up the db and table counts
+    server
+        .delete_database("two")
+        .with_yes()
+        .run()
+        .expect("Did not error when deleting database");
+
+    server
+        .write_lp_to_db(
+            "six",
+            "cpu2000,host=s1,region=us-east usage=0.9 2998574938\n",
+            Precision::Second,
+        )
+        .await?;
+
+    let Err(Error::ApiError { code, .. }) = server
+        .write_lp_to_db(
+            "six",
+            "cpu2001,host=s1,region=us-east usage=0.9 2998574938\n",
+            Precision::Second,
+        )
+        .await
+    else {
+        panic!("Did not error when exceeding table limit after soft-delete");
+    };
+    assert_eq!(code, StatusCode::UNPROCESSABLE_ENTITY);
+
     // Test that we can't add a row 500 columns long
     let mut lp_500 = String::from("cpu,host=foo,region=bar usage=2");
     let mut lp_501 = String::from("cpu,host=foo,region=bar usage=2");

--- a/influxdb3_catalog/src/catalog/versions/v2.rs
+++ b/influxdb3_catalog/src/catalog/versions/v2.rs
@@ -933,6 +933,8 @@ impl InnerCatalog {
     pub fn table_count(&self) -> usize {
         self.databases
             .resource_iter()
+            // count if not db deleted _and_ not internal
+            .filter(|db| !db.deleted && db.name().as_ref() != INTERNAL_DB_NAME)
             .map(|db| db.table_count())
             .sum()
     }


### PR DESCRIPTION
Closes #27281

`InnerCatalog::table_count()` was including tables from soft-deleted databases, causing writes to fail with `TooManyTables` even after a database was deleted.

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
