### PR TITLE
feat: Cleanup tasks bbolt entries during org deletion

### DIFF
--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -277,6 +277,7 @@ func (m *Launcher) run(ctx context.Context, opts *InfluxdOpts) (err error) {
 	}
 
 	m.kvService = kv.NewService(m.log.With(zap.String("store", "kv")), m.kvStore, ts, serviceConfig)
+	ts.Apply(tenant.WithTaskService(m.kvService))
 
 	var (
 		opLogSvc                                              = tenant.NewOpLogService(m.kvStore, m.kvService)

--- a/notification/endpoint/service/store_test.go
+++ b/notification/endpoint/service/store_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/influxdata/influxdb/v2/inmem"
 	"github.com/influxdata/influxdb/v2/kv"
 	"github.com/influxdata/influxdb/v2/kv/migration/all"
+	"github.com/influxdata/influxdb/v2/mock"
 	"github.com/influxdata/influxdb/v2/notification/endpoint/service"
 	endpointsTesting "github.com/influxdata/influxdb/v2/notification/endpoint/service/testing"
 	"github.com/influxdata/influxdb/v2/secret"
@@ -54,6 +55,7 @@ func initNotificationEndpointService(s kv.SchemaStore, f endpointsTesting.Notifi
 	}
 
 	tenantSvc := tenant.NewService(tenantStore)
+	tenantSvc.Apply(tenant.WithTaskService(mock.NewTaskService()))
 
 	secretStore, err := secret.NewStore(s)
 	require.NoError(t, err)

--- a/notification/rule/service/service_test.go
+++ b/notification/rule/service/service_test.go
@@ -58,6 +58,8 @@ func initNotificationRuleStore(s kv.Store, f NotificationRuleFields, t *testing.
 		kvsvc.TimeGenerator = influxdb.RealTimeGenerator{}
 	}
 
+	tenantSvc.Apply(tenant.WithTaskService(kvsvc))
+
 	secretStore, err := secret.NewStore(s)
 	require.NoError(t, err)
 	secretSvc := secret.NewService(secretStore)

--- a/tenant/http_server_org_test.go
+++ b/tenant/http_server_org_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/influxdata/influxdb/v2"
 	"github.com/influxdata/influxdb/v2/http"
 	"github.com/influxdata/influxdb/v2/kv"
+	"github.com/influxdata/influxdb/v2/mock"
 	"github.com/influxdata/influxdb/v2/tenant"
 	itesting "github.com/influxdata/influxdb/v2/testing"
 	"go.uber.org/zap/zaptest"
@@ -38,7 +39,9 @@ func initHttpOrgService(f itesting.OrganizationFields, t *testing.T) (influxdb.O
 		t.Fatalf("failed to populate organizations: %s", err)
 	}
 
-	handler := tenant.NewHTTPOrgHandler(zaptest.NewLogger(t), tenant.NewService(storage), nil, nil)
+	svc := tenant.NewService(storage)
+	svc.Apply(tenant.WithTaskService(mock.NewTaskService()))
+	handler := tenant.NewHTTPOrgHandler(zaptest.NewLogger(t), svc, nil, nil)
 	r := chi.NewRouter()
 	r.Mount(handler.Prefix(), handler)
 	server := httptest.NewServer(r)

--- a/tenant/service.go
+++ b/tenant/service.go
@@ -7,6 +7,7 @@ import (
 	"github.com/influxdata/influxdb/v2/kit/metric"
 	"github.com/influxdata/influxdb/v2/label"
 	"github.com/influxdata/influxdb/v2/secret"
+	"github.com/influxdata/influxdb/v2/task/taskmodel"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.uber.org/zap"
 )
@@ -35,6 +36,7 @@ type Service struct {
 	influxdb.UserResourceMappingService
 	influxdb.OrganizationService
 	influxdb.BucketService
+	taskmodel.TaskService
 }
 
 func (s *Service) RLock() {
@@ -60,6 +62,18 @@ func NewService(st *Store, UserSvcOptFns ...func(svc *UserSvc)) *Service {
 
 func (s *Service) SetUserOptions(opts ...func(*UserSvc)) {
 	s.userSvc.SetOptions(opts...)
+}
+
+type ServiceOption func(*Service)
+
+func WithTaskService(ts taskmodel.TaskService) ServiceOption {
+	return func(s *Service) { s.TaskService = ts }
+}
+
+func (s *Service) Apply(opts ...ServiceOption) {
+	for _, opt := range opts {
+		opt(s)
+	}
 }
 
 // creates a new Service with logging and metrics middleware wrappers.

--- a/tenant/service_org.go
+++ b/tenant/service_org.go
@@ -205,7 +205,7 @@ func (s *OrgSvc) DeleteOrganization(ctx context.Context, id platform.ID) error {
 	for _, b := range bs {
 		if err := s.svc.DeleteBucket(internalCtx(ctx), b.ID); err != nil {
 			if err != ErrBucketNotFound {
-				return fmt.Errorf("error deleteing buckets for organization id: %s: %w", id.String(), err)
+				return fmt.Errorf("error deleting buckets for organization id: %s: %w", id.String(), err)
 			}
 		}
 	}

--- a/tenant/service_org.go
+++ b/tenant/service_org.go
@@ -200,12 +200,12 @@ func (s *OrgSvc) DeleteOrganization(ctx context.Context, id platform.ID) error {
 	}
 	bs, _, err := s.svc.FindBuckets(ctx, filter)
 	if err != nil {
-		return fmt.Errorf("error finding buckets for organization: %s, error: %w", id, err)
+		return fmt.Errorf("error finding buckets for organization id: %s, error: %w", id.String(), err)
 	}
 	for _, b := range bs {
 		if err := s.svc.DeleteBucket(internalCtx(ctx), b.ID); err != nil {
 			if err != ErrBucketNotFound {
-				return fmt.Errorf("error deleteing buckets for organization: %s, error: %w", id, err)
+				return fmt.Errorf("error deleteing buckets for organization id: %s, error: %w", id.String(), err)
 			}
 		}
 	}
@@ -214,7 +214,7 @@ func (s *OrgSvc) DeleteOrganization(ctx context.Context, id platform.ID) error {
 		return s.store.DeleteOrg(ctx, tx, id)
 	})
 	if err != nil {
-		return fmt.Errorf("error deleting organization: %s, error: %w", id, err)
+		return fmt.Errorf("error deleting organization id: %s, error: %w", id.String(), err)
 	}
 
 	if s.svc.TaskService != nil {
@@ -228,12 +228,12 @@ func (s *OrgSvc) DeleteOrganization(ctx context.Context, id platform.ID) error {
 			}
 			for _, t := range tasks {
 				if err := s.svc.DeleteTask(ctx, t.ID); err != nil && !errors.Is(err, taskmodel.ErrTaskNotFound) {
-					return fmt.Errorf("failed to delete tasks for organization: %s, error: %w", id, err)
+					return fmt.Errorf("failed to delete tasks for organization id: %s, error: %w", id.String(), err)
 				}
 			}
 		}
 	} else {
-		return fmt.Errorf("%w: organization: %s", ErrTaskServiceNil, id)
+		return fmt.Errorf("%w: organization id: %s", ErrTaskServiceNil, id.String())
 	}
 
 	return s.removeResourceRelations(ctx, id)

--- a/tenant/service_org.go
+++ b/tenant/service_org.go
@@ -7,6 +7,7 @@ import (
 	icontext "github.com/influxdata/influxdb/v2/context"
 	"github.com/influxdata/influxdb/v2/kit/platform"
 	"github.com/influxdata/influxdb/v2/kv"
+	"github.com/influxdata/influxdb/v2/task/taskmodel"
 )
 
 type OrgSvc struct {
@@ -210,6 +211,16 @@ func (s *OrgSvc) DeleteOrganization(ctx context.Context, id platform.ID) error {
 	})
 	if err != nil {
 		return err
+	}
+
+	tasks, _, err := s.svc.FindTasks(ctx, taskmodel.TaskFilter{OrganizationID: &id})
+	if err != nil {
+		return err
+	}
+	for _, t := range tasks {
+		if err := s.svc.DeleteTask(ctx, t.ID); err != nil && err != taskmodel.ErrTaskNotFound {
+			return err
+		}
 	}
 
 	return s.removeResourceRelations(ctx, id)

--- a/tenant/service_org.go
+++ b/tenant/service_org.go
@@ -2,6 +2,8 @@ package tenant
 
 import (
 	"context"
+	"errors"
+	"fmt"
 
 	"github.com/influxdata/influxdb/v2"
 	icontext "github.com/influxdata/influxdb/v2/context"
@@ -9,6 +11,8 @@ import (
 	"github.com/influxdata/influxdb/v2/kv"
 	"github.com/influxdata/influxdb/v2/task/taskmodel"
 )
+
+var ErrTaskServiceNil = errors.New("TaskService is nil")
 
 type OrgSvc struct {
 	store *Store
@@ -196,12 +200,12 @@ func (s *OrgSvc) DeleteOrganization(ctx context.Context, id platform.ID) error {
 	}
 	bs, _, err := s.svc.FindBuckets(ctx, filter)
 	if err != nil {
-		return err
+		return fmt.Errorf("error finding buckets for organization: %s, error: %w", id, err)
 	}
 	for _, b := range bs {
 		if err := s.svc.DeleteBucket(internalCtx(ctx), b.ID); err != nil {
 			if err != ErrBucketNotFound {
-				return err
+				return fmt.Errorf("error deleteing buckets for organization: %s, error: %w", id, err)
 			}
 		}
 	}
@@ -210,7 +214,7 @@ func (s *OrgSvc) DeleteOrganization(ctx context.Context, id platform.ID) error {
 		return s.store.DeleteOrg(ctx, tx, id)
 	})
 	if err != nil {
-		return err
+		return fmt.Errorf("error deleting organization: %s, error: %w", id, err)
 	}
 
 	if s.svc.TaskService != nil {
@@ -223,11 +227,13 @@ func (s *OrgSvc) DeleteOrganization(ctx context.Context, id platform.ID) error {
 				break
 			}
 			for _, t := range tasks {
-				if err := s.svc.DeleteTask(ctx, t.ID); err != nil && err != taskmodel.ErrTaskNotFound {
-					return err
+				if err := s.svc.DeleteTask(ctx, t.ID); err != nil && !errors.Is(err, taskmodel.ErrTaskNotFound) {
+					return fmt.Errorf("failed to delete tasks for organization: %s, error: %w", id, err)
 				}
 			}
 		}
+	} else {
+		return fmt.Errorf("%w: organization: %s", ErrTaskServiceNil, id)
 	}
 
 	return s.removeResourceRelations(ctx, id)

--- a/tenant/service_org.go
+++ b/tenant/service_org.go
@@ -213,13 +213,15 @@ func (s *OrgSvc) DeleteOrganization(ctx context.Context, id platform.ID) error {
 		return err
 	}
 
-	tasks, _, err := s.svc.FindTasks(ctx, taskmodel.TaskFilter{OrganizationID: &id})
-	if err != nil {
-		return err
-	}
-	for _, t := range tasks {
-		if err := s.svc.DeleteTask(ctx, t.ID); err != nil && err != taskmodel.ErrTaskNotFound {
+	if s.svc.TaskService != nil {
+		tasks, _, err := s.svc.FindTasks(ctx, taskmodel.TaskFilter{OrganizationID: &id})
+		if err != nil {
 			return err
+		}
+		for _, t := range tasks {
+			if err := s.svc.DeleteTask(ctx, t.ID); err != nil && err != taskmodel.ErrTaskNotFound {
+				return err
+			}
 		}
 	}
 

--- a/tenant/service_org.go
+++ b/tenant/service_org.go
@@ -213,13 +213,18 @@ func (s *OrgSvc) DeleteOrganization(ctx context.Context, id platform.ID) error {
 		return err
 	}
 
-	tasks, _, err := s.svc.FindTasks(ctx, taskmodel.TaskFilter{OrganizationID: &id})
-	if err != nil {
-		return err
-	}
-	for _, t := range tasks {
-		if err := s.svc.DeleteTask(ctx, t.ID); err != nil && err != taskmodel.ErrTaskNotFound {
+	for {
+		tasks, _, err := s.svc.FindTasks(ctx, taskmodel.TaskFilter{OrganizationID: &id})
+		if err != nil {
 			return err
+		}
+		if len(tasks) == 0 {
+			break
+		}
+		for _, t := range tasks {
+			if err := s.svc.DeleteTask(ctx, t.ID); err != nil && err != taskmodel.ErrTaskNotFound {
+				return err
+			}
 		}
 	}
 

--- a/tenant/service_org.go
+++ b/tenant/service_org.go
@@ -200,12 +200,12 @@ func (s *OrgSvc) DeleteOrganization(ctx context.Context, id platform.ID) error {
 	}
 	bs, _, err := s.svc.FindBuckets(ctx, filter)
 	if err != nil {
-		return fmt.Errorf("error finding buckets for organization id: %s, error: %w", id.String(), err)
+		return fmt.Errorf("error finding buckets for organization id: %s: %w", id.String(), err)
 	}
 	for _, b := range bs {
 		if err := s.svc.DeleteBucket(internalCtx(ctx), b.ID); err != nil {
 			if err != ErrBucketNotFound {
-				return fmt.Errorf("error deleteing buckets for organization id: %s, error: %w", id.String(), err)
+				return fmt.Errorf("error deleteing buckets for organization id: %s: %w", id.String(), err)
 			}
 		}
 	}
@@ -214,7 +214,7 @@ func (s *OrgSvc) DeleteOrganization(ctx context.Context, id platform.ID) error {
 		return s.store.DeleteOrg(ctx, tx, id)
 	})
 	if err != nil {
-		return fmt.Errorf("error deleting organization id: %s, error: %w", id.String(), err)
+		return fmt.Errorf("error deleting organization id: %s: %w", id.String(), err)
 	}
 
 	if s.svc.TaskService != nil {
@@ -228,7 +228,7 @@ func (s *OrgSvc) DeleteOrganization(ctx context.Context, id platform.ID) error {
 			}
 			for _, t := range tasks {
 				if err := s.svc.DeleteTask(ctx, t.ID); err != nil && !errors.Is(err, taskmodel.ErrTaskNotFound) {
-					return fmt.Errorf("failed to delete tasks for organization id: %s, error: %w", id.String(), err)
+					return fmt.Errorf("failed to delete tasks for organization id: %s: %w", id.String(), err)
 				}
 			}
 		}

--- a/tenant/service_org_delete_test.go
+++ b/tenant/service_org_delete_test.go
@@ -1,0 +1,116 @@
+package tenant_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/influxdata/influxdb/v2"
+	"github.com/influxdata/influxdb/v2/authorization"
+	icontext "github.com/influxdata/influxdb/v2/context"
+	_ "github.com/influxdata/influxdb/v2/fluxinit/static"
+	"github.com/influxdata/influxdb/v2/kit/platform"
+	"github.com/influxdata/influxdb/v2/kv"
+	"github.com/influxdata/influxdb/v2/query/fluxlang"
+	"github.com/influxdata/influxdb/v2/task/taskmodel"
+	"github.com/influxdata/influxdb/v2/tenant"
+	itesting "github.com/influxdata/influxdb/v2/testing"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+)
+
+func TestDeleteOrganization_PurgesTasksV1(t *testing.T) {
+	ctx := context.Background()
+	store, closeStore := itesting.NewTestBoltStore(t)
+	t.Cleanup(closeStore)
+
+	tenantStore := tenant.NewStore(store)
+	ts := tenant.NewService(tenantStore)
+
+	authStore, err := authorization.NewStore(ctx, store, false)
+	require.NoError(t, err)
+	authSvc := authorization.NewService(authStore, ts)
+
+	kvSvc := kv.NewService(zaptest.NewLogger(t), store, ts, kv.ServiceConfig{
+		FluxLanguageService: fluxlang.DefaultService,
+	})
+	ts.Apply(tenant.WithTaskService(kvSvc))
+
+	user := &influxdb.User{Name: t.Name() + "-user"}
+	require.NoError(t, ts.CreateUser(ctx, user))
+
+	org := &influxdb.Organization{Name: t.Name() + "-org"}
+	require.NoError(t, ts.CreateOrganization(ctx, org))
+
+	require.NoError(t, ts.CreateUserResourceMapping(ctx, &influxdb.UserResourceMapping{
+		ResourceType: influxdb.OrgsResourceType,
+		ResourceID:   org.ID,
+		UserID:       user.ID,
+		UserType:     influxdb.Owner,
+	}))
+
+	auth := &influxdb.Authorization{
+		OrgID:       org.ID,
+		UserID:      user.ID,
+		Permissions: influxdb.OperPermissions(),
+	}
+	require.NoError(t, authSvc.CreateAuthorization(ctx, auth))
+	authCtx := icontext.SetAuthorizer(ctx, auth)
+
+	var createdIDs []platform.ID
+	for i := range 3 {
+		task, err := kvSvc.CreateTask(authCtx, taskmodel.TaskCreate{
+			Flux:           fmt.Sprintf(`option task = {name: "task-%d", every: 1h} from(bucket:"b") |> range(start:-1h)`, i),
+			OrganizationID: org.ID,
+			OwnerID:        user.ID,
+			Status:         string(taskmodel.TaskActive),
+		})
+		require.NoError(t, err)
+		createdIDs = append(createdIDs, task.ID)
+	}
+
+	before, _, err := kvSvc.FindTasks(authCtx, taskmodel.TaskFilter{OrganizationID: &org.ID})
+	require.NoError(t, err)
+	require.Len(t, before, 3)
+
+	require.NoError(t, ts.DeleteOrganization(ctx, org.ID))
+
+	after, _, err := kvSvc.FindTasks(authCtx, taskmodel.TaskFilter{OrganizationID: &org.ID})
+	require.NoError(t, err)
+	require.Empty(t, after)
+
+	require.NoError(t, store.View(ctx, func(tx kv.Tx) error {
+		taskBkt, err := tx.Bucket([]byte("tasksv1"))
+		if err != nil {
+			return err
+		}
+		for _, id := range createdIDs {
+			key, err := id.Encode()
+			require.NoError(t, err)
+			v, err := taskBkt.Get(key)
+			if !kv.IsNotFound(err) {
+				require.NoError(t, err)
+				require.Failf(t, "task still in tasksv1", "id=%s value=%q", id.String(), string(v))
+			}
+		}
+
+		idxBkt, err := tx.Bucket([]byte("taskIndexsv1"))
+		if err != nil {
+			return err
+		}
+		orgPrefix, err := org.ID.Encode()
+		require.NoError(t, err)
+		c, err := idxBkt.ForwardCursor(orgPrefix, kv.WithCursorPrefix(orgPrefix))
+		if err != nil {
+			return err
+		}
+		defer c.Close()
+		for k, _ := c.Next(); k != nil; k, _ = c.Next() {
+			if bytes.HasPrefix(k, orgPrefix) {
+				t.Errorf("taskIndexsv1 still has entry for deleted org: %x", k)
+			}
+		}
+		return c.Err()
+	}))
+}

--- a/tenant/service_org_delete_test.go
+++ b/tenant/service_org_delete_test.go
@@ -42,6 +42,7 @@ func TestDeleteOrganization_PurgesTasksV1(t *testing.T) {
 		{"zero tasks", 0},
 		{"five tasks", 5},
 		{"multi-page", taskmodel.TaskDefaultPageSize + 50},
+		{"larger multi-page", 2*(taskmodel.TaskDefaultPageSize) + 1},
 	}
 
 	for _, tc := range cases {
@@ -61,6 +62,20 @@ func TestDeleteOrganization_PurgesTasksV1(t *testing.T) {
 			assertTaskBucketsClean(ctx, t, store, org.ID, ids)
 		})
 	}
+}
+
+func TestDeleteOrganization_ErrorWhenTaskServiceNil(t *testing.T) {
+	ctx := context.Background()
+	store, closeStore := itesting.NewTestBoltStore(t)
+	t.Cleanup(closeStore)
+
+	ts := tenant.NewService(tenant.NewStore(store))
+
+	org := &influxdb.Organization{Name: t.Name() + "-org"}
+	require.NoError(t, ts.CreateOrganization(ctx, org))
+
+	err := ts.DeleteOrganization(ctx, org.ID)
+	require.ErrorIs(t, err, tenant.ErrTaskServiceNil)
 }
 
 func seedOrgWithAuth(ctx context.Context, t *testing.T, ts *tenant.Service, authSvc influxdb.AuthorizationService) (*influxdb.Organization, *influxdb.User, context.Context) {

--- a/tenant/service_org_delete_test.go
+++ b/tenant/service_org_delete_test.go
@@ -1,7 +1,6 @@
 package tenant_test
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"testing"
@@ -21,72 +20,34 @@ import (
 )
 
 func TestDeleteOrganization_PurgesTasksV1(t *testing.T) {
+	ctx := context.Background()
+	store, closeStore := itesting.NewTestBoltStore(t)
+	t.Cleanup(closeStore)
+
+	ts := tenant.NewService(tenant.NewStore(store))
+
+	authStore, err := authorization.NewStore(ctx, store, false)
+	require.NoError(t, err)
+	authSvc := authorization.NewService(authStore, ts)
+
+	kvSvc := kv.NewService(zaptest.NewLogger(t), store, ts, kv.ServiceConfig{
+		FluxLanguageService: fluxlang.DefaultService,
+	})
+	ts.Apply(tenant.WithTaskService(kvSvc))
+
 	cases := []struct {
 		name      string
 		taskCount int
 	}{
-		{name: "zero tasks", taskCount: 0},
-		{name: "five tasks", taskCount: 5},
-		{name: "multi-page", taskCount: taskmodel.TaskDefaultPageSize + 50},
+		{"zero tasks", 0},
+		{"five tasks", 5},
+		{"multi-page", taskmodel.TaskDefaultPageSize + 50},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			ctx := context.Background()
-			store, closeStore := itesting.NewTestBoltStore(t)
-			t.Cleanup(closeStore)
-
-			tenantStore := tenant.NewStore(store)
-			ts := tenant.NewService(tenantStore)
-
-			authStore, err := authorization.NewStore(ctx, store, false)
-			require.NoError(t, err)
-			authSvc := authorization.NewService(authStore, ts)
-
-			kvSvc := kv.NewService(zaptest.NewLogger(t), store, ts, kv.ServiceConfig{
-				FluxLanguageService: fluxlang.DefaultService,
-			})
-			ts.Apply(tenant.WithTaskService(kvSvc))
-
-			user := &influxdb.User{Name: t.Name() + "-user"}
-			require.NoError(t, ts.CreateUser(ctx, user))
-
-			org := &influxdb.Organization{Name: t.Name() + "-org"}
-			require.NoError(t, ts.CreateOrganization(ctx, org))
-
-			require.NoError(t, ts.CreateUserResourceMapping(ctx, &influxdb.UserResourceMapping{
-				ResourceType: influxdb.OrgsResourceType,
-				ResourceID:   org.ID,
-				UserID:       user.ID,
-				UserType:     influxdb.Owner,
-			}))
-
-			auth := &influxdb.Authorization{
-				OrgID:       org.ID,
-				UserID:      user.ID,
-				Permissions: influxdb.OperPermissions(),
-			}
-			require.NoError(t, authSvc.CreateAuthorization(ctx, auth))
-			authCtx := icontext.SetAuthorizer(ctx, auth)
-
-			var createdIDs []platform.ID
-			for i := range tc.taskCount {
-				task, err := kvSvc.CreateTask(authCtx, taskmodel.TaskCreate{
-					Flux:           fmt.Sprintf(`option task = {name: "task-%d", every: 1h} from(bucket:"b") |> range(start:-1h)`, i),
-					OrganizationID: org.ID,
-					OwnerID:        user.ID,
-					Status:         string(taskmodel.TaskActive),
-				})
-				require.NoError(t, err)
-				createdIDs = append(createdIDs, task.ID)
-			}
-
-			before, _, err := kvSvc.FindTasks(authCtx, taskmodel.TaskFilter{
-				OrganizationID: &org.ID,
-				Limit:          taskmodel.TaskMaxPageSize,
-			})
-			require.NoError(t, err)
-			require.Len(t, before, tc.taskCount)
+			org, user, authCtx := seedOrgWithAuth(ctx, t, ts, authSvc)
+			ids := seedTasks(authCtx, t, kvSvc, org.ID, user.ID, tc.taskCount)
 
 			require.NoError(t, ts.DeleteOrganization(ctx, org.ID))
 
@@ -97,36 +58,78 @@ func TestDeleteOrganization_PurgesTasksV1(t *testing.T) {
 			require.NoError(t, err)
 			require.Empty(t, after)
 
-			require.NoError(t, store.View(ctx, func(tx kv.Tx) error {
-				taskBkt, err := tx.Bucket([]byte("tasksv1"))
-				require.NoError(t, err)
-				for _, id := range createdIDs {
-					key, err := id.Encode()
-					require.NoError(t, err)
-					v, err := taskBkt.Get(key)
-					if !kv.IsNotFound(err) {
-						require.NoError(t, err)
-						require.Failf(t, "task still in tasksv1", "id=%s value=%q", id.String(), string(v))
-					}
-				}
-
-				idxBkt, err := tx.Bucket([]byte("taskIndexsv1"))
-				require.NoError(t, err)
-				orgPrefix, err := org.ID.Encode()
-				require.NoError(t, err)
-				c, err := idxBkt.ForwardCursor(orgPrefix, kv.WithCursorPrefix(orgPrefix))
-				require.NoError(t, err)
-				defer c.Close()
-				var remaining [][]byte
-				for k, _ := c.Next(); k != nil; k, _ = c.Next() {
-					if bytes.HasPrefix(k, orgPrefix) {
-						remaining = append(remaining, append([]byte(nil), k...))
-					}
-				}
-				require.NoError(t, c.Err())
-				require.Emptyf(t, remaining, "taskIndexsv1 still has entries for deleted org: %x", remaining)
-				return nil
-			}))
+			assertTaskBucketsClean(ctx, t, store, org.ID, ids)
 		})
 	}
+}
+
+func seedOrgWithAuth(ctx context.Context, t *testing.T, ts *tenant.Service, authSvc influxdb.AuthorizationService) (*influxdb.Organization, *influxdb.User, context.Context) {
+	t.Helper()
+
+	user := &influxdb.User{Name: t.Name() + "-user"}
+	require.NoError(t, ts.CreateUser(ctx, user))
+
+	org := &influxdb.Organization{Name: t.Name() + "-org"}
+	require.NoError(t, ts.CreateOrganization(ctx, org))
+
+	require.NoError(t, ts.CreateUserResourceMapping(ctx, &influxdb.UserResourceMapping{
+		ResourceType: influxdb.OrgsResourceType,
+		ResourceID:   org.ID,
+		UserID:       user.ID,
+		UserType:     influxdb.Owner,
+	}))
+
+	auth := &influxdb.Authorization{
+		OrgID:       org.ID,
+		UserID:      user.ID,
+		Permissions: influxdb.OperPermissions(),
+	}
+	require.NoError(t, authSvc.CreateAuthorization(ctx, auth))
+
+	return org, user, icontext.SetAuthorizer(ctx, auth)
+}
+
+func seedTasks(ctx context.Context, t *testing.T, svc *kv.Service, orgID, ownerID platform.ID, n int) []platform.ID {
+	t.Helper()
+	ids := make([]platform.ID, 0, n)
+	for i := range n {
+		task, err := svc.CreateTask(ctx, taskmodel.TaskCreate{
+			Flux:           fmt.Sprintf(`option task = {name: "task-%d", every: 1h} from(bucket:"b") |> range(start:-1h)`, i),
+			OrganizationID: orgID,
+			OwnerID:        ownerID,
+			Status:         string(taskmodel.TaskActive),
+		})
+		require.NoError(t, err)
+		ids = append(ids, task.ID)
+	}
+	return ids
+}
+
+func assertTaskBucketsClean(ctx context.Context, t *testing.T, store kv.Store, orgID platform.ID, ids []platform.ID) {
+	t.Helper()
+	require.NoError(t, store.View(ctx, func(tx kv.Tx) error {
+		taskBkt, err := tx.Bucket([]byte("tasksv1"))
+		require.NoError(t, err)
+		for _, id := range ids {
+			key, err := id.Encode()
+			require.NoError(t, err)
+			_, err = taskBkt.Get(key)
+			require.Truef(t, kv.IsNotFound(err), "task %s still in tasksv1", id.String())
+		}
+
+		idxBkt, err := tx.Bucket([]byte("taskIndexsv1"))
+		require.NoError(t, err)
+		orgPrefix, err := orgID.Encode()
+		require.NoError(t, err)
+		c, err := idxBkt.ForwardCursor(orgPrefix, kv.WithCursorPrefix(orgPrefix))
+		require.NoError(t, err)
+		defer c.Close()
+		var remaining [][]byte
+		for k, _ := c.Next(); k != nil; k, _ = c.Next() {
+			remaining = append(remaining, append([]byte(nil), k...))
+		}
+		require.NoError(t, c.Err())
+		require.Emptyf(t, remaining, "taskIndexsv1 still has entries for org %s: %x", orgID.String(), remaining)
+		return nil
+	}))
 }

--- a/tenant/service_org_delete_test.go
+++ b/tenant/service_org_delete_test.go
@@ -21,97 +21,112 @@ import (
 )
 
 func TestDeleteOrganization_PurgesTasksV1(t *testing.T) {
-	ctx := context.Background()
-	store, closeStore := itesting.NewTestBoltStore(t)
-	t.Cleanup(closeStore)
-
-	tenantStore := tenant.NewStore(store)
-	ts := tenant.NewService(tenantStore)
-
-	authStore, err := authorization.NewStore(ctx, store, false)
-	require.NoError(t, err)
-	authSvc := authorization.NewService(authStore, ts)
-
-	kvSvc := kv.NewService(zaptest.NewLogger(t), store, ts, kv.ServiceConfig{
-		FluxLanguageService: fluxlang.DefaultService,
-	})
-	ts.Apply(tenant.WithTaskService(kvSvc))
-
-	user := &influxdb.User{Name: t.Name() + "-user"}
-	require.NoError(t, ts.CreateUser(ctx, user))
-
-	org := &influxdb.Organization{Name: t.Name() + "-org"}
-	require.NoError(t, ts.CreateOrganization(ctx, org))
-
-	require.NoError(t, ts.CreateUserResourceMapping(ctx, &influxdb.UserResourceMapping{
-		ResourceType: influxdb.OrgsResourceType,
-		ResourceID:   org.ID,
-		UserID:       user.ID,
-		UserType:     influxdb.Owner,
-	}))
-
-	auth := &influxdb.Authorization{
-		OrgID:       org.ID,
-		UserID:      user.ID,
-		Permissions: influxdb.OperPermissions(),
-	}
-	require.NoError(t, authSvc.CreateAuthorization(ctx, auth))
-	authCtx := icontext.SetAuthorizer(ctx, auth)
-
-	var createdIDs []platform.ID
-	for i := range 3 {
-		task, err := kvSvc.CreateTask(authCtx, taskmodel.TaskCreate{
-			Flux:           fmt.Sprintf(`option task = {name: "task-%d", every: 1h} from(bucket:"b") |> range(start:-1h)`, i),
-			OrganizationID: org.ID,
-			OwnerID:        user.ID,
-			Status:         string(taskmodel.TaskActive),
-		})
-		require.NoError(t, err)
-		createdIDs = append(createdIDs, task.ID)
+	cases := []struct {
+		name      string
+		taskCount int
+	}{
+		{name: "zero tasks", taskCount: 0},
+		{name: "five tasks", taskCount: 5},
+		{name: "multi-page", taskCount: taskmodel.TaskDefaultPageSize + 50},
 	}
 
-	before, _, err := kvSvc.FindTasks(authCtx, taskmodel.TaskFilter{OrganizationID: &org.ID})
-	require.NoError(t, err)
-	require.Len(t, before, 3)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			store, closeStore := itesting.NewTestBoltStore(t)
+			t.Cleanup(closeStore)
 
-	require.NoError(t, ts.DeleteOrganization(ctx, org.ID))
+			tenantStore := tenant.NewStore(store)
+			ts := tenant.NewService(tenantStore)
 
-	after, _, err := kvSvc.FindTasks(authCtx, taskmodel.TaskFilter{OrganizationID: &org.ID})
-	require.NoError(t, err)
-	require.Empty(t, after)
-
-	require.NoError(t, store.View(ctx, func(tx kv.Tx) error {
-		taskBkt, err := tx.Bucket([]byte("tasksv1"))
-		if err != nil {
-			return err
-		}
-		for _, id := range createdIDs {
-			key, err := id.Encode()
+			authStore, err := authorization.NewStore(ctx, store, false)
 			require.NoError(t, err)
-			v, err := taskBkt.Get(key)
-			if !kv.IsNotFound(err) {
-				require.NoError(t, err)
-				require.Failf(t, "task still in tasksv1", "id=%s value=%q", id.String(), string(v))
-			}
-		}
+			authSvc := authorization.NewService(authStore, ts)
 
-		idxBkt, err := tx.Bucket([]byte("taskIndexsv1"))
-		if err != nil {
-			return err
-		}
-		orgPrefix, err := org.ID.Encode()
-		require.NoError(t, err)
-		c, err := idxBkt.ForwardCursor(orgPrefix, kv.WithCursorPrefix(orgPrefix))
-		require.NoError(t, err)
-		defer c.Close()
-		var remaining [][]byte
-		for k, _ := c.Next(); k != nil; k, _ = c.Next() {
-			if bytes.HasPrefix(k, orgPrefix) {
-				remaining = append(remaining, append([]byte(nil), k...))
+			kvSvc := kv.NewService(zaptest.NewLogger(t), store, ts, kv.ServiceConfig{
+				FluxLanguageService: fluxlang.DefaultService,
+			})
+			ts.Apply(tenant.WithTaskService(kvSvc))
+
+			user := &influxdb.User{Name: t.Name() + "-user"}
+			require.NoError(t, ts.CreateUser(ctx, user))
+
+			org := &influxdb.Organization{Name: t.Name() + "-org"}
+			require.NoError(t, ts.CreateOrganization(ctx, org))
+
+			require.NoError(t, ts.CreateUserResourceMapping(ctx, &influxdb.UserResourceMapping{
+				ResourceType: influxdb.OrgsResourceType,
+				ResourceID:   org.ID,
+				UserID:       user.ID,
+				UserType:     influxdb.Owner,
+			}))
+
+			auth := &influxdb.Authorization{
+				OrgID:       org.ID,
+				UserID:      user.ID,
+				Permissions: influxdb.OperPermissions(),
 			}
-		}
-		require.NoError(t, c.Err())
-		require.Emptyf(t, remaining, "taskIndexsv1 still has entries for deleted org: %x", remaining)
-		return nil
-	}))
+			require.NoError(t, authSvc.CreateAuthorization(ctx, auth))
+			authCtx := icontext.SetAuthorizer(ctx, auth)
+
+			var createdIDs []platform.ID
+			for i := range tc.taskCount {
+				task, err := kvSvc.CreateTask(authCtx, taskmodel.TaskCreate{
+					Flux:           fmt.Sprintf(`option task = {name: "task-%d", every: 1h} from(bucket:"b") |> range(start:-1h)`, i),
+					OrganizationID: org.ID,
+					OwnerID:        user.ID,
+					Status:         string(taskmodel.TaskActive),
+				})
+				require.NoError(t, err)
+				createdIDs = append(createdIDs, task.ID)
+			}
+
+			before, _, err := kvSvc.FindTasks(authCtx, taskmodel.TaskFilter{
+				OrganizationID: &org.ID,
+				Limit:          taskmodel.TaskMaxPageSize,
+			})
+			require.NoError(t, err)
+			require.Len(t, before, tc.taskCount)
+
+			require.NoError(t, ts.DeleteOrganization(ctx, org.ID))
+
+			after, _, err := kvSvc.FindTasks(authCtx, taskmodel.TaskFilter{
+				OrganizationID: &org.ID,
+				Limit:          taskmodel.TaskMaxPageSize,
+			})
+			require.NoError(t, err)
+			require.Empty(t, after)
+
+			require.NoError(t, store.View(ctx, func(tx kv.Tx) error {
+				taskBkt, err := tx.Bucket([]byte("tasksv1"))
+				require.NoError(t, err)
+				for _, id := range createdIDs {
+					key, err := id.Encode()
+					require.NoError(t, err)
+					v, err := taskBkt.Get(key)
+					if !kv.IsNotFound(err) {
+						require.NoError(t, err)
+						require.Failf(t, "task still in tasksv1", "id=%s value=%q", id.String(), string(v))
+					}
+				}
+
+				idxBkt, err := tx.Bucket([]byte("taskIndexsv1"))
+				require.NoError(t, err)
+				orgPrefix, err := org.ID.Encode()
+				require.NoError(t, err)
+				c, err := idxBkt.ForwardCursor(orgPrefix, kv.WithCursorPrefix(orgPrefix))
+				require.NoError(t, err)
+				defer c.Close()
+				var remaining [][]byte
+				for k, _ := c.Next(); k != nil; k, _ = c.Next() {
+					if bytes.HasPrefix(k, orgPrefix) {
+						remaining = append(remaining, append([]byte(nil), k...))
+					}
+				}
+				require.NoError(t, c.Err())
+				require.Emptyf(t, remaining, "taskIndexsv1 still has entries for deleted org: %x", remaining)
+				return nil
+			}))
+		})
+	}
 }

--- a/tenant/service_org_delete_test.go
+++ b/tenant/service_org_delete_test.go
@@ -102,15 +102,16 @@ func TestDeleteOrganization_PurgesTasksV1(t *testing.T) {
 		orgPrefix, err := org.ID.Encode()
 		require.NoError(t, err)
 		c, err := idxBkt.ForwardCursor(orgPrefix, kv.WithCursorPrefix(orgPrefix))
-		if err != nil {
-			return err
-		}
+		require.NoError(t, err)
 		defer c.Close()
+		var remaining [][]byte
 		for k, _ := c.Next(); k != nil; k, _ = c.Next() {
 			if bytes.HasPrefix(k, orgPrefix) {
-				t.Errorf("taskIndexsv1 still has entry for deleted org: %x", k)
+				remaining = append(remaining, append([]byte(nil), k...))
 			}
 		}
-		return c.Err()
+		require.NoError(t, c.Err())
+		require.Emptyf(t, remaining, "taskIndexsv1 still has entries for deleted org: %x", remaining)
+		return nil
 	}))
 }

