### PR TITLE
fix: improve WAL file sequence number management

### DIFF
--- a/influxdb3_wal/src/object_store.rs
+++ b/influxdb3_wal/src/object_store.rs
@@ -106,7 +106,17 @@ impl WalObjectStore {
         num_wal_files_to_keep: u64,
         shutdown_token: CancellationToken,
     ) -> Self {
-        let wal_file_sequence_number = last_wal_sequence_number.unwrap_or_default().next();
+        let wal_file_sequence_number = {
+            let from_snapshot = last_wal_sequence_number.unwrap_or_default().next();
+            // Also consider the newest WAL file on disk. Corrupt (e.g. 0-byte) files
+            // are skipped during replay but still occupy their sequence number on the
+            // object store. Starting with a number <= any existing file would cause an
+            // AlreadyExists error on the first flush.
+            let from_disk = newest_wal_file_num(all_wal_file_paths)
+                .map(|n| n.next())
+                .unwrap_or(from_snapshot);
+            std::cmp::max(from_snapshot, from_disk)
+        };
         let oldest_wal_file_num = oldest_wal_file_num(all_wal_file_paths);
 
         Self {
@@ -203,6 +213,21 @@ impl WalObjectStore {
                         )),
                     ) if !fail_on_error => {
                         warn!(%error, %path, "Skipping corrupt WAL file");
+                        // Even though we skip the corrupt file, we must advance the
+                        // WAL file sequence number past it so that the next flush does
+                        // not attempt to write a file with the same number, which would
+                        // cause an AlreadyExists error and trigger a shutdown.
+                        if let Ok(skipped_seq) = WalFileSequenceNumber::try_from(&path) {
+                            let mut flush_buffer = self.flush_buffer.lock().await;
+                            if skipped_seq >= flush_buffer.wal_buffer.wal_file_sequence_number {
+                                flush_buffer.wal_buffer.wal_file_sequence_number =
+                                    skipped_seq.next();
+                                info!(
+                                    new_wal_file_sequence_number = %skipped_seq.next(),
+                                    "Advanced WAL file sequence number past corrupt file"
+                                );
+                            }
+                        }
                         continue;
                     }
                     (path, Err(error)) => {
@@ -564,6 +589,25 @@ fn oldest_wal_file_num(all_wal_file_paths: &[Path]) -> Option<WalFileSequenceNum
         ?file_name_with_path,
         ?wal_file_name,
         "file name path and wal file name"
+    );
+    WalFileSequenceNumber::from_str(wal_file_name).ok()
+}
+
+/// Returns the newest (highest) WAL file sequence number from the sorted list
+/// of WAL file paths. This is used to ensure the next WAL file number is always
+/// greater than any existing file on disk, including corrupt files that may be
+/// skipped during replay.
+fn newest_wal_file_num(all_wal_file_paths: &[Path]) -> Option<WalFileSequenceNumber> {
+    let file_name_with_path = all_wal_file_paths.last()?.filename()?;
+    let wal_file_name = file_name_with_path
+        .split("/")
+        .last()?
+        .split(".wal")
+        .next()?;
+    debug!(
+        ?file_name_with_path,
+        ?wal_file_name,
+        "newest wal file name path and wal file name"
     );
     WalFileSequenceNumber::from_str(wal_file_name).ok()
 }

--- a/influxdb3_wal/src/object_store/tests.rs
+++ b/influxdb3_wal/src/object_store/tests.rs
@@ -917,8 +917,8 @@ fn test_newest_wal_file_num() {
     );
 }
 
