### PR TITLE
fix: Existing iterators in `a` would leak reference counts 

### DIFF
--- a/tsdb/index/tsi1/file_set.go
+++ b/tsdb/index/tsi1/file_set.go
@@ -37,7 +37,7 @@ func (fs *FileSet) bytes() int {
 }
 
 // Close closes all the files in the file set.
-func (fs FileSet) Close() error {
+func (fs *FileSet) Close() error {
 	return Files(fs.files).Close()
 }
 

--- a/tsdb/index/tsi1/index.go
+++ b/tsdb/index/tsi1/index.go
@@ -1057,6 +1057,8 @@ func (i *Index) TagKeySeriesIDIterator(name, key []byte) (tsdb.SeriesIDIterator,
 	for _, p := range i.partitions {
 		itr, err := p.TagKeySeriesIDIterator(name, key)
 		if err != nil {
+			// ok to ignore the error from Close() as it's better to report the error that prevented making the Iterator
+			tsdb.SeriesIDIterators(a).Close()
 			return nil, err
 		} else if itr != nil {
 			a = append(a, itr)


### PR DESCRIPTION
* fix: Existing iterators in `a` would leak reference counts

* chore: add comment about ignoring Close err; fix pointer receiver

---------


(cherry picked from commit 283d6733a21df0c49134c00601b78c0ee060949b)