### PR TITLE
feat: HEALTH_READY.md documenting /health and /ready

### DIFF
--- a/HEALTH_READY.md
+++ b/HEALTH_READY.md
@@ -307,9 +307,9 @@ Source: `http/check_handler.go`.
 }
 ```
 
-The literal message `"not ready"` is the default that every unsignaled
-`ReadyGate` emits (`kit/check/helpers.go`). The `shards` gate emits
-different messages — see below.
+Every unsignaled `ReadyGate` emits the default message `"not ready"`
+(`kit/check/helpers.go`). The `shards` gate emits different messages.
+See below.
 
 ### Registered ready gates
 

--- a/HEALTH_READY.md
+++ b/HEALTH_READY.md
@@ -563,12 +563,14 @@ Address the underlying error before you restart.
 }
 ```
 
-**Meaning:** The background bolt prober has not recorded a fresh result
+**Meaning:** The background bolt prober hasn't recorded a fresh result
 within the 5-second staleness budget. Either the prober goroutine is
-wedged in a `db.View` (the bolt mmap is unresponsive — check disk and
-kernel logs) or the host is under such severe scheduling pressure that
-the 1-second probe loop cannot run. Look at `iostat`, `dmesg`, and the
-`influxd` process's CPU/memory state.
+wedged in a `db.View` and the bolt mmap is unresponsive, or the host is
+under severe scheduling pressure that prevents the 1-second probe loop
+from running.
+
+**Action:** Check disk and kernel logs for an unresponsive mmap. Inspect
+`iostat`, `dmesg`, and the `influxd` process's CPU and memory state.
 
 ### `/health` 503 — scheduler stalled
 

--- a/HEALTH_READY.md
+++ b/HEALTH_READY.md
@@ -544,10 +544,12 @@ which indicates early initialization. Check logs for engine open progress.
 }
 ```
 
-**Meaning:** `engine.Open` returned an error and the `shards` gate has
-latched into a terminal failure. Restarting will not clear this without
-addressing the underlying error in the message. Check disk health and
-file permissions on the data directory.
+**Meaning:** `engine.Open` returned an error and the `shards` gate
+latched into a terminal failure. Restarting won't clear this without
+addressing the underlying error in the message.
+
+**Action:** Check disk health and file permissions on the data directory.
+Address the underlying error before you restart.
 
 ### `/health` 503 — bolt prober stale
 

--- a/HEALTH_READY.md
+++ b/HEALTH_READY.md
@@ -643,12 +643,13 @@ another process is holding a long-running write transaction.
 }
 ```
 
-**Meaning:** One or more shards failed to load during engine open.
-Errors accumulate — even if the engine itself opened successfully,
-`/health` will continue to report this until restart. Each `shard <id>`
-in the message identifies a specific shard directory under the
-configured data path; address each shard's underlying error before
-restarting.
+**Meaning:** One or more shards failed to load during engine open. Errors
+accumulate. Even if the engine opened successfully, `/health` continues
+to report this until restart.
+
+**Action:** Each `shard <id>` in the message identifies a specific shard
+directory under the configured data path. Address each shard's underlying
+error before you restart.
 
 ### `/health` 503 — all checks pass but the body says `"fail"`
 

--- a/HEALTH_READY.md
+++ b/HEALTH_READY.md
@@ -329,10 +329,10 @@ The launcher registers eight ready gates in this order:
 Source of truth: `cmd/influxd/launcher/health_ready_test.go` and
 `cmd/influxd/launcher/subsystems.go`.
 
-Each gate is binary: a single `Ready()` call latches it to `"pass"` for
-the life of the process. During shutdown, the launcher walks the
-labeled-closer chain and calls `Unready()` on every gate it owns, so
-`/ready` flips back to `503` while subsystems are being shut down.
+Each gate is binary. A single `Ready()` call latches it to `"pass"` for
+the life of the process. During shutdown, the launcher calls `Unready()`
+on every gate it owns, so `/ready` returns `503` while InfluxDB shuts
+down those subsystems.
 
 ### `shards` ready states (progressive)
 

--- a/HEALTH_READY.md
+++ b/HEALTH_READY.md
@@ -179,7 +179,7 @@ Background prober that runs a no-op `bolt.View` every
 (5 seconds). If no fresh probe result is recorded within the budget, the
 check flips to `"fail"` with a message of the form:
 
-```
+```text
 stale: last probe <age> ago (threshold 5s)
 ```
 

--- a/HEALTH_READY.md
+++ b/HEALTH_READY.md
@@ -442,12 +442,16 @@ A healthy instance returns `200` and a body that lists each check:
 }
 ```
 