-#[test]
-fn test_new_without_replay_advances_past_disk_files() {
+#[tokio::test]
+async fn test_new_without_replay_advances_past_disk_files() {
     // When all_wal_file_paths contains files beyond last_wal_sequence_number,
     // the initial wal_file_sequence_number should be set past the newest file
     // on disk. This prevents AlreadyExists errors when corrupt files are
@@ -958,13 +958,12 @@ fn test_new_without_replay_advances_past_disk_files() {
 
     // The sequence number should be 1788 (past the newest file on disk),
     // not 1784 (last_wal_sequence_number + 1)
-    let seq = futures::executor::block_on(async {
-        wal.flush_buffer
-            .lock()
-            .await
-            .wal_buffer
-            .wal_file_sequence_number
-    });
+    let seq = wal
+        .flush_buffer
+        .lock()
+        .await
+        .wal_buffer
+        .wal_file_sequence_number;
     assert_eq!(seq, WalFileSequenceNumber::new(1788));
 }
 

--- a/influxdb3_wal/src/object_store/tests.rs
+++ b/influxdb3_wal/src/object_store/tests.rs
@@ -892,3 +892,144 @@ impl WalFileNotifier for TestNotifier {
         self
     }
 }
+
+#[test]
+fn test_newest_wal_file_num() {
+    // Empty list returns None
+    assert_eq!(newest_wal_file_num(&[]), None);
+
+    // Single file
+    let paths = vec![Path::from("my_host/wal/00000000005.wal")];
+    assert_eq!(
+        newest_wal_file_num(&paths),
+        Some(WalFileSequenceNumber::new(5))
+    );
+
+    // Multiple sorted files - should return the last (highest)
+    let paths = vec![
+        Path::from("my_host/wal/00000000010.wal"),
+        Path::from("my_host/wal/00000000020.wal"),
+        Path::from("my_host/wal/00000000030.wal"),
+    ];
+    assert_eq!(
+        newest_wal_file_num(&paths),
+        Some(WalFileSequenceNumber::new(30))
+    );
+}
+
+#[test]
+fn test_new_without_replay_advances_past_disk_files() {
+    // When all_wal_file_paths contains files beyond last_wal_sequence_number,
+    // the initial wal_file_sequence_number should be set past the newest file
+    // on disk. This prevents AlreadyExists errors when corrupt files are
+    // skipped during replay (issue #26970).
+    let time_provider: Arc<dyn TimeProvider> =
+        Arc::new(MockProvider::new(Time::from_timestamp_nanos(0)));
+    let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let notifier: Arc<dyn WalFileNotifier> = Arc::new(TestNotifier::default());
+    let wal_config = WalConfig {
+        max_write_buffer_size: 100,
+        flush_interval: Duration::from_secs(1),
+        snapshot_size: 2,
+        gen1_duration: Gen1Duration::new_1m(),
+        ..Default::default()
+    };
+
+    // Simulate: snapshot says last WAL was 1783, but disk has corrupt files 1784-1787
+    let all_wal_file_paths = vec![
+        Path::from("my_host/wal/00000001784.wal"),
+        Path::from("my_host/wal/00000001785.wal"),
+        Path::from("my_host/wal/00000001786.wal"),
+        Path::from("my_host/wal/00000001787.wal"),
+    ];
+
+    let wal = WalObjectStore::new_without_replay(
+        time_provider,
+        object_store,
+        "my_host",
+        notifier,
+        wal_config,
+        Some(WalFileSequenceNumber::new(1783)),
+        None,
+        &all_wal_file_paths,
+        10,
+        CancellationToken::new(),
+    );
+
+    // The sequence number should be 1788 (past the newest file on disk),
+    // not 1784 (last_wal_sequence_number + 1)
+    let seq = futures::executor::block_on(async {
+        wal.flush_buffer
+            .lock()
+            .await
+            .wal_buffer
+            .wal_file_sequence_number
+    });
+    assert_eq!(seq, WalFileSequenceNumber::new(1788));
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_replay_advances_sequence_number_past_corrupt_files() {
+    // When corrupt WAL files are skipped during replay, the sequence number
+    // must be advanced past them so the next flush does not collide (issue #26970).
+    let time_provider: Arc<dyn TimeProvider> =
+        Arc::new(MockProvider::new(Time::from_timestamp_nanos(0)));
+    let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let notifier: Arc<dyn WalFileNotifier> = Arc::new(TestNotifier::default());
+    let wal_config = WalConfig {
+        max_write_buffer_size: 100,
+        flush_interval: Duration::from_secs(1),
+        snapshot_size: 2,
+        gen1_duration: Gen1Duration::new_1m(),
+        ..Default::default()
+    };
+
+    // Write empty (corrupt) WAL files to the object store
+    for i in 5..=8 {
+        let path = wal_path("my_host", WalFileSequenceNumber::new(i));
+        object_store
+            .put(&path, PutPayload::from_static(b""))
+            .await
+            .unwrap();
+    }
+
+    let all_wal_file_paths = vec![
+        Path::from("my_host/wal/00000000005.wal"),
+        Path::from("my_host/wal/00000000006.wal"),
+        Path::from("my_host/wal/00000000007.wal"),
+        Path::from("my_host/wal/00000000008.wal"),
+    ];
+
+    // Start with last_wal_sequence_number = 4
+    let wal = WalObjectStore::new_without_replay(
+        time_provider,
+        object_store,
+        "my_host",
+        notifier,
+        wal_config,
+        Some(WalFileSequenceNumber::new(4)),
+        None,
+        &all_wal_file_paths,
+        10,
+        CancellationToken::new(),
+    );
+
+    // new_without_replay should already set it to 9 based on disk files,
+    // but verify replay also handles it correctly
+    wal.replay(
+        Some(WalFileSequenceNumber::new(4)),
+        &all_wal_file_paths,
+        4,
+        false,
+    )
+    .await
+    .unwrap();
+
+    let seq = wal
+        .flush_buffer
+        .lock()
+        .await
+        .wal_buffer
+        .wal_file_sequence_number;
+    assert_eq!(seq, WalFileSequenceNumber::new(9));
+}


### PR DESCRIPTION
Closes #26970

## Problem

After an unclean shutdown (e.g. power outage), empty (0-byte) WAL files can be left on disk.
On restart, PR #26556 correctly skips these corrupt files during replay with a warning.
However, the WAL file sequence number is **not advanced** past the skipped files.

When the first new write arrives and the WAL buffer is flushed, the system attempts to persist a WAL file using the same sequence number as one of the skipped corrupt files.
Because the corrupt file still exists on the object store, `put_opts` with `PutMode::Create` returns an `AlreadyExists` error, which triggers an immediate shutdown.
If the service is configured to auto-restart, this creates an infinite crash loop until the corrupt files are manually removed.

**Reproduction sequence (from the issue logs):**

1. Unclean shutdown leaves 0-byte WAL files: `00000001784.wal` through `00000001787.wal`
2. On restart, `new_without_replay()` sets `wal_file_sequence_number` to `last_wal_sequence_number + 1` (= 1784), based solely on the snapshot metadata
3. `replay()` skips all four corrupt files (`WalFileTooSmall`) but does not update the sequence number
4. First flush attempts to write `00000001784.wal` → `AlreadyExists` → shutdown

## Fix

This change introduces two layers of defense, both in `influxdb3_wal/src/object_store.rs`:

**1. `new_without_replay()` — initialization-time guard**

The initial `wal_file_sequence_number` now takes the **maximum** of:
- `last_wal_sequence_number + 1` (from snapshot metadata, the existing behavior)
- `newest_wal_file_on_disk + 1` (derived from the sorted list of WAL file paths)

This ensures the starting sequence number is always greater than any file that exists on the object store, regardless of whether those files are valid or corrupt.

A new helper function `newest_wal_file_num()` (mirroring the existing `oldest_wal_file_num()`) is added to extract the highest sequence number from the sorted WAL file path list.

**2. `replay()` — replay-time guard**

When a corrupt WAL file is skipped during replay, the code now parses the sequence number from the file path and advances `wal_file_sequence_number` if the skipped file's number is ≥ the current value.
This handles edge cases where corrupt files are interleaved with valid files during replay.

## Result

Using the issue's example (corrupt files 1784–1787):
- **Before:** sequence number stays at 1784 → `AlreadyExists` → shutdown
- **After:** `new_without_replay()` sets sequence number to 1788 at initialization;
  `replay()` would also advance it to 1788 as each corrupt file is skipped.
  First flush writes `00000001788.wal` with no conflict.

## Tests

Three new tests are added in `influxdb3_wal/src/object_store/tests.rs`:

**`test_newest_wal_file_num`**
Unit test for the new `newest_wal_file_num()` helper function. Verifies:
- Returns `None` for an empty path list
- Returns the correct sequence number for a single-element list
- Returns the highest (last) sequence number from a sorted multi-element list

**`test_new_without_replay_advances_past_disk_files`**
Reproduces the core scenario from issue #26970.
Sets `last_wal_sequence_number` to 1783 while providing `all_wal_file_paths` containing files 1784–1787 (simulating corrupt files left on disk after an unclean shutdown).
Asserts that `new_without_replay()` initializes `wal_file_sequence_number` to 1788, not 1784.

**`test_replay_advances_sequence_number_past_corrupt_files`**
End-to-end test that writes actual empty (0-byte) files to an in-memory object store, then runs `replay()` with `fail_on_error=false`.
Verifies that after all four corrupt files are skipped, `wal_file_sequence_number` is correctly advanced to 9 (one past the highest corrupt file number 8).

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).