### PR TITLE
chore(sync): influxdb_pro 2026-05-01

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -271,10 +271,8 @@ jobs:
           command: cargo install cargo-deny --locked
       - run:
           name: cargo-deny Checks
-          # `--warn unsound` downgrades RustSec `informational = "unsound"`
-          # advisories to warnings, they flag API soundness concerns, not
-          # exploitable vulnerabilities, so we don't want them to fail CI.
           command: cargo deny check -s --warn unsound
+
   doc:
     docker:
       - image: quay.io/influxdb/rust:ci

--- a/.circleci/packages/influxdb3/fs/usr/share/influxdb3/influxdb3-core.conf
+++ b/.circleci/packages/influxdb3/fs/usr/share/influxdb3/influxdb3-core.conf
@@ -228,6 +228,10 @@
 # URL of plugin repository (env: INFLUXDB3_PLUGIN_REPO)
 #plugin-repo="<URL>"
 
+# Restrict plugin triggers to the provided trigger type(s). Comma-separated
+# list of: wal, schedule, request (env: INFLUXDB3_RESTRICT_PLUGIN_TRIGGERS_TO)
+#restrict-plugin-triggers-to="<TYPES>"
+
 # =============================================================================
 # Data Lifecycle & Retention
 # =============================================================================

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,7 +168,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -179,7 +179,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2775,7 +2775,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3578,7 +3578,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -4261,6 +4261,7 @@ dependencies = [
  "arrow-flight",
  "arrow-json",
  "arrow-schema",
+ "async-trait",
  "authz",
  "base64 0.21.7",
  "bytes",
@@ -4308,6 +4309,7 @@ dependencies = [
  "metric_exporters",
  "mime",
  "object_store",
+ "object_store_utils",
  "observability_deps",
  "parquet",
  "parquet_file",
@@ -4883,7 +4885,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5455,7 +5457,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5730,6 +5732,7 @@ dependencies = [
  "backon",
  "bytes",
  "futures",
+ "iox_time",
  "object_store",
  "observability_deps",
  "tokio",
@@ -6600,7 +6603,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.37",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6637,7 +6640,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -7101,7 +7104,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7138,7 +7141,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.12",
+ "rustls-webpki 0.103.13",
  "subtle",
  "zeroize",
 ]
@@ -7187,9 +7190,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -7655,7 +7658,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8079,7 +8082,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8328,9 +8331,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.0"
+version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a91135f59b1cbf38c91e73cf3386fca9bb77915c45ce2771460c9d92f0f3d776"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "bytes",
  "libc",
@@ -9572,7 +9575,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -212,7 +212,7 @@ regex = "1.11.1"
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "stream", "json"] }
 rstest = "0.26"
 rustls = { version = "0.23", default-features = false, features = ["logging", "ring", "std", "tls12"] }
-rustls-webpki = { version = "0.103.12", default-features = false, features = ["ring", "std"] }
+rustls-webpki = { version = "0.103.13", default-features = false, features = ["ring", "std"] }
 secrecy = "0.8.0"
 serde = { version = "1.0", features = ["derive"] }
 # serde_json is set to 1.0.127 to prevent a conflict with core, if that gets updated upstream, this

--- a/core/README.md
+++ b/core/README.md
@@ -1,0 +1,21 @@
+# `oss/core`
+
+`oss/core` contains the lower-level shared crates shared across:
+
+- InfluxDB 3 Core
+- InfluxDB 3 Enterprise
+- InfluxDB 3 IOx
+
+These crates provide common building blocks such as query execution, schema and data
+types, HTTP and gRPC utilities, observability helpers, and supporting Arrow and Parquet
+infrastructure.
+
+
+Examples of crates in this directory include:
+
+- query and planner crates such as `iox_query`, `iox_query_influxql`, and `query_functions`
+- shared data model crates such as `data_types`, `schema`, and `mutable_batch`
+- service and protocol crates such as `generated_types`, `service_grpc_flight`, and `iox_http`
+- common runtime and observability crates such as `executor`, `metric`, `trace`, and `trogging`
+
+As a rule of thumb, code belongs in `core` when it is product-agnostic infrastructure.

--- a/core/data_types/src/columns.rs
+++ b/core/data_types/src/columns.rs
@@ -411,6 +411,25 @@ impl std::fmt::Display for ColumnType {
     }
 }
 
