### PR TITLE
chore(1.11): update go 1.26.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ parameters:
     # when updating the go version, should also update the go version in go.mod
     description: docker tag for cross build container from quay.io . Created by https://github.com/influxdata/edge/tree/master/dockerfiles/cross-builder .
     type: string
-    default: go1.24.13-latest
+    default: go1.26.2-latest
 
   workflow:
     type: string

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/influxdata/influxdb
 
-go 1.24.0
+go 1.26.0
 
-toolchain go1.24.13
+toolchain go1.26.2
 
 require (
 	collectd.org v0.3.0

--- a/monitor/service_test.go
+++ b/monitor/service_test.go
@@ -106,7 +106,7 @@ func TestMonitor_StoreStatistics(t *testing.T) {
 		}
 		if spec.ReplicaN != nil {
 			if got, want := *spec.ReplicaN, monitor.MonitorRetentionPolicyReplicaN; got != want {
-				t.Errorf("unexpected replica number: got=%q want=%q", got, want)
+				t.Errorf("unexpected replica number: got=%d want=%d", got, want)
 			}
 		} else {
 			t.Error("expected replica number in retention policy spec")


### PR DESCRIPTION
* Updates reference go in go.mod to go1.26.2
* Updates go image in .circleci/config.yml to go1.26.2-latest
* Fixes test `monitor/service_test.go` to use correct verb for return type int

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
