### PR TITLE
fix(influxdb3_catalog): include table name and column count in TooManyColumns error

### DIFF
--- a/influxdb3_catalog/src/catalog/versions/v1/update.rs
+++ b/influxdb3_catalog/src/catalog/versions/v1/update.rs
@@ -828,7 +828,11 @@ impl DatabaseCatalogTransaction {
             }),
             None => {
                 if table_def.num_columns() >= self.columns_per_table_limit {
-                    return Err(CatalogError::TooManyColumns(self.columns_per_table_limit));
+                    return Err(CatalogError::TooManyColumns {
+                        table_name: Arc::clone(&table_def.table_name),
+                        would_have: table_def.num_columns() + 1,
+                        limit: self.columns_per_table_limit,
+                    });
                 }
                 if matches!(column_type, FieldDataType::Tag)
                     && table_def.num_tag_columns() >= NUM_TAG_COLUMNS_LIMIT
@@ -885,7 +889,11 @@ impl DatabaseCatalogTransaction {
             return Err(CatalogError::TooManyTagColumns(NUM_TAG_COLUMNS_LIMIT));
         }
         if tags.len() + fields.len() > self.columns_per_table_limit - 1 {
-            return Err(CatalogError::TooManyColumns(self.columns_per_table_limit));
+            return Err(CatalogError::TooManyColumns {
+                table_name: Arc::from(table_name),
+                would_have: tags.len() + fields.len() + 1,
+                limit: self.columns_per_table_limit,
+            });
         }
 
         // Validate tag and field names using the same rules as the line protocol parser

--- a/influxdb3_catalog/src/catalog/versions/v2/update.rs
+++ b/influxdb3_catalog/src/catalog/versions/v2/update.rs
@@ -1280,7 +1280,11 @@ impl TableTransaction {
     #[inline]
     fn check_columns_limit(&self) -> Result<()> {
         if self.num_columns() >= self.column_limit {
-            Err(CatalogError::TooManyColumns(self.column_limit))
+            Err(CatalogError::TooManyColumns {
+                table_name: Arc::clone(&self.table.table_name),
+                would_have: self.num_columns() + 1,
+                limit: self.column_limit,
+            })
         } else {
             Ok(())
         }
@@ -1677,7 +1681,11 @@ impl DatabaseCatalogTransaction {
                 return Err(CatalogError::TooManyTagColumns(NUM_TAG_COLUMNS_LIMIT));
             }
             if c.num_columns() > self.columns_per_table_limit {
-                return Err(CatalogError::TooManyColumns(self.columns_per_table_limit));
+                return Err(CatalogError::TooManyColumns {
+                    table_name: Arc::from(table_name),
+                    would_have: c.num_columns(),
+                    limit: self.columns_per_table_limit,
+                });
             }
         }
 

--- a/influxdb3_catalog/src/catalog/versions/v2/update/tests.rs
+++ b/influxdb3_catalog/src/catalog/versions/v2/update/tests.rs
@@ -267,7 +267,22 @@ mod create_table {
             "field2",
             InfluxColumnType::Field(InfluxFieldType::Integer),
         );
-        assert!(matches!(result, Err(CatalogError::TooManyColumns(3))));
+        let err = result.unwrap_err();
+        let CatalogError::TooManyColumns {
+            table_name,
+            would_have,
+            limit,
+        } = &err
+        else {
+            panic!("expected TooManyColumns, got {err:?}");
+        };
+        assert_eq!(table_name.as_ref(), "test_table");
+        assert_eq!(*would_have, 4);
+        assert_eq!(*limit, 3);
+        // Surface the table name in the formatted message so API responses are not opaque.
+        let msg = err.to_string();
+        assert!(msg.contains("test_table"), "missing table name in: {msg}");
+        assert!(msg.contains("limit: 3"), "missing limit in: {msg}");
     }
 
     #[tokio::test]
@@ -1176,7 +1191,18 @@ mod update_table {
             "field2",
             InfluxColumnType::Field(InfluxFieldType::Integer),
         );
-        assert!(matches!(result, Err(CatalogError::TooManyColumns(3))));
+        let err = result.unwrap_err();
+        let CatalogError::TooManyColumns {
+            table_name,
+            would_have,
+            limit,
+        } = &err
+        else {
+            panic!("expected TooManyColumns, got {err:?}");
+        };
+        assert_eq!(table_name.as_ref(), "test_table");
+        assert_eq!(*would_have, 4);
+        assert_eq!(*limit, 3);
     }
 }
 

--- a/influxdb3_catalog/src/error.rs
+++ b/influxdb3_catalog/src/error.rs
@@ -48,8 +48,15 @@ pub enum CatalogError {
     #[error("invalid node registration")]
     InvalidNodeRegistration,
 
-    #[error("Update to schema would exceed number of columns per table limit of {0} columns")]
-    TooManyColumns(usize),
+    #[error(
+        "Update to schema would exceed columns per table limit for table '{table_name}': \
+        table would have {would_have} column(s) (limit: {limit})"
+    )]
+    TooManyColumns {
+        table_name: Arc<str>,
+        would_have: usize,
+        limit: usize,
+    },
 
     #[error("Update to schema would exceed number of tag columns per table limit of {0} columns")]
     TooManyTagColumns(usize),

--- a/influxdb3_server/src/http.rs
+++ b/influxdb3_server/src/http.rs
@@ -481,7 +481,7 @@ impl V2WriteApiError {
                 | CatalogError::InvalidConfiguration { .. }
                 | CatalogError::InvalidColumnType { .. }
                 | CatalogError::ReservedColumn(_)
-                | CatalogError::TooManyColumns(_)
+                | CatalogError::TooManyColumns { .. }
                 | CatalogError::TooManyTagColumns(_)
                 | CatalogError::TooManyTables { .. }
                 | CatalogError::TooManyDbs(_)
@@ -659,7 +659,7 @@ impl IntoResponse for CatalogError {
             | Self::DuplicateColumn { .. }
             | Self::InvalidColumnType { .. }
             | Self::NodeAlreadyStopped { .. } => Either::Right(StatusCode::BAD_REQUEST),
-            Self::TooManyColumns(_)
+            Self::TooManyColumns { .. }
             | Self::TooManyTables { .. }
             | Self::TooManyDbs(_)
             | Self::TooManyTagColumns(_)


### PR DESCRIPTION
Closes #26859

`TooManyColumns(usize)` carried only the limit, leaving API responses opaque about which table and how many columns triggered the error. Replace with `{ table_name, would_have, limit }`, mirroring the shape of `TooManyTables`.

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).