+impl std::str::FromStr for ColumnType {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "i64" => Ok(Self::I64),
+            "u64" => Ok(Self::U64),
+            "f64" => Ok(Self::F64),
+            "bool" => Ok(Self::Bool),
+            "string" => Ok(Self::String),
+            "time" => Ok(Self::Time),
+            "tag" => Ok(Self::Tag),
+            _ => Err(format!(
+                "invalid column type '{s}': valid types are i64, u64, f64, bool, string, time, tag"
+            )),
+        }
+    }
+}
+
 impl TryFrom<&ArrowDataType> for ColumnType {
     type Error = &'static str;
 

--- a/core/iox_v1_query_api/src/handler.rs
+++ b/core/iox_v1_query_api/src/handler.rs
@@ -61,6 +61,48 @@ struct QueryPlan {
     context: IOxSessionContext,
 }
 
+/// A V1 `/query` request parsed but not yet executed.
+///
+/// Returned by [`V1HttpHandler::extract_query_request`] and consumed by
+/// [`V1HttpHandler::execute_query`]. Callers can read
+/// [`Self::requested_database`] between the two phases to wire up
+/// observability that needs the database name from the request.
+///
+/// The inner fields hold the auth token bytes and the raw query text;
+/// the manual `Debug` impl redacts both so accidental `{:?}` formatting
+/// can't leak them into logs.
+pub struct ExtractedV1Request {
+    span_ctx: Option<SpanContext>,
+    token: Option<Vec<u8>>,
+    params: QueryParams,
+    format: QueryFormat,
+}
+
+impl std::fmt::Debug for ExtractedV1Request {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ExtractedV1Request")
+            .field("requested_database", &self.requested_database())
+            .field("token", &self.token.as_ref().map(|_| "<redacted>"))
+            .field("query", &self.params.query.as_ref().map(|_| "<redacted>"))
+            .field("format", &self.format)
+            .finish()
+    }
+}
+
+impl ExtractedV1Request {
+    /// The database name as supplied by the request — URL query string,
+    /// `application/x-www-form-urlencoded` body, or multipart `db` field.
+    /// Empty strings collapse to `None`, matching `execute_query`'s own
+    /// handling.
+    ///
+    /// This is the request-level value only. Per-statement DB/RP overrides
+    /// embedded in InfluxQL (e.g. `SELECT … FROM "otherdb"."rp"."m"`) are
+    /// resolved during execution and are not reflected here.
+    pub fn requested_database(&self) -> Option<&str> {
+        self.params.database.as_deref().filter(|s| !s.is_empty())
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct V1HttpHandler {
     database: Arc<dyn QueryDatabase>,
@@ -132,7 +174,19 @@ impl V1HttpHandler {
             .map_err(|e| HttpError::InternalError(e.to_string()))
     }
 
-    async fn handle_parameterized_query(&self, mut req: Request) -> Result<Response, HttpError> {
+    async fn handle_parameterized_query(&self, req: Request) -> Result<Response, HttpError> {
+        let extracted = self.extract_query_request(req).await?;
+        self.execute_query(extracted).await
+    }
+
+    /// Parse the request: trace context, auth token, and body params/format.
+    ///
+    /// Splitting this out from execution lets callers inspect the resolved
+    /// `database` (e.g. for service-level logging) before the request runs.
+    pub async fn extract_query_request(
+        &self,
+        mut req: Request,
+    ) -> Result<ExtractedV1Request, HttpError> {
         let span_ctx = Some(SpanContext::new_with_optional_collector(
             self.trace_collector.as_ref().map(Arc::clone),
         ));
@@ -142,6 +196,26 @@ impl V1HttpHandler {
         let token = self.get_token_from_request(&mut req)?;
 
         let (params, format) = extract_request(req).await?;
+
+        Ok(ExtractedV1Request {
+            span_ctx,
+            token,
+            params,
+            format,
+        })
+    }
+
+    /// Execute a previously parsed V1 request.
+    pub async fn execute_query(
+        &self,
+        extracted: ExtractedV1Request,
+    ) -> Result<Response, HttpError> {
+        let ExtractedV1Request {
+            span_ctx,
+            token,
+            params,
+            format,
+        } = extracted;
 
         let QueryParams {
             chunk_size,
@@ -974,5 +1048,115 @@ mod tests {
         },{
             insta::assert_snapshot!(res);
         });
+    }
+
+    /// Helper: build a fresh handler for `extract_query_request` tests.
+    /// These tests do not exercise execution, so the database / authz
+    /// implementations are inert.
+    fn handler_for_extract_tests() -> V1HttpHandler {
+        let db: Arc<dyn QueryDatabase> = Arc::new(TestDatabaseStore::default());
+        V1HttpHandler::new(db, None, None, "test".to_string())
+    }
+
+    #[tokio::test]
+    async fn extract_query_request_db_in_url() {
+        let req = RequestBuilder::new()
+            .method("GET")
+            .uri("http://h/query?db=mydb&q=SELECT%201")
+            .body(empty_request_body())
+            .unwrap();
+        let extracted = handler_for_extract_tests()
+            .extract_query_request(req)
+            .await
+            .expect("extract should succeed");
+        assert_eq!(extracted.requested_database(), Some("mydb"));
+    }
+
+    #[tokio::test]
+    async fn extract_query_request_db_in_form_body() {
+        let req = RequestBuilder::new()
+            .method("POST")
+            .uri("http://h/query")
+            .header("Content-Type", "application/x-www-form-urlencoded")
+            .body(iox_http_util::bytes_to_request_body("db=mydb&q=SELECT+1"))
+            .unwrap();
+        let extracted = handler_for_extract_tests()
+            .extract_query_request(req)
+            .await
+            .expect("extract should succeed");
+        assert_eq!(extracted.requested_database(), Some("mydb"));
+    }
+
+    #[tokio::test]
+    async fn extract_query_request_db_in_multipart_body() {
+        let boundary = "----v1tests-boundary-9f8d";
+        let body = format!(
+            "--{boundary}\r\n\
+             Content-Disposition: form-data; name=\"db\"\r\n\r\n\
+             mydb\r\n\
+             --{boundary}\r\n\
+             Content-Disposition: form-data; name=\"q\"\r\n\r\n\
+             SELECT 1\r\n\
+             --{boundary}--\r\n"
+        );
+        let req = RequestBuilder::new()
+            .method("POST")
+            .uri("http://h/query")
+            .header(
+                "Content-Type",
+                format!("multipart/form-data; boundary={boundary}"),
+            )
+            .body(iox_http_util::bytes_to_request_body(body))
+            .unwrap();
+        let extracted = handler_for_extract_tests()
+            .extract_query_request(req)
+            .await
+            .expect("extract should succeed");
+        assert_eq!(extracted.requested_database(), Some("mydb"));
+    }
+
+    #[tokio::test]
+    async fn extract_query_request_debug_redacts_token_and_query() {
+        // Token comes from the `p=` URL parameter on the V1 path — that's
+        // one of the two real ingress points for V1 auth (the other is
+        // `AuthorizationHeaderExtension` in `req.extensions()`, which is
+        // populated by upstream middleware not present in this unit test).
+        let req = RequestBuilder::new()
+            .method("POST")
+            .uri("http://h/query?p=supersecret-token-bytes")
+            .header("Content-Type", "application/x-www-form-urlencoded")
+            .body(iox_http_util::bytes_to_request_body(
+                "db=mydb&q=SELECT+secret_field+FROM+t",
+            ))
+            .unwrap();
+        let extracted = handler_for_extract_tests()
+            .extract_query_request(req)
+            .await
+            .expect("extract should succeed");
+        // Sanity: the token actually got captured, otherwise we'd be
+        // proving redaction of a None field.
+        assert!(
+            extracted.token.is_some(),
+            "test fixture should populate a token via ?p="
+        );
+        let dbg = format!("{extracted:?}");
+        assert!(!dbg.contains("supersecret-token-bytes"), "{dbg}");
+        assert!(!dbg.contains("secret_field"), "{dbg}");
+        // Database name is fine to display.
+        assert!(dbg.contains("mydb"), "{dbg}");
+    }
+
+    #[tokio::test]
+    async fn extract_query_request_empty_db_collapses_to_none() {
+        let req = RequestBuilder::new()
+            .method("GET")
+            .uri("http://h/query?db=&q=SELECT%201")
+            .body(empty_request_body())
+            .unwrap();
+        let extracted = handler_for_extract_tests()
+            .extract_query_request(req)
+            .await
+            .expect("extract should succeed");
+        assert_eq!(extracted.requested_database(), None);
     }
 }

--- a/core/iox_v1_query_api/src/lib.rs
+++ b/core/iox_v1_query_api/src/lib.rs
@@ -12,7 +12,7 @@ use types::Statement;
 mod error;
 pub use error::HttpError;
 mod handler;
-pub use handler::V1HttpHandler;
+pub use handler::{ExtractedV1Request, V1HttpHandler};
 mod response;
 mod types;
 mod value;

--- a/core/service_grpc_flight/src/lib.rs
+++ b/core/service_grpc_flight/src/lib.rs
@@ -116,7 +116,7 @@ const IOX_FLIGHT_PARTITIONS_RESPONSE_TRAILER: &str = "x-influxdata-partitions";
 const IOX_FLIGHT_PARQUET_FILES_RESPONSE_TRAILER: &str = "x-influxdata-parquet-files";
 
 /// Trailer that describes the peak memory usage of a query.
-const IOX_FLIGHT_MAX_MEMORY_RESPONSE_TRAILER: &str = "x-influxdata-max-memory-bytes";
+pub const IOX_FLIGHT_MAX_MEMORY_RESPONSE_TRAILER: &str = "x-influxdata-max-memory-bytes";
 
 /// Trailer that describes the latency to planning from ingester response.
 const IOX_FLIGHT_INGESTER_LATENCY_PLAN_RESPONSE_TRAILER: &str =

--- a/deny.toml
+++ b/deny.toml
@@ -29,6 +29,13 @@ ignore = [
     # via datafusion-udf-wasm/wasmtime/rustls 0.22.x, with the same current
     # incompatibility on the available upstream fix path.
     "RUSTSEC-2026-0098",
+    # rustls-webpki CRL parsing reachable panic; only 0.103.13+ and 0.104.0-alpha.7+
+    # ship the fix. The 0.103.x transitive is patched via the Cargo.toml pin bump,
+    # but the 0.102.x transitive is still stuck via datafusion-udf-wasm/wasmtime/
+    # rustls 0.22.x with no patched 0.102.x release available. We don't configure
+    # CRLs anywhere in this repo, so the panic is unreachable in practice on that
+    # remaining 0.102.x path.
+    "RUSTSEC-2026-0104",
 
     # wasmtime 41.0.4 advisories (transitive dep via datafusion-udf-wasm)
     #
@@ -55,6 +62,9 @@ ignore = [
     # Guest realloc validation (single-component host-guest interaction; low risk given UDFs are disabled):
     "RUSTSEC-2026-0091", # GHSA-394w-hwhg-8vgm: OOB write from unvalidated guest realloc
     #
+    # Panic when allocating a table that is larger than host address space.
+    # The UDF/WASM parts are currently unused in production.
+    "RUSTSEC-2026-0114",
     # TODO: update wasmtime via datafusion-udf-wasm to a patched version (>=42.0.2)
 ]
 git-fetch-with-cli = true

--- a/influxdb3/src/commands/serve.rs
+++ b/influxdb3/src/commands/serve.rs
@@ -10,8 +10,8 @@ use influxdb3_cache::{
     last_cache::{self, LastCacheProvider},
     parquet_cache::create_cached_obj_store_and_oracle,
 };
-use influxdb3_catalog::{CatalogError, catalog::Catalog};
-use influxdb3_clap_blocks::plugins::{PackageManager, ProcessingEngineConfig};
+use influxdb3_catalog::{CatalogError, catalog::Catalog, log::PluginType};
+use influxdb3_clap_blocks::plugins::{PackageManager, PluginTriggerType, ProcessingEngineConfig};
 use influxdb3_clap_blocks::{
     datafusion::IoxQueryDatafusionConfig, memory_size::MemorySizeMb,
     object_store::ObjectStoreConfig, socket_addr::SocketAddr, tokio::TokioDatafusionConfig,
@@ -1197,6 +1197,7 @@ pub async fn command(config: Config, user_params: HashMap<String, String>) -> Re
         Arc::clone(&write_buffer),
         Arc::clone(&query_executor) as _,
         Arc::clone(&processing_engine),
+        restricted_plugin_trigger_types(&config.processing_engine_config),
         config.max_http_request_size,
         Arc::clone(&authorizer),
     ));
@@ -1396,6 +1397,18 @@ pub(crate) fn setup_processing_engine_env_manager(
         package_manager,
         plugin_repo: config.plugin_repo.clone(),
     }
+}
+
+fn restricted_plugin_trigger_types(config: &ProcessingEngineConfig) -> Vec<PluginType> {
+    config
+        .restrict_plugin_triggers_to
+        .iter()
+        .map(|trigger_type| match trigger_type {
+            PluginTriggerType::Wal => PluginType::WalRows,
+            PluginTriggerType::Schedule => PluginType::Schedule,
+            PluginTriggerType::Request => PluginType::Request,
+        })
+        .collect()
 }
 
 fn determine_package_manager() -> Arc<dyn PythonEnvironmentManager> {

--- a/influxdb3/src/commands/serve/cli_params.rs
+++ b/influxdb3/src/commands/serve/cli_params.rs
@@ -119,6 +119,7 @@ const NON_SENSITIVE_PARAMS: &[&str] = &[
     "virtual-env-location",
     "package-manager",
     "plugin-repo",
+    "restrict-plugin-triggers-to",
     // Other parameters
     "tcp-listener-file-path",
     // Tokio console parameters

--- a/influxdb3/src/help/serve.txt
+++ b/influxdb3/src/help/serve.txt
@@ -73,6 +73,10 @@ Examples
   --package-manager <MANAGER>      Python package manager  
                                     [possible values: discover, pip, uv, disabled] [default: discover]
                                     [env: INFLUXDB3_PACKAGE_MANAGER=]
+  --restrict-plugin-triggers-to <TYPE>...
+                                    Restrict plugin triggers to the provided trigger type(s)
+                                    [possible values: wal, schedule, request]
+                                    [env: INFLUXDB3_RESTRICT_PLUGIN_TRIGGERS_TO=]
 
 {}
   -h, --help                       Print help information

--- a/influxdb3/src/help/serve_all.txt
+++ b/influxdb3/src/help/serve_all.txt
@@ -153,6 +153,9 @@ Examples:
                                                  [env: INFLUXDB3_PACKAGE_MANAGER=]
   --plugin-repo <URL>                          URL of plugin repository
                                                  [env: INFLUXDB3_PLUGIN_REPO=]
+  --restrict-plugin-triggers-to <TYPE>...      Restrict plugin triggers to the provided trigger type(s)
+                                                 [possible values: wal, schedule, request]
+                                                 [env: INFLUXDB3_RESTRICT_PLUGIN_TRIGGERS_TO=]
 
 {}
   --gen1-duration <DURATION>                   Duration for Parquet file arrangement [default: 10m]

--- a/influxdb3/tests/server/mod.rs
+++ b/influxdb3/tests/server/mod.rs
@@ -39,6 +39,7 @@ mod limits;
 mod logs;
 mod packages;
 mod ping;
+mod plugin_restriction;
 mod query;
 mod system_tables;
 mod write;
@@ -95,6 +96,7 @@ pub struct TestConfig {
     plugin_dir: Option<String>,
     virtual_env_dir: Option<String>,
     package_manager: Option<String>,
+    restrict_plugin_triggers_to: Vec<String>,
     // If None, use memory object store.
     object_store_dir: Option<String>,
     disable_authz: Vec<String>,
@@ -161,6 +163,15 @@ impl TestConfig {
 
     pub fn with_package_manager<S: Into<String>>(mut self, package_manager: S) -> Self {
         self.package_manager = Some(package_manager.into());
+        self
+    }
+
+    pub fn with_restrict_plugin_triggers_to<I, S>(mut self, types: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.restrict_plugin_triggers_to = types.into_iter().map(Into::into).collect();
         self
     }
 
@@ -272,6 +283,12 @@ impl ConfigProvider for TestConfig {
                 "--package-manager".to_string(),
                 package_manager.to_owned(),
             ]);
+        }
+        if !self.restrict_plugin_triggers_to.is_empty() {
+            args.push("--restrict-plugin-triggers-to".to_string());
+            for t in &self.restrict_plugin_triggers_to {
+                args.push(t.to_owned());
+            }
         }
         args.push("--node-id".to_string());
         if let Some(host) = &self.node_id {

--- a/influxdb3/tests/server/plugin_restriction.rs
+++ b/influxdb3/tests/server/plugin_restriction.rs
@@ -1,0 +1,206 @@
+use crate::server::{ConfigProvider, TestServer};
+use anyhow::Result;
+use tempfile::TempDir;
+
+struct PluginTest {
+    plugin_dir: TempDir,
+    plugin_filename: &'static str,
+}
+
+impl PluginTest {
+    fn new() -> Result<Self> {
+        let plugin_dir = TempDir::new()?;
+        let plugin_path = plugin_dir.path().join("test_plugin.py");
+        std::fs::write(
+            &plugin_path,
+            b"def process_scheduled_call(influxdb3_local, schedule_time, args=None): pass\n",
+        )?;
+        Ok(Self {
+            plugin_dir,
+            plugin_filename: "test_plugin.py",
+        })
+    }
+
+    fn plugin_dir_str(&self) -> String {
+        self.plugin_dir.path().to_string_lossy().into_owned()
+    }
+}
+
+#[test_log::test(tokio::test)]
+async fn test_restrict_plugin_triggers_to_schedule_rejects_other_types() -> Result<()> {
+    let setup = PluginTest::new()?;
+
+    let server = TestServer::configure()
+        .with_plugin_dir(setup.plugin_dir_str())
+        .with_restrict_plugin_triggers_to(["schedule"])
+        .spawn()
+        .await;
+
+    server.create_database("testdb").run()?;
+
+    // WAL trigger (all_tables) should be rejected
+    let err = server
+        .create_trigger("testdb", "wal_trigger", setup.plugin_filename, "all_tables")
+        .run()
+        .expect_err("WAL trigger should be rejected when only schedule is allowed");
+    assert!(
+        err.to_string()
+            .contains("server is configured to reject WalRows"),
+        "Expected restriction error, got: {err}"
+    );
+
+    // WAL trigger (table:X) should also be rejected
+    let err = server
+        .create_trigger(
+            "testdb",
+            "wal_table_trigger",
+            setup.plugin_filename,
+            "table:cpu",
+        )
+        .run()
+        .expect_err("Table WAL trigger should be rejected when only schedule is allowed");
+    assert!(
+        err.to_string()
+            .contains("server is configured to reject WalRows"),
+        "Expected restriction error, got: {err}"
+    );
+
+    // Request trigger should be rejected
+    let err = server
+        .create_trigger(
+            "testdb",
+            "request_trigger",
+            setup.plugin_filename,
+            "request:mypath",
+        )
+        .run()
+        .expect_err("Request trigger should be rejected when only schedule is allowed");
+    assert!(
+        err.to_string()
+            .contains("server is configured to reject Request"),
+        "Expected restriction error, got: {err}"
+    );
+
+    // Schedule trigger (every:) should be allowed
+    server
+        .create_trigger(
+            "testdb",
+            "every_trigger",
+            setup.plugin_filename,
+            "every:10s",
+        )
+        .disabled(true)
+        .run()
+        .expect("every:10s schedule trigger should be allowed");
+
+    // Schedule trigger (cron:) should also be allowed
+    server
+        .create_trigger(
+            "testdb",
+            "cron_trigger",
+            setup.plugin_filename,
+            "cron:* * * * * *",
+        )
+        .disabled(true)
+        .run()
+        .expect("cron schedule trigger should be allowed");
+
+    Ok(())
+}
+
+#[test_log::test(tokio::test)]
+async fn test_restrict_plugin_triggers_to_wal_rejects_other_types() -> Result<()> {
+    let setup = PluginTest::new()?;
+
+    let server = TestServer::configure()
+        .with_plugin_dir(setup.plugin_dir_str())
+        .with_restrict_plugin_triggers_to(["wal"])
+        .spawn()
+        .await;
+
+    server.create_database("testdb").run()?;
+
+    // Schedule trigger should be rejected
+    let err = server
+        .create_trigger(
+            "testdb",
+            "schedule_trigger",
+            setup.plugin_filename,
+            "every:10s",
+        )
+        .run()
+        .expect_err("Schedule trigger should be rejected when only WAL is allowed");
+    assert!(
+        err.to_string()
+            .contains("server is configured to reject Schedule"),
+        "Expected restriction error, got: {err}"
+    );
+
+    // Request trigger should be rejected
+    let err = server
+        .create_trigger(
+            "testdb",
+            "request_trigger",
+            setup.plugin_filename,
+            "request:mypath",
+        )
+        .run()
+        .expect_err("Request trigger should be rejected when only WAL is allowed");
+    assert!(
+        err.to_string()
+            .contains("server is configured to reject Request"),
+        "Expected restriction error, got: {err}"
+    );
+
+    // WAL trigger should be allowed
+    server
+        .create_trigger("testdb", "wal_trigger", setup.plugin_filename, "all_tables")
+        .disabled(true)
+        .run()
+        .expect("WAL trigger should be allowed");
+
+    Ok(())
+}
+
+#[test_log::test(tokio::test)]
+async fn test_no_plugin_trigger_restriction_allows_all_types() -> Result<()> {
+    let setup = PluginTest::new()?;
+
+    let server = TestServer::configure()
+        .with_plugin_dir(setup.plugin_dir_str())
+        .spawn()
+        .await;
+
+    server.create_database("testdb").run()?;
+
+    // All trigger types should be allowed with no restriction
+    server
+        .create_trigger("testdb", "wal_trigger", setup.plugin_filename, "all_tables")
+        .disabled(true)
+        .run()
+        .expect("WAL trigger should be allowed with no restriction");
+
+    server
+        .create_trigger(
+            "testdb",
+            "schedule_trigger",
+            setup.plugin_filename,
+            "every:10s",
+        )
+        .disabled(true)
+        .run()
+        .expect("Schedule trigger should be allowed with no restriction");
+
+    server
+        .create_trigger(
+            "testdb",
+            "request_trigger",
+            setup.plugin_filename,
+            "request:mypath",
+        )
+        .disabled(true)
+        .run()
+        .expect("Request trigger should be allowed with no restriction");
+
+    Ok(())
+}

--- a/influxdb3_clap_blocks/src/plugins.rs
+++ b/influxdb3_clap_blocks/src/plugins.rs
@@ -18,6 +18,23 @@ pub struct ProcessingEngineConfig {
     pub package_manager: PackageManager,
     #[clap(long = "plugin-repo", env = "INFLUXDB3_PLUGIN_REPO")]
     pub plugin_repo: Option<String>,
+    /// Restrict plugin triggers to the provided trigger type(s).
+    #[clap(
+        long = "restrict-plugin-triggers-to",
+        env = "INFLUXDB3_RESTRICT_PLUGIN_TRIGGERS_TO",
+        value_enum,
+        value_delimiter = ',',
+        num_args = 1..
+    )]
+    pub restrict_plugin_triggers_to: Vec<PluginTriggerType>,
+}
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq, clap::ValueEnum)]
+pub enum PluginTriggerType {
+    #[value(alias = "wal_flush")]
+    Wal,
+    Schedule,
+    Request,
 }
 
 #[derive(Debug, Clone, Copy, Default, clap::ValueEnum)]

--- a/influxdb3_commands/src/helpers.rs
+++ b/influxdb3_commands/src/helpers.rs
@@ -5,9 +5,8 @@ use std::{str::FromStr, sync::OnceLock};
 use influxdb3_server::all_paths;
 use observability_deps::tracing::trace;
 
-const DISABLED_AUTHZ_TOO_MANY_VALUES_ERR: &str = "--disable-authz cannot take more than 3 items";
-const DISABLED_AUTHZ_INVALID_VALUE_ERR: &str =
-    "invalid value passed in for --disable-authz, allowed values are health, ping, and metrics";
+const DISABLED_AUTHZ_TOO_MANY_VALUES_ERR: &str = "--disable-authz cannot take more than 4 items";
+const DISABLED_AUTHZ_INVALID_VALUE_ERR: &str = "invalid value passed in for --disable-authz, allowed values are health, ping, metrics, and ready";
 
 static AUTHZ_DISABLED_RESOURCES: OnceLock<Vec<&'static str>> = OnceLock::new();
 
@@ -41,12 +40,12 @@ impl FromStr for DisableAuthzList {
 
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
         let resources: Vec<String> = s.split(',').map(|s| s.trim().to_string()).collect();
-        if resources.len() > 3 {
+        if resources.len() > 4 {
             return Err(DISABLED_AUTHZ_TOO_MANY_VALUES_ERR);
         }
 
         for r in &resources {
-            if !["health", "ping", "metrics"]
+            if !["health", "ping", "metrics", "ready"]
                 .iter()
                 .any(|resource| resource == r)
             {
@@ -67,6 +66,10 @@ impl FromStr for DisableAuthzList {
 
                 if path == "metrics" {
                     return vec![all_paths::API_METRICS];
+                }
+
+                if path == "ready" {
+                    return vec![all_paths::API_V3_READY];
                 }
                 vec![]
             })

--- a/influxdb3_commands/src/helpers/tests.rs
+++ b/influxdb3_commands/src/helpers/tests.rs
@@ -4,15 +4,19 @@ use crate::helpers::{DISABLED_AUTHZ_INVALID_VALUE_ERR, DISABLED_AUTHZ_TOO_MANY_V
 
 use super::DisableAuthzList;
 
+// AUTHZ_DISABLED_RESOURCES is a OnceLock whose state persists for the lifetime of
+// the test process. Successful-parse tests must run in a deterministic order --
+// we combine the coverage into a single test to avoid racing on the global state.
 #[test]
 fn test_parses_disabled_authz() {
-    let list: DisableAuthzList = "health,ping,metrics".parse().expect("parseable");
+    let list: DisableAuthzList = "health,ping,metrics,ready".parse().expect("parseable");
     let all_mapped = list.get_mapped_endpoints();
-    assert_eq!(4, all_mapped.len());
+    assert_eq!(5, all_mapped.len());
     assert_eq!(*all_mapped.first().unwrap(), all_paths::API_V3_HEALTH);
     assert_eq!(*all_mapped.get(1).unwrap(), all_paths::API_V1_HEALTH);
     assert_eq!(*all_mapped.get(2).unwrap(), all_paths::API_PING);
     assert_eq!(*all_mapped.get(3).unwrap(), all_paths::API_METRICS);
+    assert_eq!(*all_mapped.get(4).unwrap(), all_paths::API_V3_READY);
 }
 
 #[test]
@@ -33,7 +37,7 @@ fn test_fails_to_parse_disabled_authz_list_too_many_values_err() {
 
 #[test]
 fn test_fails_to_parse_disabled_authz_list_too_many_allowed_values_err() {
-    let list = "health,metrics,ping,health"
+    let list = "health,metrics,ping,health,ready"
         .parse::<DisableAuthzList>()
         .unwrap_err();
     assert_eq!(list, DISABLED_AUTHZ_TOO_MANY_VALUES_ERR);

--- a/influxdb3_server/Cargo.toml
+++ b/influxdb3_server/Cargo.toml
@@ -26,6 +26,7 @@ iox_time = { path = "../core/iox_time" }
 iox_v1_query_api = { path = "../core/iox_v1_query_api" }
 metric = { path = "../core/metric" }
 metric_exporters = { path = "../core/metric_exporters" }
+object_store_utils = { path = "../object_store_utils" }
 observability_deps = { path = "../core/observability_deps" }
 schema = { path = "../core/schema" }
 service_grpc_flight = { path = "../core/service_grpc_flight" }
@@ -50,6 +51,7 @@ influxdb3_write = { path = "../influxdb3_write" }
 # crates.io Dependencies
 anyhow.workspace = true
 arrow.workspace = true
+async-trait.workspace = true
 arrow-csv.workspace = true
 arrow-flight.workspace = true
 arrow-json.workspace = true

--- a/influxdb3_server/src/all_paths.rs
+++ b/influxdb3_server/src/all_paths.rs
@@ -6,6 +6,7 @@ pub(crate) const API_V3_QUERY_INFLUXQL: &str = "/api/v3/query_influxql";
 pub(crate) const API_V1_QUERY: &str = "/query";
 pub const API_V3_HEALTH: &str = "/health";
 pub const API_V1_HEALTH: &str = "/api/v1/health";
+pub const API_V3_READY: &str = "/ready";
 pub(crate) const API_V3_ENGINE: &str = "/api/v3/engine/";
 pub(crate) const API_V3_CONFIGURE_DISTINCT_CACHE: &str = "/api/v3/configure/distinct_cache";
 pub(crate) const API_V3_CONFIGURE_LAST_CACHE: &str = "/api/v3/configure/last_cache";

--- a/influxdb3_server/src/http.rs
+++ b/influxdb3_server/src/http.rs
@@ -33,7 +33,7 @@ use influxdb3_cache::distinct_cache;
 use influxdb3_cache::last_cache;
 use influxdb3_catalog::CatalogError;
 use influxdb3_catalog::catalog::HardDeletionTime;
-use influxdb3_catalog::log::FieldDataType;
+use influxdb3_catalog::log::{FieldDataType, PluginType, TriggerSpecificationDefinition};
 use influxdb3_id::TokenId;
 use influxdb3_internal_api::query_executor::{
     QueryExecutor, QueryExecutorError, ShowDatabases, ShowRetentionPolicies,
@@ -381,6 +381,9 @@ pub enum Error {
 
     #[error("Current node mode does not use the processing engine")]
     NoProcessingEngine,
+
+    #[error("invalid request: {0}")]
+    InvalidRequest(String),
 
     #[error(transparent)]
     LegacyWriteParse(#[from] WriteParseError),
@@ -926,6 +929,10 @@ impl IntoResponse for Error {
                 .status(StatusCode::METHOD_NOT_ALLOWED)
                 .body(bytes_to_response_body(self.to_string()))
                 .unwrap(),
+            Self::InvalidRequest(_) => ResponseBuilder::new()
+                .status(StatusCode::BAD_REQUEST)
+                .body(bytes_to_response_body(self.to_string()))
+                .unwrap(),
             Self::MissingDb(_) | Self::MissingTable(_) | Self::NoHandler => ResponseBuilder::new()
                 .status(StatusCode::NOT_FOUND)
                 .body(bytes_to_response_body(self.to_string()))
@@ -985,6 +992,7 @@ pub struct HttpApi {
     common_state: CommonServerState,
     write_buffer: Arc<dyn WriteBuffer>,
     processing_engine: Arc<ProcessingEngineManagerImpl>,
+    allowed_plugin_trigger_types: Vec<PluginType>,
     time_provider: Arc<dyn TimeProvider>,
     pub(crate) query_executor: Arc<dyn QueryExecutor>,
     max_request_bytes: usize,
@@ -993,12 +1001,14 @@ pub struct HttpApi {
 }
 
 impl HttpApi {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         common_state: CommonServerState,
         time_provider: Arc<dyn TimeProvider>,
         write_buffer: Arc<dyn WriteBuffer>,
         query_executor: Arc<dyn QueryExecutor>,
         processing_engine: Arc<ProcessingEngineManagerImpl>,
+        allowed_plugin_trigger_types: Vec<PluginType>,
         max_request_bytes: usize,
         authorizer: Arc<dyn AuthProvider>,
     ) -> Self {
@@ -1015,6 +1025,7 @@ impl HttpApi {
             authorizer,
             legacy_write_param_unifier,
             processing_engine,
+            allowed_plugin_trigger_types,
         }
     }
 }
@@ -1545,6 +1556,10 @@ impl HttpApi {
             self.read_body_json(req).await?
         };
         debug!(%db, %plugin_filename, %trigger_name, %trigger_specification, %disabled, "configure_processing_engine_trigger");
+        validate_restricted_plugin_trigger_specification(
+            &trigger_specification,
+            &self.allowed_plugin_trigger_types,
+        )?;
         let plugin_filename = self
             .processing_engine
             .validate_plugin_filename(&plugin_filename)
@@ -2865,6 +2880,25 @@ pub(crate) async fn route_admin_token_recovery_request(
         .insert(ACCESS_CONTROL_ALLOW_ORIGIN, HeaderValue::from_static("*"));
 
     Ok(response)
+}
+
+fn validate_restricted_plugin_trigger_specification(
+    trigger_specification: &str,
+    allowed_plugin_trigger_types: &[PluginType],
+) -> Result<()> {
+    if allowed_plugin_trigger_types.is_empty() {
+        return Ok(());
+    }
+
+    let trigger = TriggerSpecificationDefinition::from_string_rep(trigger_specification)?;
+    let plugin_type = trigger.plugin_type();
+    if allowed_plugin_trigger_types.contains(&plugin_type) {
+        Ok(())
+    } else {
+        Err(Error::InvalidRequest(format!(
+            "server is configured to reject {plugin_type} plugin triggers"
+        )))
+    }
 }
 
 #[cfg(test)]

--- a/influxdb3_server/src/http/tests.rs
+++ b/influxdb3_server/src/http/tests.rs
@@ -2,8 +2,8 @@ use http::{HeaderMap, HeaderValue, StatusCode, header::ACCEPT};
 use http::{Request, Uri};
 
 use super::{
-    MAXIMUM_DATABASE_NAME_LENGTH, extract_client_ip, extract_db_from_query_param,
-    truncate_for_logging,
+    MAXIMUM_DATABASE_NAME_LENGTH, PluginType, extract_client_ip, extract_db_from_query_param,
+    truncate_for_logging, validate_restricted_plugin_trigger_specification,
 };
 use crate::http::{AuthenticationError, Error};
 
@@ -69,6 +69,43 @@ fn test_validate_db_name() {
     assert_validate_db_name!("-foo", Err(ValidateDbNameError::InvalidStartChar));
     assert_validate_db_name!("/", Err(ValidateDbNameError::InvalidStartChar));
     assert_validate_db_name!("", Err(ValidateDbNameError::Empty));
+}
+
+#[test]
+fn test_validate_restricted_plugin_trigger_specification() {
+    assert!(validate_restricted_plugin_trigger_specification("all_tables", &[]).is_ok());
+
+    let schedule_only = [PluginType::Schedule];
+    assert!(
+        validate_restricted_plugin_trigger_specification("cron:* * * * * *", &schedule_only)
+            .is_ok()
+    );
+    assert!(validate_restricted_plugin_trigger_specification("every:10s", &schedule_only).is_ok());
+
+    assert!(matches!(
+        validate_restricted_plugin_trigger_specification("all_tables", &schedule_only),
+        Err(Error::InvalidRequest(_))
+    ));
+    assert!(matches!(
+        validate_restricted_plugin_trigger_specification("table:cpu", &schedule_only),
+        Err(Error::InvalidRequest(_))
+    ));
+    assert!(matches!(
+        validate_restricted_plugin_trigger_specification("request:foo", &schedule_only),
+        Err(Error::InvalidRequest(_))
+    ));
+
+    let wal_and_request = [PluginType::WalRows, PluginType::Request];
+    assert!(
+        validate_restricted_plugin_trigger_specification("table:cpu", &wal_and_request).is_ok()
+    );
+    assert!(
+        validate_restricted_plugin_trigger_specification("request:foo", &wal_and_request).is_ok()
+    );
+    assert!(matches!(
+        validate_restricted_plugin_trigger_specification("every:10s", &wal_and_request),
+        Err(Error::InvalidRequest(_))
+    ));
 }
 
 #[tokio::test]

--- a/influxdb3_server/src/tests.rs
+++ b/influxdb3_server/src/tests.rs
@@ -1445,6 +1445,7 @@ async fn setup_server(start_time: i64) -> (String, CancellationToken, Arc<dyn Wr
         Arc::clone(&write_buffer),
         Arc::clone(&query_executor) as _,
         Arc::clone(&processing_engine),
+        vec![],
         usize::MAX,
         Arc::clone(&authorizer) as _,
     ));

--- a/influxdb3_types/src/write.rs
+++ b/influxdb3_types/src/write.rs
@@ -1,4 +1,4 @@
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Serialize, Serializer};
 
 /// Nanoseconds has units of nanoseconds (naturally)
 pub type Nanoseconds = i64;
@@ -151,6 +151,36 @@ impl std::str::FromStr for Precision {
             _ => return Err(format!("unrecognized precision unit: {s}")),
         };
         Ok(p)
+    }
+}
+
+/// A single write request can have many lines in it. A writer can request to accept all lines that are valid, while
+/// returning an error for any invalid lines. This is the error information for a single invalid line.
+///
+/// `original_line` is stored in full in memory but truncated on serialize: the serialized output caps the field
+/// at 20 bytes, rounded down to the nearest UTF-8 char boundary. Consumers reading the serialized form should not
+/// assume `original_line` is the complete input line.
+#[derive(Debug)]
+pub struct WriteLineError {
+    pub original_line: String,
+    pub line_number: usize,
+    pub error_message: String,
+}
+
+impl Serialize for WriteLineError {
+    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        use serde::ser::SerializeStruct;
+        let mut state = serializer.serialize_struct("WriteLineError", 3)?;
+        const TRUNCATE_LIMIT: usize = 20;
+        let truncated_line =
+            &self.original_line[..self.original_line.floor_char_boundary(TRUNCATE_LIMIT)];
+        state.serialize_field("error_message", &self.error_message)?;
+        state.serialize_field("line_number", &self.line_number)?;
+        state.serialize_field("original_line", truncated_line)?;
+        state.end()
     }
 }
 

--- a/influxdb3_types/src/write/tests.rs
+++ b/influxdb3_types/src/write/tests.rs
@@ -262,6 +262,45 @@ fn test_to_nanos_explicit_all_precisions() {
 }
 
 #[test]
+fn test_write_line_error_serialize_truncates_at_utf8_boundary() {
+    // Serialize caps `original_line` at this many bytes (mirrors the constant in the impl).
+    const TRUNCATE_LIMIT: usize = 20;
+
+    // 19 ASCII bytes followed by a 2-byte 'é' starting at byte 19. A naive `[..TRUNCATE_LIMIT]`
+    // slice lands in the middle of 'é' and would panic; floor_char_boundary backs up to byte 19.
+    let long_line = format!("{}érest of the line", "a".repeat(19));
+    assert!(
+        !long_line.is_char_boundary(TRUNCATE_LIMIT),
+        "test premise: byte {TRUNCATE_LIMIT} must fall inside a multi-byte char",
+    );
+
+    let err = WriteLineError {
+        original_line: long_line,
+        line_number: 1,
+        error_message: "bad line".to_string(),
+    };
+    let json = serde_json::to_string(&err).expect("serialize must not panic");
+    let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+    let emitted = parsed["original_line"]
+        .as_str()
+        .expect("original_line must serialize as a JSON string");
+
+    assert_eq!(emitted, "a".repeat(19));
+
+    // Short input passes through unchanged.
+    let short = "short line";
+    assert!(short.len() < TRUNCATE_LIMIT);
+    let err = WriteLineError {
+        original_line: short.to_string(),
+        line_number: 2,
+        error_message: "bad".to_string(),
+    };
+    let json = serde_json::to_string(&err).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(parsed["original_line"].as_str().unwrap(), short);
+}
+
+#[test]
 fn test_to_nanos_default_truncation() {
     assert_eq!(
         Precision::Second.to_nanos(None, TEST_TS_NANOS).unwrap(),

--- a/influxdb3_write/src/lib.rs
+++ b/influxdb3_write/src/lib.rs
@@ -37,7 +37,7 @@ use iox_query::QueryChunk;
 use iox_time::Time;
 use observability_deps::tracing::debug;
 use schema::TIME_COLUMN_NAME;
-use serde::{Deserialize, Serialize, Serializer};
+use serde::{Deserialize, Serialize};
 use std::{fmt::Debug, sync::Arc};
 use thiserror::Error;
 
@@ -81,7 +81,7 @@ pub trait Bufferer: Debug + Send + Sync + 'static {
     /// Returns the database schema provider
     fn catalog(&self) -> Arc<Catalog>;
 
-    /// Reutrns the WAL this bufferer is using
+    /// Returns the WAL this bufferer is using
     fn wal(&self) -> Arc<dyn Wal>;
 
     /// Returns the parquet files for a given database and table
@@ -130,34 +130,7 @@ pub trait LastCacheManager: Debug + Send + Sync + 'static {
     fn last_cache_provider(&self) -> Arc<LastCacheProvider>;
 }
 
-/// A single write request can have many lines in it. A writer can request to accept all lines that are valid, while
-/// returning an error for any invalid lines. This is the error information for a single invalid line.
-#[derive(Debug)]
-pub struct WriteLineError {
-    pub original_line: String,
-    pub line_number: usize,
-    pub error_message: String,
-}
-
-impl Serialize for WriteLineError {
-    fn serialize<S>(&self, serializer: S) -> std::result::Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        use serde::ser::SerializeStruct;
-        let mut state = serializer.serialize_struct("WriteLineError", 3)?;
-        const TRUNCATE_LIMIT: usize = 20;
-        let truncated_line = if self.original_line.len() > TRUNCATE_LIMIT {
-            &self.original_line[..TRUNCATE_LIMIT]
-        } else {
-            &self.original_line
-        };
-        state.serialize_field("error_message", &self.error_message)?;
-        state.serialize_field("line_number", &self.line_number)?;
-        state.serialize_field("original_line", truncated_line)?;
-        state.end()
-    }
-}
+pub use influxdb3_types::write::WriteLineError;
 
 /// A write that has been validated against the catalog schema, written to the WAL (if configured), and buffered in
 /// memory. This is the summary information for the write along with any errors that were encountered.

--- a/install_influxdb.sh
+++ b/install_influxdb.sh
@@ -1437,8 +1437,11 @@ else
     STARTUP_CHOICE=${STARTUP_CHOICE:-1}
 
     case "$STARTUP_CHOICE" in
-        1)
+        1|*)
             # Quick Start - use defaults and check for existing license
+            if [ "$STARTUP_CHOICE" != "1" ]; then
+                printf "Invalid choice. Using Quick Start (option 1).\n"
+            fi
             setup_quick_start_defaults enterprise
             setup_license_for_quick_start
             START_SERVICE="y"
@@ -1450,12 +1453,6 @@ else
         3)
             # Skip startup
             START_SERVICE="n"
-            ;;
-        *)
-            printf "Invalid choice. Using Quick Start (option 1).\n"
-            setup_quick_start_defaults enterprise
-            setup_license_for_quick_start
-            START_SERVICE="y"
             ;;
     esac
 

--- a/object_store_utils/Cargo.toml
+++ b/object_store_utils/Cargo.toml
@@ -10,6 +10,7 @@ test-helpers = ["tokio"]
 
 [dependencies]
 # core deps
+iox_time = { path = "../core/iox_time" }
 observability_deps = { path = "../core/observability_deps" }
 
 # crates.io deps

--- a/object_store_utils/src/lib.rs
+++ b/object_store_utils/src/lib.rs
@@ -7,6 +7,12 @@ pub use retryable_object_store::set_default_retry_params;
 mod adaptive_put;
 pub use adaptive_put::{AdaptivePutExt, DEFAULT_MULTIPART_CHUNK_SIZE};
 
+mod object_store_health;
+pub use object_store_health::{ErrorCategory, ObjectStoreHealth};
+
+mod observed_object_store;
+pub use observed_object_store::ObservedObjectStore;
+
 #[cfg(any(feature = "test-helpers", test))]
 mod test_object_store;
 #[cfg(any(feature = "test-helpers", test))]

--- a/object_store_utils/src/object_store_health.rs
+++ b/object_store_utils/src/object_store_health.rs
@@ -1,0 +1,198 @@
+//! Shared state for tracking object store health, used by the `/ready` endpoint.
+//!
+//! [`ObjectStoreHealth`] is intended to be shared between writers (an
+//! `ObservedObjectStore` wrapper and a startup probe) and a reader (the
+//! `/ready` HTTP handler). Reads must be lock-free since the handler may be
+//! polled frequently.
+
+use iox_time::Time;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
+
+/// Operator-friendly classification of an [`object_store::Error`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum ErrorCategory {
+    AuthFailure = 1,
+    NotFound = 2,
+    Timeout = 3,
+    ConfigError = 4,
+    Unknown = 5,
+}
+
+impl ErrorCategory {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::AuthFailure => "auth_failure",
+            Self::NotFound => "not_found",
+            Self::Timeout => "timeout",
+            Self::ConfigError => "config_error",
+            Self::Unknown => "unknown",
+        }
+    }
+
+    pub fn hint(self) -> &'static str {
+        match self {
+            Self::AuthFailure => {
+                "object store returned access denied; verify credentials and IAM policy"
+            }
+            Self::NotFound => {
+                "object store target path was not found; verify bucket and prefix configuration"
+            }
+            Self::Timeout => {
+                "object store request timed out; verify network connectivity to the endpoint"
+            }
+            Self::ConfigError => {
+                "object store is misconfigured; check --object-store and related flags"
+            }
+            Self::Unknown => "object store request failed; check logs for details",
+        }
+    }
+
+    /// Classify an [`object_store::Error`] into an operator-friendly category.
+    ///
+    /// Note: this does **not** return [`ErrorCategory::Timeout`]. The
+    /// `object_store` crate has no dedicated timeout variant; timeouts surface
+    /// as `Error::Generic` with the timeout wrapped inside an opaque source,
+    /// and walking that chain to reliably detect timeouts is fragile across
+    /// crate versions. Runtime operation timeouts are therefore categorized as
+    /// [`ErrorCategory::Unknown`] by this function.
+    ///
+    /// [`ErrorCategory::Timeout`] is reserved for callers that know a timeout
+    /// occurred because they applied an explicit `tokio::time::timeout`
+    /// wrapper themselves (e.g. the startup probe in `ready_probe.rs`). Such
+    /// callers should set the category directly via
+    /// [`ObjectStoreHealth::record_error`] rather than relying on this
+    /// function.
+    pub fn categorize(err: &object_store::Error) -> Self {
+        use object_store::Error;
+        match err {
+            Error::PermissionDenied { .. } | Error::Unauthenticated { .. } => Self::AuthFailure,
+            Error::NotFound { .. } => Self::NotFound,
+            Error::NotSupported { .. } | Error::NotImplemented | Error::InvalidPath { .. } => {
+                Self::ConfigError
+            }
+            _ => Self::Unknown,
+        }
+    }
+}
+
+/// Lock-free shared state recording the last successful and last failed object
+/// store operation.
+///
+/// `last_success_at` is nanoseconds since the Unix epoch in an [`AtomicI64`],
+/// using `0` as the unset sentinel.
+///
+/// The last-error state (timestamp + category) is packed into a single
+/// [`AtomicU64`] rather than two separate atomics. Packing ensures readers
+/// always see a consistent `(timestamp, category)` pair: with two atomics and
+/// `Relaxed` ordering, a reader could observe a new timestamp alongside an old
+/// or zero category (or vice versa), which would render as a timestamp without
+/// a category in `/ready` responses. Using a single atomic eliminates that
+/// window without needing `Acquire`/`Release` ordering or a lock.
+///
+/// Packing layout (64 bits):
+///   - bits 63..56: [`ErrorCategory`] discriminant (0 = unset)
+///   - bits 55..0:  nanoseconds since the Unix epoch (truncated to 56 bits)
+///
+/// 56 bits of nanos covers through roughly year 2285, which is plenty for
+/// practical server runtimes. We assume timestamps are non-negative; a
+/// negative timestamp would alias into the category byte when masked. In
+/// practice `TimeProvider::now()` returns non-negative values, so this does
+/// not arise.
+///
+/// The packed value `0` is reserved for "no error recorded" (category 0 is
+/// not a valid discriminant).
+#[derive(Debug, Default)]
+pub struct ObjectStoreHealth {
+    last_success_at: AtomicI64,
+    last_error: AtomicU64,
+}
+
+const ERROR_TIMESTAMP_MASK: u64 = 0x00FF_FFFF_FFFF_FFFF;
+
+impl ObjectStoreHealth {
+    /// Construct a fresh, shared [`ObjectStoreHealth`]. All fields start
+    /// unset; [`is_ok`](Self::is_ok) returns `false` until the first success
+    /// is recorded.
+    pub fn new() -> Arc<Self> {
+        Arc::new(Self::default())
+    }
+
+    /// Record that an object store operation succeeded at `at`. Overwrites
+    /// any previously recorded success timestamp. Does not clear prior error
+    /// state; [`last_error_at`](Self::last_error_at) keeps its value so
+    /// operators retain historical context after recovery. Use
+    /// [`is_ok`](Self::is_ok) or compare timestamps to determine current
+    /// health.
+    pub fn record_success(&self, at: Time) {
+        self.last_success_at
+            .store(at.timestamp_nanos(), Ordering::Relaxed);
+    }
+
+    /// Record that an object store operation failed at `at` with the given
+    /// category. Writes atomically -- readers never observe a new timestamp
+    /// with an old category (or vice versa). Overwrites any previously
+    /// recorded error.
+    pub fn record_error(&self, at: Time, category: ErrorCategory) {
+        let nanos = at.timestamp_nanos() as u64 & ERROR_TIMESTAMP_MASK;
+        let packed = ((category as u8 as u64) << 56) | nanos;
+        self.last_error.store(packed, Ordering::Relaxed);
+    }
+
+    /// Return the timestamp of the most recent recorded success, or `None`
+    /// if no success has ever been recorded.
+    pub fn last_success_at(&self) -> Option<Time> {
+        match self.last_success_at.load(Ordering::Relaxed) {
+            0 => None,
+            ns => Some(Time::from_timestamp_nanos(ns)),
+        }
+    }
+
+    /// Return the timestamp of the most recent recorded error, or `None` if
+    /// no error has ever been recorded. Paired with
+    /// [`last_error_category`](Self::last_error_category) via a single
+    /// atomic, so the two are always mutually consistent.
+    pub fn last_error_at(&self) -> Option<Time> {
+        let packed = self.last_error.load(Ordering::Relaxed);
+        if packed == 0 {
+            return None;
+        }
+        Some(Time::from_timestamp_nanos(
+            (packed & ERROR_TIMESTAMP_MASK) as i64,
+        ))
+    }
+
+    /// Return the category of the most recent recorded error, or `None` if
+    /// no error has ever been recorded. Paired with
+    /// [`last_error_at`](Self::last_error_at) via a single atomic.
+    pub fn last_error_category(&self) -> Option<ErrorCategory> {
+        let packed = self.last_error.load(Ordering::Relaxed);
+        if packed == 0 {
+            return None;
+        }
+        match (packed >> 56) as u8 {
+            1 => Some(ErrorCategory::AuthFailure),
+            2 => Some(ErrorCategory::NotFound),
+            3 => Some(ErrorCategory::Timeout),
+            4 => Some(ErrorCategory::ConfigError),
+            5 => Some(ErrorCategory::Unknown),
+            _ => None,
+        }
+    }
+
+    /// True if the most recent known state is a success.
+    ///
+    /// Returns `false` when no success has ever been recorded, or when the most
+    /// recent error is at or after the most recent success.
+    pub fn is_ok(&self) -> bool {
+        match (self.last_success_at(), self.last_error_at()) {
+            (None, _) => false,
+            (Some(_), None) => true,
+            (Some(s), Some(e)) => s > e,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/object_store_utils/src/object_store_health/tests.rs
+++ b/object_store_utils/src/object_store_health/tests.rs
@@ -1,0 +1,197 @@
+use super::*;
+
+fn boxed_err(msg: &'static str) -> Box<dyn std::error::Error + Send + Sync + 'static> {
+    Box::<dyn std::error::Error + Send + Sync>::from(msg)
+}
+
+#[test]
+fn new_state_is_not_ok() {
+    let health = ObjectStoreHealth::new();
+    assert!(!health.is_ok());
+    assert_eq!(health.last_success_at(), None);
+    assert_eq!(health.last_error_at(), None);
+    assert_eq!(health.last_error_category(), None);
+}
+
+#[test]
+fn success_then_nothing_is_ok() {
+    let health = ObjectStoreHealth::new();
+    health.record_success(Time::from_timestamp_nanos(1_000));
+    assert!(health.is_ok());
+    assert_eq!(
+        health.last_success_at(),
+        Some(Time::from_timestamp_nanos(1_000))
+    );
+    assert_eq!(health.last_error_at(), None);
+}
+
+#[test]
+fn success_then_error_is_not_ok() {
+    let health = ObjectStoreHealth::new();
+    health.record_success(Time::from_timestamp_nanos(1_000));
+    health.record_error(
+        Time::from_timestamp_nanos(2_000),
+        ErrorCategory::AuthFailure,
+    );
+    assert!(!health.is_ok());
+    assert_eq!(
+        health.last_error_category(),
+        Some(ErrorCategory::AuthFailure)
+    );
+}
+
+#[test]
+fn error_then_success_is_ok() {
+    let health = ObjectStoreHealth::new();
+    health.record_error(Time::from_timestamp_nanos(1_000), ErrorCategory::NotFound);
+    health.record_success(Time::from_timestamp_nanos(2_000));
+    assert!(health.is_ok());
+    assert_eq!(health.last_error_category(), Some(ErrorCategory::NotFound));
+}
+
+#[test]
+fn categorize_maps_object_store_errors() {
+    use object_store::Error;
+
+    let permission_denied = Error::PermissionDenied {
+        path: "p".to_string(),
+        source: boxed_err("denied"),
+    };
+    assert_eq!(
+        ErrorCategory::categorize(&permission_denied),
+        ErrorCategory::AuthFailure
+    );
+
+    let unauthenticated = Error::Unauthenticated {
+        path: "p".to_string(),
+        source: boxed_err("no creds"),
+    };
+    assert_eq!(
+        ErrorCategory::categorize(&unauthenticated),
+        ErrorCategory::AuthFailure
+    );
+
+    let not_found = Error::NotFound {
+        path: "p".to_string(),
+        source: boxed_err("missing"),
+    };
+    assert_eq!(
+        ErrorCategory::categorize(&not_found),
+        ErrorCategory::NotFound
+    );
+
+    let not_supported = Error::NotSupported {
+        source: boxed_err("nope"),
+    };
+    assert_eq!(
+        ErrorCategory::categorize(&not_supported),
+        ErrorCategory::ConfigError
+    );
+
+    let generic = Error::Generic {
+        store: "s3",
+        source: boxed_err("boom"),
+    };
+    assert_eq!(ErrorCategory::categorize(&generic), ErrorCategory::Unknown);
+}
+
+// The error state is packed into a single AtomicU64 (category in the top
+// byte, 56-bit nanos in the low bits). The tests below exercise that packing
+// layout explicitly -- a regression in the masking/shifting would show up
+// here rather than deeper in the integration tests.
+
+#[test]
+fn record_error_roundtrips_realistic_timestamp() {
+    // Exercise the 56-bit truncation with a real wall-clock timestamp. Any
+    // time after ~1972 has bit 56 or higher set, so this reliably catches a
+    // regression where the mask was widened/narrowed incorrectly or the
+    // shift was off-by-one.
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system time >= UNIX_EPOCH")
+        .as_nanos() as i64;
+    assert!(
+        (nanos as u64 & !0x00FF_FFFF_FFFF_FFFF) != 0,
+        "test timestamp must exercise the high bits cleared by the mask"
+    );
+
+    let health = ObjectStoreHealth::new();
+    health.record_error(Time::from_timestamp_nanos(nanos), ErrorCategory::Timeout);
+
+    // The stored timestamp is the low 56 bits of the original; the high 8
+    // bits are lost to the mask. Both accessors should observe the same
+    // masked value and the category is not corrupted by the masking.
+    let expected_nanos = (nanos as u64 & 0x00FF_FFFF_FFFF_FFFF) as i64;
+    assert_eq!(
+        health.last_error_at(),
+        Some(Time::from_timestamp_nanos(expected_nanos))
+    );
+    assert_eq!(health.last_error_category(), Some(ErrorCategory::Timeout));
+}
+
+#[test]
+fn record_error_overwrites_both_fields() {
+    // Verify that a second record_error updates BOTH the timestamp and the
+    // category together. If the pack/unpack logic were buggy, a reader could
+    // see the new timestamp with the old category (or vice versa).
+    let health = ObjectStoreHealth::new();
+    health.record_error(Time::from_timestamp_nanos(1_000), ErrorCategory::NotFound);
+    assert_eq!(
+        health.last_error_at(),
+        Some(Time::from_timestamp_nanos(1_000))
+    );
+    assert_eq!(health.last_error_category(), Some(ErrorCategory::NotFound));
+
+    health.record_error(
+        Time::from_timestamp_nanos(5_000),
+        ErrorCategory::ConfigError,
+    );
+    assert_eq!(
+        health.last_error_at(),
+        Some(Time::from_timestamp_nanos(5_000))
+    );
+    assert_eq!(
+        health.last_error_category(),
+        Some(ErrorCategory::ConfigError)
+    );
+}
+
+#[test]
+fn every_category_roundtrips_through_packing() {
+    // Each discriminant must round-trip correctly; a typo in the reverse
+    // match in last_error_category would break silently for one variant.
+    let cases = [
+        ErrorCategory::AuthFailure,
+        ErrorCategory::NotFound,
+        ErrorCategory::Timeout,
+        ErrorCategory::ConfigError,
+        ErrorCategory::Unknown,
+    ];
+    for category in cases {
+        let health = ObjectStoreHealth::new();
+        health.record_error(Time::from_timestamp_nanos(42), category);
+        assert_eq!(
+            health.last_error_category(),
+            Some(category),
+            "category {:?} did not round-trip",
+            category
+        );
+        assert_eq!(health.last_error_at(), Some(Time::from_timestamp_nanos(42)));
+    }
+}
+
+#[test]
+fn record_error_at_epoch_zero_is_readable() {
+    // Edge case: nanos == 0 packs to (category << 56) | 0. The packed value
+    // is non-zero as long as category != 0, so the "packed == 0 means unset"
+    // sentinel still works. Recording an error at epoch 0 with any real
+    // category must remain observable as "an error exists".
+    let health = ObjectStoreHealth::new();
+    health.record_error(Time::from_timestamp_nanos(0), ErrorCategory::AuthFailure);
+
+    assert_eq!(health.last_error_at(), Some(Time::from_timestamp_nanos(0)));
+    assert_eq!(
+        health.last_error_category(),
+        Some(ErrorCategory::AuthFailure)
+    );
+}

--- a/object_store_utils/src/observed_object_store.rs
+++ b/object_store_utils/src/observed_object_store.rs
@@ -1,0 +1,206 @@
+//! [`ObservedObjectStore`] wraps an inner [`ObjectStore`] and feeds the result
+//! of every operation into a shared [`ObjectStoreHealth`] handle for use by
+//! the `/ready` endpoint.
+
+use std::ops::Range;
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use futures::StreamExt;
+use futures::stream::BoxStream;
+use iox_time::TimeProvider;
+use object_store::{
+    GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta, ObjectStore,
+    PutMultipartOptions, PutOptions, PutPayload, PutResult, Result, path::Path,
+};
+
+use crate::object_store_health::{ErrorCategory, ObjectStoreHealth};
+
+#[derive(Debug)]
+pub struct ObservedObjectStore {
+    inner: Arc<dyn ObjectStore>,
+    health: Arc<ObjectStoreHealth>,
+    time_provider: Arc<dyn TimeProvider>,
+}
+
+/// Update the health handle based on a single operation's outcome. Shared
+/// between per-call observation and per-stream-item observation so the
+/// NotFound-as-success rule stays consistent across all surfaces.
+fn record_outcome<T>(
+    health: &ObjectStoreHealth,
+    time_provider: &dyn TimeProvider,
+    result: &Result<T>,
+) {
+    let now = time_provider.now();
+    match result {
+        // NotFound means the store responded successfully but the requested
+        // path does not exist. For connectivity/credential readiness this
+        // is a success: the network and auth paths both worked.
+        Ok(_) | Err(object_store::Error::NotFound { .. }) => health.record_success(now),
+        Err(e) => health.record_error(now, ErrorCategory::categorize(e)),
+    }
+}
+
+impl ObservedObjectStore {
+    pub fn new(
+        inner: Arc<dyn ObjectStore>,
+        health: Arc<ObjectStoreHealth>,
+        time_provider: Arc<dyn TimeProvider>,
+    ) -> Self {
+        Self {
+            inner,
+            health,
+            time_provider,
+        }
+    }
+
+    fn observe<T>(&self, result: &Result<T>) {
+        record_outcome(&self.health, self.time_provider.as_ref(), result);
+    }
+}
+
+impl std::fmt::Display for ObservedObjectStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "ObservedObjectStore({})", self.inner)
+    }
+}
+
+#[async_trait]
+impl ObjectStore for ObservedObjectStore {
+    async fn put(&self, location: &Path, payload: PutPayload) -> Result<PutResult> {
+        let r = self.inner.put(location, payload).await;
+        self.observe(&r);
+        r
+    }
+
+    async fn put_opts(
+        &self,
+        location: &Path,
+        payload: PutPayload,
+        opts: PutOptions,
+    ) -> Result<PutResult> {
+        let r = self.inner.put_opts(location, payload, opts).await;
+        self.observe(&r);
+        r
+    }
+
+    async fn put_multipart(&self, location: &Path) -> Result<Box<dyn MultipartUpload>> {
+        let r = self.inner.put_multipart(location).await;
+        self.observe(&r);
+        r
+    }
+
+    async fn put_multipart_opts(
+        &self,
+        location: &Path,
+        opts: PutMultipartOptions,
+    ) -> Result<Box<dyn MultipartUpload>> {
+        let r = self.inner.put_multipart_opts(location, opts).await;
+        self.observe(&r);
+        r
+    }
+
+    async fn get(&self, location: &Path) -> Result<GetResult> {
+        let r = self.inner.get(location).await;
+        self.observe(&r);
+        r
+    }
+
+    async fn get_opts(&self, location: &Path, options: GetOptions) -> Result<GetResult> {
+        let r = self.inner.get_opts(location, options).await;
+        self.observe(&r);
+        r
+    }
+
+    async fn get_range(&self, location: &Path, range: Range<u64>) -> Result<Bytes> {
+        let r = self.inner.get_range(location, range).await;
+        self.observe(&r);
+        r
+    }
+
+    async fn get_ranges(&self, location: &Path, ranges: &[Range<u64>]) -> Result<Vec<Bytes>> {
+        let r = self.inner.get_ranges(location, ranges).await;
+        self.observe(&r);
+        r
+    }
+
+    async fn head(&self, location: &Path) -> Result<ObjectMeta> {
+        let r = self.inner.head(location).await;
+        self.observe(&r);
+        r
+    }
+
+    async fn delete(&self, location: &Path) -> Result<()> {
+        let r = self.inner.delete(location).await;
+        self.observe(&r);
+        r
+    }
+
+    fn delete_stream<'a>(
+        &'a self,
+        locations: BoxStream<'a, Result<Path>>,
+    ) -> BoxStream<'a, Result<Path>> {
+        let health = Arc::clone(&self.health);
+        let time_provider = Arc::clone(&self.time_provider);
+        self.inner
+            .delete_stream(locations)
+            .inspect(move |r| record_outcome(&health, time_provider.as_ref(), r))
+            .boxed()
+    }
+
+    fn list(&self, prefix: Option<&Path>) -> BoxStream<'static, Result<ObjectMeta>> {
+        let health = Arc::clone(&self.health);
+        let time_provider = Arc::clone(&self.time_provider);
+        self.inner
+            .list(prefix)
+            .inspect(move |r| record_outcome(&health, time_provider.as_ref(), r))
+            .boxed()
+    }
+
+    fn list_with_offset(
+        &self,
+        prefix: Option<&Path>,
+        offset: &Path,
+    ) -> BoxStream<'static, Result<ObjectMeta>> {
+        let health = Arc::clone(&self.health);
+        let time_provider = Arc::clone(&self.time_provider);
+        self.inner
+            .list_with_offset(prefix, offset)
+            .inspect(move |r| record_outcome(&health, time_provider.as_ref(), r))
+            .boxed()
+    }
+
+    async fn list_with_delimiter(&self, prefix: Option<&Path>) -> Result<ListResult> {
+        let r = self.inner.list_with_delimiter(prefix).await;
+        self.observe(&r);
+        r
+    }
+
+    async fn copy(&self, from: &Path, to: &Path) -> Result<()> {
+        let r = self.inner.copy(from, to).await;
+        self.observe(&r);
+        r
+    }
+
+    async fn rename(&self, from: &Path, to: &Path) -> Result<()> {
+        let r = self.inner.rename(from, to).await;
+        self.observe(&r);
+        r
+    }
+
+    async fn copy_if_not_exists(&self, from: &Path, to: &Path) -> Result<()> {
+        let r = self.inner.copy_if_not_exists(from, to).await;
+        self.observe(&r);
+        r
+    }
+
+    async fn rename_if_not_exists(&self, from: &Path, to: &Path) -> Result<()> {
+        let r = self.inner.rename_if_not_exists(from, to).await;
+        self.observe(&r);
+        r
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/object_store_utils/src/observed_object_store/tests.rs
+++ b/object_store_utils/src/observed_object_store/tests.rs
@@ -1,0 +1,204 @@
+use super::*;
+use futures::stream;
+use iox_time::{MockProvider, Time};
+use object_store::memory::InMemory;
+
+fn setup() -> (ObservedObjectStore, Arc<ObjectStoreHealth>) {
+    let inner: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let health = ObjectStoreHealth::new();
+    let time_provider: Arc<dyn TimeProvider> =
+        Arc::new(MockProvider::new(Time::from_timestamp_nanos(1_000_000_000)));
+    let store = ObservedObjectStore::new(inner, Arc::clone(&health), Arc::clone(&time_provider));
+    (store, health)
+}
+
+#[tokio::test]
+async fn put_and_head_record_success() {
+    let (store, health) = setup();
+
+    let path = Path::from("foo");
+    store
+        .put(&path, PutPayload::from_static(b"hello"))
+        .await
+        .unwrap();
+    store.head(&path).await.unwrap();
+
+    assert!(health.is_ok());
+    assert!(health.last_success_at().is_some());
+    assert!(health.last_error_at().is_none());
+}
+
+#[tokio::test]
+async fn head_missing_records_success() {
+    let (store, health) = setup();
+
+    let path = Path::from("missing");
+    let _ = store.head(&path).await;
+
+    assert!(health.is_ok());
+    assert!(health.last_success_at().is_some());
+    assert!(health.last_error_at().is_none());
+}
+
+#[tokio::test]
+async fn get_on_existing_path_records_success() {
+    let (store, health) = setup();
+
+    let path = Path::from("foo");
+    store
+        .put(&path, PutPayload::from_static(b"hello"))
+        .await
+        .unwrap();
+    let _ = store.get(&path).await.unwrap();
+
+    assert!(health.is_ok());
+}
+
+#[tokio::test]
+async fn get_missing_records_success() {
+    let (store, health) = setup();
+
+    let path = Path::from("missing");
+    let _ = store.get(&path).await;
+
+    assert!(health.is_ok());
+    assert!(health.last_error_at().is_none());
+}
+
+#[tokio::test]
+async fn delete_existing_records_success() {
+    let (store, health) = setup();
+
+    let path = Path::from("foo");
+    store
+        .put(&path, PutPayload::from_static(b"hello"))
+        .await
+        .unwrap();
+    store.delete(&path).await.unwrap();
+
+    assert!(health.is_ok());
+}
+
+#[tokio::test]
+async fn list_with_delimiter_records_success_on_empty() {
+    let (store, health) = setup();
+
+    let _ = store.list_with_delimiter(None).await.unwrap();
+
+    assert!(health.is_ok());
+}
+
+#[tokio::test]
+async fn copy_records_success() {
+    let (store, health) = setup();
+
+    let from = Path::from("a");
+    let to = Path::from("b");
+    store
+        .put(&from, PutPayload::from_static(b"data"))
+        .await
+        .unwrap();
+    store.copy(&from, &to).await.unwrap();
+
+    assert!(health.is_ok());
+}
+
+#[tokio::test]
+async fn list_yielding_items_records_success() {
+    let (store, health) = setup();
+
+    store
+        .put(&Path::from("a"), PutPayload::from_static(b"x"))
+        .await
+        .unwrap();
+    store
+        .put(&Path::from("b"), PutPayload::from_static(b"y"))
+        .await
+        .unwrap();
+
+    let items: Vec<_> = store.list(None).collect().await;
+    assert_eq!(items.len(), 2);
+    assert!(health.is_ok());
+    assert!(health.last_error_at().is_none());
+}
+
+#[tokio::test]
+async fn list_empty_does_not_update_health() {
+    let (store, health) = setup();
+
+    // Drain the stream; it should yield zero items but still have been driven
+    // past the producer, exercising the wrapper.
+    let items: Vec<_> = store.list(None).collect().await;
+    assert!(items.is_empty());
+
+    // An empty list does not yield any Result for inspect() to observe, so
+    // the health state remains pristine. This is by design: empty list is
+    // not evidence of "store responded successfully to our request" at the
+    // granularity we care about. Non-empty lists or other ops keep the
+    // signal fresh.
+    assert!(!health.is_ok());
+    assert!(health.last_success_at().is_none());
+}
+
+#[tokio::test]
+async fn list_with_offset_yielding_items_records_success() {
+    let (store, health) = setup();
+
+    store
+        .put(&Path::from("a"), PutPayload::from_static(b"x"))
+        .await
+        .unwrap();
+    store
+        .put(&Path::from("b"), PutPayload::from_static(b"y"))
+        .await
+        .unwrap();
+
+    // Offset past "a" so only "b" should be yielded.
+    let items: Vec<_> = store
+        .list_with_offset(None, &Path::from("a"))
+        .collect()
+        .await;
+    assert_eq!(items.len(), 1);
+    assert!(health.is_ok());
+}
+
+#[tokio::test]
+async fn delete_stream_successful_items_record_success() {
+    let (store, health) = setup();
+
+    store
+        .put(&Path::from("a"), PutPayload::from_static(b"x"))
+        .await
+        .unwrap();
+    store
+        .put(&Path::from("b"), PutPayload::from_static(b"y"))
+        .await
+        .unwrap();
+
+    // Fresh state after the puts: we want to see delete_stream specifically
+    // drive the observation.
+    let locations = stream::iter(vec![Ok(Path::from("a")), Ok(Path::from("b"))]).boxed();
+    let deleted: Vec<_> = store.delete_stream(locations).collect().await;
+    assert_eq!(deleted.len(), 2);
+    assert!(health.is_ok());
+    assert!(health.last_error_at().is_none());
+}
+
+#[tokio::test]
+async fn delete_stream_yielding_error_records_error() {
+    let (store, health) = setup();
+
+    // Feed an input stream that itself yields an error; the delete_stream
+    // implementation on InMemory passes errors through to its output. Our
+    // wrapper should observe the error and flip the health signal.
+    let err = || object_store::Error::Generic {
+        store: "test",
+        source: "synthetic error".into(),
+    };
+    let locations = stream::iter(vec![Ok(Path::from("a")), Err(err())]).boxed();
+    let _: Vec<_> = store.delete_stream(locations).collect().await;
+
+    assert!(!health.is_ok());
+    assert!(health.last_error_at().is_some());
+    assert_eq!(health.last_error_category(), Some(ErrorCategory::Unknown));
+}


### PR DESCRIPTION
Source: ad8686d895cadac4972a612dd2b5e4d0e0adfabf

Commits:
- `4bf54d028e` chore(ci): cargo audit ignore for 'RUSTSEC-2026-0114' (influxdata/influxdb_pro#3365)
- `dca0fabb21` feat: add plugin trigger type restrictions (influxdata/influxdb_pro#3293)
- `0ecab6db06` feat(grpc): emit query-stats gRPC trailers on Enterprise Flight do_get (influxdata/influxdb_pro#3295)
- `b681835416` fix(WriteLineError): slice string at utf-8 boundary (influxdata/influxdb_pro#3292)
- `545100cfba` fix(sll): include database_id on v1 /query entries (influxdata/influxdb_pro#3284)
- `694b428ba3` feat: add import command to CLI to exercise the Bulk Import API (influxdata/influxdb_pro#3162)
- `c1c0d3373d` chore: Remove iox-sync from justfiles and readme (influxdata/influxdb_pro#3256)
- `2a03788008` docs: fix rustdoc (influxdata/influxdb_pro#3222)
- `5d80136a7e` feat(pacha_tree): wire V2 compactor into Combined mode HTTP test endpoints (influxdata/influxdb_pro#3216)
- `ce9a862a4a` feat(server): add /ready endpoint with object store health check (influxdata/influxdb_pro#3185)
- `85e125f679` fix(tokio): update to 1.52.1 for spawn_blocking fix (influxdata/influxdb_pro#3200)