-During startup, `/ready` typically shows the `shards` gate progressing:
+Probe `/ready` during startup to watch the `shards` gate progress--for example:
 
+```sh
+curl -sS -o body.json -w '%{http_code}\n' http://localhost:8086/ready
 ```
-$ curl -sS -o body.json -w '%{http_code}\n' http://localhost:8086/ready
-503
-$ jq . body.json
+
+The command returns `503`, and the body lists only the checks that
+haven't passed:
+
+```json
 {
   "status": "starting",
   "started": "2026-05-26T15:42:30.123456789Z",
@@ -463,13 +467,23 @@ $ jq . body.json
 }
 ```
 
-Distinguishing a 200 response from a 503 from the body alone:
+Distinguish a `200` from a `503` using the body alone--for example:
 
+```sh
+curl -sS http://localhost:8086/ready | jq -r .status
 ```
-$ curl -sS http://localhost:8086/ready  | jq -r .status
-ready
 
-$ curl -sS http://localhost:8086/health | jq -r .status
+```text
+ready
+```
+
+Do the same for `/health`:
+
+```sh
+curl -sS http://localhost:8086/health | jq -r .status
+```
+
+```text
 pass
 ```
 

--- a/HEALTH_READY.md
+++ b/HEALTH_READY.md
@@ -597,11 +597,13 @@ runtime profile or a stack dump.
 }
 ```
 
-**Meaning:** The SQLite metadata store handle is nil — the store was
-closed or never opened. This should only be observed transiently during
-startup (before SQL migrations complete) or during shutdown. If it
-persists, the SQLite store failed to open; check `influxd` logs for the
-underlying error.
+**Meaning:** The SQLite metadata store handle is nil because the store
+was closed or never opened. InfluxDB reports this state only briefly,
+while it starts up (before SQL migrations complete) or while it shuts
+down.
+
+**Action:** If the failure persists, the SQLite store failed to open.
+Check `influxd` logs for the underlying error.
 
 ### `/health` 503 — sqlite ping error
 

--- a/HEALTH_READY.md
+++ b/HEALTH_READY.md
@@ -642,12 +642,14 @@ restarting.
 
 ### `/health` 503 — all checks pass but the body says `"fail"`
 
-If `/health` returns `503` but the `checks` array contains only
-`"pass"` entries, the response is being constructed under an
-inconsistent observation (a check transitioned between the aggregation
-walk and the per-check render). Retry the request — the inconsistency
-window is bounded by the probe interval. If the condition persists
-across many requests, file an issue with the body and headers attached.
+**Meaning:** `/health` returned `503` but the `checks` array contains
+only `"pass"` entries. The response was constructed under an inconsistent
+observation, where a check transitioned between the aggregation walk and
+the per-check render.
+
+**Action:** Retry the request. The inconsistency window is bounded by the
+probe interval. If the condition persists across many requests, file an
+issue with the body and headers attached.
 
 ---
 

--- a/HEALTH_READY.md
+++ b/HEALTH_READY.md
@@ -249,7 +249,7 @@ Source: `cmd/influxd/run/startup_logger.go`.
 
 ### JSON envelope
 
-```
+```text
 {
   "status":  "ready" | "starting",   // aggregate over all ready gates
   "started": "<RFC3339Nano timestamp>",

--- a/HEALTH_READY.md
+++ b/HEALTH_READY.md
@@ -1,0 +1,647 @@
+# `/health` and `/ready`
+
+A reference and operator guide for the two unauthenticated diagnostic
+endpoints served by `influxd`.
+
+## Overview
+
+`influxd` serves two diagnostic endpoints at the root of the HTTP server:
+
+- **`/ready`** — readiness gates. Reports whether each one-time startup
+  phase (KV migrations, SQL migrations, engine open, shard enumeration,
+  service init, etc.) has completed. Use it to decide when a node is
+  ready to accept traffic.
+- **`/health`** — liveness contributors. Reports whether each subsystem
+  is currently healthy. Recomputed on every request. Use it for ongoing
+  liveness monitoring after startup has completed.
+
+Both endpoints are mounted by `HealthReadyHandler` at root **before** the
+full API handler is installed (`http/check_handler.go`,
+`http/api_handler.go`). They are available from the moment the PID file
+is written. Until the main API handler is installed, any request to a
+path other than `/health` or `/ready` receives `503 Service Unavailable`
+with the body:
+
+```json
+{"status":"starting"}
+```
+
+This pre-API 503 is byte-exact (pinned by
+`http/check_handler_jsoncompat_test.go`).
+
+## Endpoint summary
+
+| Path                            | Methods | 200 body status | 503 body status   |
+|---------------------------------|---------|-----------------|-------------------|
+| `/health`, `/health/`           | GET     | `"pass"`        | `"fail"`          |
+| `/ready`, `/ready/`             | GET     | `"ready"`       | `"starting"`      |
+| any other path (pre-API)        | any     | —               | `"starting"`      |
+
+Trailing slashes are accepted on both endpoints. Query parameters are
+ignored — `/health?cachebust=1` is matched as `/health`.
+
+Path constants are defined in `http/handler.go` as `HealthPath` and
+`ReadyPath`.
+
+## Response headers
+
+Every response written by `HealthReadyHandler` carries:
+
+| Header              | Value                              |
+|---------------------|------------------------------------|
+| `Content-Type`      | `application/json; charset=utf-8`  |
+| `X-Influxdb-Build`  | `OSS`                              |
+| `X-Influxdb-Version`| The build version string           |
+
+Source: `http/check_handler.go`, `NewHealthReadyHandler`.
+
+---
+
+## `/health`
+
+### JSON envelope
+
+```
+{
+  "name":    "influxdb",          // constant
+  "status":  "pass" | "fail",     // aggregate over all health checks
+  "message": "<top-level message>",
+  "checks":  [ <Check>, ... ],    // always present; may be []
+  "version": "<build version>",
+  "commit":  "<build commit>"
+}
+```
+
+Each entry in `checks` is:
+
+```
+{
+  "name":    "<check name>",      // always present
+  "status":  "pass" | "fail",     // always present
+  "message": "<detail>"           // omitted when empty
+}
+```
+
+Per-check `message` and the rarely-used `checks` sub-array are
+`omitempty` (see `kit/check/response.go`).
+
+### Status codes
+
+- `200 OK` when **every** registered health check reports `"pass"`.
+- `503 Service Unavailable` when **any** check reports `"fail"`.
+
+Aggregation rule: any single `"fail"` makes the aggregate `"fail"`
+(`kit/check/check.go`).
+
+### Top-level `message`
+
+- On `200`, `message` is the constant string `"healthy"`.
+- On `503`, `message` is taken from the **first** failing check that has
+  a non-empty message. If no failing check has a message, the body falls
+  back to `"fail"`. If there are no failing checks at all (the response
+  was forced to fail by some other path), it falls back to `"starting"`.
+  See `firstFailureMessage` in `http/check_handler.go`.
+
+### Example: 200 with one passing check
+
+```json
+{
+  "name": "influxdb",
+  "status": "pass",
+  "message": "healthy",
+  "checks": [
+    {
+      "name": "alpha",
+      "status": "pass"
+    }
+  ],
+  "version": "<build version>",
+  "commit": "<build commit>"
+}
+```
+
+### Example: 200 with no checks registered
+
+```json
+{
+  "name": "influxdb",
+  "status": "pass",
+  "message": "healthy",
+  "checks": [],
+  "version": "<build version>",
+  "commit": "<build commit>"
+}
+```
+
+### Example: 503 with one failing check
+
+```json
+{
+  "name": "influxdb",
+  "status": "fail",
+  "message": "unreachable",
+  "checks": [
+    {
+      "name": "query",
+      "status": "fail",
+      "message": "unreachable"
+    }
+  ],
+  "version": "<build version>",
+  "commit": "<build commit>"
+}
+```
+
+(JSON trees taken verbatim from `http/check_handler_jsoncompat_test.go`.)
+
+### Registered `/health` checks
+
+The launcher registers the following named health checks. The exact set
+depends on whether the server is running with on-disk metadata or
+in-memory metadata (test mode).
+
+| Check name        | Disk mode | Memory mode |
+|-------------------|:---------:|:-----------:|
+| `bolt`            |     ✓     |             |
+| `sqlite`          |     ✓     |      ✓      |
+| `query`           |     ✓     |      ✓      |
+| `influxql`        |     ✓     |      ✓      |
+| `task-scheduler`  |     ✓     |      ✓      |
+| `shards`          |     ✓     |      ✓      |
+
+Source of truth: `cmd/influxd/launcher/health_ready_test.go`.
+
+#### `bolt`
+
+Background prober that runs a no-op `bolt.View` every
+`DefaultProbeInterval` (1 second). The result is wrapped in a
+`FreshnessResponse` with a staleness budget of `DefaultProbeStaleness`
+(5 seconds). If no fresh probe result is recorded within the budget, the
+check flips to `"fail"` with a message of the form:
+
+```
+stale: last probe <age> ago (threshold 5s)
+```
+
+Other failure modes:
+
+- `"bolt database not open"` — store was closed or never opened.
+- The underlying error string from `bolt.View` when a probe transaction
+  returns an error.
+
+Source: `bolt/kv.go`, `kit/check/freshness.go`.
+
+#### `sqlite`
+
+Synchronous `db.PingContext` performed under the SqlStore read lock so a
+concurrent `RestoreSqlStore` swap cannot tear the handle. Probe duration
+is bounded by `check.DefaultProbeTimeout` (500ms). Failure modes:
+
+- `"sqlite database not open"` — store was closed or never opened.
+- The underlying error string from `PingContext` when the probe fails or
+  times out.
+
+Source: `sqlite/sqlite.go`.
+
+#### `query`, `influxql`
+
+Liveness contributors registered by the launcher for the Flux query
+controller and InfluxQL proxy executor respectively. A `"fail"` on
+either indicates the corresponding query path is not currently serving
+requests.
+
+Source: `query/bridges.go`, `influxql/query/proxy_executor.go`,
+`cmd/influxd/launcher/launcher.go`.
+
+#### `task-scheduler`
+
+Compares the task scheduler's next-run timestamp (`TreeScheduler.When()`)
+to wall-clock time. Possible states:
+
+| Condition                                              | Status | Message                          |
+|--------------------------------------------------------|--------|----------------------------------|
+| `When()` returns zero (no scheduled work)              | pass   | `scheduler idle: no scheduled runs` |
+| `When()` is in the future                              | pass   | `next run in <duration>`         |
+| `When()` is in the past by ≤ 30s (the pulse threshold) | pass   | `on time, dispatch lag <duration>` |
+| `When()` is in the past by > 30s                       | fail   | `scheduler stalled: next run due <duration> ago` |
+
+The threshold is `DefaultSchedulerPulseThreshold = 30 * time.Second`
+(`cmd/influxd/run/scheduler_pulse.go`).
+
+#### `shards`
+
+Reports the accumulated shard-load errors observed during engine
+startup. `"pass"` until at least one shard fails to load; thereafter
+`"fail"` with a message of the form:
+
+```
+<n> shard(s) failed to load: shard <id>: <err>; shard <id>: <err>; ...
+```
+
+The same name (`shards`) appears in `/ready` with different semantics —
+see below.
+
+Source: `cmd/influxd/run/startup_logger.go`.
+
+---
+
+## `/ready`
+
+### JSON envelope
+
+```
+{
+  "status":  "ready" | "starting",   // aggregate over all ready gates
+  "started": "<RFC3339Nano timestamp>",
+  "up":      "<duration>",
+  "checks":  [ <Check>, ... ]        // omitted on 200; failing-only on 503
+}
+```
+
+Notes:
+
+- `started` is the time `HealthReadyHandler` was constructed. It does
+  not change across requests.
+- `up` is `time.Since(started)`, formatted as a `toml.Duration` string
+  (e.g. `"2.5s"`, `"1h23m45.6s"`).
+- `checks` is `omitempty`. On a `200` response it is **absent
+  entirely**, not an empty array. On a `503` it contains **only the
+  failing** gates.
+
+Source: `http/check_handler.go`.
+
+### Status codes
+
+- `200 OK` with body `"status": "ready"` when **every** registered ready
+  gate has been signaled `Ready()`.
+- `503 Service Unavailable` with body `"status": "starting"` when **any**
+  gate has not yet been signaled (or has been signaled `Unready()` during
+  shutdown).
+
+### Example: 200 (no failing checks)
+
+```json
+{
+  "status": "ready",
+  "started": "2026-05-26T15:42:30.123456789Z",
+  "up": "1m32.4s"
+}
+```
+
+`checks` is omitted by `omitempty`.
+
+### Example: 503 (one gate unsignaled)
+
+```json
+{
+  "status": "starting",
+  "started": "2026-05-26T15:42:30.123456789Z",
+  "up": "1.2s",
+  "checks": [
+    {
+      "name": "metastores",
+      "status": "fail",
+      "message": "not ready"
+    }
+  ]
+}
+```
+
+The literal message `"not ready"` is the default that every unsignaled
+`ReadyGate` emits (`kit/check/helpers.go`). The `shards` gate emits
+different messages — see below.
+
+### Registered ready gates
+
+The launcher registers eight ready gates in this order:
+
+1. `bolt` — KV (BoltDB) migrations complete.
+2. `sqlite` — SQLite migrations complete.
+3. `engine` — storage engine `Open` returned successfully.
+4. `replications` — replication service `Open` returned successfully.
+5. `query` — Flux query controller initialized.
+6. `tasks` — task system initialized (pre-signaled when started with
+   `--no-tasks`).
+7. `task-scheduler` — `TreeScheduler` started.
+8. `shards` — shard enumeration and loading complete (see below for
+   progress states).
+
+Source of truth: `cmd/influxd/launcher/health_ready_test.go` and
+`cmd/influxd/launcher/subsystems.go`.
+
+Each gate is binary: a single `Ready()` call latches it to `"pass"` for
+the life of the process. During shutdown, the launcher walks the
+labeled-closer chain and calls `Unready()` on every gate it owns, so
+`/ready` flips back to `503` while subsystems are being shut down.
+
+### `shards` ready states (progressive)
+
+The `shards` ready gate is the only one that reports progress before
+latching. Its observable states are:
+
+| When                                                                            | Status | Message                                       |
+|---------------------------------------------------------------------------------|--------|-----------------------------------------------|
+| Engine has not yet enumerated any shard                                         | fail   | `waiting for shard enumeration`               |
+| Enumeration started, some shards still loading                                  | fail   | `loading shards N.N% (<completed> / <total>)` |
+| `engine.Open` returned with no error                                            | pass   | `ready: <n> shards loaded in <duration>`      |
+| `engine.Open` returned an error (terminal)                                      | fail   | `shard loading failed: <error>`               |
+
+The percentage updates every time an individual shard finishes loading;
+it is computed as `completed / total * 100` against atomic counters.
+
+Source: `cmd/influxd/run/startup_logger.go`.
+
+---
+
+## Operator how-to
+
+### When the endpoints become available
+
+`/health` and `/ready` start serving as soon as the PID file is written.
+This is intentionally earlier than the rest of the API: a probe agent
+can begin polling immediately and observe startup progress through the
+gate state.
+
+While the API handler is still being assembled, any request to a path
+other than `/health` or `/ready` returns `503` with:
+
+```json
+{"status":"starting"}
+```
+
+This includes `/api/v2/*`, `/query`, `/write`, etc. Once the main API
+handler is installed via `SetHandler`, those paths are served normally.
+
+### Picking the right endpoint
+
+Use `/ready`:
+
+- To gate traffic during boot — for example, in a load balancer's
+  health check or a Kubernetes startup probe.
+- To observe startup progress (the `shards` gate reports a percentage).
+- For a clean shutdown signal: when the process begins shutting down,
+  the launcher flips gates back to `Unready()` and `/ready` returns
+  `503` before the listener stops accepting connections.
+
+Use `/health`:
+
+- For ongoing liveness checks once the process is up.
+- To detect transient degradation (a stuck `bolt` probe, a stalled
+  scheduler, a shard load failure that occurred after startup
+  completed).
+
+Key behavioral difference: once a `/ready` gate has been signaled
+`Ready()`, it does not transition back to `"fail"` unless the launcher
+calls `Unready()` (shutdown). So `/ready` will not flap during normal
+operation. `/health` is recomputed on every request and **will** reflect
+transient failures.
+
+### curl examples
+
+Probe `/ready` and `/health` and inspect the body:
+
+```
+$ curl -sS -o body.json -w '%{http_code}\n' http://localhost:8086/ready
+200
+$ jq . body.json
+{
+  "status": "ready",
+  "started": "2026-05-26T15:42:30.123456789Z",
+  "up": "1m32.4s"
+}
+
+$ curl -sS -o body.json -w '%{http_code}\n' http://localhost:8086/health
+200
+$ jq . body.json
+{
+  "name": "influxdb",
+  "status": "pass",
+  "message": "healthy",
+  "checks": [
+    { "name": "bolt", "status": "pass" },
+    { "name": "sqlite", "status": "pass" },
+    { "name": "query", "status": "pass" },
+    { "name": "influxql", "status": "pass" },
+    { "name": "task-scheduler", "status": "pass", "message": "scheduler idle: no scheduled runs" },
+    { "name": "shards", "status": "pass" }
+  ],
+  "version": "<build version>",
+  "commit": "<build commit>"
+}
+```
+
+During startup, `/ready` typically shows the `shards` gate progressing:
+
+```
+$ curl -sS -o body.json -w '%{http_code}\n' http://localhost:8086/ready
+503
+$ jq . body.json
+{
+  "status": "starting",
+  "started": "2026-05-26T15:42:30.123456789Z",
+  "up": "4.2s",
+  "checks": [
+    { "name": "engine",       "status": "fail", "message": "not ready" },
+    { "name": "replications", "status": "fail", "message": "not ready" },
+    { "name": "query",        "status": "fail", "message": "not ready" },
+    { "name": "tasks",        "status": "fail", "message": "not ready" },
+    { "name": "task-scheduler","status": "fail", "message": "not ready" },
+    { "name": "shards",       "status": "fail", "message": "loading shards 47.0% (94 / 200)" }
+  ]
+}
+```
+
+Distinguishing a 200 response from a 503 from the body alone:
+
+```
+$ curl -sS http://localhost:8086/ready  | jq -r .status
+ready
+
+$ curl -sS http://localhost:8086/health | jq -r .status
+pass
+```
+
+The HTTP status code is the authoritative signal; the body string is for
+human readability.
+
+---
+
+## Troubleshooting: per-subsystem failure scenarios
+
+For each scenario below, the JSON snippet is the relevant portion of the
+`/health` or `/ready` response — other fields elided for brevity.
+
+### `/ready` 503 — shards still loading
+
+```json
+{
+  "status": "starting",
+  "checks": [
+    { "name": "shards", "status": "fail", "message": "loading shards 47.0% (94 / 200)" }
+  ]
+}
+```
+
+**Meaning:** Normal startup. The engine has enumerated 200 shards and 94
+have finished opening. Wait — the percentage updates each time another
+shard completes. If the percentage stops climbing, check `influxd` logs
+for `Finished loading shard` lines; whichever shard is currently in
+flight is logged when it completes.
+
+### `/ready` 503 — shards enumeration not yet started
+
+```json
+{
+  "status": "starting",
+  "checks": [
+    { "name": "shards", "status": "fail", "message": "waiting for shard enumeration" }
+  ]
+}
+```
+
+**Meaning:** The engine has not yet begun calling `AddShard`. Either the
+engine is still in early initialization (look for the `engine` gate also
+failing with `"not ready"`) or the engine is blocked before
+enumeration. Check logs for engine open progress.
+
+### `/ready` 503 — terminal shard load failure
+
+```json
+{
+  "status": "starting",
+  "checks": [
+    { "name": "shards", "status": "fail", "message": "shard loading failed: open /var/lib/influxdb2/engine/data/2/.../000000001-000000001.tsm: input/output error" }
+  ]
+}
+```
+
+**Meaning:** `engine.Open` returned an error and the `shards` gate has
+latched into a terminal failure. Restarting will not clear this without
+addressing the underlying error in the message. Check disk health and
+file permissions on the data directory.
+
+### `/health` 503 — bolt prober stale
+
+```json
+{
+  "status": "fail",
+  "message": "stale: last probe 12.3s ago (threshold 5s)",
+  "checks": [
+    { "name": "bolt", "status": "fail", "message": "stale: last probe 12.3s ago (threshold 5s)" }
+  ]
+}
+```
+
+**Meaning:** The background bolt prober has not recorded a fresh result
+within the 5-second staleness budget. Either the prober goroutine is
+wedged in a `db.View` (the bolt mmap is unresponsive — check disk and
+kernel logs) or the host is under such severe scheduling pressure that
+the 1-second probe loop cannot run. Look at `iostat`, `dmesg`, and the
+`influxd` process's CPU/memory state.
+
+### `/health` 503 — scheduler stalled
+
+```json
+{
+  "status": "fail",
+  "message": "scheduler stalled: next run due 1m45s ago",
+  "checks": [
+    { "name": "task-scheduler", "status": "fail", "message": "scheduler stalled: next run due 1m45s ago" }
+  ]
+}
+```
+
+**Meaning:** The task scheduler's next-run timestamp is more than 30
+seconds behind wall clock — its dispatch loop fired a timer but never
+advanced. Look for blocked goroutines in the scheduler (use the runtime
+profile or stack dump). If this fires only at boot and clears within a
+few seconds, it is likely a cold-start dispatch and not a real wedge.
+
+### `/health` 503 — sqlite not open
+
+```json
+{
+  "status": "fail",
+  "message": "sqlite database not open",
+  "checks": [
+    { "name": "sqlite", "status": "fail", "message": "sqlite database not open" }
+  ]
+}
+```
+
+**Meaning:** The SQLite metadata store handle is nil — the store was
+closed or never opened. This should only be observed transiently during
+startup (before SQL migrations complete) or during shutdown. If it
+persists, the SQLite store failed to open; check `influxd` logs for the
+underlying error.
+
+### `/health` 503 — sqlite ping error
+
+```json
+{
+  "status": "fail",
+  "message": "context deadline exceeded",
+  "checks": [
+    { "name": "sqlite", "status": "fail", "message": "context deadline exceeded" }
+  ]
+}
+```
+
+**Meaning:** `db.PingContext` did not return within the 500ms probe
+deadline, or returned an I/O error. Check disk health on the SQLite
+database file and whether another process is holding a long-running
+write transaction.
+
+### `/health` 503 — accumulated shard load failures
+
+```json
+{
+  "status": "fail",
+  "message": "3 shard(s) failed to load: shard 41: I/O error; shard 87: corrupt index; shard 102: I/O error",
+  "checks": [
+    { "name": "shards", "status": "fail",
+      "message": "3 shard(s) failed to load: shard 41: I/O error; shard 87: corrupt index; shard 102: I/O error" }
+  ]
+}
+```
+
+**Meaning:** One or more shards failed to load during engine open.
+Errors accumulate — even if the engine itself opened successfully,
+`/health` will continue to report this until restart. Each `shard <id>`
+in the message identifies a specific shard directory under the
+configured data path; address each shard's underlying error before
+restarting.
+
+### `/health` 503 — all checks pass but the body says `"fail"`
+
+If `/health` returns `503` but the `checks` array contains only
+`"pass"` entries, the response is being constructed under an
+inconsistent observation (a check transitioned between the aggregation
+walk and the per-check render). Retry the request — the inconsistency
+window is bounded by the probe interval. If the condition persists
+across many requests, file an issue with the body and headers attached.
+
+---
+
+## Sources
+
+This document is derived from the implementation introduced in commit
+`67afeb385b` (PR #27370). Authoritative source files:
+
+- `http/check_handler.go` — endpoint handler, JSON envelopes.
+- `http/check_handler_jsoncompat_test.go` — pinned wire format.
+- `http/handler.go` — `HealthPath`, `ReadyPath` constants.
+- `kit/check/check.go` — status enum, aggregation rule.
+- `kit/check/freshness.go` — staleness model and stale-message format.
+- `kit/check/helpers.go` — `ReadyGate`, `DefaultProbeTimeout`.
+- `kit/check/response.go` — per-check JSON shape and `omitempty` rules.
+- `bolt/kv.go` — bolt probe and failure messages.
+- `sqlite/sqlite.go` — sqlite probe and failure messages.
+- `cmd/influxd/run/scheduler_pulse.go` — task-scheduler check.
+- `cmd/influxd/run/startup_logger.go` — shards progress and accumulated
+  shard load errors.
+- `cmd/influxd/launcher/launcher.go` — gate registration, `Ready` /
+  `Unready` call sites.
+- `cmd/influxd/launcher/subsystems.go` — canonical subsystem names.
+- `cmd/influxd/launcher/health_ready_test.go` — authoritative
+  `/health` and `/ready` check sets.

--- a/HEALTH_READY.md
+++ b/HEALTH_READY.md
@@ -61,7 +61,7 @@ Source: `http/check_handler.go`, `NewHealthReadyHandler`.
 
 ### JSON envelope
 
-```
+```text
 {
   "name":    "influxdb",          // constant
   "status":  "pass" | "fail",     // aggregate over all health checks

--- a/HEALTH_READY.md
+++ b/HEALTH_READY.md
@@ -578,10 +578,12 @@ the 1-second probe loop cannot run. Look at `iostat`, `dmesg`, and the
 ```
 
 **Meaning:** The task scheduler's next-run timestamp is more than 30
-seconds behind wall clock — its dispatch loop fired a timer but never
-advanced. Look for blocked goroutines in the scheduler (use the runtime
-profile or stack dump). If this fires only at boot and clears within a
-few seconds, it is likely a cold-start dispatch and not a real wedge.
+seconds behind wall clock. Its dispatch loop fired a timer but never
+advanced. If this fires only at boot and clears within a few seconds,
+it's likely a cold-start dispatch and not a real wedge.
+
+**Action:** Look for blocked goroutines in the scheduler using the
+runtime profile or a stack dump.
 
 ### `/health` 503 — sqlite not open
 

--- a/HEALTH_READY.md
+++ b/HEALTH_READY.md
@@ -398,21 +398,33 @@ transient failures.
 
 ### curl examples
 
-Probe `/ready` and `/health` and inspect the body:
+Probe `/ready` and inspect the response--for example:
 
+```sh
+curl -sS -o body.json -w '%{http_code}\n' http://localhost:8086/ready
 ```
-$ curl -sS -o body.json -w '%{http_code}\n' http://localhost:8086/ready
-200
-$ jq . body.json
+
+The command prints the HTTP status code to stdout and writes the
+response body to `body.json`. A ready instance returns `200` and the
+following body:
+
+```json
 {
   "status": "ready",
   "started": "2026-05-26T15:42:30.123456789Z",
   "up": "1m32.4s"
 }
+```
 
-$ curl -sS -o body.json -w '%{http_code}\n' http://localhost:8086/health
-200
-$ jq . body.json
+Probe `/health` the same way:
+
+```sh
+curl -sS -o body.json -w '%{http_code}\n' http://localhost:8086/health
+```
+
+A healthy instance returns `200` and a body that lists each check:
+
+```json
 {
   "name": "influxdb",
   "status": "pass",

--- a/HEALTH_READY.md
+++ b/HEALTH_READY.md
@@ -509,10 +509,12 @@ For each scenario below, the JSON snippet is the relevant portion of the
 ```
 
 **Meaning:** Normal startup. The engine has enumerated 200 shards and 94
-have finished opening. Wait — the percentage updates each time another
-shard completes. If the percentage stops climbing, check `influxd` logs
-for `Finished loading shard` lines; whichever shard is currently in
-flight is logged when it completes.
+have finished opening. The percentage updates each time another shard
+completes.
+
+**Action:** Wait for loading to finish. If the percentage stops climbing,
+check `influxd` logs for `Finished loading shard` lines. The shard
+currently in flight is logged when it completes.
 
 ### `/ready` 503 — shards enumeration not yet started
 

--- a/HEALTH_READY.md
+++ b/HEALTH_READY.md
@@ -38,7 +38,7 @@ This pre-API 503 is byte-exact (pinned by
 | any other path (pre-API)        | any     | —               | `"starting"`      |
 
 Trailing slashes are accepted on both endpoints. Query parameters are
-ignored — `/health?cachebust=1` is matched as `/health`.
+ignored--for example, `/health?cachebust=1` is matched as `/health`.
 
 Path constants are defined in `http/handler.go` as `HealthPath` and
 `ReadyPath`.

--- a/HEALTH_READY.md
+++ b/HEALTH_READY.md
@@ -234,7 +234,7 @@ Reports the accumulated shard-load errors observed during engine
 startup. `"pass"` until at least one shard fails to load; thereafter
 `"fail"` with a message of the form:
 
-```
+```text
 <n> shard(s) failed to load: shard <id>: <err>; shard <id>: <err>; ...
 ```
 

--- a/HEALTH_READY.md
+++ b/HEALTH_READY.md
@@ -624,10 +624,11 @@ Check `influxd` logs for the underlying error.
 }
 ```
 
-**Meaning:** `db.PingContext` did not return within the 500ms probe
-deadline, or returned an I/O error. Check disk health on the SQLite
-database file and whether another process is holding a long-running
-write transaction.
+**Meaning:** `db.PingContext` didn't return within the 500ms probe
+deadline, or it returned an I/O error.
+
+**Action:** Check disk health on the SQLite database file and whether
+another process is holding a long-running write transaction.
 
 ### `/health` 503 — accumulated shard load failures
 

--- a/HEALTH_READY.md
+++ b/HEALTH_READY.md
@@ -390,11 +390,11 @@ Use `/health`:
   scheduler, a shard load failure that occurred after startup
   completed).
 
-Key behavioral difference: once a `/ready` gate has been signaled
-`Ready()`, it does not transition back to `"fail"` unless the launcher
-calls `Unready()` (shutdown). So `/ready` will not flap during normal
-operation. `/health` is recomputed on every request and **will** reflect
-transient failures.
+> [!IMPORTANT]
+> Once a `/ready` gate has been signaled `Ready()`, it does not transition
+> back to `"fail"` unless the launcher calls `Unready()` (shutdown). So
+> `/ready` will not flap during normal operation. `/health` is recomputed
+> on every request and **will** reflect transient failures.
 
 ### curl examples
 

--- a/HEALTH_READY.md
+++ b/HEALTH_READY.md
@@ -527,10 +527,11 @@ currently in flight is logged when it completes.
 }
 ```
 
-**Meaning:** The engine has not yet begun calling `AddShard`. Either the
-engine is still in early initialization (look for the `engine` gate also
-failing with `"not ready"`) or the engine is blocked before
-enumeration. Check logs for engine open progress.
+**Meaning:** The engine hasn't yet begun calling `AddShard`. The engine
+is either still in early initialization or blocked before enumeration.
+
+**Action:** Look for the `engine` gate also failing with `"not ready"`,
+which indicates early initialization. Check logs for engine open progress.
 
 ### `/ready` 503 — terminal shard load failure
 

--- a/HEALTH_READY.md
+++ b/HEALTH_READY.md
@@ -74,7 +74,7 @@ Source: `http/check_handler.go`, `NewHealthReadyHandler`.
 
 Each entry in `checks` is:
 
-```
+```text
 {
   "name":    "<check name>",      // always present
   "status":  "pass" | "fail",     // always present


### PR DESCRIPTION
Added documentation file for /health and /ready endpoints
as implemented by https://github.com/influxdata/influxdb/pull/27370