### PR TITLE
fix: level 3 compactions stop occurring

### DIFF
--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -2391,10 +2391,8 @@ func (e *Engine) compactHiPriorityLevel(grp CompactionGroup, level int, fast boo
 	}
 
 	if e.compactionLimiter.TryTake() {
-		{
-			val := atomic.AddInt64(e.activeCompactions.countForLevel(level), 1)
-			e.Stats.Active.With(labelForLevel(level)).Set(float64(val))
-		}
+		val := atomic.AddInt64(e.activeCompactions.countForLevel(level), 1)
+		e.Stats.Active.With(labelForLevel(level)).Set(float64(val))
 
 		wg.Add(1)
 		go func() {
@@ -2428,11 +2426,15 @@ func (e *Engine) compactLoPriorityLevel(grp CompactionGroup, level int, fast boo
 	if e.compactionLimiter.TryTake() {
 		val := atomic.AddInt64(e.activeCompactions.countForLevel(level), 1)
 		e.Stats.Active.With(labelForLevel(level)).Set(float64(val))
+
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			val := atomic.AddInt64(e.activeCompactions.countForLevel(level), 1)
-			e.Stats.Active.With(labelForLevel(level)).Set(float64(val))
+			defer func() {
+				val := atomic.AddInt64(e.activeCompactions.countForLevel(level), -1)
+				e.Stats.Active.With(labelForLevel(level)).Set(float64(val))
+			}()
+
 			defer e.compactionLimiter.Release()
 			s.Apply()
 			// Release the files in the compaction plan

--- a/tsdb/engine/tsm1/engine_internal_test.go
+++ b/tsdb/engine/tsm1/engine_internal_test.go
@@ -2,14 +2,19 @@ package tsm1
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/influxdata/influxdb/v2/models"
+	"github.com/influxdata/influxdb/v2/pkg/limiter"
 	"github.com/influxdata/influxdb/v2/tsdb"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 	"go.uber.org/zap/zaptest"
 )
 
@@ -96,4 +101,117 @@ func (a seriesIDSets) ForEach(f func(ids *tsdb.SeriesIDSet)) error {
 		f(v)
 	}
 	return nil
+}
+
+// TestCompactLoPriorityLevel_ReleasesActiveCount verifies that
+// compactLoPriorityLevel returns the activeCompactions level counter to its
+// pre-call value after the spawned goroutine completes.
+func TestCompactLoPriorityLevel_ReleasesActiveCount(t *testing.T) {
+	e := newCompactionTestEngine()
+
+	var wg sync.WaitGroup
+	started := e.compactLoPriorityLevel(CompactionGroup{}, 3, true, &wg)
+	require.True(t, started, "compactLoPriorityLevel should have started a goroutine")
+	wg.Wait()
+
+	require.Equal(t, int64(0), atomic.LoadInt64(&e.activeCompactions.l3),
+		"activeCompactions.l3 should return to 0 after the compaction goroutine exits")
+}
+
+// TestCompactLoPriorityLevel_LeavesSchedulerRunnable verifies that after a
+// compactLoPriorityLevel goroutine completes, Scheduler.next() can still
+// pick work for any level whose queue is non-empty.
+func TestCompactLoPriorityLevel_LeavesSchedulerRunnable(t *testing.T) {
+	const maxConcurrency = 2
+	e := newCompactionTestEngine()
+	e.compactionLimiter = limiter.NewFixed(maxConcurrency)
+	e.Scheduler = newScheduler(e.activeCompactions, maxConcurrency)
+
+	for lvl := 1; lvl <= TotalCompactionLevels; lvl++ {
+		e.Scheduler.SetDepth(lvl, 10)
+	}
+
+	var wg sync.WaitGroup
+	require.True(t, e.compactLoPriorityLevel(CompactionGroup{}, 3, true, &wg))
+	wg.Wait()
+
+	level, runnable := e.Scheduler.next()
+	require.True(t, runnable,
+		"Scheduler.next() should remain runnable after a compaction goroutine exits")
+	require.Equal(t, 1, level,
+		"Scheduler.next() should pick level 1 when all queues are equally deep and no compactions are active")
+}
+
+// TestCompactHiPriorityLevel_ReleasesActiveCount verifies the same invariant
+// as TestCompactLoPriorityLevel_ReleasesActiveCount for the hi-priority path,
+// which is used for both level 1 and level 2 compactions.
+func TestCompactHiPriorityLevel_ReleasesActiveCount(t *testing.T) {
+	tests := []struct {
+		level   int
+		counter func(*compactionCounter) *int64
+	}{
+		{level: 1, counter: func(c *compactionCounter) *int64 { return &c.l1 }},
+		{level: 2, counter: func(c *compactionCounter) *int64 { return &c.l2 }},
+	}
+	for _, tt := range tests {
+		t.Run(fmt.Sprintf("level=%d", tt.level), func(t *testing.T) {
+			e := newCompactionTestEngine()
+
+			var wg sync.WaitGroup
+			started := e.compactHiPriorityLevel(CompactionGroup{}, tt.level, false, &wg)
+			require.True(t, started)
+			wg.Wait()
+
+			require.Equal(t, int64(0), atomic.LoadInt64(tt.counter(e.activeCompactions)))
+		})
+	}
+}
+
+// TestCompactFull_ReleasesActiveCount verifies that compactFull returns the
+// activeCompactions.full counter to its pre-call value after the spawned
+// goroutine completes.
+func TestCompactFull_ReleasesActiveCount(t *testing.T) {
+	e := newCompactionTestEngine()
+
+	var wg sync.WaitGroup
+	started := e.compactFull(CompactionGroup{}, &wg)
+	require.True(t, started)
+	wg.Wait()
+
+	require.Equal(t, int64(0), atomic.LoadInt64(&e.activeCompactions.full),
+		"activeCompactions.full should return to 0 after the compaction goroutine exits")
+}
+
+// TestCompactOptimize_ReleasesActiveCount verifies that compactOptimize returns
+// the activeCompactions.optimize counter to its pre-call value after the
+// spawned goroutine completes.
+func TestCompactOptimize_ReleasesActiveCount(t *testing.T) {
+	e := newCompactionTestEngine()
+
+	var wg sync.WaitGroup
+	require.NoError(t, e.compactOptimize(CompactionGroup{}, tsdb.DefaultMaxPointsPerBlock, &wg))
+	wg.Wait()
+
+	require.Equal(t, int64(0), atomic.LoadInt64(&e.activeCompactions.optimize),
+		"activeCompactions.optimize should return to 0 after the compaction goroutine exits")
+}
+
+// newCompactionTestEngine builds a minimal *Engine sufficient for invoking the
+// per-level compaction kickoff helpers. The Compactor is left in its default
+// disabled state so CompactFast/CompactFull return errCompactionsDisabled
+// immediately, letting the spawned goroutine exit quickly without needing
+// real TSM files.
+func newCompactionTestEngine() *Engine {
+	activeCompactions := &compactionCounter{}
+	return &Engine{
+		id:                         1,
+		logger:                     zap.NewNop(),
+		Compactor:                  NewCompactor(),
+		FileStore:                  &FileStore{},
+		CompactionPlan:             &DefaultPlanner{filesInUse: map[string]struct{}{}},
+		activeCompactions:          activeCompactions,
+		Stats:                      newEngineMetrics(tsdb.EngineTags{}),
+		compactionLimiter:          limiter.NewFixed(2),
+		optimizedCompactionLimiter: limiter.NewFixed(2),
+	}
 }


### PR DESCRIPTION
A leak causing the level 3 concurrent compactions quota to drop to zero and stop level 3 compactions is fixed. Test cases have been added to ensure that compactLoPriorityLevel, compactHiPriorityLevel, compactFull, and compactOptimize do not leak. Only compactLoPriorityLevel had a leak.

This is a clean cherry-pick from main-2.x.

(cherry picked from commit 56dc8bf8f563158a2c046893e134764dcd0aca13)

Closes: #27413