--- a/tenant/service_org_test.go
+++ b/tenant/service_org_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/influxdata/influxdb/v2"
 	"github.com/influxdata/influxdb/v2/kv"
+	"github.com/influxdata/influxdb/v2/mock"
 	"github.com/influxdata/influxdb/v2/tenant"
 	influxdbtesting "github.com/influxdata/influxdb/v2/testing"
 )
@@ -44,7 +45,9 @@ func initOrganizationService(s kv.Store, f influxdbtesting.OrganizationFields, t
 		t.Fatalf("failed to populate organizations: %s", err)
 	}
 
-	return tenant.NewService(storage), "tenant/", func() {
+	svc := tenant.NewService(storage)
+	svc.Apply(tenant.WithTaskService(mock.NewTaskService()))
+	return svc, "tenant/", func() {
 		// go direct to storage for test data
 		if err := s.Update(context.Background(), func(tx kv.Tx) error {
 			for _, o := range f.Organizations {

--- a/tenant/service_test.go
+++ b/tenant/service_test.go
@@ -887,6 +887,7 @@ func initBoltTenantService(t *testing.T, f tenantFields) (*tenant.Service, func(
 	}
 
 	svc := tenant.NewService(store)
+	svc.Apply(tenant.WithTaskService(mock.NewTaskService()))
 
 	for _, u := range f.Users {
 		if err := svc.CreateUser(context.Background(), u); err != nil {

--- a/testing/organization_service.go
+++ b/testing/organization_service.go
@@ -3,6 +3,7 @@ package testing
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"sort"
 	"strings"
 	"testing"
@@ -750,7 +751,17 @@ func DeleteOrganization(init func(OrganizationFields, *testing.T) (influxdb.Orga
 			defer done()
 			ctx := context.Background()
 			err := s.DeleteOrganization(ctx, tt.args.ID)
-			diffPlatformErrors(tt.name, err, tt.wants.err, false, false, t)
+			expectedErr := tt.wants.err
+			if isInMem {
+				if e, ok := expectedErr.(*errors.Error); ok {
+					expectedErr = &errors.Error{
+						Code: e.Code,
+						Op:   e.Op,
+						Msg:  fmt.Sprintf("error deleting organization id: %s: %s", tt.args.ID.String(), e.Msg),
+					}
+				}
+			}
+			diffPlatformErrors(tt.name, err, expectedErr, false, false, t)
 
 			filter := influxdb.OrganizationFilter{}
 			organizations, _, err := s.FindOrganizations(ctx, filter)


### PR DESCRIPTION
During organization deletion in influxdb we don't currently clean up task resources which causes an error during startup.

Closes #27361 