### PR TITLE
fix: align jaeger tracing flag names

### DIFF
--- a/.circleci/packages/influxdb3/fs/usr/lib/influxdb3/influxdb3-launcher
+++ b/.circleci/packages/influxdb3/fs/usr/lib/influxdb3/influxdb3-launcher
@@ -93,6 +93,7 @@ TOML_KEY_ENVVAR: Dict[str, Dict[str, str]] = {
         "traces-exporter-jaeger-agent-port": "INFLUXDB3_TRACES_EXPORTER_JAEGER_AGENT_PORT",
         "traces-exporter-jaeger-debug-name": "INFLUXDB3_TRACES_EXPORTER_JAEGER_DEBUG_NAME",
         "traces-exporter-jaeger-service-name": "INFLUXDB3_TRACES_EXPORTER_JAEGER_SERVICE_NAME",
+        "traces-exporter-jaeger-tags": "INFLUXDB3_TRACES_EXPORTER_JAEGER_TAGS",
         "traces-exporter-jaeger-trace-context-header-name": "INFLUXDB3_TRACES_EXPORTER_JAEGER_TRACE_CONTEXT_HEADER_NAME",
         "traces-jaeger-debug-name": "INFLUXDB3_TRACES_EXPORTER_JAEGER_DEBUG_NAME",
         "traces-jaeger-max-msgs-per-second": "INFLUXDB3_TRACES_JAEGER_MAX_MSGS_PER_SECOND",

--- a/.circleci/packages/influxdb3/fs/usr/share/influxdb3/influxdb3-core.conf
+++ b/.circleci/packages/influxdb3/fs/usr/share/influxdb3/influxdb3-core.conf
@@ -478,10 +478,10 @@
 
 # Header for force sampling
 # Default: jaeger-debug-id (env: TRACES_EXPORTER_JAEGER_DEBUG_NAME)
-#traces-jaeger-debug-name="jaeger-debug-id"
+#traces-exporter-jaeger-debug-name="jaeger-debug-id"
 
 # Key-value pairs for tracing spans (env: TRACES_EXPORTER_JAEGER_TAGS)
-#traces-jaeger-tags="<TAGS>"
+#traces-exporter-jaeger-tags="<TAGS>"
 
 # Max messages per second
 # Default: 1000 (env: TRACES_JAEGER_MAX_MSGS_PER_SECOND)

--- a/core/trace_exporters/src/lib.rs
+++ b/core/trace_exporters/src/lib.rs
@@ -102,7 +102,8 @@ pub struct TracingConfig {
     ///
     /// Only used if `--traces-exporter` is "jaeger".
     #[clap(
-        long = "traces-jaeger-debug-name",
+        long = "traces-exporter-jaeger-debug-name",
+        alias = "traces-jaeger-debug-name",
         env = "TRACES_EXPORTER_JAEGER_DEBUG_NAME",
         default_value = "jaeger-debug-id",
         action
@@ -115,7 +116,8 @@ pub struct TracingConfig {
     ///
     /// Only used if `--traces-exporter` is "jaeger".
     #[clap(
-        long = "traces-jaeger-tags",
+        long = "traces-exporter-jaeger-tags",
+        alias = "traces-jaeger-tags",
         env = "TRACES_EXPORTER_JAEGER_TAGS",
         value_delimiter = ',',
         action
@@ -210,4 +212,56 @@ fn jaeger_exporter(config: &TracingConfig) -> Result<Arc<AsyncExporter>> {
     }
 
     Ok(Arc::new(AsyncExporter::new(jaeger)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::{CommandFactory, Parser};
+
+    #[test]
+    fn jaeger_debug_and_tags_flags_match_exporter_env_names() {
+        let cmd = TracingConfig::command();
+
+        assert_long_option_has_env(
+            &cmd,
+            "traces-exporter-jaeger-debug-name",
+            "TRACES_EXPORTER_JAEGER_DEBUG_NAME",
+        );
+        assert_long_option_has_env(
+            &cmd,
+            "traces-exporter-jaeger-tags",
+            "TRACES_EXPORTER_JAEGER_TAGS",
+        );
+    }
+
+    #[test]
+    fn deprecated_jaeger_debug_and_tags_flags_remain_accepted() {
+        let config = TracingConfig::try_parse_from([
+            "cmd",
+            "--traces-jaeger-debug-name",
+            "debug-header",
+            "--traces-jaeger-tags",
+            "env=prod,region=west",
+        ])
+        .expect("deprecated Jaeger flags should still parse");
+
+        assert_eq!(config.traces_jaeger_debug_name, "debug-header");
+        let tags = config.traces_jaeger_tags.expect("tags should be parsed");
+        assert_eq!(tags.len(), 2);
+        assert_eq!(tags[0].key(), "env");
+        assert_eq!(tags[1].key(), "region");
+    }
+
+    fn assert_long_option_has_env(cmd: &clap::Command, long: &str, env: &str) {
+        let arg = cmd
+            .get_arguments()
+            .find(|arg| arg.get_long() == Some(long))
+            .unwrap_or_else(|| panic!("missing --{long}"));
+        assert_eq!(
+            arg.get_env().and_then(std::ffi::OsStr::to_str),
+            Some(env),
+            "--{long} should use {env}"
+        );
+    }
 }

--- a/influxdb3/src/commands/serve/cli_params.rs
+++ b/influxdb3/src/commands/serve/cli_params.rs
@@ -81,8 +81,8 @@ const NON_SENSITIVE_PARAMS: &[&str] = &[
     "traces-exporter-jaeger-agent-port",
     "traces-exporter-jaeger-service-name",
     "traces-exporter-jaeger-trace-context-header-name",
-    "traces-jaeger-debug-name",
-    "traces-jaeger-tags",
+    "traces-exporter-jaeger-debug-name",
+    "traces-exporter-jaeger-tags",
     "traces-jaeger-max-msgs-per-second",
     // DataFusion parameters
     "datafusion-config",

--- a/influxdb3/src/help/serve_all.txt
+++ b/influxdb3/src/help/serve_all.txt
@@ -268,9 +268,9 @@ Examples:
                                                                 [env: INFLUXDB3_TRACES_EXPORTER_JAEGER_SERVICE_NAME=]
   --traces-exporter-jaeger-trace-context-header-name <NAME>    Header for trace context [default: uber-trace-id]
                                                                 [env: INFLUXDB3_TRACES_EXPORTER_JAEGER_TRACE_CONTEXT_HEADER_NAME=]
-  --traces-jaeger-debug-name <NAME>                            Header for force sampling [default: jaeger-debug-id]
+  --traces-exporter-jaeger-debug-name <NAME>                   Header for force sampling [default: jaeger-debug-id]
                                                                 [env: INFLUXDB3_TRACES_EXPORTER_JAEGER_DEBUG_NAME=]
-  --traces-jaeger-tags <TAGS>                                  Key-value pairs for tracing spans
+  --traces-exporter-jaeger-tags <TAGS>                         Key-value pairs for tracing spans
                                                                 [env: INFLUXDB3_TRACES_EXPORTER_JAEGER_TAGS=]
   --traces-jaeger-max-msgs-per-second <N>                      Max messages per second [default: 1000]
                                                                 [env: INFLUXDB3_TRACES_JAEGER_MAX_MSGS_PER_SECOND=]


### PR DESCRIPTION
Closes #27406

Align the canonical Jaeger debug-name and tags flags with the rest of the
`--traces-exporter-jaeger-*` family (and with their env var names), while
keeping the previous shorter names as backwards-compatible aliases.

## Changes
- Rename `--traces-jaeger-debug-name` → `--traces-exporter-jaeger-debug-name`
  (alias kept) in `core/trace_exporters/src/lib.rs`.
- Rename `--traces-jaeger-tags` → `--traces-exporter-jaeger-tags`
  (alias kept) in `core/trace_exporters/src/lib.rs`.
- Update the packaged `influxdb3-core.conf`, the `serve_all.txt` help text,
  and the launcher TOML→env mapping in `influxdb3-launcher` so the new
  canonical names are first-class while legacy spellings still resolve.
- Update the non-sensitive parameter categorization in
  `influxdb3/src/commands/serve/cli_params.rs`.
- Add unit tests covering both the new flag→env mapping and the deprecated
  flag aliases continuing to parse.

## Tests
- `cargo nextest run --workspace`
- `cargo clippy --all-targets --workspace -- -D warnings`
- `cargo fmt --all`
- `python3 -m py_compile .circleci/packages/influxdb3/fs/usr/lib/influxdb3/influxdb3-launcher`
- `git diff --check`

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).