### PR TITLE
docs: update v2 README for clarity and version context

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,7 @@ This repository contains multiple InfluxDB versions on separate branches:
 | v3 Core | [`main`](https://github.com/influxdata/influxdb/tree/main) | SQL, InfluxQL | [docs.influxdata.com/influxdb3/core/](https://docs.influxdata.com/influxdb3/core/) |
 | **v2.x (this branch)** | [`main-2.x`](https://github.com/influxdata/influxdb/tree/main-2.x) | Flux, InfluxQL | [docs.influxdata.com/influxdb/v2/](https://docs.influxdata.com/influxdb/v2/) |
 | v1.x | [`master-1.x`](https://github.com/influxdata/influxdb/tree/master-1.x) | InfluxQL, Flux | [docs.influxdata.com/influxdb/v1/](https://docs.influxdata.com/influxdb/v1/) |
+
+## Support
+
+For community support, feedback channels, and documentation requests, see [Support and feedback](https://docs.influxdata.com/influxdb/v2/get-started/#support-and-feedback).


### PR DESCRIPTION
## Goal

Update the `main-2.x` README to optimize clarity for humans, AI agents, and search engines. Establish the relationship between this branch and the other version branches (`main` for v3 Core, `master-1.x` for v1.x).

Companion to #27315 (main) and #27316 (master-1.x).

## Summary
- Update tagline to identify InfluxDB OSS v2 and TSM storage engine
- Add version banner mirroring docs.influxdata.com tone, directing users to InfluxDB 3 Core
- Add technical summary (version, branch, storage engine, query languages, API, compatibility, license, docs)
- Remove stale InfluxDB Cloud signup CTA (no longer available for new signups)
- Clean up Install section wording
- Pin Get Started link to v2 docs (avoid future `/latest/` redirect to v3)
- Rewrite Get Started description for clarity (organizations, buckets, setup options)
- Update Flux section with InfluxDB 3 migration guidance and InfluxQL recommendation
- Remove stale Additional Resources and Learn InfluxDB sections
- Add Other InfluxDB Versions branch table (matches format in #27315)
- Add Support section linking to v2 docs

## Test plan
- [x] Verify README renders correctly on GitHub (banner, technical summary, branch table)
- [x] Verify all links resolve to correct pages
- [x] Compare with #27315 (main) and #27316 (master-1.x) for cross-branch consistency