### PR TITLE
fix: call findGenerations once per compaction plan (#27304)

### DIFF
--- a/tsdb/engine/tsm1/compact.go
+++ b/tsdb/engine/tsm1/compact.go
@@ -124,15 +124,19 @@ type CompactionGroup []string
 // CompactionPlanner determines what TSM files and WAL segments to include in a
 // given compaction run.
 type CompactionPlanner interface {
-	Plan(lastWrite time.Time) ([]CompactionGroup, int64)
-	PlanLevel(level int) ([]CompactionGroup, int64)
+	FindGenerations() TsmGenerations
+	// The generations argument to Plan, PlanLevel, and PlamOptimize must be sorted
+	// as it is in DefaultPlanner.FindGenerations
+
+	Plan(generations TsmGenerations, lastWrite time.Time) ([]CompactionGroup, int64)
+	PlanLevel(generations TsmGenerations, level int) ([]CompactionGroup, int64)
 	// PlanOptimize will return the groups for compaction, the compaction group length,
 	// and the amount of generations within the compaction group.
 	// generationCount needs to be set to decide how many points per block during compaction.
 	// This value is mostly ignored in normal compaction code paths, but,
 	// for the edge case where there is a single generation with many
 	// files under 2 GB this value is an important indicator.
-	PlanOptimize(lastWrite time.Time) (compactGroup []CompactionGroup, compactionGroupLen int64, generationCount int64)
+	PlanOptimize(generations TsmGenerations, lastWrite time.Time) (compactGroup []CompactionGroup, compactionGroupLen int64, generationCount int64)
 	Release(group []CompactionGroup)
 	FullyCompacted() (bool, string)
 
@@ -268,7 +272,7 @@ func (c *DefaultPlanner) SetFileStore(fs *FileStore) {
 	c.FileStore = fs
 }
 
-func (c *DefaultPlanner) generationsFullyCompacted(gens tsmGenerations) (bool, string) {
+func (c *DefaultPlanner) generationsFullyCompacted(gens TsmGenerations) (bool, string) {
 	if len(gens) > 1 {
 		return false, "not fully compacted and not idle because of more than one generation"
 	} else if gens.hasTombstones() {
@@ -309,7 +313,7 @@ func (c *DefaultPlanner) generationsFullyCompacted(gens tsmGenerations) (bool, s
 // FullyCompacted returns true if the shard is fully compacted.
 // Used to check if an optimization can occur and shard hot-ness.
 func (c *DefaultPlanner) FullyCompacted() (bool, string) {
-	return c.generationsFullyCompacted(c.findGenerations())
+	return c.generationsFullyCompacted(c.FindGenerations())
 }
 
 // ForceFull causes the planner to return a full compaction plan the next time
@@ -324,7 +328,7 @@ func (c *DefaultPlanner) ForceFull() {
 type leveltestFnType func(currentLevel int, candidateLevel int) bool
 
 // PlanLevel returns a set of TSM files to rewrite for a specific level.
-func (c *DefaultPlanner) PlanLevel(level int) ([]CompactionGroup, int64) {
+func (c *DefaultPlanner) PlanLevel(generations TsmGenerations, level int) ([]CompactionGroup, int64) {
 	// If a full plan has been requested, don't plan any levels which will prevent
 	// the full plan from acquiring them.
 	c.mu.RLock()
@@ -333,11 +337,6 @@ func (c *DefaultPlanner) PlanLevel(level int) ([]CompactionGroup, int64) {
 		return nil, 0
 	}
 	c.mu.RUnlock()
-
-	// Determine the generations from all files on disk.  We need to treat
-	// a generation conceptually as a single file even though it may be
-	// split across several files in sequence.
-	generations := c.findGenerations()
 
 	// If there is only one generation and no tombstones, then there's nothing to
 	// do.
@@ -349,7 +348,7 @@ func (c *DefaultPlanner) PlanLevel(level int) ([]CompactionGroup, int64) {
 		func(currentLevel int, candidateLevel int) bool { return currentLevel == candidateLevel })
 
 	// Remove any groups in the wrong level
-	var levelGroups []tsmGenerations
+	var levelGroups []TsmGenerations
 	levelGroupIndices := make(map[int]int)
 	for i, cur := range groups {
 		if cur.level() == level {
@@ -400,18 +399,18 @@ func (c *DefaultPlanner) PlanLevel(level int) ([]CompactionGroup, int64) {
 	return cGroups, int64(len(cGroups))
 }
 
-func (c *DefaultPlanner) groupAdjacentGenerations(generations tsmGenerations, levelTestFn leveltestFnType) []tsmGenerations {
+func (c *DefaultPlanner) groupAdjacentGenerations(generations TsmGenerations, levelTestFn leveltestFnType) []TsmGenerations {
 	// Group each generation by level such that two adjacent generations in the same
 	// level become part of the same group.
 	// generations in use halt the accumulation of a group
 	// Capture orphaned generations that are followed by a higher level generation
-	var currentGen tsmGenerations
+	var currentGen TsmGenerations
 	var groups tsmGenerationGroups
 
 	moveToNextGroup := func() {
 		if len(currentGen) > 0 {
 			groups = append(groups, currentGen)
-			currentGen = tsmGenerations{}
+			currentGen = TsmGenerations{}
 		}
 	}
 	for i := 0; i < len(generations); i++ {
@@ -442,7 +441,7 @@ func (c *DefaultPlanner) groupAdjacentGenerations(generations tsmGenerations, le
 // PlanOptimize returns all TSM files if they are in different generations in order
 // to optimize the index across TSM files.  Each returned compaction group can be
 // compacted concurrently.
-func (c *DefaultPlanner) PlanOptimize(lastWrite time.Time) (compactGroup []CompactionGroup, compactionGroupLen int64, generationCount int64) {
+func (c *DefaultPlanner) PlanOptimize(generations TsmGenerations, lastWrite time.Time) (compactGroup []CompactionGroup, compactionGroupLen int64, generationCount int64) {
 	// If a full plan has been requested, don't plan any levels which will prevent
 	// the full plan from acquiring them.
 	c.mu.RLock()
@@ -452,10 +451,6 @@ func (c *DefaultPlanner) PlanOptimize(lastWrite time.Time) (compactGroup []Compa
 	}
 	c.mu.RUnlock()
 
-	// Determine the generations from all files on disk.  We need to treat
-	// a generation conceptually as a single file even though it may be
-	// split across several files in sequence.
-	generations := c.findGenerations()
 	fullyCompacted, _ := c.generationsFullyCompacted(generations)
 
 	if fullyCompacted || time.Since(lastWrite) < c.compactFullWriteColdDuration {
@@ -491,9 +486,7 @@ func (c *DefaultPlanner) PlanOptimize(lastWrite time.Time) (compactGroup []Compa
 
 // Plan returns a set of TSM files to rewrite for level 4 or higher.  The planning returns
 // multiple groups if possible to allow compactions to run concurrently.
-func (c *DefaultPlanner) Plan(lastWrite time.Time) ([]CompactionGroup, int64) {
-	generations := c.findGenerations()
-
+func (c *DefaultPlanner) Plan(generations TsmGenerations, lastWrite time.Time) ([]CompactionGroup, int64) {
 	c.mu.RLock()
 	forceFull := c.forceFull
 	c.mu.RUnlock()
@@ -623,7 +616,7 @@ func (c *DefaultPlanner) Plan(lastWrite time.Time) ([]CompactionGroup, int64) {
 	// Loop through the generations in groups of size step and see if we can compact all (or
 	// some of them as generationGroup)
 	var groups tsmGenerationGroups
-	var currentGroup tsmGenerations
+	var currentGroup TsmGenerations
 
 	for i := 0; i < len(generations); {
 		moveToNextGroup := func() {
@@ -636,7 +629,7 @@ func (c *DefaultPlanner) Plan(lastWrite time.Time) ([]CompactionGroup, int64) {
 			}
 		}
 
-		currentGroup = make(tsmGenerations, 0, step)
+		currentGroup = make(TsmGenerations, 0, step)
 		// Group
 		for j := 0; j < step && (j+i) < len(generations); j++ {
 			gen := generations[j+i]
@@ -703,9 +696,9 @@ func (c *DefaultPlanner) isInUse(t *tsmGeneration) bool {
 	return false
 }
 
-// findGenerations groups all the TSM files by generation based
-// on their filename, then returns the generations in descending order (newest first).
-func (c *DefaultPlanner) findGenerations() tsmGenerations {
+// FindGenerations groups all the TSM files by generation based
+// on their filename, then returns the generations in ascending order (oldest first).
+func (c *DefaultPlanner) FindGenerations() TsmGenerations {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
@@ -721,7 +714,7 @@ func (c *DefaultPlanner) findGenerations() tsmGenerations {
 		group.files = append(group.files, f)
 	}
 
-	orderedGenerations := make(tsmGenerations, 0, len(generations))
+	orderedGenerations := make(TsmGenerations, 0, len(generations))
 	for _, g := range generations {
 		orderedGenerations = append(orderedGenerations, g)
 	}
@@ -1918,12 +1911,12 @@ func (c *cacheKeyIterator) Err() error {
 	return c.err
 }
 
-type tsmGenerations []*tsmGeneration
+type TsmGenerations []*tsmGeneration
 
-func (a tsmGenerations) Len() int           { return len(a) }
-func (a tsmGenerations) Less(i, j int) bool { return a[i].id < a[j].id }
-func (a tsmGenerations) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
-func (a tsmGenerations) hasTombstones() bool {
+func (a TsmGenerations) Len() int           { return len(a) }
+func (a TsmGenerations) Less(i, j int) bool { return a[i].id < a[j].id }
+func (a TsmGenerations) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+func (a TsmGenerations) hasTombstones() bool {
 	for _, g := range a {
 		if g.hasTombstones() {
 			return true
@@ -1932,7 +1925,7 @@ func (a tsmGenerations) hasTombstones() bool {
 	return false
 }
 
-func (a tsmGenerations) level() int {
+func (a TsmGenerations) level() int {
 	var level int
 	for _, g := range a {
 		lev := g.level()
@@ -1943,7 +1936,7 @@ func (a tsmGenerations) level() int {
 	return level
 }
 
-func (a tsmGenerations) String() string {
+func (a TsmGenerations) String() string {
 	var b strings.Builder
 	for i, g := range a {
 		if i > 0 {
@@ -1954,8 +1947,8 @@ func (a tsmGenerations) String() string {
 	return b.String()
 }
 
-func (a tsmGenerations) chunk(size int) []tsmGenerations {
-	var chunks []tsmGenerations
+func (a TsmGenerations) chunk(size int) []TsmGenerations {
+	var chunks []TsmGenerations
 	for len(a) > 0 {
 		if len(a) >= size {
 			chunks = append(chunks, a[:size])
@@ -1968,7 +1961,7 @@ func (a tsmGenerations) chunk(size int) []tsmGenerations {
 	return chunks
 }
 
-func (a tsmGenerations) IsSorted() bool {
+func (a TsmGenerations) IsSorted() bool {
 	if len(a) == 1 {
 		return true
 	}
@@ -1981,7 +1974,7 @@ func (a tsmGenerations) IsSorted() bool {
 	return true
 }
 
-type tsmGenerationGroups []tsmGenerations
+type tsmGenerationGroups []TsmGenerations
 
 type latencies struct {
 	i      int

--- a/tsdb/engine/tsm1/compact_test.go
+++ b/tsdb/engine/tsm1/compact_test.go
@@ -1688,7 +1688,7 @@ func TestDefaultPlanner_Plan_Min(t *testing.T) {
 		newFakeFileStore(withFileStats(t, fileStats)), tsdb.DefaultCompactFullWriteColdDuration,
 	)
 
-	tsm, pLen := cp.Plan(time.Now())
+	tsm, pLen := cp.Plan(cp.FindGenerations(), time.Now())
 	if exp, got := 0, len(tsm); got != exp {
 		t.Fatalf("tsm file length mismatch: got %v, exp %v", got, exp)
 	} else if pLen != int64(len(tsm)) {
@@ -1736,7 +1736,7 @@ func TestDefaultPlanner_Plan_CombineSequence(t *testing.T) {
 	)
 
 	expFiles := []tsm1.FileStat{data[0], data[1], data[2], data[3]}
-	tsm, pLen := cp.Plan(time.Now())
+	tsm, pLen := cp.Plan(cp.FindGenerations(), time.Now())
 	if exp, got := len(expFiles), len(tsm[0]); got != exp {
 		t.Fatalf("tsm file length mismatch: got %v, exp %v", got, exp)
 	} else if pLen != int64(len(tsm)) {
@@ -1797,7 +1797,7 @@ func TestDefaultPlanner_Plan_MultipleGroups(t *testing.T) {
 
 	expFiles := []tsm1.FileStat{data[0], data[1], data[2], data[3],
 		data[4], data[5], data[6], data[7]}
-	tsm, pLen := cp.Plan(time.Now())
+	tsm, pLen := cp.Plan(cp.FindGenerations(), time.Now())
 
 	if got, exp := len(tsm), 2; got != exp {
 		t.Fatalf("compaction group length mismatch: got %v, exp %v", got, exp)
@@ -1885,7 +1885,7 @@ func TestDefaultPlanner_PlanLevel_SmallestCompactionStep(t *testing.T) {
 	)
 
 	expFiles := []tsm1.FileStat{data[4], data[5], data[6], data[7], data[8], data[9], data[10], data[11]}
-	tsm, pLen := cp.PlanLevel(1)
+	tsm, pLen := cp.PlanLevel(cp.FindGenerations(), 1)
 	if exp, got := len(expFiles), len(tsm[0]); got != exp {
 		t.Fatalf("tsm file length mismatch: got %v, exp %v", got, exp)
 	} else if pLen != int64(len(tsm)) {
@@ -1937,7 +1937,7 @@ func TestDefaultPlanner_PlanLevel_SplitFile(t *testing.T) {
 	)
 
 	expFiles := []tsm1.FileStat{data[0], data[1], data[2], data[3], data[4]}
-	tsm, pLen := cp.PlanLevel(3)
+	tsm, pLen := cp.PlanLevel(cp.FindGenerations(), 3)
 	if exp, got := len(expFiles), len(tsm[0]); got != exp {
 		t.Fatalf("tsm file length mismatch: got %v, exp %v", got, exp)
 	} else if pLen != int64(len(tsm)) {
@@ -1989,7 +1989,7 @@ func TestDefaultPlanner_PlanLevel_IsolatedHighLevel(t *testing.T) {
 	)
 
 	expFiles := []tsm1.FileStat{}
-	tsm, pLen := cp.PlanLevel(3)
+	tsm, pLen := cp.PlanLevel(cp.FindGenerations(), 3)
 	if exp, got := len(expFiles), len(tsm); got != exp {
 		t.Fatalf("tsm file length mismatch: got %v, exp %v", got, exp)
 	} else if pLen != int64(len(tsm)) {
@@ -2031,7 +2031,7 @@ func TestDefaultPlanner_PlanLevel3_MinFiles(t *testing.T) {
 	)
 
 	expFiles := []tsm1.FileStat{}
-	tsm, pLen := cp.PlanLevel(3)
+	tsm, pLen := cp.PlanLevel(cp.FindGenerations(), 3)
 	if exp, got := len(expFiles), len(tsm); got != exp {
 		t.Fatalf("tsm file length mismatch: got %v, exp %v", got, exp)
 	} else if pLen != int64(len(tsm)) {
@@ -2062,7 +2062,7 @@ func TestDefaultPlanner_PlanLevel2_MinFiles(t *testing.T) {
 	)
 
 	expFiles := []tsm1.FileStat{}
-	tsm, pLen := cp.PlanLevel(2)
+	tsm, pLen := cp.PlanLevel(cp.FindGenerations(), 2)
 	if exp, got := len(expFiles), len(tsm); got != exp {
 		t.Fatalf("tsm file length mismatch: got %v, exp %v", got, exp)
 	} else if pLen != int64(len(tsm)) {
@@ -2105,7 +2105,7 @@ func TestDefaultPlanner_PlanLevel_Tombstone(t *testing.T) {
 	)
 
 	expFiles := []tsm1.FileStat{data[0], data[1]}
-	tsm, pLen := cp.PlanLevel(3)
+	tsm, pLen := cp.PlanLevel(cp.FindGenerations(), 3)
 	if exp, got := len(expFiles), len(tsm[0]); got != exp {
 		t.Fatalf("tsm file length mismatch: got %v, exp %v", got, exp)
 	} else if pLen != int64(len(tsm)) {
@@ -2162,7 +2162,7 @@ func TestDefaultPlanner_PlanLevel_Multiple(t *testing.T) {
 
 	expFiles1 := []tsm1.FileStat{data[0], data[1], data[2], data[3], data[4], data[5], data[6], data[7]}
 
-	tsm, pLen := cp.PlanLevel(1)
+	tsm, pLen := cp.PlanLevel(cp.FindGenerations(), 1)
 	if exp, got := len(expFiles1), len(tsm[0]); got != exp {
 		t.Fatalf("tsm file length mismatch: got %v, exp %v", got, exp)
 	} else if pLen != int64(len(tsm)) {
@@ -2252,7 +2252,8 @@ func TestDefaultPlanner_PlanLevel_InUse(t *testing.T) {
 	expFiles1 := data[0:8]
 	expFiles2 := data[8:16]
 
-	tsm, pLen := cp.PlanLevel(1)
+	generations := cp.FindGenerations()
+	tsm, pLen := cp.PlanLevel(generations, 1)
 	if exp, got := len(expFiles1), len(tsm[0]); got != exp {
 		t.Fatalf("tsm file length mismatch: got %v, exp %v", got, exp)
 	} else if pLen != int64(len(tsm)) {
@@ -2277,7 +2278,7 @@ func TestDefaultPlanner_PlanLevel_InUse(t *testing.T) {
 
 	cp.Release(tsm[1:])
 
-	tsm, pLen = cp.PlanLevel(1)
+	tsm, pLen = cp.PlanLevel(generations, 1)
 	if exp, got := len(expFiles2), len(tsm[0]); got != exp {
 		t.Fatalf("tsm file length mismatch: got %v, exp %v", got, exp)
 	} else if pLen != int64(len(tsm)) {
@@ -2313,7 +2314,7 @@ func TestDefaultPlanner_PlanOptimize_NoLevel4(t *testing.T) {
 	)
 
 	expFiles := []tsm1.FileStat{}
-	tsm, pLen, gLen := cp.PlanOptimize(time.Now().Add(-tsdb.DefaultCompactFullWriteColdDuration + 1))
+	tsm, pLen, gLen := cp.PlanOptimize(cp.FindGenerations(), time.Now().Add(-tsdb.DefaultCompactFullWriteColdDuration+1))
 	if exp, got := len(expFiles), len(tsm); got != exp {
 		t.Fatalf("tsm file length mismatch: got %v, exp %v", got, exp)
 	} else if pLen != int64(len(tsm)) {
@@ -2346,7 +2347,7 @@ func TestDefaultPlanner_PlanOptimize_Tombstones(t *testing.T) {
 	)
 
 	expFiles := []tsm1.FileStat{data[0], data[1], data[2]}
-	tsm, pLen, _ := cp.PlanOptimize(time.Now().Add(-tsdb.DefaultCompactFullWriteColdDuration + 1))
+	tsm, pLen, _ := cp.PlanOptimize(cp.FindGenerations(), time.Now().Add(-tsdb.DefaultCompactFullWriteColdDuration+1))
 	if exp, got := len(expFiles), len(tsm[0]); got != exp {
 		t.Fatalf("tsm file length mismatch: got %v, exp %v", got, exp)
 	} else if pLen != int64(len(tsm)) {
@@ -2396,7 +2397,7 @@ func TestDefaultPlanner_Plan_FullOnCold(t *testing.T) {
 		time.Nanosecond,
 	)
 
-	tsm, pLen := cp.Plan(time.Now().Add(-time.Second))
+	tsm, pLen := cp.Plan(cp.FindGenerations(), time.Now().Add(-time.Second))
 	if exp, got := len(data), len(tsm[0]); got != exp {
 		t.Fatalf("tsm file length mismatch: got %v, exp %v", got, exp)
 	} else if pLen != int64(len(tsm)) {
@@ -2429,7 +2430,7 @@ func TestDefaultPlanner_Plan_SkipMaxSizeFiles(t *testing.T) {
 		tsdb.DefaultCompactFullWriteColdDuration,
 	)
 
-	tsm, pLen := cp.Plan(time.Now())
+	tsm, pLen := cp.Plan(cp.FindGenerations(), time.Now())
 	if exp, got := 0, len(tsm); got != exp {
 		t.Fatalf("tsm file length mismatch: got %v, exp %v", got, exp)
 	} else if pLen != int64(len(tsm)) {
@@ -2463,7 +2464,7 @@ func TestDefaultPlanner_Plan_SkipPlanningAfterFull(t *testing.T) {
 
 	cp := tsm1.NewDefaultPlanner(ffs, time.Nanosecond)
 
-	plan, pLen := cp.Plan(time.Now().Add(-time.Second))
+	plan, pLen := cp.Plan(cp.FindGenerations(), time.Now().Add(-time.Second))
 	// first verify that our test set would return files
 	if exp, got := 4, len(plan[0]); got != exp {
 		t.Fatalf("tsm file length mismatch: got %v, exp %v", got, exp)
@@ -2499,7 +2500,8 @@ func TestDefaultPlanner_Plan_SkipPlanningAfterFull(t *testing.T) {
 	overFs := newFakeFileStore(withFileStats(t, over), withDefaultBlockCount(tsdb.DefaultMaxPointsPerBlock))
 	cp.FileStore = overFs
 
-	plan, pLen = cp.Plan(time.Now().Add(-time.Second))
+	overGens := cp.FindGenerations()
+	plan, pLen = cp.Plan(overGens, time.Now().Add(-time.Second))
 	if exp, got := 0, len(plan); got != exp {
 		t.Fatalf("tsm file length mismatch: got %v, exp %v", got, exp)
 	} else if pLen != int64(len(plan)) {
@@ -2507,7 +2509,7 @@ func TestDefaultPlanner_Plan_SkipPlanningAfterFull(t *testing.T) {
 	}
 	cp.Release(plan)
 
-	plan, pLen, _ = cp.PlanOptimize(time.Now().Add(-tsdb.DefaultCompactFullWriteColdDuration + 1))
+	plan, pLen, _ = cp.PlanOptimize(overGens, time.Now().Add(-tsdb.DefaultCompactFullWriteColdDuration+1))
 	// ensure the optimize planner would pick this up
 	if exp, got := 1, len(plan); got != exp {
 		t.Fatalf("tsm file length mismatch: got %v, exp %v", got, exp)
@@ -2520,7 +2522,7 @@ func TestDefaultPlanner_Plan_SkipPlanningAfterFull(t *testing.T) {
 	// ensure that it will plan if last modified has changed
 	ffs.lastModified = time.Now()
 
-	cGroups, pLen := cp.Plan(time.Now())
+	cGroups, pLen := cp.Plan(cp.FindGenerations(), time.Now())
 	if exp, got := 4, len(cGroups[0]); got != exp {
 		t.Fatalf("tsm file length mismatch: got %v, exp %v", got, exp)
 	} else if pLen != int64(len(cGroups)) {
@@ -2579,7 +2581,7 @@ func TestDefaultPlanner_Plan_TwoGenLevel3(t *testing.T) {
 
 	cp := tsm1.NewDefaultPlanner(fs, time.Hour)
 
-	tsm, pLen := cp.Plan(time.Now().Add(-24 * time.Hour))
+	tsm, pLen := cp.Plan(cp.FindGenerations(), time.Now().Add(-24*time.Hour))
 	if exp, got := 1, len(tsm); got != exp {
 		t.Fatalf("tsm file length mismatch: got %v, exp %v", got, exp)
 	} else if pLen != int64(len(tsm)) {
@@ -2616,7 +2618,7 @@ func TestDefaultPlanner_Plan_NotFullOverMaxsize(t *testing.T) {
 		time.Nanosecond,
 	)
 
-	plan, pLen := cp.Plan(time.Now().Add(-time.Second))
+	plan, pLen := cp.Plan(cp.FindGenerations(), time.Now().Add(-time.Second))
 	// first verify that our test set would return files
 	if exp, got := 4, len(plan[0]); got != exp {
 		t.Fatalf("tsm file length mismatch: got %v, exp %v", got, exp)
@@ -2640,7 +2642,7 @@ func TestDefaultPlanner_Plan_NotFullOverMaxsize(t *testing.T) {
 	overFs := newFakeFileStore(withFileStats(t, over), withDefaultBlockCount(100))
 
 	cp.FileStore = overFs
-	cGroups, pLen := cp.Plan(time.Now().Add(-time.Second))
+	cGroups, pLen := cp.Plan(cp.FindGenerations(), time.Now().Add(-time.Second))
 	if exp, got := 1, len(cGroups); got != exp {
 		t.Fatalf("tsm file length mismatch: got %v, exp %v", got, exp)
 	} else if pLen != int64(len(cGroups)) {
@@ -2680,7 +2682,7 @@ func TestDefaultPlanner_Plan_CompactsMiddleSteps(t *testing.T) {
 	)
 
 	expFiles := []tsm1.FileStat{data[0], data[1], data[2], data[3]}
-	tsm, pLen := cp.Plan(time.Now())
+	tsm, pLen := cp.Plan(cp.FindGenerations(), time.Now())
 	if exp, got := len(expFiles), len(tsm[0]); got != exp {
 		t.Fatalf("tsm file length mismatch: got %v, exp %v", got, exp)
 	} else if pLen != int64(len(tsm)) {
@@ -2722,7 +2724,7 @@ func TestDefaultPlanner_Plan_LargeGeneration(t *testing.T) {
 		tsdb.DefaultCompactFullWriteColdDuration,
 	)
 
-	tsm, pLen := cp.Plan(time.Now())
+	tsm, pLen := cp.Plan(cp.FindGenerations(), time.Now())
 	if exp, got := 0, len(tsm); got != exp {
 		t.Fatalf("tsm file length mismatch: got %v, exp %v", got, exp)
 	} else if pLen != int64(len(tsm)) {
@@ -2790,7 +2792,8 @@ func TestDefaultPlanner_Plan_ForceFull(t *testing.T) {
 		tsdb.DefaultCompactFullWriteColdDuration,
 	)
 
-	tsm, pLen := cp.PlanLevel(1)
+	generations := cp.FindGenerations()
+	tsm, pLen := cp.PlanLevel(generations, 1)
 	if exp, got := 1, len(tsm); got != exp {
 		t.Fatalf("tsm file length mismatch: got %v, exp %v", got, exp)
 	} else if pLen != int64(len(tsm)) {
@@ -2798,7 +2801,7 @@ func TestDefaultPlanner_Plan_ForceFull(t *testing.T) {
 	}
 	cp.Release(tsm)
 
-	tsm, pLen = cp.PlanLevel(2)
+	tsm, pLen = cp.PlanLevel(generations, 2)
 	if exp, got := 1, len(tsm); got != exp {
 		t.Fatalf("tsm file length mismatch: got %v, exp %v", got, exp)
 	} else if pLen != int64(len(tsm)) {
@@ -2809,7 +2812,7 @@ func TestDefaultPlanner_Plan_ForceFull(t *testing.T) {
 	cp.ForceFull()
 
 	// Level plans should not return any plans
-	tsm, pLen = cp.PlanLevel(1)
+	tsm, pLen = cp.PlanLevel(generations, 1)
 	if exp, got := 0, len(tsm); got != exp {
 		t.Fatalf("tsm file length mismatch: got %v, exp %v", got, exp)
 	} else if pLen != int64(len(tsm)) {
@@ -2817,7 +2820,7 @@ func TestDefaultPlanner_Plan_ForceFull(t *testing.T) {
 	}
 	cp.Release(tsm)
 
-	tsm, pLen = cp.PlanLevel(2)
+	tsm, pLen = cp.PlanLevel(generations, 2)
 	if exp, got := 0, len(tsm); got != exp {
 		t.Fatalf("tsm file length mismatch: got %v, exp %v", got, exp)
 	} else if pLen != int64(len(tsm)) {
@@ -2825,7 +2828,7 @@ func TestDefaultPlanner_Plan_ForceFull(t *testing.T) {
 	}
 	cp.Release(tsm)
 
-	tsm, pLen = cp.Plan(time.Now())
+	tsm, pLen = cp.Plan(generations, time.Now())
 	if exp, got := 1, len(tsm); got != exp {
 		t.Fatalf("tsm file length mismatch: got %v, exp %v", got, exp)
 	} else if pLen != int64(len(tsm)) {
@@ -2838,7 +2841,7 @@ func TestDefaultPlanner_Plan_ForceFull(t *testing.T) {
 	cp.Release(tsm)
 
 	// Level plans should return plans now that Plan has been called
-	tsm, pLen = cp.PlanLevel(1)
+	tsm, pLen = cp.PlanLevel(generations, 1)
 	if exp, got := 1, len(tsm); got != exp {
 		t.Fatalf("tsm file length mismatch: got %v, exp %v", got, exp)
 	} else if pLen != int64(len(tsm)) {
@@ -2846,7 +2849,7 @@ func TestDefaultPlanner_Plan_ForceFull(t *testing.T) {
 	}
 	cp.Release(tsm)
 
-	tsm, pLen = cp.PlanLevel(2)
+	tsm, pLen = cp.PlanLevel(generations, 2)
 	if exp, got := 1, len(tsm); got != exp {
 		t.Fatalf("tsm file length mismatch: got %v, exp %v", got, exp)
 	} else if pLen != int64(len(tsm)) {
@@ -2882,7 +2885,7 @@ func TestDefaultPlanner_Plan_SizeDisparitySkipsLargerGenerations(t *testing.T) {
 	)
 
 	// Call Plan which should skip gens 1 and 2 due to size disparity
-	tsm, pLen := cp.Plan(time.Now())
+	tsm, pLen := cp.Plan(cp.FindGenerations(), time.Now())
 
 	// Should return 1 compaction group containing gens 3, 4, 5, 6 (4 files)
 	if exp, got := 1, len(tsm); got != exp {
@@ -2936,7 +2939,7 @@ func TestDefaultPlanner_Plan_LookAheadPreventsSkip(t *testing.T) {
 	)
 
 	// Call Plan with a past lastWrite time to trigger full compaction path
-	tsm, pLen := cp.Plan(time.Now().Add(-time.Second))
+	tsm, pLen := cp.Plan(cp.FindGenerations(), time.Now().Add(-time.Second))
 
 	// Should return 1 compaction group
 	if exp, got := 1, len(tsm); got != exp {

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -2287,19 +2287,21 @@ func makePlannedCompactionGroup(groups []CompactionGroup, pointsPerBlock int) []
 	return planned
 }
 
-func (e *Engine) planCompactionsLevel(level int) []PlannedCompactionGroup {
-
-	groups, _ := e.CompactionPlan.PlanLevel(level)
+func (e *Engine) planCompactionsLevel(generations TsmGenerations, level int) []PlannedCompactionGroup {
+	groups, _ := e.CompactionPlan.PlanLevel(generations, level)
 	return makePlannedCompactionGroup(groups, tsdb.DefaultMaxPointsPerBlock)
 }
 
 func (e *Engine) planCompactionsInner() ([]PlannedCompactionGroup, []PlannedCompactionGroup, []PlannedCompactionGroup, []PlannedCompactionGroup, []PlannedCompactionGroup) {
+	generations := e.CompactionPlan.FindGenerations()
+
 	// Find our compaction plans
-	level1Groups := e.planCompactionsLevel(1)
-	level2Groups := e.planCompactionsLevel(2)
-	level3Groups := e.planCompactionsLevel(3)
-	l4Groups, _ := e.CompactionPlan.Plan(e.LastModified())
-	l5Groups, _, l5GenCount := e.CompactionPlan.PlanOptimize(e.LastModified())
+	level1Groups := e.planCompactionsLevel(generations, 1)
+	level2Groups := e.planCompactionsLevel(generations, 2)
+	level3Groups := e.planCompactionsLevel(generations, 3)
+	lastModified := e.LastModified()
+	l4Groups, _ := e.CompactionPlan.Plan(generations, lastModified)
+	l5Groups, _, l5GenCount := e.CompactionPlan.PlanOptimize(generations, lastModified)
 
 	// Some groups in level 4 may contain already optimized files. In these cases, it is
 	// desireable to maintain optimization for the entire group to avoid "going backwards" on the

--- a/tsdb/engine/tsm1/engine_test.go
+++ b/tsdb/engine/tsm1/engine_test.go
@@ -2872,11 +2872,14 @@ type mockPlanner struct{}
 func (m *mockPlanner) GetAggressiveCompactionPointsPerBlock() int { return 0 }
 func (m *mockPlanner) SetAggressiveCompactionPointsPerBlock(aggressiveCompactionPointsPerBlock int) {
 }
-func (m *mockPlanner) Plan(lastWrite time.Time) ([]tsm1.CompactionGroup, int64) { return nil, 0 }
-func (m *mockPlanner) PlanLevel(level int) ([]tsm1.CompactionGroup, int64) {
+func (m *mockPlanner) FindGenerations() tsm1.TsmGenerations { return nil }
+func (m *mockPlanner) Plan(generations tsm1.TsmGenerations, lastWrite time.Time) ([]tsm1.CompactionGroup, int64) {
 	return nil, 0
 }
-func (m *mockPlanner) PlanOptimize(lastWrite time.Time) ([]tsm1.CompactionGroup, int64, int64) {
+func (m *mockPlanner) PlanLevel(generations tsm1.TsmGenerations, level int) ([]tsm1.CompactionGroup, int64) {
+	return nil, 0
+}
+func (m *mockPlanner) PlanOptimize(generations tsm1.TsmGenerations, lastWrite time.Time) ([]tsm1.CompactionGroup, int64, int64) {
 	return nil, 0, 0
 }
 func (m *mockPlanner) Release(groups []tsm1.CompactionGroup) {}


### PR DESCRIPTION
Avoid duplicate calls to DefaultPlanner.findGenerations to reduce CPU and RAM requirements in compaction planning

Closes https://github.com/influxdata/influxdb/issues/27302

(cherry picked from commit 288807df8ec99702cc3d480a44c609a097d3248a)

Closes https://github.com/influxdata/influxdb/issues/27303
