### PR TITLE
chore(sync): influxdb_pro 2026-05-01

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -271,7 +271,7 @@ jobs:
           command: cargo install cargo-deny --locked
       - run:
           name: cargo-deny Checks
-          command: cargo deny check -s
+          command: cargo deny check -s --warn unsound
 
   doc:
     docker:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,7 +144,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -155,7 +155,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -444,7 +444,7 @@ dependencies = [
 
 [[package]]
 name = "arrow_util"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -541,7 +541,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "authz"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -655,7 +655,7 @@ dependencies = [
 
 [[package]]
 name = "backoff"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "rand 0.9.2",
  "snafu 0.9.0",
@@ -1069,7 +1069,7 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "catalog_cache"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "bytes",
  "criterion 0.8.2",
@@ -1207,7 +1207,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "client_util"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "http 1.4.0",
  "iox_http_util",
@@ -1785,7 +1785,7 @@ dependencies = [
 
 [[package]]
 name = "data_types"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -2518,7 +2518,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion_util"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -2602,7 +2602,7 @@ dependencies = [
 
 [[package]]
 name = "dml"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "arrow_util",
  "data_types",
@@ -2709,12 +2709,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "error_reporting"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "datafusion",
  "snafu 0.9.0",
@@ -2744,7 +2744,7 @@ dependencies = [
 
 [[package]]
 name = "executor"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "futures",
  "metric",
@@ -2825,7 +2825,7 @@ dependencies = [
 
 [[package]]
 name = "flightsql"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -3032,7 +3032,7 @@ dependencies = [
 
 [[package]]
 name = "futures_test_utils"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "clap",
  "futures",
@@ -3043,7 +3043,7 @@ dependencies = [
 
 [[package]]
 name = "generated_types"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "bytes",
  "pbjson",
@@ -3499,7 +3499,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -3692,7 +3692,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb2_client"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "bytes",
  "futures",
@@ -3711,7 +3711,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3801,7 +3801,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_authz"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "async-trait",
  "authz",
@@ -3818,7 +3818,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_cache"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3853,7 +3853,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_catalog"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3905,7 +3905,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_clap_blocks"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3942,7 +3942,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_client"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "bytes",
  "hashbrown 0.14.5",
@@ -3962,7 +3962,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_commands"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -3981,7 +3981,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_id"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "indexmap 2.13.0",
  "serde",
@@ -3991,7 +3991,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_internal_api"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4012,7 +4012,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_load_generator"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4041,7 +4041,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_process"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "iox_time",
  "uuid",
@@ -4049,7 +4049,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_processing_engine"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4093,7 +4093,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_py_api"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -4121,7 +4121,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_query_executor"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4171,7 +4171,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_server"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4254,7 +4254,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_shutdown"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "futures",
  "futures-util",
@@ -4269,14 +4269,14 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_startup"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "chrono",
 ]
 
 [[package]]
 name = "influxdb3_sys_events"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4295,7 +4295,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_system_tables"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4327,7 +4327,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_telemetry"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "futures",
  "futures-util",
@@ -4348,7 +4348,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_test_helpers"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4361,7 +4361,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_types"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4381,7 +4381,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_wal"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "async-trait",
  "bitcode",
@@ -4409,7 +4409,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_write"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4478,7 +4478,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb_influxql_parser"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "assert_matches",
  "chrono",
@@ -4495,7 +4495,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb_iox_client"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -4524,7 +4524,7 @@ dependencies = [
 
 [[package]]
 name = "ingester_query_grpc"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "base64 0.22.1",
  "data_types",
@@ -4581,7 +4581,7 @@ checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
 
 [[package]]
 name = "iox_http"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -4601,7 +4601,7 @@ dependencies = [
 
 [[package]]
 name = "iox_http_util"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "futures",
  "http 1.4.0",
@@ -4612,7 +4612,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "arrow",
  "arrow_util",
@@ -4661,7 +4661,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query_influxql"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "arrow",
  "assert_matches",
@@ -4688,7 +4688,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query_influxql_rewrite"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "influxdb_influxql_parser",
  "thiserror 2.0.18",
@@ -4696,7 +4696,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query_params"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "arrow",
  "assert_matches",
@@ -4710,7 +4710,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query_udf"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "datafusion-udf-wasm-host",
  "datafusion-udf-wasm-query",
@@ -4721,7 +4721,7 @@ dependencies = [
 
 [[package]]
 name = "iox_system_tables"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4731,7 +4731,7 @@ dependencies = [
 
 [[package]]
 name = "iox_time"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "chrono",
  "parking_lot",
@@ -4740,7 +4740,7 @@ dependencies = [
 
 [[package]]
 name = "iox_v1_query_api"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4801,7 +4801,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4854,7 +4854,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jemalloc_stats"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "snafu 0.9.0",
  "tikv-jemalloc-ctl",
@@ -4999,7 +4999,7 @@ dependencies = [
 
 [[package]]
 name = "linear_buffer"
-version = "3.9.1"
+version = "3.9.2"
 
 [[package]]
 name = "linux-raw-sys"
@@ -5043,7 +5043,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "logfmt"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "humantime",
  "parking_lot",
@@ -5151,14 +5151,14 @@ dependencies = [
 
 [[package]]
 name = "metric"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "parking_lot",
 ]
 
 [[package]]
 name = "metric_exporters"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "metric",
  "mockito",
@@ -5283,7 +5283,7 @@ checksum = "9252111cf132ba0929b6f8e030cac2a24b507f3a4d6db6fb2896f27b354c714b"
 
 [[package]]
 name = "mutable_batch"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "arrow",
  "arrow_util",
@@ -5301,7 +5301,7 @@ dependencies = [
 
 [[package]]
 name = "mutable_batch_lp"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "arrow_util",
  "assert_matches",
@@ -5317,7 +5317,7 @@ dependencies = [
 
 [[package]]
 name = "mutable_batch_pb"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "arrow_util",
  "criterion 0.8.2",
@@ -5375,7 +5375,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5555,7 +5555,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_limit"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5567,7 +5567,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_mem_cache"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5594,7 +5594,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_metrics"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "async-trait",
  "bloom2",
@@ -5619,7 +5619,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_mock"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5633,7 +5633,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_size_hinting"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "chrono",
  "http 1.4.0",
@@ -5643,7 +5643,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_utils"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "async-trait",
  "backon",
@@ -5656,7 +5656,7 @@ dependencies = [
 
 [[package]]
 name = "observability_deps"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "tracing",
 ]
@@ -5721,7 +5721,7 @@ dependencies = [
 
 [[package]]
 name = "panic_logging"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "metric",
  "test_helpers",
@@ -5796,7 +5796,7 @@ dependencies = [
 
 [[package]]
 name = "parquet_file"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "arrow",
  "arrow_util",
@@ -5825,7 +5825,7 @@ dependencies = [
 
 [[package]]
 name = "partition"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "arrow",
  "assert_matches",
@@ -6122,7 +6122,7 @@ dependencies = [
 
 [[package]]
 name = "predicate"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6468,7 +6468,7 @@ dependencies = [
 
 [[package]]
 name = "query_functions"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "arrow",
  "chrono",
@@ -6511,7 +6511,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.37",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6548,7 +6548,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -7012,7 +7012,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7049,7 +7049,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.10",
+ "rustls-webpki 0.103.13",
  "subtle",
  "zeroize",
 ]
@@ -7098,9 +7098,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -7151,7 +7151,7 @@ dependencies = [
 
 [[package]]
 name = "schema"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "arrow",
  "base64 0.22.1",
@@ -7334,7 +7334,7 @@ dependencies = [
 
 [[package]]
 name = "service_common"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -7348,7 +7348,7 @@ dependencies = [
 
 [[package]]
 name = "service_grpc_flight"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -7415,7 +7415,7 @@ dependencies = [
 
 [[package]]
 name = "sharder"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "criterion 0.8.2",
  "data_types",
@@ -7557,7 +7557,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7937,7 +7937,7 @@ dependencies = [
 
 [[package]]
 name = "table_batch"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "arrow_util",
  "bitvec",
@@ -7981,7 +7981,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8023,7 +8023,7 @@ dependencies = [
 
 [[package]]
 name = "test_helpers"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "async-trait",
  "dotenvy",
@@ -8042,7 +8042,7 @@ dependencies = [
 
 [[package]]
 name = "test_helpers_authz"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "futures",
  "generated_types",
@@ -8315,7 +8315,7 @@ dependencies = [
 
 [[package]]
 name = "tokio_metrics_bridge"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "metric",
  "parking_lot",
@@ -8324,7 +8324,7 @@ dependencies = [
 
 [[package]]
 name = "tokio_watchdog"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "metric",
  "test_helpers",
@@ -8547,7 +8547,7 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tower_trailer"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "futures",
  "http 1.4.0",
@@ -8559,7 +8559,7 @@ dependencies = [
 
 [[package]]
 name = "trace"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "chrono",
  "parking_lot",
@@ -8569,7 +8569,7 @@ dependencies = [
 
 [[package]]
 name = "trace_exporters"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8586,7 +8586,7 @@ dependencies = [
 
 [[package]]
 name = "trace_http"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "bytes",
  "futures",
@@ -8681,7 +8681,7 @@ dependencies = [
 
 [[package]]
 name = "tracker"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "futures",
  "hashbrown 0.14.5",
@@ -8701,7 +8701,7 @@ dependencies = [
 
 [[package]]
 name = "trogging"
-version = "3.9.1"
+version = "3.9.2"
 dependencies = [
  "clap",
  "logfmt",
@@ -9470,7 +9470,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,7 +125,7 @@ exclude = [
 #
 # For porting to the actual OSS repo (influxdb), this would need to change to `-nightly`, i.e., by
 # stripping the `-oss`.
-version = "3.9.1"
+version = "3.9.2"
 authors = ["InfluxData OSS Developers"]
 edition = "2024"
 license = "MIT OR Apache-2.0"
@@ -211,7 +211,7 @@ regex = "1.11.1"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "stream", "json"] }
 rstest = "0.26"
 rustls = { version = "0.23", default-features = false, features = ["logging", "ring", "std", "tls12"] }
-rustls-webpki = { version = "0.103", default-features = false, features = ["ring", "std"] }
+rustls-webpki = { version = "0.103.13", default-features = false, features = ["ring", "std"] }
 secrecy = "0.8.0"
 serde = { version = "1.0", features = ["derive"] }
 # serde_json is set to 1.0.127 to prevent a conflict with core, if that gets updated upstream, this
@@ -230,7 +230,7 @@ sysinfo = "<0.38"
 tempfile = "3.14.0"
 test-log = { version = "0.2.16", features = ["trace"] }
 thiserror = "1.0"
-tokio = { version = "1.45", features = ["full"] }
+tokio = { version = "1.50.0", features = ["full"] }
 tokio-rustls = { version = "0.25", default-features = false, features = ["ring", "tls12"] }
 tokio-util = { version = "0.7.13", features = ["rt"] }
 tonic = { version = "0.14", features = ["tls-native-roots"] }

--- a/deny.toml
+++ b/deny.toml
@@ -21,6 +21,21 @@ ignore = [
     # (requires CA compromise). Stuck on 0.102.x via wasmtime's rustls 0.22.x
     # dep in datafusion-udf-wasm. Upstream also ignores this advisory.
     "RUSTSEC-2026-0049",
+    # rustls-webpki 0.102.8 wildcard name-constraint bug; stuck on 0.102.x via
+    # wasmtime's rustls 0.22.x dep in datafusion-udf-wasm. Upstream fix pulls in
+    # newer DataFusion/wasmtime and is not yet compatible with this repo.
+    "RUSTSEC-2026-0099",
+    # rustls-webpki 0.102.8 URI name-constraint bug; same transitive 0.102.x path
+    # via datafusion-udf-wasm/wasmtime/rustls 0.22.x, with the same current
+    # incompatibility on the available upstream fix path.
+    "RUSTSEC-2026-0098",
+    # rustls-webpki CRL parsing reachable panic; only 0.103.13+ and 0.104.0-alpha.7+
+    # ship the fix. The 0.103.x transitive is patched via the Cargo.toml pin bump,
+    # but the 0.102.x transitive is still stuck via datafusion-udf-wasm/wasmtime/
+    # rustls 0.22.x with no patched 0.102.x release available. We don't configure
+    # CRLs anywhere in this repo, so the panic is unreachable in practice on that
+    # remaining 0.102.x path.
+    "RUSTSEC-2026-0104",
 
     # wasmtime 41.0.4 advisories (transitive dep via datafusion-udf-wasm)
     #
@@ -46,6 +61,7 @@ ignore = [
     #
     # Guest realloc validation (single-component host-guest interaction; low risk given UDFs are disabled):
     "RUSTSEC-2026-0091", # GHSA-394w-hwhg-8vgm: OOB write from unvalidated guest realloc
+    "RUSTSEC-2026-0114", # GHSA-p8xm-42r7-89xg: Panic when allocating a table exceeding the size of the host's address space
     #
     # TODO: update wasmtime via datafusion-udf-wasm to a patched version (>=42.0.2)
 ]


### PR DESCRIPTION
Source: 5616bb89c8f2229f4218c67acd7d351ad2966a53

Commits:
- `5616bb89c8` chore: ignore more RUSTSECs for UDFs
- `181bd84ade` chore: update tokio to 1.50.0 for consistent versioning
- `64360800cb` chore: update version to 3.9.2 in Cargo.toml (influxdata/influxdb_pro#3356)
- `a566d9f755` chore: address cargo-audit failures (RUSTSEC-2026-0104)
- `2998bcd9bb` chore: Address cargo audit failures (influxdata/influxdb_pro#3155)
- `66e650f9b8` chore(cargo-deny): Downgrade unsound info advisories to warnings (influxdata/influxdb_pro#3115) (influxdata/influxdb_pro#3116)
- `e1e5a6f103` chore: cherry pick audit fix and multipart put for parquet (influxdata/influxdb_pro#3114)
- `299b99fb8d` fix: ignore wasmtime 41.0.4 security advisories in cargo-deny (influxdata/influxdb_pro#3090)
- `215c85bd8b` chore: update versions to 3.9.1 (influxdata/influxdb_pro#3087)

