### PR TITLE
feat: Add check for `MaxAgeSeconds` for EDR

### DIFF
--- a/replication.go
+++ b/replication.go
@@ -12,7 +12,7 @@ const (
 	DefaultReplicationMaxQueueSizeBytes       = 2 * MinReplicationMaxQueueSizeBytes
 	DefaultReplicationMaxAge            int64 = 604800  // 1 week, in seconds
 	MinReplicationMaxAgeSeconds         int64 = 60      // 1 minute
-	MaxReplicationMaxAgeSeconds         int64 = 1209600 // 2 weeks
+	MaxReplicationMaxAgeSeconds         int64 = 5184000 // 2 months
 )
 
 var ErrMaxQueueSizeTooSmall = errors.Error{
@@ -81,16 +81,19 @@ type CreateReplicationRequest struct {
 	MaxAgeSeconds        int64       `json:"maxAgeSeconds,omitempty"`
 }
 
+func CheckMaxAgeInRange(maxAge int64) error {
+	if maxAge != 0 && (maxAge < MinReplicationMaxAgeSeconds || maxAge > MaxReplicationMaxAgeSeconds) {
+		return &ErrMaxAgeOutOfRange
+	}
+	return nil
+}
+
 func (r *CreateReplicationRequest) OK() error {
 	if r.MaxQueueSizeBytes < MinReplicationMaxQueueSizeBytes {
 		return &ErrMaxQueueSizeTooSmall
 	}
 
-	if r.MaxAgeSeconds != 0 && (r.MaxAgeSeconds < MinReplicationMaxAgeSeconds || r.MaxAgeSeconds > MaxReplicationMaxAgeSeconds) {
-		return &ErrMaxAgeOutOfRange
-	}
-
-	return nil
+	return CheckMaxAgeInRange(r.MaxAgeSeconds)
 }
 
 // UpdateReplicationRequest contains a partial update to existing info about a replication.
@@ -110,9 +113,8 @@ func (r *UpdateReplicationRequest) OK() error {
 		return &ErrMaxQueueSizeTooSmall
 	}
 
-	if r.MaxAgeSeconds != nil && *r.MaxAgeSeconds != 0 &&
-		(*r.MaxAgeSeconds < MinReplicationMaxAgeSeconds || *r.MaxAgeSeconds > MaxReplicationMaxAgeSeconds) {
-		return &ErrMaxAgeOutOfRange
+	if r.MaxAgeSeconds != nil {
+		return CheckMaxAgeInRange(*r.MaxAgeSeconds)
 	}
 
 	return nil

--- a/replication.go
+++ b/replication.go
@@ -10,6 +10,9 @@ import (
 const (
 	MinReplicationMaxQueueSizeBytes     int64 = 33554430 // 32 MiB
 	DefaultReplicationMaxQueueSizeBytes       = 2 * MinReplicationMaxQueueSizeBytes
+	// MaxAgeSeconds bounds the queue purge window. 0 disables purging (unbounded growth);
+	// too-small values purge faster than replication can drain (data loss, churn);
+	// too-large values retain data indefinitely (memory/latency bloat).
 	DefaultReplicationMaxAge            int64 = 604800  // 1 week, in seconds
 	MinReplicationMaxAgeSeconds         int64 = 60      // 1 minute
 	MaxReplicationMaxAgeSeconds         int64 = 5184000 // 2 months
@@ -82,6 +85,7 @@ type CreateReplicationRequest struct {
 }
 
 func CheckMaxAgeInRange(maxAge int64) error {
+	// 0 is allowed as a sentinel meaning "use default"; non-zero must fall within bounds.
 	if maxAge != 0 && (maxAge < MinReplicationMaxAgeSeconds || maxAge > MaxReplicationMaxAgeSeconds) {
 		return &ErrMaxAgeOutOfRange
 	}

--- a/replication.go
+++ b/replication.go
@@ -10,12 +10,20 @@ import (
 const (
 	MinReplicationMaxQueueSizeBytes     int64 = 33554430 // 32 MiB
 	DefaultReplicationMaxQueueSizeBytes       = 2 * MinReplicationMaxQueueSizeBytes
-	DefaultReplicationMaxAge            int64 = 604800 // 1 week, in seconds
+	DefaultReplicationMaxAge            int64 = 604800  // 1 week, in seconds
+	MinReplicationMaxAgeSeconds         int64 = 60      // 1 minute
+	MaxReplicationMaxAgeSeconds         int64 = 1209600 // 2 weeks
 )
 
 var ErrMaxQueueSizeTooSmall = errors.Error{
 	Code: errors.EInvalid,
 	Msg:  fmt.Sprintf("maxQueueSize too small, must be at least %d", MinReplicationMaxQueueSizeBytes),
+}
+
+var ErrMaxAgeOutOfRange = errors.Error{
+	Code: errors.EInvalid,
+	Msg: fmt.Sprintf("maxAgeSeconds must be 0 (use default) or between %d and %d",
+		MinReplicationMaxAgeSeconds, MaxReplicationMaxAgeSeconds),
 }
 
 // Replication contains all info about a replication that should be returned to users.
@@ -78,6 +86,10 @@ func (r *CreateReplicationRequest) OK() error {
 		return &ErrMaxQueueSizeTooSmall
 	}
 
+	if r.MaxAgeSeconds != 0 && (r.MaxAgeSeconds < MinReplicationMaxAgeSeconds || r.MaxAgeSeconds > MaxReplicationMaxAgeSeconds) {
+		return &ErrMaxAgeOutOfRange
+	}
+
 	return nil
 }
 
@@ -94,12 +106,13 @@ type UpdateReplicationRequest struct {
 }
 
 func (r *UpdateReplicationRequest) OK() error {
-	if r.MaxQueueSizeBytes == nil {
-		return nil
+	if r.MaxQueueSizeBytes != nil && *r.MaxQueueSizeBytes < MinReplicationMaxQueueSizeBytes {
+		return &ErrMaxQueueSizeTooSmall
 	}
 
-	if *r.MaxQueueSizeBytes < MinReplicationMaxQueueSizeBytes {
-		return &ErrMaxQueueSizeTooSmall
+	if r.MaxAgeSeconds != nil && *r.MaxAgeSeconds != 0 &&
+		(*r.MaxAgeSeconds < MinReplicationMaxAgeSeconds || *r.MaxAgeSeconds > MaxReplicationMaxAgeSeconds) {
+		return &ErrMaxAgeOutOfRange
 	}
 
 	return nil

--- a/replication.go
+++ b/replication.go
@@ -84,7 +84,7 @@ type CreateReplicationRequest struct {
 	MaxAgeSeconds        int64       `json:"maxAgeSeconds,omitempty"`
 }
 
-func CheckMaxAgeInRange(maxAge int64) error {
+func checkMaxAgeInRange(maxAge int64) error {
 	// 0 is allowed as a sentinel meaning "use default"; non-zero must fall within bounds.
 	if maxAge != 0 && (maxAge < MinReplicationMaxAgeSeconds || maxAge > MaxReplicationMaxAgeSeconds) {
 		return &ErrMaxAgeOutOfRange
@@ -97,7 +97,7 @@ func (r *CreateReplicationRequest) OK() error {
 		return &ErrMaxQueueSizeTooSmall
 	}
 
-	return CheckMaxAgeInRange(r.MaxAgeSeconds)
+	return checkMaxAgeInRange(r.MaxAgeSeconds)
 }
 
 // UpdateReplicationRequest contains a partial update to existing info about a replication.
@@ -118,7 +118,7 @@ func (r *UpdateReplicationRequest) OK() error {
 	}
 
 	if r.MaxAgeSeconds != nil {
-		return CheckMaxAgeInRange(*r.MaxAgeSeconds)
+		return checkMaxAgeInRange(*r.MaxAgeSeconds)
 	}
 
 	return nil

--- a/replication.go
+++ b/replication.go
@@ -13,9 +13,9 @@ const (
 	// MaxAgeSeconds bounds the queue purge window. 0 disables purging (unbounded growth);
 	// too-small values purge faster than replication can drain (data loss, churn);
 	// too-large values retain data indefinitely (memory/latency bloat).
-	DefaultReplicationMaxAge            int64 = 604800  // 1 week, in seconds
-	MinReplicationMaxAgeSeconds         int64 = 60      // 1 minute
-	MaxReplicationMaxAgeSeconds         int64 = 5184000 // 2 months
+	DefaultReplicationMaxAge    int64 = 604800  // 1 week, in seconds
+	MinReplicationMaxAgeSeconds int64 = 60      // 1 minute
+	MaxReplicationMaxAgeSeconds int64 = 5184000 // 2 months
 )
 
 var ErrMaxQueueSizeTooSmall = errors.Error{

--- a/replication_test.go
+++ b/replication_test.go
@@ -1,0 +1,74 @@
+package influxdb
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateReplicationRequestOK_MaxAge(t *testing.T) {
+	okSize := DefaultReplicationMaxQueueSizeBytes
+
+	tests := []struct {
+		name          string
+		maxAgeSeconds int64
+		expectErr     error
+	}{
+		{"zero accepted as default", 0, nil},
+		{"in range lower bound", MinReplicationMaxAgeSeconds, nil},
+		{"in range typical", DefaultReplicationMaxAge, nil},
+		{"in range upper bound", MaxReplicationMaxAgeSeconds, nil},
+		{"negative rejected", -1, &ErrMaxAgeOutOfRange},
+		{"below minimum rejected", MinReplicationMaxAgeSeconds - 1, &ErrMaxAgeOutOfRange},
+		{"above maximum rejected", MaxReplicationMaxAgeSeconds + 1, &ErrMaxAgeOutOfRange},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := CreateReplicationRequest{
+				MaxQueueSizeBytes: okSize,
+				MaxAgeSeconds:     tt.maxAgeSeconds,
+			}
+			err := req.OK()
+			if tt.expectErr == nil {
+				require.NoError(t, err)
+			} else {
+				require.Equal(t, tt.expectErr, err)
+			}
+		})
+	}
+}
+
+func TestUpdateReplicationRequestOK_MaxAge(t *testing.T) {
+	okSize := DefaultReplicationMaxQueueSizeBytes
+	mk := func(v int64) *int64 { return &v }
+
+	tests := []struct {
+		name          string
+		maxAgeSeconds *int64
+		expectErr     error
+	}{
+		{"nil skipped", nil, nil},
+		{"zero accepted as default", mk(0), nil},
+		{"in range lower bound", mk(MinReplicationMaxAgeSeconds), nil},
+		{"in range upper bound", mk(MaxReplicationMaxAgeSeconds), nil},
+		{"negative rejected", mk(-1), &ErrMaxAgeOutOfRange},
+		{"below minimum rejected", mk(MinReplicationMaxAgeSeconds - 1), &ErrMaxAgeOutOfRange},
+		{"above maximum rejected", mk(MaxReplicationMaxAgeSeconds + 1), &ErrMaxAgeOutOfRange},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := UpdateReplicationRequest{
+				MaxQueueSizeBytes: &okSize,
+				MaxAgeSeconds:     tt.maxAgeSeconds,
+			}
+			err := req.OK()
+			if tt.expectErr == nil {
+				require.NoError(t, err)
+			} else {
+				require.Equal(t, tt.expectErr, err)
+			}
+		})
+	}
+}

--- a/replications/internal/queue_management.go
+++ b/replications/internal/queue_management.go
@@ -484,7 +484,7 @@ func (qm *durableQueueManager) newReplicationQueue(id platform.ID, orgID platfor
 	done := make(chan struct{})
 	// check for max age minimum
 	var maxAgeTime time.Duration
-	if maxAgeSeconds < 0 {
+	if maxAgeSeconds <= 0 {
 		maxAgeTime = defaultMaxAge
 	} else {
 		maxAgeTime = time.Duration(maxAgeSeconds) * time.Second

--- a/replications/internal/queue_management.go
+++ b/replications/internal/queue_management.go
@@ -483,10 +483,23 @@ func (qm *durableQueueManager) newReplicationQueue(id platform.ID, orgID platfor
 	logger := qm.logger.With(zap.String("replication_id", id.String()))
 	done := make(chan struct{})
 	// check for max age minimum
+	// Legacy persisted replications predate API bounds validation, so clamp
+	// out-of-range positive values to [Min, Max] rather than passing them through.
 	var maxAgeTime time.Duration
-	if maxAgeSeconds <= 0 {
+	switch {
+	case maxAgeSeconds <= 0:
 		maxAgeTime = defaultMaxAge
-	} else {
+	case maxAgeSeconds < influxdb.MinReplicationMaxAgeSeconds:
+		maxAgeTime = time.Duration(influxdb.MinReplicationMaxAgeSeconds) * time.Second
+		logger.Warn("maxAgeSeconds below minimum; clamping",
+			zap.Int64("requested", maxAgeSeconds),
+			zap.Int64("clamped_to", influxdb.MinReplicationMaxAgeSeconds))
+	case maxAgeSeconds > influxdb.MaxReplicationMaxAgeSeconds:
+		maxAgeTime = time.Duration(influxdb.MaxReplicationMaxAgeSeconds) * time.Second
+		logger.Warn("maxAgeSeconds above maximum; clamping",
+			zap.Int64("requested", maxAgeSeconds),
+			zap.Int64("clamped_to", influxdb.MaxReplicationMaxAgeSeconds))
+	default:
 		maxAgeTime = time.Duration(maxAgeSeconds) * time.Second
 	}
 

--- a/replications/internal/queue_management_test.go
+++ b/replications/internal/queue_management_test.go
@@ -723,9 +723,12 @@ func TestNewReplicationQueueMaxAge(t *testing.T) {
 	}{
 		{"zero uses default", 0, weekDefault},
 		{"negative uses default", -1, weekDefault},
+		{"below minimum clamped to min", 1, minAge},
+		{"just below minimum clamped to min", influxdb.MinReplicationMaxAgeSeconds - 1, minAge},
 		{"at minimum kept", influxdb.MinReplicationMaxAgeSeconds, minAge},
 		{"in range kept", influxdb.DefaultReplicationMaxAge, weekDefault},
 		{"at maximum kept", influxdb.MaxReplicationMaxAgeSeconds, maxAge},
+		{"just above maximum clamped to max", influxdb.MaxReplicationMaxAgeSeconds + 1, maxAge},
 	}
 
 	for _, tt := range tests {

--- a/replications/internal/queue_management_test.go
+++ b/replications/internal/queue_management_test.go
@@ -709,6 +709,34 @@ func TestGetReplications(t *testing.T) {
 	require.ElementsMatch(t, expectedRepls, repls)
 }
 
+func TestNewReplicationQueueMaxAge(t *testing.T) {
+	t.Parallel()
+
+	weekDefault := time.Duration(influxdb.DefaultReplicationMaxAge) * time.Second
+	minAge := time.Duration(influxdb.MinReplicationMaxAgeSeconds) * time.Second
+	maxAge := time.Duration(influxdb.MaxReplicationMaxAgeSeconds) * time.Second
+
+	tests := []struct {
+		name          string
+		maxAgeSeconds int64
+		expected      time.Duration
+	}{
+		{"zero uses default", 0, weekDefault},
+		{"negative uses default", -1, weekDefault},
+		{"at minimum kept", influxdb.MinReplicationMaxAgeSeconds, minAge},
+		{"in range kept", influxdb.DefaultReplicationMaxAge, weekDefault},
+		{"at maximum kept", influxdb.MaxReplicationMaxAgeSeconds, maxAge},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, qm := initQueueManager(t)
+			rq := qm.newReplicationQueue(id1, orgID1, localBucketID1, nil, tt.maxAgeSeconds)
+			require.Equal(t, tt.expected, rq.maxAge)
+		})
+	}
+}
+
 func TestReplicationStartMissingQueue(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Fixes an issue where we don't validate `MaxAgeSeconds` in EDR

Pulled from internal issue:

```
When MaxAgeSeconds == 0:

    Effect: The queue will never purge any items, leading to infinite retention of data. Data will accumulate indefinitely, potentially causing memory bloat and resource exhaustion.
    Replication Impact: There will be no purging, meaning the queue may accumulate unnecessary data over time. However, replication tasks should still work fine, though the queue may get larger without being properly cleaned up.

When MaxAgeSeconds == 1 (or other small values):

    Effect : The queue will attempt to purge items that are older than 1 second, leading to constant purging. This could result in frequent purging, where data is removed before replication tasks can process it.
    Replication Impact: Replication tasks could be blocked or delayed, as the data that should be replicated is removed before the task can retrieve it. The queue may be empty or contain only very recent data, making replication infeasible.
    Excessive Overhead : The constant checking and purging of the queue could lead to inefficiencies and additional computational overhead, impacting performance.

When MaxAgeSeconds is excessively large (e.g. MaxAgeSeconds = 3153600000 for 100 years):

    Effect: The queue will retain data for an unreasonably long period, leading to excessive data retention.
    Replication Impact: With a long retention period, replication tasks may need to deal with huge amounts of data, potentially leading to slower replication, increased latency, and higher memory usage.
    Performance Issues: Large values for MaxAgeSeconds may cause the system to hold onto data for too long, consuming more memory and slowing down the overall replication process, making the system less efficient.
```