### PR TITLE
chore(1.11): upgrade go to v1.26.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ parameters:
     # when updating the go version, should also update the go version in go.mod
     description: docker tag for cross build container from quay.io . Created by https://github.com/influxdata/edge/tree/master/dockerfiles/cross-builder .
     type: string
-    default: go1.26.2-latest
+    default: go1.26.3-latest
 
   workflow:
     type: string

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/influxdata/influxdb
 
 go 1.26.0
 
-toolchain go1.26.2
+toolchain go1.26.3
 
 require (
 	collectd.org v0.3.0


### PR DESCRIPTION
upgrades reference go to go1.26.3


- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
