### PR TITLE
fix: split compaction queue depth from active running count (#27416)

### DIFF
--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -2374,11 +2374,12 @@ func (e *Engine) PlanCompactions() ([]PlannedCompactionGroup, []PlannedCompactio
 	// Update the level plan queue stats
 	// For stats, use the length needed, even if the lock was
 	// not acquired
-	atomic.StoreInt64(&e.activeCompactions.l1, int64(len(l1)))
-	atomic.StoreInt64(&e.activeCompactions.l2, int64(len(l2)))
-	atomic.StoreInt64(&e.activeCompactions.l3, int64(len(l3)))
-	atomic.StoreInt64(&e.activeCompactions.full, int64(len(l4)))
-	atomic.StoreInt64(&e.activeCompactions.optimize, int64(len(l5)))
+	e.Stats.Queued.With(labelForLevel(1)).Set(float64(len(l1)))
+	e.Stats.Queued.With(labelForLevel(2)).Set(float64(len(l2)))
+	e.Stats.Queued.With(labelForLevel(3)).Set(float64(len(l3)))
+	e.Stats.Queued.With(prometheus.Labels{levelKey: levelFull}).Set(float64(len(l4)))
+	e.Stats.Queued.With(prometheus.Labels{levelKey: levelOpt}).Set(float64(len(l5)))
+
 	return l1, l2, l3, l4, l5
 }
 

--- a/tsdb/engine/tsm1/engine_internal_test.go
+++ b/tsdb/engine/tsm1/engine_internal_test.go
@@ -196,6 +196,21 @@ func TestCompactOptimize_ReleasesActiveCount(t *testing.T) {
 		"activeCompactions.optimize should return to 0 after the compaction goroutine exits")
 }
 
+// TestScheduler_RunnableWhenOnlyQueueDepthsSet verifies the post-fix contract:
+// the scheduler gates on active-running counts only, never on queue depths,
+// so a plan with depth >= maxConcurrency does not block scheduling.
+func TestScheduler_RunnableWhenOnlyQueueDepthsSet(t *testing.T) {
+	const maxConcurrency = 1
+	activeCompactions := &compactionCounter{}
+	s := newScheduler(activeCompactions, maxConcurrency)
+
+	s.SetDepth(1, 130)
+
+	level, runnable := s.next()
+	require.True(t, runnable, "scheduler must remain runnable when queue depth (130) >= maxConcurrency (1)")
+	require.Equal(t, 1, level)
+}
+
 // newCompactionTestEngine builds a minimal *Engine sufficient for invoking the
 // per-level compaction kickoff helpers. The Compactor is left in its default
 // disabled state so CompactFast/CompactFull return errCompactionsDisabled

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -528,8 +528,9 @@ func (s *Store) loadShards(ctx context.Context) error {
 	if lim == 0 {
 		lim = runtime.GOMAXPROCS(0) / 2 // Default to 50% of cores for compactions
 
-		if lim < 1 {
-			lim = 1
+		// Floor of 2, allows for large compactions to not hog all compactions.
+		if lim < 2 {
+			lim = 2
 		}
 	}
 


### PR DESCRIPTION
(cherry picked from commit 5d7876d50dfccbbb5164292721b7e7279b36d779)
