### PR TITLE
chore: sync oss and bump version to 3.9.0-0.rc.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -481,11 +481,10 @@ jobs:
           steps:
             - run:
                 # XXX: better to use 'cargo:rustc-link-arg=-Wl,-rpath,@executable_path/python/lib'
-                name: adjust LC_LOAD_DYLIB path for darwin
+                name: adjust LC_RPATH path for darwin
                 command: |
-                  export PBS_LIBPYTHON=$(grep '^lib_name=' /tmp/workspace/python-artifacts/<< parameters.target >>/pyo3_config_file.txt | cut -d = -f 2)
-                  echo "Running: /osxcross/bin/aarch64-apple-darwin22.2-install_name_tool -change '/install/lib/lib${PBS_LIBPYTHON}.dylib' '@executable_path/python/lib/lib${PBS_LIBPYTHON}.dylib' '${PWD}/target/<< parameters.target >>/<< parameters.profile >>/influxdb3'"
-                  /osxcross/bin/aarch64-apple-darwin22.2-install_name_tool -change "/install/lib/lib${PBS_LIBPYTHON}.dylib" "@executable_path/python/lib/lib${PBS_LIBPYTHON}.dylib" "${PWD}/target/<< parameters.target >>/<< parameters.profile >>/influxdb3"
+                  echo "Running: /osxcross/bin/aarch64-apple-darwin22.2-install_name_tool -add_rpath '@executable_path/python/lib' '${PWD}/target/<< parameters.target >>/<< parameters.profile >>/influxdb3'"
+                  /osxcross/bin/aarch64-apple-darwin22.2-install_name_tool -add_rpath '@executable_path/python/lib' "${PWD}/target/<< parameters.target >>/<< parameters.profile >>/influxdb3"
                   # re-sign after install_name_tool since osxcross won't do it
                   echo "Running: /usr/local/bin/rcodesign sign '${PWD}/target/<< parameters.target >>/<< parameters.profile >>/influxdb3'"
                   /usr/local/bin/rcodesign sign "${PWD}/target/<< parameters.target >>/<< parameters.profile >>/influxdb3"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -468,7 +468,7 @@ dependencies = [
 
 [[package]]
 name = "arrow_util"
-version = "3.9.0-0.rc.4"
+version = "3.9.0-0.rc.5"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -565,7 +565,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "authz"
-version = "3.9.0-0.rc.4"
+version = "3.9.0-0.rc.5"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -679,7 +679,7 @@ dependencies = [
 
 [[package]]
 name = "backoff"
-version = "3.9.0-0.rc.4"
+version = "3.9.0-0.rc.5"
 dependencies = [
  "rand 0.9.2",
  "snafu 0.9.0",
@@ -1007,15 +1007,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "camino"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
 name = "cap-fs-ext"
 version = "3.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1094,29 +1085,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cargo-platform"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e35af189006b9c0f00a064685c727031e3ed2d8020f7ba284d78cc2671bd36ea"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "cargo_metadata"
-version = "0.19.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5eb614ed4c27c5d706420e4320fbe3216ab31fa1c33cd8246ac36dae4479ba"
-dependencies = [
- "camino",
- "cargo-platform",
- "semver",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
-]
-
-[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1124,7 +1092,7 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "catalog_cache"
-version = "3.9.0-0.rc.4"
+version = "3.9.0-0.rc.5"
 dependencies = [
  "bytes",
  "criterion 0.8.2",
@@ -1262,7 +1230,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "client_util"
-version = "3.9.0-0.rc.4"
+version = "3.9.0-0.rc.5"
 dependencies = [
  "http 1.4.0",
  "iox_http_util",
@@ -1832,7 +1800,7 @@ dependencies = [
 
 [[package]]
 name = "data_types"
-version = "3.9.0-0.rc.4"
+version = "3.9.0-0.rc.5"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -2565,7 +2533,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion_util"
-version = "3.9.0-0.rc.4"
+version = "3.9.0-0.rc.5"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -2649,7 +2617,7 @@ dependencies = [
 
 [[package]]
 name = "dml"
-version = "3.9.0-0.rc.4"
+version = "3.9.0-0.rc.5"
 dependencies = [
  "arrow_util",
  "data_types",
@@ -2761,7 +2729,7 @@ dependencies = [
 
 [[package]]
 name = "error_reporting"
-version = "3.9.0-0.rc.4"
+version = "3.9.0-0.rc.5"
 dependencies = [
  "datafusion",
  "snafu 0.9.0",
@@ -2791,7 +2759,7 @@ dependencies = [
 
 [[package]]
 name = "executor"
-version = "3.9.0-0.rc.4"
+version = "3.9.0-0.rc.5"
 dependencies = [
  "futures",
  "metric",
@@ -2872,7 +2840,7 @@ dependencies = [
 
 [[package]]
 name = "flightsql"
-version = "3.9.0-0.rc.4"
+version = "3.9.0-0.rc.5"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -3076,7 +3044,7 @@ dependencies = [
 
 [[package]]
 name = "futures_test_utils"
-version = "3.9.0-0.rc.4"
+version = "3.9.0-0.rc.5"
 dependencies = [
  "clap",
  "futures",
@@ -3087,7 +3055,7 @@ dependencies = [
 
 [[package]]
 name = "generated_types"
-version = "3.9.0-0.rc.4"
+version = "3.9.0-0.rc.5"
 dependencies = [
  "bytes",
  "pbjson",
@@ -3736,7 +3704,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb2_client"
-version = "3.9.0-0.rc.4"
+version = "3.9.0-0.rc.5"
 dependencies = [
  "bytes",
  "futures",
@@ -3755,7 +3723,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3"
-version = "3.9.0-0.rc.4"
+version = "3.9.0-0.rc.5"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3844,7 +3812,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_authz"
-version = "3.9.0-0.rc.4"
+version = "3.9.0-0.rc.5"
 dependencies = [
  "async-trait",
  "authz",
@@ -3861,7 +3829,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_cache"
-version = "3.9.0-0.rc.4"
+version = "3.9.0-0.rc.5"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3896,7 +3864,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_catalog"
-version = "3.9.0-0.rc.4"
+version = "3.9.0-0.rc.5"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3948,7 +3916,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_clap_blocks"
-version = "3.9.0-0.rc.4"
+version = "3.9.0-0.rc.5"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3983,7 +3951,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_client"
-version = "3.9.0-0.rc.4"
+version = "3.9.0-0.rc.5"
 dependencies = [
  "bytes",
  "hashbrown 0.14.5",
@@ -4003,7 +3971,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_commands"
-version = "3.9.0-0.rc.4"
+version = "3.9.0-0.rc.5"
 dependencies = [
  "anyhow",
  "clap",
@@ -4022,7 +3990,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_id"
-version = "3.9.0-0.rc.4"
+version = "3.9.0-0.rc.5"
 dependencies = [
  "indexmap 2.13.0",
  "serde",
@@ -4032,7 +4000,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_internal_api"
-version = "3.9.0-0.rc.4"
+version = "3.9.0-0.rc.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4053,7 +4021,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_load_generator"
-version = "3.9.0-0.rc.4"
+version = "3.9.0-0.rc.5"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4082,16 +4050,15 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_process"
-version = "3.9.0-0.rc.4"
+version = "3.9.0-0.rc.5"
 dependencies = [
- "cargo_metadata",
  "iox_time",
  "uuid",
 ]
 
 [[package]]
 name = "influxdb3_processing_engine"
-version = "3.9.0-0.rc.4"
+version = "3.9.0-0.rc.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4135,7 +4102,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_py_api"
-version = "3.9.0-0.rc.4"
+version = "3.9.0-0.rc.5"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -4163,7 +4130,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_query_executor"
-version = "3.9.0-0.rc.4"
+version = "3.9.0-0.rc.5"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4213,7 +4180,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_server"
-version = "3.9.0-0.rc.4"
+version = "3.9.0-0.rc.5"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4296,7 +4263,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_shutdown"
-version = "3.9.0-0.rc.4"
+version = "3.9.0-0.rc.5"
 dependencies = [
  "futures",
  "futures-util",
@@ -4311,7 +4278,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_sys_events"
-version = "3.9.0-0.rc.4"
+version = "3.9.0-0.rc.5"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4330,7 +4297,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_system_tables"
-version = "3.9.0-0.rc.4"
+version = "3.9.0-0.rc.5"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4362,7 +4329,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_telemetry"
-version = "3.9.0-0.rc.4"
+version = "3.9.0-0.rc.5"
 dependencies = [
  "futures",
  "futures-util",
@@ -4383,7 +4350,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_test_helpers"
-version = "3.9.0-0.rc.4"
+version = "3.9.0-0.rc.5"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4396,7 +4363,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_types"
-version = "3.9.0-0.rc.4"
+version = "3.9.0-0.rc.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4416,7 +4383,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_wal"
-version = "3.9.0-0.rc.4"
+version = "3.9.0-0.rc.5"
 dependencies = [
  "async-trait",
  "bitcode",
@@ -4444,7 +4411,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_write"
-version = "3.9.0-0.rc.4"
+version = "3.9.0-0.rc.5"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4513,7 +4480,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb_influxql_parser"
-version = "3.9.0-0.rc.4"
+version = "3.9.0-0.rc.5"
 dependencies = [
  "assert_matches",
  "chrono",
@@ -4530,7 +4497,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb_iox_client"
-version = "3.9.0-0.rc.4"
+version = "3.9.0-0.rc.5"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -4559,7 +4526,7 @@ dependencies = [
 
 [[package]]
 name = "ingester_query_grpc"
-version = "3.9.0-0.rc.4"
+version = "3.9.0-0.rc.5"
 dependencies = [
  "base64 0.22.1",
  "data_types",
@@ -4616,7 +4583,7 @@ checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
 
 [[package]]
 name = "iox_http"
-version = "3.9.0-0.rc.4"
+version = "3.9.0-0.rc.5"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -4636,7 +4603,7 @@ dependencies = [
 
 [[package]]
 name = "iox_http_util"
-version = "3.9.0-0.rc.4"
+version = "3.9.0-0.rc.5"
 dependencies = [
  "futures",
  "http 1.4.0",
@@ -4647,7 +4614,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query"
-version = "3.9.0-0.rc.4"
+version = "3.9.0-0.rc.5"
 dependencies = [
  "arrow",
  "arrow_util",
@@ -4696,7 +4663,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query_influxql"
-version = "3.9.0-0.rc.4"
+version = "3.9.0-0.rc.5"
 dependencies = [
  "arrow",
  "assert_matches",
@@ -4723,7 +4690,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query_influxql_rewrite"
-version = "3.9.0-0.rc.4"
+version = "3.9.0-0.rc.5"
 dependencies = [
  "influxdb_influxql_parser",
  "thiserror 2.0.18",
@@ -4731,7 +4698,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query_params"
-version = "3.9.0-0.rc.4"
+version = "3.9.0-0.rc.5"
 dependencies = [
  "arrow",
  "assert_matches",
@@ -4745,7 +4712,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query_udf"
-version = "3.9.0-0.rc.4"
+version = "3.9.0-0.rc.5"
 dependencies = [
  "datafusion-udf-wasm-host",
  "datafusion-udf-wasm-query",
@@ -4756,7 +4723,7 @@ dependencies = [
 
 [[package]]
 name = "iox_system_tables"
-version = "3.9.0-0.rc.4"
+version = "3.9.0-0.rc.5"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4766,7 +4733,7 @@ dependencies = [
 
 [[package]]
 name = "iox_time"
-version = "3.9.0-0.rc.4"
+version = "3.9.0-0.rc.5"
 dependencies = [
  "chrono",
  "parking_lot",
@@ -4775,7 +4742,7 @@ dependencies = [
 
 [[package]]
 name = "iox_v1_query_api"
-version = "3.9.0-0.rc.4"
+version = "3.9.0-0.rc.5"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4889,7 +4856,7 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "jemalloc_stats"
-version = "3.9.0-0.rc.4"
+version = "3.9.0-0.rc.5"
 dependencies = [
  "snafu 0.9.0",
  "tikv-jemalloc-ctl",
@@ -5032,7 +4999,7 @@ dependencies = [
 
 [[package]]
 name = "linear_buffer"
-version = "3.9.0-0.rc.4"
+version = "3.9.0-0.rc.5"
 
 [[package]]
 name = "linux-raw-sys"
@@ -5076,7 +5043,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "logfmt"
-version = "3.9.0-0.rc.4"
+version = "3.9.0-0.rc.5"
 dependencies = [
  "humantime",
  "parking_lot",
@@ -5184,14 +5151,14 @@ dependencies = [
 
 [[package]]
 name = "metric"
-version = "3.9.0-0.rc.4"
+version = "3.9.0-0.rc.5"
 dependencies = [
  "parking_lot",
 ]
 
 [[package]]
 name = "metric_exporters"
-version = "3.9.0-0.rc.4"
+version = "3.9.0-0.rc.5"
 dependencies = [
  "metric",
  "mockito",
@@ -5316,7 +5283,7 @@ checksum = "9252111cf132ba0929b6f8e030cac2a24b507f3a4d6db6fb2896f27b354c714b"
 
 [[package]]
 name = "mutable_batch"
-version = "3.9.0-0.rc.4"
+version = "3.9.0-0.rc.5"
 dependencies = [
  "arrow",
  "arrow_util",
@@ -5334,7 +5301,7 @@ dependencies = [
 
 [[package]]
 name = "mutable_batch_lp"
-version = "3.9.0-0.rc.4"
+version = "3.9.0-0.rc.5"
 dependencies = [
  "arrow_util",
  "assert_matches",
@@ -5350,7 +5317,7 @@ dependencies = [
 
 [[package]]
 name = "mutable_batch_pb"
-version = "3.9.0-0.rc.4"
+version = "3.9.0-0.rc.5"
 dependencies = [
  "arrow_util",
  "criterion 0.8.2",
@@ -5588,7 +5555,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_mem_cache"
-version = "3.9.0-0.rc.4"
+version = "3.9.0-0.rc.5"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5615,7 +5582,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_metrics"
-version = "3.9.0-0.rc.4"
+version = "3.9.0-0.rc.5"
 dependencies = [
  "async-trait",
  "bloom2",
@@ -5640,7 +5607,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_mock"
-version = "3.9.0-0.rc.4"
+version = "3.9.0-0.rc.5"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5654,7 +5621,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_size_hinting"
-version = "3.9.0-0.rc.4"
+version = "3.9.0-0.rc.5"
 dependencies = [
  "chrono",
  "http 1.4.0",
@@ -5664,7 +5631,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_utils"
-version = "3.9.0-0.rc.4"
+version = "3.9.0-0.rc.5"
 dependencies = [
  "async-trait",
  "backon",
@@ -5677,7 +5644,7 @@ dependencies = [
 
 [[package]]
 name = "observability_deps"
-version = "3.9.0-0.rc.4"
+version = "3.9.0-0.rc.5"
 dependencies = [
  "tracing",
 ]
@@ -5742,7 +5709,7 @@ dependencies = [
 
 [[package]]
 name = "panic_logging"
-version = "3.9.0-0.rc.4"
+version = "3.9.0-0.rc.5"
 dependencies = [
  "metric",
  "test_helpers",
@@ -5817,7 +5784,7 @@ dependencies = [
 
 [[package]]
 name = "parquet_file"
-version = "3.9.0-0.rc.4"
+version = "3.9.0-0.rc.5"
 dependencies = [
  "arrow",
  "arrow_util",
@@ -5846,7 +5813,7 @@ dependencies = [
 
 [[package]]
 name = "partition"
-version = "3.9.0-0.rc.4"
+version = "3.9.0-0.rc.5"
 dependencies = [
  "arrow",
  "assert_matches",
@@ -6149,7 +6116,7 @@ dependencies = [
 
 [[package]]
 name = "predicate"
-version = "3.9.0-0.rc.4"
+version = "3.9.0-0.rc.5"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6495,7 +6462,7 @@ dependencies = [
 
 [[package]]
 name = "query_functions"
-version = "3.9.0-0.rc.4"
+version = "3.9.0-0.rc.5"
 dependencies = [
  "arrow",
  "chrono",
@@ -7177,7 +7144,7 @@ dependencies = [
 
 [[package]]
 name = "schema"
-version = "3.9.0-0.rc.4"
+version = "3.9.0-0.rc.5"
 dependencies = [
  "arrow",
  "base64 0.22.1",
@@ -7360,7 +7327,7 @@ dependencies = [
 
 [[package]]
 name = "service_common"
-version = "3.9.0-0.rc.4"
+version = "3.9.0-0.rc.5"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -7374,7 +7341,7 @@ dependencies = [
 
 [[package]]
 name = "service_grpc_flight"
-version = "3.9.0-0.rc.4"
+version = "3.9.0-0.rc.5"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -7441,7 +7408,7 @@ dependencies = [
 
 [[package]]
 name = "sharder"
-version = "3.9.0-0.rc.4"
+version = "3.9.0-0.rc.5"
 dependencies = [
  "criterion 0.8.2",
  "data_types",
@@ -7963,7 +7930,7 @@ dependencies = [
 
 [[package]]
 name = "table_batch"
-version = "3.9.0-0.rc.4"
+version = "3.9.0-0.rc.5"
 dependencies = [
  "arrow_util",
  "bitvec",
@@ -7983,9 +7950,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d863878d212c87a19c1a610eb53bb01fe12951c0501cf5a0d65f724914a667a"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
 dependencies = [
  "filetime",
  "libc",
@@ -8049,7 +8016,7 @@ dependencies = [
 
 [[package]]
 name = "test_helpers"
-version = "3.9.0-0.rc.4"
+version = "3.9.0-0.rc.5"
 dependencies = [
  "async-trait",
  "dotenvy",
@@ -8068,7 +8035,7 @@ dependencies = [
 
 [[package]]
 name = "test_helpers_authz"
-version = "3.9.0-0.rc.4"
+version = "3.9.0-0.rc.5"
 dependencies = [
  "futures",
  "generated_types",
@@ -8341,7 +8308,7 @@ dependencies = [
 
 [[package]]
 name = "tokio_metrics_bridge"
-version = "3.9.0-0.rc.4"
+version = "3.9.0-0.rc.5"
 dependencies = [
  "metric",
  "parking_lot",
@@ -8350,7 +8317,7 @@ dependencies = [
 
 [[package]]
 name = "tokio_watchdog"
-version = "3.9.0-0.rc.4"
+version = "3.9.0-0.rc.5"
 dependencies = [
  "metric",
  "test_helpers",
@@ -8573,7 +8540,7 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tower_trailer"
-version = "3.9.0-0.rc.4"
+version = "3.9.0-0.rc.5"
 dependencies = [
  "futures",
  "http 1.4.0",
@@ -8585,7 +8552,7 @@ dependencies = [
 
 [[package]]
 name = "trace"
-version = "3.9.0-0.rc.4"
+version = "3.9.0-0.rc.5"
 dependencies = [
  "chrono",
  "parking_lot",
@@ -8595,7 +8562,7 @@ dependencies = [
 
 [[package]]
 name = "trace_exporters"
-version = "3.9.0-0.rc.4"
+version = "3.9.0-0.rc.5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8612,7 +8579,7 @@ dependencies = [
 
 [[package]]
 name = "trace_http"
-version = "3.9.0-0.rc.4"
+version = "3.9.0-0.rc.5"
 dependencies = [
  "bytes",
  "futures",
@@ -8707,7 +8674,7 @@ dependencies = [
 
 [[package]]
 name = "tracker"
-version = "3.9.0-0.rc.4"
+version = "3.9.0-0.rc.5"
 dependencies = [
  "futures",
  "hashbrown 0.14.5",
@@ -8727,7 +8694,7 @@ dependencies = [
 
 [[package]]
 name = "trogging"
-version = "3.9.0-0.rc.4"
+version = "3.9.0-0.rc.5"
 dependencies = [
  "clap",
  "logfmt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,7 +123,7 @@ exclude = [
 #
 # For porting to the actual OSS repo (influxdb), this would need to change to `-nightly`, i.e., by
 # stripping the `-oss`.
-version = "3.9.0-0.rc.4"
+version = "3.9.0-0.rc.5"
 authors = ["InfluxData OSS Developers"]
 edition = "2024"
 license = "MIT OR Apache-2.0"

--- a/deny.toml
+++ b/deny.toml
@@ -17,6 +17,10 @@ ignore = [
     # there are multiple replacements at this time but there isn't
     # yet a clear choice
     "RUSTSEC-2025-0141",
+    # rustls-webpki 0.102.8 CRL distribution point matching bug; low impact
+    # (requires CA compromise). Stuck on 0.102.x via wasmtime's rustls 0.22.x
+    # dep in datafusion-udf-wasm. Upstream also ignores this advisory.
+    "RUSTSEC-2026-0049",
 ]
 git-fetch-with-cli = true
 

--- a/influxdb3/src/commands/serve.rs
+++ b/influxdb3/src/commands/serve.rs
@@ -749,7 +749,8 @@ pub async fn command(config: Config, user_params: HashMap<String, String>) -> Re
         version = %INFLUXDB3_VERSION.as_ref() as &str,
         uuid = %PROCESS_UUID_STR.as_ref() as &str,
         num_cpus,
-        "InfluxDB 3 Core server starting",
+        product_name = influxdb3_server::PRODUCT_NAME,
+        "server starting",
     );
     debug!(%build_malloc_conf, "build configuration");
 
@@ -1553,6 +1554,7 @@ pub fn setup_metric_registry() -> Arc<metric::Registry> {
             "Start time of the process since unix epoch in seconds.",
         )
         .recorder(&[
+            ("product_name", influxdb3_server::PRODUCT_NAME),
             ("version", INFLUXDB3_VERSION.as_ref()),
             ("git_hash", INFLUXDB3_GIT_HASH),
             ("uuid", PROCESS_UUID_STR.as_ref()),

--- a/influxdb3/src/lib.rs
+++ b/influxdb3/src/lib.rs
@@ -14,7 +14,7 @@ clippy::future_not_send
 use clap::{CommandFactory, FromArgMatches, parser::ValueSource};
 use dotenvy::dotenv;
 use influxdb3_clap_blocks::tokio::{TokioDatafusionConfig, TokioIoConfig};
-use influxdb3_process::VERSION_STRING;
+use influxdb3_server::VERSION_STRING;
 use influxdb3_telemetry::ServeInvocationMethod;
 use observability_deps::tracing::warn;
 use owo_colors::OwoColorize;

--- a/influxdb3/tests/server/ping.rs
+++ b/influxdb3/tests/server/ping.rs
@@ -1,4 +1,4 @@
-use influxdb3_process::{INFLUXDB3_BUILD, INFLUXDB3_VERSION};
+use influxdb3_process::INFLUXDB3_VERSION;
 use reqwest::Method;
 use serde_json::Value;
 
@@ -51,7 +51,7 @@ async fn test_ping() {
                 .unwrap()
                 .to_str()
                 .unwrap(),
-            &INFLUXDB3_BUILD[..]
+            "Core",
         );
 
         let json = resp.json::<Value>().await.unwrap();

--- a/influxdb3_commands/src/query.rs
+++ b/influxdb3_commands/src/query.rs
@@ -9,6 +9,7 @@ use tokio::{
     fs::OpenOptions,
     io::{self, AsyncWriteExt},
 };
+use url::Url;
 
 use crate::common::Format;
 
@@ -42,6 +43,10 @@ pub struct Config {
     /// Common InfluxDB 3 server config
     #[clap(flatten)]
     influxdb3_config: InfluxDb3Config,
+
+    /// Override host URL for query operations
+    #[clap(long = "query-host", env = "INFLUXDB3_QUERY_HOST_URL")]
+    query_host_url: Option<Url>,
 
     /// The query language used to format the provided query string
     #[clap(
@@ -91,6 +96,7 @@ pub async fn command(config: Config) -> Result<()> {
         database_name,
         auth_token,
     } = config.influxdb3_config;
+    let host_url = config.query_host_url.unwrap_or(host_url);
     let mut client = influxdb3_client::Client::new(host_url, config.ca_cert, config.tls_no_verify)?;
     if let Some(t) = auth_token {
         client = client.with_auth_token(t.expose_secret());

--- a/influxdb3_commands/src/write.rs
+++ b/influxdb3_commands/src/write.rs
@@ -8,6 +8,7 @@ use clap::Parser;
 use influxdb3_client::Precision;
 use secrecy::ExposeSecret;
 use tokio::io;
+use url::Url;
 
 use super::common::InfluxDb3Config;
 
@@ -40,6 +41,10 @@ pub struct Config {
     /// Common InfluxDB 3 server config
     #[clap(flatten)]
     influxdb3_config: InfluxDb3Config,
+
+    /// Override host URL for write operations
+    #[clap(long = "write-host", env = "INFLUXDB3_WRITE_HOST_URL")]
+    write_host_url: Option<Url>,
 
     /// File path to load the write data from
     ///
@@ -81,6 +86,7 @@ pub async fn command(config: Config) -> Result<()> {
         database_name,
         auth_token,
     } = config.influxdb3_config;
+    let host_url = config.write_host_url.unwrap_or(host_url);
     let mut client = influxdb3_client::Client::new(host_url, config.ca_cert, config.tls_no_verify)?;
     if let Some(t) = auth_token {
         client = client.with_auth_token(t.expose_secret());

--- a/influxdb3_process/Cargo.toml
+++ b/influxdb3_process/Cargo.toml
@@ -5,9 +5,6 @@ authors.workspace = true
 edition.workspace = true
 license.workspace = true
 
-[package.metadata.influxdb3]
-build = "Core"
-
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
@@ -16,9 +13,6 @@ iox_time = { path = "../core/iox_time" }
 
 # Crates.io dependencies
 uuid.workspace = true
-
-[build-dependencies]
-cargo_metadata.workspace = true
 
 [lints]
 workspace = true

--- a/influxdb3_process/build.rs
+++ b/influxdb3_process/build.rs
@@ -2,7 +2,6 @@
 // time, panic'ing if it can not be found
 //
 // https://stackoverflow.com/questions/43753491/include-git-commit-hash-as-string-into-rust-program
-use cargo_metadata::MetadataCommand;
 use std::process::Command;
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -13,20 +12,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Populate env!(GIT_HASH_SHORT) with the current git commit
     let git_hash_short = get_git_hash_short();
     println!("cargo:rustc-env=GIT_HASH_SHORT={git_hash_short}");
-
-    let path = std::env::var("CARGO_MANIFEST_DIR").unwrap();
-    let meta = MetadataCommand::new()
-        .manifest_path("./Cargo.toml")
-        .current_dir(&path)
-        .exec()
-        .unwrap();
-
-    let root = meta.root_package().unwrap();
-    let build = root.metadata["influxdb3"]["build"]
-        .as_str()
-        .unwrap_or("Core");
-    println!("cargo:rerun-if-env-changed=INFLUXDB3_BUILD_VERSION");
-    println!("cargo:rustc-env=INFLUXDB3_BUILD_VERSION={build}");
 
     Ok(())
 }

--- a/influxdb3_process/src/lib.rs
+++ b/influxdb3_process/src/lib.rs
@@ -10,10 +10,6 @@ pub const INFLUXDB3_PROCESS_NAME: &str = "influxdb3";
 pub static INFLUXDB3_VERSION: LazyLock<&'static str> =
     LazyLock::new(|| option_env!("CARGO_PKG_VERSION").unwrap_or("UNKNOWN"));
 
-/// Build information.
-pub static INFLUXDB3_BUILD: LazyLock<&'static str> =
-    LazyLock::new(|| env!("INFLUXDB3_BUILD_VERSION"));
-
 /// Build-time GIT revision hash.
 pub static INFLUXDB3_GIT_HASH: &str = env!(
     "GIT_HASH",
@@ -26,16 +22,15 @@ pub static INFLUXDB3_GIT_HASH_SHORT: &str = env!(
     "Can not find find GIT HASH in build environment"
 );
 
-/// Version string that is combined from [`INFLUXDB3_VERSION`] and [`INFLUXDB3_GIT_HASH`].
-pub static VERSION_STRING: LazyLock<&'static str> = LazyLock::new(|| {
-    let s = format!(
-        "{}, revision {}",
+/// Build a version string with a product name, version, and git hash.
+pub fn build_version_string(product: &str) -> String {
+    format!(
+        "{}, {}, revision {}",
+        product,
         &INFLUXDB3_VERSION[..],
         INFLUXDB3_GIT_HASH
-    );
-    let s: Box<str> = Box::from(s);
-    Box::leak(s)
-});
+    )
+}
 
 /// A UUID that is unique for the process lifetime.
 pub static PROCESS_UUID_STR: LazyLock<&'static str> = LazyLock::new(|| {
@@ -90,11 +85,3 @@ pub trait ProcessUuidGetter: Send + Sync {
 
 /// Process start time.
 pub static PROCESS_START_TIME: LazyLock<Time> = LazyLock::new(|| SystemProvider::new().now());
-
-/// String version of [`usize::MAX`].
-#[allow(dead_code)]
-pub static USIZE_MAX: LazyLock<&'static str> = LazyLock::new(|| {
-    let s = usize::MAX.to_string();
-    let s: Box<str> = Box::from(s);
-    Box::leak(s)
-});

--- a/influxdb3_server/src/http.rs
+++ b/influxdb3_server/src/http.rs
@@ -1,5 +1,6 @@
 //! HTTP API service implementations for `server`
 
+use crate::INFLUXDB3_BUILD;
 use crate::{CommonServerState, all_paths};
 use arrow::record_batch::RecordBatch;
 use arrow::util::pretty;
@@ -38,9 +39,7 @@ use influxdb3_id::TokenId;
 use influxdb3_internal_api::query_executor::{
     QueryExecutor, QueryExecutorError, ShowDatabases, ShowRetentionPolicies,
 };
-use influxdb3_process::{
-    INFLUXDB3_BUILD, INFLUXDB3_GIT_HASH_SHORT, INFLUXDB3_VERSION, ProcessUuidWrapper,
-};
+use influxdb3_process::{INFLUXDB3_GIT_HASH_SHORT, INFLUXDB3_VERSION, ProcessUuidWrapper};
 use influxdb3_processing_engine::ProcessingEngineManagerImpl;
 use influxdb3_processing_engine::manager::ProcessingEngineError;
 use influxdb3_types::http::*;
@@ -1084,6 +1083,7 @@ impl HttpApi {
     fn ping(&self) -> Result<Response> {
         let process_uuid = ProcessUuidWrapper::new();
         let body = serde_json::to_string(&PingResponse {
+            product_name: crate::PRODUCT_NAME.to_string(),
             version: INFLUXDB3_VERSION.to_string(),
             revision: INFLUXDB3_GIT_HASH_SHORT.to_string(),
             process_id: *process_uuid.get(),

--- a/influxdb3_server/src/lib.rs
+++ b/influxdb3_server/src/lib.rs
@@ -29,11 +29,12 @@ use hyper_util::server::graceful::GracefulShutdown;
 use hyper_util::service::TowerToHyperService;
 use influxdb3_authz::AuthProvider;
 use influxdb3_catalog::catalog::Catalog;
+use influxdb3_process::build_version_string;
 use influxdb3_telemetry::store::TelemetryStore;
 use observability_deps::tracing::{error, info, trace, warn};
 use std::fmt::Debug;
 use std::path::PathBuf;
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 use thiserror::Error;
 use tokio::io::AsyncWriteExt;
 use tokio::net::TcpListener;
@@ -49,6 +50,12 @@ use trace_http::ctx::TraceHeaderParser;
 use trace_http::metrics::{MetricFamily, RequestMetrics};
 use trace_http::tower::{ServiceProtocol, TraceLayer};
 use unified_service::{RemoteAddrLayer, UnifiedService};
+
+pub const PRODUCT_NAME: &str = "InfluxDB 3 Core";
+pub const INFLUXDB3_BUILD: &str = "Core";
+
+/// Version string combining the product name, [`influxdb3_process::INFLUXDB3_VERSION`], and [`influxdb3_process::INFLUXDB3_GIT_HASH`].
+pub static VERSION_STRING: LazyLock<String> = LazyLock::new(|| build_version_string(PRODUCT_NAME));
 
 #[derive(Debug, Error)]
 pub enum Error {

--- a/influxdb3_types/src/http.rs
+++ b/influxdb3_types/src/http.rs
@@ -68,6 +68,8 @@ pub enum Error {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct PingResponse {
+    #[serde(default)]
+    pub product_name: String,
     pub version: String,
     pub revision: String,
     pub process_id: Uuid,


### PR DESCRIPTION
Brings in changes from https://github.com/influxdata/influxdb/pull/27298.