### PR TITLE
fix: split compaction queue depth from active running count

### DIFF
--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -710,6 +710,12 @@ type compactionCounter struct {
 	l3       int64
 	full     int64
 	optimize int64
+
+	queueL1       int64
+	queueL2       int64
+	queueL3       int64
+	queueFull     int64
+	queueOptimize int64
 }
 
 func (c *compactionCounter) countForLevel(l int) *int64 {
@@ -2374,11 +2380,18 @@ func (e *Engine) PlanCompactions() ([]PlannedCompactionGroup, []PlannedCompactio
 	// Update the level plan queue stats
 	// For stats, use the length needed, even if the lock was
 	// not acquired
-	atomic.StoreInt64(&e.activeCompactions.l1, int64(len(l1)))
-	atomic.StoreInt64(&e.activeCompactions.l2, int64(len(l2)))
-	atomic.StoreInt64(&e.activeCompactions.l3, int64(len(l3)))
-	atomic.StoreInt64(&e.activeCompactions.full, int64(len(l4)))
-	atomic.StoreInt64(&e.activeCompactions.optimize, int64(len(l5)))
+	atomic.StoreInt64(&e.activeCompactions.queueL1, int64(len(l1)))
+	atomic.StoreInt64(&e.activeCompactions.queueL2, int64(len(l2)))
+	atomic.StoreInt64(&e.activeCompactions.queueL3, int64(len(l3)))
+	atomic.StoreInt64(&e.activeCompactions.queueFull, int64(len(l4)))
+	atomic.StoreInt64(&e.activeCompactions.queueOptimize, int64(len(l5)))
+
+	e.Stats.Queued.With(labelForLevel(1)).Set(float64(len(l1)))
+	e.Stats.Queued.With(labelForLevel(2)).Set(float64(len(l2)))
+	e.Stats.Queued.With(labelForLevel(3)).Set(float64(len(l3)))
+	e.Stats.Queued.With(prometheus.Labels{levelKey: levelFull}).Set(float64(len(l4)))
+	e.Stats.Queued.With(prometheus.Labels{levelKey: levelOpt}).Set(float64(len(l5)))
+
 	return l1, l2, l3, l4, l5
 }
 

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -710,12 +710,6 @@ type compactionCounter struct {
 	l3       int64
 	full     int64
 	optimize int64
-
-	queueL1       int64
-	queueL2       int64
-	queueL3       int64
-	queueFull     int64
-	queueOptimize int64
 }
 
 func (c *compactionCounter) countForLevel(l int) *int64 {
@@ -2380,12 +2374,6 @@ func (e *Engine) PlanCompactions() ([]PlannedCompactionGroup, []PlannedCompactio
 	// Update the level plan queue stats
 	// For stats, use the length needed, even if the lock was
 	// not acquired
-	atomic.StoreInt64(&e.activeCompactions.queueL1, int64(len(l1)))
-	atomic.StoreInt64(&e.activeCompactions.queueL2, int64(len(l2)))
-	atomic.StoreInt64(&e.activeCompactions.queueL3, int64(len(l3)))
-	atomic.StoreInt64(&e.activeCompactions.queueFull, int64(len(l4)))
-	atomic.StoreInt64(&e.activeCompactions.queueOptimize, int64(len(l5)))
-
 	e.Stats.Queued.With(labelForLevel(1)).Set(float64(len(l1)))
 	e.Stats.Queued.With(labelForLevel(2)).Set(float64(len(l2)))
 	e.Stats.Queued.With(labelForLevel(3)).Set(float64(len(l3)))

--- a/tsdb/engine/tsm1/engine_internal_test.go
+++ b/tsdb/engine/tsm1/engine_internal_test.go
@@ -227,8 +227,6 @@ func TestScheduler_RunnableWhenOnlyQueueDepthsSet(t *testing.T) {
 	activeCompactions := &compactionCounter{}
 	s := newScheduler(activeCompactions, maxConcurrency)
 
-	atomic.StoreInt64(&activeCompactions.queueL1, 130)
-
 	s.SetDepth(1, 130)
 
 	level, runnable := s.next()

--- a/tsdb/engine/tsm1/engine_internal_test.go
+++ b/tsdb/engine/tsm1/engine_internal_test.go
@@ -196,29 +196,6 @@ func TestCompactOptimize_ReleasesActiveCount(t *testing.T) {
 		"activeCompactions.optimize should return to 0 after the compaction goroutine exits")
 }
 
-// TestPlanCompactions_DoesNotClobberActiveCounters is a regression test for
-// #27409. PlanCompactions stores plan queue depths for stats reporting; those
-// writes must not land on the active running counters that Scheduler.next()
-// reads to gate concurrency.
-func TestPlanCompactions_DoesNotClobberActiveCounters(t *testing.T) {
-	e := newCompactionTestEngine()
-	e.CompactionPlan.(*DefaultPlanner).FileStore = e.FileStore
-
-	atomic.StoreInt64(&e.activeCompactions.l1, 1)
-	atomic.StoreInt64(&e.activeCompactions.l2, 2)
-	atomic.StoreInt64(&e.activeCompactions.l3, 3)
-	atomic.StoreInt64(&e.activeCompactions.full, 4)
-	atomic.StoreInt64(&e.activeCompactions.optimize, 5)
-
-	_, _, _, _, _ = e.PlanCompactions()
-
-	require.Equal(t, int64(1), atomic.LoadInt64(&e.activeCompactions.l1))
-	require.Equal(t, int64(2), atomic.LoadInt64(&e.activeCompactions.l2))
-	require.Equal(t, int64(3), atomic.LoadInt64(&e.activeCompactions.l3))
-	require.Equal(t, int64(4), atomic.LoadInt64(&e.activeCompactions.full))
-	require.Equal(t, int64(5), atomic.LoadInt64(&e.activeCompactions.optimize))
-}
-
 // TestScheduler_RunnableWhenOnlyQueueDepthsSet verifies the post-fix contract:
 // the scheduler gates on active-running counts only, never on queue depths,
 // so a plan with depth >= maxConcurrency does not block scheduling.

--- a/tsdb/engine/tsm1/engine_internal_test.go
+++ b/tsdb/engine/tsm1/engine_internal_test.go
@@ -196,6 +196,46 @@ func TestCompactOptimize_ReleasesActiveCount(t *testing.T) {
 		"activeCompactions.optimize should return to 0 after the compaction goroutine exits")
 }
 
+// TestPlanCompactions_DoesNotClobberActiveCounters is a regression test for
+// #27409. PlanCompactions stores plan queue depths for stats reporting; those
+// writes must not land on the active running counters that Scheduler.next()
+// reads to gate concurrency.
+func TestPlanCompactions_DoesNotClobberActiveCounters(t *testing.T) {
+	e := newCompactionTestEngine()
+	e.CompactionPlan.(*DefaultPlanner).FileStore = e.FileStore
+
+	atomic.StoreInt64(&e.activeCompactions.l1, 1)
+	atomic.StoreInt64(&e.activeCompactions.l2, 2)
+	atomic.StoreInt64(&e.activeCompactions.l3, 3)
+	atomic.StoreInt64(&e.activeCompactions.full, 4)
+	atomic.StoreInt64(&e.activeCompactions.optimize, 5)
+
+	_, _, _, _, _ = e.PlanCompactions()
+
+	require.Equal(t, int64(1), atomic.LoadInt64(&e.activeCompactions.l1))
+	require.Equal(t, int64(2), atomic.LoadInt64(&e.activeCompactions.l2))
+	require.Equal(t, int64(3), atomic.LoadInt64(&e.activeCompactions.l3))
+	require.Equal(t, int64(4), atomic.LoadInt64(&e.activeCompactions.full))
+	require.Equal(t, int64(5), atomic.LoadInt64(&e.activeCompactions.optimize))
+}
+
+// TestScheduler_RunnableWhenOnlyQueueDepthsSet verifies the post-fix contract:
+// the scheduler gates on active-running counts only, never on queue depths,
+// so a plan with depth >= maxConcurrency does not block scheduling.
+func TestScheduler_RunnableWhenOnlyQueueDepthsSet(t *testing.T) {
+	const maxConcurrency = 1
+	activeCompactions := &compactionCounter{}
+	s := newScheduler(activeCompactions, maxConcurrency)
+
+	atomic.StoreInt64(&activeCompactions.queueL1, 130)
+
+	s.SetDepth(1, 130)
+
+	level, runnable := s.next()
+	require.True(t, runnable, "scheduler must remain runnable when queue depth (130) >= maxConcurrency (1)")
+	require.Equal(t, 1, level)
+}
+
 // newCompactionTestEngine builds a minimal *Engine sufficient for invoking the
 // per-level compaction kickoff helpers. The Compactor is left in its default
 // disabled state so CompactFast/CompactFull return errCompactionsDisabled

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -528,8 +528,9 @@ func (s *Store) loadShards(ctx context.Context) error {
 	if lim == 0 {
 		lim = runtime.GOMAXPROCS(0) / 2 // Default to 50% of cores for compactions
 
-		if lim < 1 {
-			lim = 1
+		// Floor of 4 gives one slot per lane: L1, L2, L3, full/opt.
+		if lim < 4 {
+			lim = 4
 		}
 	}
 

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -528,9 +528,9 @@ func (s *Store) loadShards(ctx context.Context) error {
 	if lim == 0 {
 		lim = runtime.GOMAXPROCS(0) / 2 // Default to 50% of cores for compactions
 
-		// Floor of 4 gives one slot per lane: L1, L2, L3, full/opt.
-		if lim < 4 {
-			lim = 4
+		// Floor of 2, allows for large compactions to not hog all compactions.
+		if lim < 2 {
+			lim = 2
 		}
 	}
 


### PR DESCRIPTION
`PlanCompactions` wrote plan queue depths into the `activeCompactions` fields the scheduler reads as running counts, blocking all compactions when `MaxConcurrentCompactions` was small. Adds separate queue fields, points the stat writes there, and floors the auto default at 4.

Closes #27409 