### PR TITLE
feat: enable token hashing by default

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -811,7 +811,7 @@ jobs:
       - attach_workspace:
           at: ~/project
       - run:
-          command: ./bin/influxd_linux_amd64/influxd --store=memory --log-level=debug
+          command: ./bin/influxd_linux_amd64/influxd --use-hashed-tokens=false --store=memory --log-level=debug
           background: true
       - run: mkdir -p ~/project/results
       - run:

--- a/authorization/storage.go
+++ b/authorization/storage.go
@@ -21,8 +21,9 @@ import (
 /*---
 Token storage and verification
 
-Storage of hashed tokens has been added as an optional feature. This stores only the hash of a token
-in BoltDB. Token hashing is enabled with the `--use-hashed-tokens` option.
+Tokens are stored as hashes in BoltDB by default. Prior to version 2.8, only raw, unhashed tokens were
+supported. Opt-in support for hashed tokens was introduced in 2.8.0. Since 2.9.0, token hashing is on
+by default but still supports opt-out with "--use-hashed-tokens=false"
 
 Upgrading the BoltDB schema is automatic on startup when using a new version of InfluxDB with token hashing support.
 Additionally, raw tokens are automatically migrated to hashed tokens if `--use-hashed-tokens` is configured.
@@ -201,6 +202,8 @@ func NewStore(ctx context.Context, kvStore kv.Store, useHashedTokens bool, opts 
 		s.log = zap.NewNop()
 	}
 
+	s.log.Info("Creating authorization store", zap.Bool("UseHashedTokens", useHashedTokens))
+
 	if err := s.setup(ctx); err != nil {
 		return nil, fmt.Errorf("error during authorization store setup: %w", err)
 	}
@@ -324,6 +327,10 @@ func (s *Store) MigrateTokens(ctx context.Context) error {
 	})
 	if err != nil {
 		return err
+	}
+
+	if len(authsNeedingUpdate) > 0 {
+		s.log.Info("Migrating raw tokens to hashed tokens", zap.Int("count", len(authsNeedingUpdate)))
 	}
 
 	for batch := range slices.Chunk(authsNeedingUpdate, 100) {

--- a/authorization/storage.go
+++ b/authorization/storage.go
@@ -26,7 +26,7 @@ supported. Opt-in support for hashed tokens was introduced in 2.8.0. Since 2.9.0
 by default but still supports opt-out with "--use-hashed-tokens=false"
 
 Upgrading the BoltDB schema is automatic on startup when using a new version of InfluxDB with token hashing support.
-Additionally, raw tokens are automatically migrated to hashed tokens if `--use-hashed-tokens` is configured.
+Additionally, raw tokens are automatically migrated to hashed tokens if whenever token hashing is enabled.
 Due to the schema changes, to use a version of InfluxDB without hashed token support, a manual downgrade using
 `influxd downgrade` must be run. Any tokens stored as hashed tokens will be unusable by the old version of InfluxDB
 and must be reset or recreated.

--- a/cmd/influxd/launcher/cmd.go
+++ b/cmd/influxd/launcher/cmd.go
@@ -257,6 +257,7 @@ func NewOpts(viper *viper.Viper) *InfluxdOpts {
 		HardeningEnabled:         false,
 		TemplateFileUrlsDisabled: false,
 		StrongPasswords:          false,
+		UseHashedTokens:          true,
 	}
 }
 
@@ -711,7 +712,7 @@ func (o *InfluxdOpts) BindCliOpts() []cli.Opt {
 			DestP:   &o.UseHashedTokens,
 			Flag:    "use-hashed-tokens",
 			Default: o.UseHashedTokens,
-			Desc:    "enable storing hashed API tokens on disk (improves security, but prevents downgrades to < 2.8)",
+			Desc:    "enable storing hashed API tokens on disk (enabled by default; pass --use-hashed-tokens=false to disable for < 2.8 compatibility)",
 		},
 	}
 }

--- a/cmd/influxd/upgrade/upgrade.go
+++ b/cmd/influxd/upgrade/upgrade.go
@@ -88,13 +88,12 @@ func (o *optionsV1) populateDirs() {
 }
 
 type optionsV2 struct {
-	boltPath        string
-	cliConfigsPath  string
-	enginePath      string
-	cqPath          string
-	configPath      string
-	rmConflicts     bool
-	useHashedTokens bool
+	boltPath       string
+	cliConfigsPath string
+	enginePath     string
+	cqPath         string
+	configPath     string
+	rmConflicts    bool
 
 	userName  string
 	password  string
@@ -200,12 +199,6 @@ func NewCommand(ctx context.Context, v *viper.Viper) (*cobra.Command, error) {
 			Flag:    "continuous-query-export-path",
 			Default: filepath.Join(homeOrAnyDir(), "continuous_queries.txt"),
 			Desc:    "path for exported 1.x continuous queries",
-		},
-		{
-			DestP:   &options.target.useHashedTokens,
-			Flag:    "use-hashed-tokens",
-			Default: options.target.useHashedTokens,
-			Desc:    "enable token hashing",
 		},
 		{
 			DestP:   &options.target.userName,
@@ -661,7 +654,11 @@ func newInfluxDBv2(ctx context.Context, opts *optionsV2, log *zap.Logger) (svc *
 	svc.ts.BucketService = storage.NewBucketService(log, svc.ts.BucketService, engine)
 
 	hashVariantName := authorization.DefaultHashVariantName // In the future this could come from opts.
-	authStoreV2, err := authorization.NewStore(ctx, svc.store, opts.useHashedTokens, authorization.WithAuthorizationHashVariantName(hashVariantName), authorization.WithLogger(log))
+	// We explicitly disable hashed tokens during upgrade processes. The actual token hashing
+	// will be done on every influxd startup, so it doesn't have to be done now. Also, if the
+	// user does not want to enable token hashing, having the upgrade command hash by default might
+	// cause issues because they might not realize that the upgrade command also needs "--use-token-hashing=false".
+	authStoreV2, err := authorization.NewStore(ctx, svc.store, false, authorization.WithAuthorizationHashVariantName(hashVariantName), authorization.WithLogger(log))
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/influxd/upgrade/upgrade.go
+++ b/cmd/influxd/upgrade/upgrade.go
@@ -657,7 +657,7 @@ func newInfluxDBv2(ctx context.Context, opts *optionsV2, log *zap.Logger) (svc *
 	// We explicitly disable hashed tokens during upgrade processes. The actual token hashing
 	// will be done on every influxd startup, so it doesn't have to be done now. Also, if the
 	// user does not want to enable token hashing, having the upgrade command hash by default might
-	// cause issues because they might not realize that the upgrade command also needs "--use-token-hashing=false".
+	// cause issues because they might not realize that the upgrade command also needs "--use-hashed-tokens=false".
 	authStoreV2, err := authorization.NewStore(ctx, svc.store, false, authorization.WithAuthorizationHashVariantName(hashVariantName), authorization.WithLogger(log))
 	if err != nil {
 		return nil, err

--- a/cmd/influxd/upgrade/upgrade_test.go
+++ b/cmd/influxd/upgrade/upgrade_test.go
@@ -323,7 +323,7 @@ func TestUpgradeRealDB(t *testing.T) {
 			require.NotEqual(t, token, auths[0].HashedToken, "hashed token should not be the token.")
 			require.Empty(t, auths[0].Token, "token should be empty when token hashing is enabled. Was UseHashedTokens default changed?")
 
-			// Verify the that the HashedToken has been hashed properly.
+			// Verify that HashedToken has been hashed properly.
 			decoder := crypt.NewDecoder()
 			require.NoError(t, influxdb2.RegisterDecoder(decoder))
 			digest, err := decoder.Decode(auths[0].HashedToken)

--- a/cmd/influxd/upgrade/upgrade_test.go
+++ b/cmd/influxd/upgrade/upgrade_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 	"github.com/dustin/go-humanize"
+	"github.com/go-crypt/crypt"
 	"github.com/google/go-cmp/cmp"
 	"github.com/influxdata/influx-cli/v2/clients"
 	"github.com/influxdata/influxdb/v2"
@@ -20,6 +21,7 @@ import (
 	"github.com/influxdata/influxdb/v2/cmd/influxd/launcher"
 	"github.com/influxdata/influxdb/v2/internal/testutil"
 	"github.com/influxdata/influxdb/v2/kit/cli"
+	"github.com/influxdata/influxdb/v2/pkg/crypt/algorithm/influxdb2"
 	"github.com/influxdata/influxdb/v2/v1/services/meta"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -209,6 +211,7 @@ func TestUpgradeRealDB(t *testing.T) {
 	configPath := filepath.Join(tl.Path, "config.toml")
 
 	v1opts := &optionsV1{configFile: v1ConfigPath}
+	token := "my-token"
 	v2opts := &optionsV2{
 		boltPath:       boltPath,
 		enginePath:     enginePath,
@@ -220,7 +223,7 @@ func TestUpgradeRealDB(t *testing.T) {
 		orgName:        "my-org",
 		bucket:         "my-bucket",
 		retention:      "7d",
-		token:          "my-token",
+		token:          token,
 	}
 
 	opts := &options{source: *v1opts, target: *v2opts, force: true}
@@ -231,6 +234,7 @@ func TestUpgradeRealDB(t *testing.T) {
 	v := viper.New()
 	v.SetConfigFile(configPath)
 	require.NoError(t, v.ReadInConfig())
+	// Don't adjust lOpts.UseHashedTokens. This test will fail if UseHashedTokens does not default to true.
 	lOpts := launcher.NewOpts(v)
 	cliOpts := lOpts.BindCliOpts()
 
@@ -315,17 +319,27 @@ func TestUpgradeRealDB(t *testing.T) {
 			auths, _, err := tl.Launcher.AuthorizationService().FindAuthorizations(ctx, influxdb.AuthorizationFilter{})
 			require.NoError(t, err)
 			require.Len(t, auths, 1)
+			require.NotEmpty(t, auths[0].HashedToken, "hashed token should not be empty when token hashing is enabled. Was UseHashedTokens default changed?")
+			require.NotEqual(t, token, auths[0].HashedToken, "hashed token should not be the token.")
+			require.Empty(t, auths[0].Token, "token should be empty when token hashing is enabled. Was UseHashedTokens default changed?")
 
-			respBody := mustRunQuery(t, tl, "test", "select count(avg) from stat", auths[0].Token)
+			// Verify the that the HashedToken has been hashed properly.
+			decoder := crypt.NewDecoder()
+			require.NoError(t, influxdb2.RegisterDecoder(decoder))
+			digest, err := decoder.Decode(auths[0].HashedToken)
+			require.NoError(t, err)
+			require.True(t, digest.Match(token), "HashedToken does not match token")
+
+			respBody := mustRunQuery(t, tl, "test", "select count(avg) from stat", token)
 			require.Contains(t, respBody, `["1970-01-01T00:00:00Z",5776]`)
 
-			respBody = mustRunQuery(t, tl, "mydb", "select count(avg) from testv1", auths[0].Token)
+			respBody = mustRunQuery(t, tl, "mydb", "select count(avg) from testv1", token)
 			require.Contains(t, respBody, `["1970-01-01T00:00:00Z",2882]`)
 
-			respBody = mustRunQuery(t, tl, "mydb", "select count(i) from testv1", auths[0].Token)
+			respBody = mustRunQuery(t, tl, "mydb", "select count(i) from testv1", token)
 			require.Contains(t, respBody, `["1970-01-01T00:00:00Z",21]`)
 
-			respBody = mustRunQuery(t, tl, "mydb", `select count(line) from mydb."1week".log`, auths[0].Token)
+			respBody = mustRunQuery(t, tl, "mydb", `select count(line) from mydb."1week".log`, token)
 			require.Contains(t, respBody, `["1970-01-01T00:00:00Z",1]`)
 
 			cqBytes, err := os.ReadFile(cqPath)

--- a/scripts/ci/test-downgrade.sh
+++ b/scripts/ci/test-downgrade.sh
@@ -87,7 +87,7 @@ function wait_for_influxd () {
 function setup_influxd () {
     local -r influxd_path=$1 tmp=$2
     INFLUXD_BOLT_PATH="${tmp}/influxd.bolt" INFLUXD_SQLITE_PATH="${tmp}/influxd.sqlite" INFLUXD_ENGINE_PATH="${tmp}/engine" \
-        "$influxd_path" &
+        "$influxd_path" --use-hashed-tokens=false &
     local -r influxd_pid="$!"
 
     wait_for_influxd "$influxd_pid"


### PR DESCRIPTION
Enable token hashing by default. Pass "--use-token-hashing=false" on influxd command line to disable.

- Make hashed tokens on by default for main influxd command.
- Update command line help for "--use-hashed-tokens".
- Remove "--use-hashed-tokens" command line parameter for `influxd upgrade` command. Tokens are now only converted when influxd is run with token hashing enabled.
- Add log message when raw tokens are hashed at influxd startup.
- Add log message indicating if hashed tokens are enabled.
- Add log message when raw tokens are hashed at influxd startup.
- Add log message indicating if hashed tokens are enabled.
- Update tests as needed.
- Update code comments to reflect token hashing is now default.