### PR TITLE
feat: Adds storage-compact-throughput to config

### DIFF
--- a/cmd/influxd/launcher/cmd.go
+++ b/cmd/influxd/launcher/cmd.go
@@ -577,6 +577,11 @@ func (o *InfluxdOpts) BindCliOpts() []cli.Opt {
 			Flag:  "storage-compact-throughput-burst",
 			Desc:  "The rate limit in bytes per second that we will allow TSM compactions to write to disk.",
 		},
+		{
+			DestP: &o.StorageConfig.Data.CompactThroughput,
+			Flag:  "storage-compact-throughput",
+			Desc:  "The rate in bytes per second that we will allow TSM compactions to write to disk.",
+		},
 		// limits
 		{
 			DestP: &o.StorageConfig.Data.MaxConcurrentCompactions,

--- a/cmd/influxd/launcher/cmd.go
+++ b/cmd/influxd/launcher/cmd.go
@@ -575,7 +575,7 @@ func (o *InfluxdOpts) BindCliOpts() []cli.Opt {
 		{
 			DestP: &o.StorageConfig.Data.CompactThroughputBurst,
 			Flag:  "storage-compact-throughput-burst",
-			Desc:  "The rate limit in bytes per second that we will allow TSM compactions to write to disk.",
+			Desc:  "The maximum burst capacity in bytes per second that we will allow TSM compactions to write to disk.",
 		},
 		{
 			DestP: &o.StorageConfig.Data.CompactThroughput,

--- a/cmd/influxd/upgrade/config.go
+++ b/cmd/influxd/upgrade/config.go
@@ -26,6 +26,7 @@ var passthroughConfigRules = map[string]string{
 	"data.cache-snapshot-memory-size":                      "storage-cache-snapshot-memory-size",
 	"data.cache-snapshot-write-cold-duration":              "storage-cache-snapshot-write-cold-duration",
 	"data.compact-full-write-cold-duration":                "storage-compact-full-write-cold-duration",
+	"data.compact-throughput":                              "storage-compact-throughput",
 	"data.compact-throughput-burst":                        "storage-compact-throughput-burst",
 	"data.max-concurrent-compactions":                      "storage-max-concurrent-compactions",
 	"data.max-index-log-file-size":                         "storage-max-index-log-file-size",

--- a/cmd/influxd/upgrade/config_test.go
+++ b/cmd/influxd/upgrade/config_test.go
@@ -437,6 +437,7 @@ storage-cache-max-memory-size = 1073741824
 storage-cache-snapshot-memory-size = 26214400
 storage-cache-snapshot-write-cold-duration = "10m0s"
 storage-compact-full-write-cold-duration = "4h0m0s"
+storage-compact-throughput = 50331648
 storage-compact-throughput-burst = 50331648
 storage-max-concurrent-compactions = 0
 storage-max-index-log-file-size = 1048576

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -559,6 +559,10 @@ func (s *Store) loadShards(ctx context.Context) error {
 	throughputBurst := int(s.EngineOptions.Config.CompactThroughputBurst)
 	if throughput > 0 {
 		if throughputBurst < throughput {
+			s.Logger.Info("Compaction throughput burst is less than throughput, raising burst to match throughput",
+				zap.Int("configured_throughput_bytes_per_second_burst", throughputBurst),
+				zap.Int("throughput_bytes_per_second", throughput),
+			)
 			throughputBurst = throughput
 		}
 

--- a/tsdb/store_test.go
+++ b/tsdb/store_test.go
@@ -20,6 +20,11 @@ import (
 	"time"
 
 	"github.com/davecgh/go-spew/spew"
+	"github.com/influxdata/influxql"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+	"golang.org/x/time/rate"
+
 	"github.com/influxdata/influxdb/v2/influxql/query"
 	"github.com/influxdata/influxdb/v2/internal"
 	"github.com/influxdata/influxdb/v2/models"
@@ -27,10 +32,8 @@ import (
 	"github.com/influxdata/influxdb/v2/pkg/slices"
 	"github.com/influxdata/influxdb/v2/pkg/snowflake"
 	"github.com/influxdata/influxdb/v2/predicate"
+	"github.com/influxdata/influxdb/v2/toml"
 	"github.com/influxdata/influxdb/v2/tsdb"
-	"github.com/influxdata/influxql"
-	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zaptest"
 )
 
 // Ensure the store can delete a retention policy and all shards under
@@ -1115,6 +1118,66 @@ func TestStore_WRRSegments(t *testing.T) {
 			createWRRSnapshot(t, sh1WALPath)
 			sh1Uncommitted = nil
 			checkReopen(t)
+		})
+	}
+}
+
+// Ensure the store wires the configured compaction throughput rate limits
+// into the limiter the compactor uses.
+func TestStore_CompactionThroughputConfigs(t *testing.T) {
+	const (
+		throughput = 10 * 1024 * 1024 // 10 MB/s
+		burst      = 25 * 1024 * 1024 // 25 MB/s
+	)
+
+	for _, index := range tsdb.RegisteredIndexes() {
+		t.Run(index, func(t *testing.T) {
+			s := NewStore(t, index)
+			s.EngineOptions.Config.CompactThroughput = toml.Size(throughput)
+			s.EngineOptions.Config.CompactThroughputBurst = toml.Size(burst)
+
+			require.NoError(t, s.Open(context.Background()))
+			defer s.CloseStore(t, index)
+
+			lim := s.EngineOptions.CompactionThroughputLimiter
+			require.NotNil(t, lim, "expected a compaction throughput limiter to be configured")
+
+			// The limiter the compactor uses must reflect the configured values.
+			require.Equal(t, burst, lim.Burst())
+
+			rl, ok := lim.(*rate.Limiter)
+			require.True(t, ok, "expected limiter to be a *rate.Limiter")
+			require.Equal(t, rate.Limit(throughput), rl.Limit())
+		})
+	}
+}
+
+// Ensure the store clamps the compaction throughput burst up to the throughput
+// rate when a smaller burst is configured.
+func TestStore_CompactionThroughputBurstClamped(t *testing.T) {
+	const (
+		throughput = 10 * 1024 * 1024 // 10 MB/s
+		burst      = 1 * 1024 * 1024  // 1 MB/s, smaller than throughput
+	)
+
+	for _, index := range tsdb.RegisteredIndexes() {
+		t.Run(index, func(t *testing.T) {
+			s := NewStore(t, index)
+			s.EngineOptions.Config.CompactThroughput = toml.Size(throughput)
+			s.EngineOptions.Config.CompactThroughputBurst = toml.Size(burst)
+
+			require.NoError(t, s.Open(context.Background()))
+			defer s.CloseStore(t, index)
+
+			lim := s.EngineOptions.CompactionThroughputLimiter
+			require.NotNil(t, lim, "expected a compaction throughput limiter to be configured")
+
+			// A burst smaller than the throughput is raised to the throughput.
+			require.Equal(t, throughput, lim.Burst())
+
+			rl, ok := lim.(*rate.Limiter)
+			require.True(t, ok, "expected limiter to be a *rate.Limiter")
+			require.Equal(t, rate.Limit(throughput), rl.Limit())
 		})
 	}
 }


### PR DESCRIPTION
Adds `storage-compact-throughput` to v2 configuration. This should address compactions not keeping up in certain environments when a user requires further configuration. 
