### PR TITLE
feat: add statistics and adaptive growth to TagValueSeriesIDCache

### DIFF
--- a/etc/config.sample.toml
+++ b/etc/config.sample.toml
@@ -200,9 +200,12 @@
   # when observed evictions are below mean - conservatism*sigma, so higher
   # values demand a wider statistical margin before shrinking. The valid
   # range is [0.0, +Inf): 0.0 admits at the median (50% of at-target windows
-  # shrink); 2.0 admits in about 2.3% of at-target windows. The default 2.0
-  # is conservative (memory-retaining; resistant to grow/shrink oscillation).
-  # series-id-set-cache-shrink-conservatism = 2.0
+  # shrink); 2.5 admits in about 0.62% of at-target windows. The default 2.5
+  # is conservative (memory-retaining; resistant to grow/shrink oscillation)
+  # and adds extra margin for workloads with high access skew, where the true
+  # eviction-count distribution is wider than the independent-Bernoulli
+  # approximation underlying the bound.
+  # series-id-set-cache-shrink-conservatism = 2.5
 
   # The size of tar buffer window size in bytes while running tar
   # streaming operations such as renaming and copying tar files during backups.

--- a/etc/config.sample.toml
+++ b/etc/config.sample.toml
@@ -168,12 +168,14 @@
   series-id-set-cache-size = 100
 
   # Adaptive sizing for the TSI series-id-set cache. When enabled, the cache
-  # starts at series-id-set-cache-size and grows (doubling) up to
-  # series-id-set-cache-max-size whenever its observed query hit rate falls
-  # below series-id-set-cache-target-hit-rate while it is evicting. The cache
-  # never shrinks. Adaptive sizing trades higher heap usage for fewer cache
-  # misses on workloads whose working set of tag key/value predicates exceeds
-  # series-id-set-cache-size.
+  # sizes itself between series-id-set-cache-size and series-id-set-cache-max-size
+  # as the workload changes. It grows (doubling) up to the max whenever its
+  # observed query hit rate falls below series-id-set-cache-target-hit-rate while
+  # it is evicting, and shrinks back toward series-id-set-cache-size when the
+  # working set contracts (it reclaims heap by dropping entries that go unused),
+  # so heap usage tracks the active working set rather than the historical peak.
+  # Adaptive sizing trades higher heap usage for fewer cache misses on workloads
+  # whose working set of tag key/value predicates exceeds series-id-set-cache-size.
   #
   # Both settings must be specified together to enable adaptive sizing, or both
   # left at 0 to disable it (the default). When enabled,
@@ -190,6 +192,17 @@
   # rate is met or series-id-set-cache-max-size is reached. A value of 0.0
   # disables adaptive sizing; a value of 1.0 is rejected (unachievable).
   # series-id-set-cache-target-hit-rate = 0.0
+
+  # How conservative the adaptive shrink policy should be, in standard
+  # deviations below the at-target eviction count's mean. The eviction count
+  # over a window of m Gets at hit rate T is approximately Binomial(m, 1-T),
+  # with mean m*(1-T) and variance m*T*(1-T); the shrink gate admits only
+  # when observed evictions are below mean - conservatism*sigma, so higher
+  # values demand a wider statistical margin before shrinking. The valid
+  # range is [0.0, +Inf): 0.0 admits at the median (50% of at-target windows
+  # shrink); 2.0 admits in about 2.3% of at-target windows. The default 2.0
+  # is conservative (memory-retaining; resistant to grow/shrink oscillation).
+  # series-id-set-cache-shrink-conservatism = 2.0
 
   # The size of tar buffer window size in bytes while running tar
   # streaming operations such as renaming and copying tar files during backups.

--- a/etc/config.sample.toml
+++ b/etc/config.sample.toml
@@ -167,6 +167,29 @@
   # increase in cache size may lead to an increase in heap usage.
   series-id-set-cache-size = 100
 
+  # Adaptive sizing for the TSI series-id-set cache. When enabled, the cache
+  # starts at series-id-set-cache-size and grows (doubling) up to
+  # series-id-set-cache-max-size whenever its observed query hit rate falls
+  # below series-id-set-cache-target-hit-rate while it is evicting. The cache
+  # never shrinks. Adaptive sizing trades higher heap usage for fewer cache
+  # misses on workloads whose working set of tag key/value predicates exceeds
+  # series-id-set-cache-size.
+  #
+  # Both settings must be specified together to enable adaptive sizing, or both
+  # left at 0 to disable it (the default). When enabled,
+  # series-id-set-cache-size must be > 0 and series-id-set-cache-max-size must
+  # be >= series-id-set-cache-size.
+
+  # The upper bound on adaptive growth of the series-id-set cache. A value of 0
+  # disables adaptive sizing.
+  # series-id-set-cache-max-size = 0
+
+  # The desired query hit rate for the series-id-set cache, expressed as a
+  # fraction in (0.0, 1.0]. The cache grows adaptively until either this hit
+  # rate is met or series-id-set-cache-max-size is reached. A value of 0.0
+  # disables adaptive sizing.
+  # series-id-set-cache-target-hit-rate = 0.0
+
   # The size of tar buffer window size in bytes while running tar
   # streaming operations such as renaming and copying tar files during backups.
   # The default value is 1MB. This should only change if backups are having performance issues

--- a/etc/config.sample.toml
+++ b/etc/config.sample.toml
@@ -178,7 +178,8 @@
   # Both settings must be specified together to enable adaptive sizing, or both
   # left at 0 to disable it (the default). When enabled,
   # series-id-set-cache-size must be > 0 and series-id-set-cache-max-size must
-  # be >= series-id-set-cache-size.
+  # be > series-id-set-cache-size (a cache that cannot grow is just a fixed
+  # cache; set only series-id-set-cache-size for that).
 
   # The upper bound on adaptive growth of the series-id-set cache. A value of 0
   # disables adaptive sizing.

--- a/etc/config.sample.toml
+++ b/etc/config.sample.toml
@@ -186,9 +186,9 @@
   # series-id-set-cache-max-size = 0
 
   # The desired query hit rate for the series-id-set cache, expressed as a
-  # fraction in (0.0, 1.0]. The cache grows adaptively until either this hit
+  # fraction in (0.0, 1.0). The cache grows adaptively until either this hit
   # rate is met or series-id-set-cache-max-size is reached. A value of 0.0
-  # disables adaptive sizing.
+  # disables adaptive sizing; a value of 1.0 is rejected (unachievable).
   # series-id-set-cache-target-hit-rate = 0.0
 
   # The size of tar buffer window size in bytes while running tar

--- a/tests/server_adaptive_cache_test.go
+++ b/tests/server_adaptive_cache_test.go
@@ -1,0 +1,196 @@
+package tests
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/influxdata/influxdb/tsdb"
+	"github.com/stretchr/testify/require"
+)
+
+// TestServer_AdaptiveTSICache_GrowAndShrink exercises the adaptive TSI tag-value
+// series-ID cache end to end through the real write + query path, starting from
+// the default initial cache size and driving repeated growth and shrinkage with
+// high-cardinality data. Behavior is verified through the operator-facing
+// SHOW STATS surface (the tsi1_cache measurement, including the capacity and
+// shrink_eviction fields this feature adds).
+//
+// The cache is a tsi1-only feature that must be enabled via config, so the test
+// configures and runs its own in-process server; it skips on inmem, remote
+// servers, and -short.
+func TestServer_AdaptiveTSICache_GrowAndShrink(t *testing.T) {
+	t.Parallel()
+
+	if RemoteEnabled() {
+		t.Skip("Skipping. Needs an in-process server configured with the adaptive cache")
+	}
+	if indexType != tsdb.TSI1IndexName {
+		t.Skip("Skipping. Adaptive TSI series-ID cache is a tsi1-only feature")
+	}
+	if testing.Short() {
+		t.Skip("Skipping in short mode")
+	}
+
+	const (
+		// N distinct host tag values. N must comfortably exceed maxCap so the
+		// working set never fits the cache and capacity pins at the max during
+		// growth.
+		N = 2000
+
+		floorCap = 100 // initial cache size == floor (minCapacity)
+		maxCap   = 800 // capacity doubles 100 -> 200 -> 400 -> 800
+
+		// Growth driver. /.+/ matches every host but NOT the empty string, so it
+		// routes to matchTagValueEqualNotEmptySeriesIDIterator, which does one
+		// cache Get/Put per matching tag value (driving misses and evictions).
+		// NOTE: /.*/ matches the empty string and would route to the
+		// equal-empty path, which skips the per-value cache entirely -- it would
+		// silently never exercise the cache. Do not use /.*/ here.
+		growthQuery = `SELECT count(value) FROM db0.rp0.cpu WHERE host =~ /.+/`
+
+		// Shrink driver. The highest-sorted hosts (server001950..server001999)
+		// are the most-recently-Put values and are therefore guaranteed resident
+		// after growth, so every Get is a pure hit (no forced evictions in the
+		// shrink window). 50 values is well under floorCap, so the warm set stays
+		// pinned at the front of the LRU and the untouched cold tail is shed.
+		warmQuery = `SELECT count(value) FROM db0.rp0.cpu WHERE host =~ /server0019[5-9][0-9]/`
+	)
+
+	c := NewConfig()
+	c.Data.SeriesIDSetCacheSize = floorCap          // default small initial size
+	c.Data.SeriesIDSetCacheMaxSize = maxCap         // enables adaptive sizing
+	c.Data.SeriesIDSetCacheTargetHitRate = 0.5      // keeps adaptive windows ~= occupancy
+	c.Data.SeriesIDSetCacheShrinkConservatism = 2.5 // default; not relied upon (windows are pure-hit)
+	require.NoError(t, c.Data.Validate(), "adaptive cache config must validate")
+
+	s := OpenDefaultServer(c)
+	defer s.Close()
+
+	// Write N high-cardinality series at a single timestamp so all points land
+	// in one shard (one cache). Zero-pad host numbers so lexical order matches
+	// numeric order, which is what makes the warm-set choice above deterministic.
+	ts := mustParseTime(time.RFC3339Nano, "2000-01-01T00:00:00Z").UnixNano()
+	var buf bytes.Buffer
+	for i := 0; i < N; i++ {
+		fmt.Fprintf(&buf, "cpu,host=server%06d value=100 %d\n", i, ts)
+	}
+	s.MustWrite("db0", "rp0", buf.String(), nil)
+
+	// Sanity: a single shard means a single tsi1_cache, so the stat deltas below
+	// describe one cache rather than an aggregate of several.
+	require.Len(t, s.(*LocalServer).Server.TSDBStore.ShardIDs(), 1,
+		"all writes should land in a single shard")
+
+	// Two grow->shrink cycles demonstrate repeated growth and shrinkage. Each
+	// cycle captures the cumulative eviction/shrink_eviction counters at its
+	// start and asserts the per-cycle delta is positive.
+	for cycle := 0; cycle < 2; cycle++ {
+		// ---- GROWTH ----
+		capBefore, _, hitBefore, missBefore, evBefore, _ := tsiCacheStats(t, s)
+
+		for i := 0; i < 3; i++ {
+			_, err := s.Query(growthQuery)
+			require.NoErrorf(t, err, "cycle %d: growth query", cycle)
+		}
+
+		peakCap, _, hitAfter, missAfter, evAfter, _ := tsiCacheStats(t, s)
+
+		// Prove the cache was actually exercised before trusting capacity moves;
+		// this fails loudly if the query ever stops pushing the tag predicate
+		// down to the tag-value cache.
+		require.Greaterf(t, hitAfter+missAfter, hitBefore+missBefore,
+			"cycle %d: cache must be exercised (hits+misses should increase)", cycle)
+		require.Greaterf(t, peakCap, capBefore,
+			"cycle %d: capacity should grow above %d", cycle, capBefore)
+		require.LessOrEqualf(t, peakCap, int64(maxCap),
+			"cycle %d: capacity must not exceed the configured max", cycle)
+		require.Greaterf(t, evAfter, evBefore,
+			"cycle %d: forced evictions should increase", cycle)
+		require.Greaterf(t, missAfter, missBefore,
+			"cycle %d: cache misses should increase", cycle)
+
+		// ---- SHRINK (poll until observed) ----
+		// A shrink needs a full window of pure-hit Gets to elapse after the
+		// post-grow cooldown drains. The exact number of Gets the planner issues
+		// per query is not predictable, so poll until the capacity drops and a
+		// shrink eviction is recorded, rather than hard-coding counts. Warm
+		// queries are batched between SHOW STATS reads because each SHOW STATS
+		// recomputes database cardinality.
+		_, _, _, _, _, shrinkBefore := tsiCacheStats(t, s)
+
+		var capNow, shrinkNow int64
+		const maxBatches = 200
+		for batch := 0; batch < maxBatches; batch++ {
+			for i := 0; i < 20; i++ {
+				_, err := s.Query(warmQuery)
+				require.NoErrorf(t, err, "cycle %d: warm query", cycle)
+			}
+			capNow, _, _, _, _, shrinkNow = tsiCacheStats(t, s)
+			if capNow < peakCap && shrinkNow > shrinkBefore {
+				break
+			}
+		}
+
+		require.Lessf(t, capNow, peakCap,
+			"cycle %d: capacity should shrink below the grown peak %d", cycle, peakCap)
+		require.GreaterOrEqualf(t, capNow, int64(floorCap),
+			"cycle %d: capacity must not drop below the floor", cycle)
+		require.Greaterf(t, shrinkNow, shrinkBefore,
+			"cycle %d: shrink_eviction should increase", cycle)
+	}
+}
+
+// tsiCacheStats runs SHOW STATS and returns the aggregated tsi1_cache counters.
+// Rows are summed across shards (one is expected). The measurement and field
+// names are hardcoded because they are unexported in package tsi1. JSON numbers
+// decode into interface{} as float64, so they are coerced back to int64.
+func tsiCacheStats(t *testing.T, s Server) (capacity, size, hit, miss, evict, shrinkEvict int64) {
+	t.Helper()
+
+	raw, err := s.Query("SHOW STATS")
+	require.NoError(t, err)
+
+	var resp struct {
+		Results []struct {
+			Series []struct {
+				Name    string          `json:"name"`
+				Columns []string        `json:"columns"`
+				Values  [][]interface{} `json:"values"`
+			} `json:"series"`
+		} `json:"results"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(raw), &resp))
+
+	field := func(cols []string, row []interface{}, name string) int64 {
+		for i, c := range cols {
+			if c == name && i < len(row) {
+				if f, ok := row[i].(float64); ok {
+					return int64(f)
+				}
+			}
+		}
+		return 0
+	}
+
+	var found bool
+	for _, res := range resp.Results {
+		for _, ser := range res.Series {
+			if ser.Name != "tsi1_cache" || len(ser.Values) == 0 {
+				continue
+			}
+			found = true
+			row := ser.Values[0]
+			capacity += field(ser.Columns, row, "capacity")
+			size += field(ser.Columns, row, "size")
+			hit += field(ser.Columns, row, "hit")
+			miss += field(ser.Columns, row, "miss")
+			evict += field(ser.Columns, row, "eviction")
+			shrinkEvict += field(ser.Columns, row, "shrink_eviction")
+		}
+	}
+	require.True(t, found, "SHOW STATS did not surface a tsi1_cache row")
+	return
+}

--- a/tsdb/config.go
+++ b/tsdb/config.go
@@ -101,7 +101,7 @@ const (
 // rather than duplicating the message text.
 var (
 	ErrSeriesIDSetCacheMaxSizeNegative      = errors.New("series-id-set-cache-max-size must be non-negative")
-	ErrSeriesIDSetCacheTargetHitRateRange   = errors.New("series-id-set-cache-target-hit-rate must be in [0.0, 1.0]")
+	ErrSeriesIDSetCacheTargetHitRateRange   = errors.New("series-id-set-cache-target-hit-rate must be in [0.0, 1.0)")
 	ErrAdaptiveCacheSizingPairing           = errors.New("series-id-set-cache-max-size and series-id-set-cache-target-hit-rate must both be set to enable adaptive cache sizing, or both be zero to disable it")
 	ErrAdaptiveCacheSizingRequiresCacheSize = errors.New("series-id-set-cache-size must be > 0 to use adaptive cache sizing")
 	ErrAdaptiveCacheMaxSizeTooSmall         = errors.New("series-id-set-cache-max-size must be > series-id-set-cache-size")
@@ -202,10 +202,12 @@ type Config struct {
 	SeriesIDSetCacheMaxSize int `toml:"series-id-set-cache-max-size"`
 
 	// SeriesIDSetCacheTargetHitRate is the desired Get hit rate for the
-	// TSI series-id-set cache, expressed as a fraction in (0.0, 1.0].
+	// TSI series-id-set cache, expressed as a fraction in (0.0, 1.0).
 	// When set together with SeriesIDSetCacheMaxSize, the cache grows
 	// adaptively until either the target rate is met or the max size is
-	// reached. A value of 0.0 disables adaptive sizing.
+	// reached. A value of 0.0 disables adaptive sizing. A value of 1.0 is
+	// rejected: it is unachievable (the cache would never stop growing or
+	// shrinking toward it).
 	SeriesIDSetCacheTargetHitRate float64 `toml:"series-id-set-cache-target-hit-rate"`
 
 	// SeriesFileMaxConcurrentSnapshotCompactions is the maximum number of concurrent snapshot compactions
@@ -286,7 +288,7 @@ func (c *Config) Validate() error {
 	if c.SeriesIDSetCacheMaxSize < 0 {
 		return ErrSeriesIDSetCacheMaxSizeNegative
 	}
-	if c.SeriesIDSetCacheTargetHitRate < 0 || c.SeriesIDSetCacheTargetHitRate > 1 {
+	if c.SeriesIDSetCacheTargetHitRate < 0 || c.SeriesIDSetCacheTargetHitRate >= 1 {
 		return ErrSeriesIDSetCacheTargetHitRateRange
 	}
 	adaptiveMax := c.SeriesIDSetCacheMaxSize > 0

--- a/tsdb/config.go
+++ b/tsdb/config.go
@@ -96,6 +96,17 @@ const (
 	DefaultTarStreamBufferSize = toml.SSize(1024 * 1024) // 1MB
 )
 
+// Validation errors returned by Config.Validate for the TSI series-id-set
+// cache settings. Exported so tests can assert on them with errors.Is
+// rather than duplicating the message text.
+var (
+	ErrSeriesIDSetCacheMaxSizeNegative      = errors.New("series-id-set-cache-max-size must be non-negative")
+	ErrSeriesIDSetCacheTargetHitRateRange   = errors.New("series-id-set-cache-target-hit-rate must be in [0.0, 1.0]")
+	ErrAdaptiveCacheSizingPairing           = errors.New("series-id-set-cache-max-size and series-id-set-cache-target-hit-rate must both be set to enable adaptive cache sizing, or both be zero to disable it")
+	ErrAdaptiveCacheSizingRequiresCacheSize = errors.New("series-id-set-cache-size must be > 0 to use adaptive cache sizing")
+	ErrAdaptiveCacheMaxSizeTooSmall         = errors.New("series-id-set-cache-max-size must be > series-id-set-cache-size")
+)
+
 var SingleGenerationReasonText string = SingleGenerationReason()
 
 // SingleGenerationReason outputs a log message for our single generation compaction
@@ -273,22 +284,22 @@ func (c *Config) Validate() error {
 	}
 
 	if c.SeriesIDSetCacheMaxSize < 0 {
-		return errors.New("series-id-set-cache-max-size must be non-negative")
+		return ErrSeriesIDSetCacheMaxSizeNegative
 	}
 	if c.SeriesIDSetCacheTargetHitRate < 0 || c.SeriesIDSetCacheTargetHitRate > 1 {
-		return errors.New("series-id-set-cache-target-hit-rate must be in [0.0, 1.0]")
+		return ErrSeriesIDSetCacheTargetHitRateRange
 	}
 	adaptiveMax := c.SeriesIDSetCacheMaxSize > 0
 	adaptiveTarget := c.SeriesIDSetCacheTargetHitRate > 0
 	if adaptiveMax != adaptiveTarget {
-		return errors.New("series-id-set-cache-max-size and series-id-set-cache-target-hit-rate must both be set to enable adaptive cache sizing, or both be zero to disable it")
+		return ErrAdaptiveCacheSizingPairing
 	}
 	if adaptiveMax {
 		if c.SeriesIDSetCacheSize <= 0 {
-			return errors.New("series-id-set-cache-size must be > 0 to use adaptive cache sizing")
+			return ErrAdaptiveCacheSizingRequiresCacheSize
 		}
-		if c.SeriesIDSetCacheMaxSize < c.SeriesIDSetCacheSize {
-			return errors.New("series-id-set-cache-max-size must be >= series-id-set-cache-size")
+		if c.SeriesIDSetCacheMaxSize <= c.SeriesIDSetCacheSize {
+			return ErrAdaptiveCacheMaxSizeTooSmall
 		}
 	}
 

--- a/tsdb/config.go
+++ b/tsdb/config.go
@@ -77,6 +77,12 @@ const (
 	// DefaultSeriesIDSetCacheSize is the default number of series ID sets to cache in the TSI index.
 	DefaultSeriesIDSetCacheSize = 100
 
+	// DefaultAdaptiveCacheMinSamples is the default floor on the number of
+	// Get operations observed in a single adaptive-sizing window before the
+	// policy is allowed to act on the measured hit rate. Below this floor
+	// the rate is treated as too noisy to react to.
+	DefaultAdaptiveCacheMinSamples = 100
+
 	// DefaultSeriesFileMaxConcurrentSnapshotCompactions is the maximum number of concurrent series
 	// partition snapshot compactions that can run at one time.
 	// A value of 0 results in runtime.GOMAXPROCS(0).
@@ -176,6 +182,21 @@ type Config struct {
 	// Setting series-id-set-cache-size to 0 disables the cache.
 	SeriesIDSetCacheSize int `toml:"series-id-set-cache-size"`
 
+	// SeriesIDSetCacheMaxSize is the upper bound on adaptive growth of the
+	// TSI series-id-set cache. When set to a value greater than
+	// SeriesIDSetCacheSize and SeriesIDSetCacheTargetHitRate is also set,
+	// the cache will grow (doubling) past its initial size up to this
+	// ceiling whenever the observed hit rate falls below the target while
+	// the cache is evicting. A value of 0 disables adaptive sizing.
+	SeriesIDSetCacheMaxSize int `toml:"series-id-set-cache-max-size"`
+
+	// SeriesIDSetCacheTargetHitRate is the desired Get hit rate for the
+	// TSI series-id-set cache, expressed as a fraction in (0.0, 1.0].
+	// When set together with SeriesIDSetCacheMaxSize, the cache grows
+	// adaptively until either the target rate is met or the max size is
+	// reached. A value of 0.0 disables adaptive sizing.
+	SeriesIDSetCacheTargetHitRate float64 `toml:"series-id-set-cache-target-hit-rate"`
+
 	// SeriesFileMaxConcurrentSnapshotCompactions is the maximum number of concurrent snapshot compactions
 	// that can be running at one time across all series partitions in a database. Snapshots scheduled
 	// to run when the limit is reached are blocked until a running snaphsot completes.  Only snapshot
@@ -249,6 +270,26 @@ func (c *Config) Validate() error {
 
 	if c.SeriesIDSetCacheSize < 0 {
 		return errors.New("series-id-set-cache-size must be non-negative")
+	}
+
+	if c.SeriesIDSetCacheMaxSize < 0 {
+		return errors.New("series-id-set-cache-max-size must be non-negative")
+	}
+	if c.SeriesIDSetCacheTargetHitRate < 0 || c.SeriesIDSetCacheTargetHitRate > 1 {
+		return errors.New("series-id-set-cache-target-hit-rate must be in [0.0, 1.0]")
+	}
+	adaptiveMax := c.SeriesIDSetCacheMaxSize > 0
+	adaptiveTarget := c.SeriesIDSetCacheTargetHitRate > 0
+	if adaptiveMax != adaptiveTarget {
+		return errors.New("series-id-set-cache-max-size and series-id-set-cache-target-hit-rate must both be set to enable adaptive cache sizing, or both be zero to disable it")
+	}
+	if adaptiveMax {
+		if c.SeriesIDSetCacheSize <= 0 {
+			return errors.New("series-id-set-cache-size must be > 0 to use adaptive cache sizing")
+		}
+		if c.SeriesIDSetCacheMaxSize < c.SeriesIDSetCacheSize {
+			return errors.New("series-id-set-cache-max-size must be >= series-id-set-cache-size")
+		}
 	}
 
 	if c.SeriesFileMaxConcurrentSnapshotCompactions < 0 {

--- a/tsdb/config.go
+++ b/tsdb/config.go
@@ -88,9 +88,14 @@ const (
 	// deviations below the at-target eviction count's mean at which the shrink
 	// eviction gate sits. Values >= 0.0 (the validated range) demand the cache
 	// outperform target by that statistical margin before any shrink fires;
-	// higher values are more conservative. 2.0 is the default: shrink admits in
-	// roughly 2.3% of windows in which the cache is exactly at target.
-	DefaultSeriesIDSetCacheShrinkConservatism = 2.0
+	// higher values are more conservative. 2.5 is the default: shrink admits in
+	// roughly 0.62% of windows in which the cache is exactly at target. The
+	// extra margin over the 2.0σ choice (~2.3%) covers the fact that real cache
+	// access is correlated (locality, Zipfian skew) so the at-target eviction
+	// distribution is wider than the independent-Bernoulli approximation; the
+	// conservative default trades a bit of memory for fewer false-positive
+	// shrinks on skewed workloads.
+	DefaultSeriesIDSetCacheShrinkConservatism = 2.5
 
 	// DefaultSeriesFileMaxConcurrentSnapshotCompactions is the maximum number of concurrent series
 	// partition snapshot compactions that can run at one time.
@@ -228,8 +233,10 @@ type Config struct {
 	// gate admits shrink when observed evictions are below μ − conservatism·σ.
 	// Values >= 0.0 are accepted; higher values demand a wider statistical margin
 	// before shrinking (more memory-retaining, more anti-oscillation). The
-	// default is DefaultSeriesIDSetCacheShrinkConservatism (2.0). Validation
-	// rejects NaN, ±Inf, and values < 0.0.
+	// default is DefaultSeriesIDSetCacheShrinkConservatism (2.5) — conservative
+	// because the binomial model assumes independent misses, while real cache
+	// access is correlated, so the true at-target distribution is wider than σ
+	// here. Validation rejects NaN, ±Inf, and values < 0.0.
 	SeriesIDSetCacheShrinkConservatism float64 `toml:"series-id-set-cache-shrink-conservatism"`
 
 	// SeriesFileMaxConcurrentSnapshotCompactions is the maximum number of concurrent snapshot compactions

--- a/tsdb/config.go
+++ b/tsdb/config.go
@@ -3,6 +3,7 @@ package tsdb
 import (
 	"errors"
 	"fmt"
+	"math"
 	"time"
 
 	"github.com/influxdata/influxdb/monitor/diagnostics"
@@ -83,6 +84,14 @@ const (
 	// the rate is treated as too noisy to react to.
 	DefaultAdaptiveCacheMinSamples = 100
 
+	// DefaultSeriesIDSetCacheShrinkConservatism is the default number of standard
+	// deviations below the at-target eviction count's mean at which the shrink
+	// eviction gate sits. Values >= 0.0 (the validated range) demand the cache
+	// outperform target by that statistical margin before any shrink fires;
+	// higher values are more conservative. 2.0 is the default: shrink admits in
+	// roughly 2.3% of windows in which the cache is exactly at target.
+	DefaultSeriesIDSetCacheShrinkConservatism = 2.0
+
 	// DefaultSeriesFileMaxConcurrentSnapshotCompactions is the maximum number of concurrent series
 	// partition snapshot compactions that can run at one time.
 	// A value of 0 results in runtime.GOMAXPROCS(0).
@@ -100,11 +109,12 @@ const (
 // cache settings. Exported so tests can assert on them with errors.Is
 // rather than duplicating the message text.
 var (
-	ErrSeriesIDSetCacheMaxSizeNegative      = errors.New("series-id-set-cache-max-size must be non-negative")
-	ErrSeriesIDSetCacheTargetHitRateRange   = errors.New("series-id-set-cache-target-hit-rate must be in [0.0, 1.0)")
-	ErrAdaptiveCacheSizingPairing           = errors.New("series-id-set-cache-max-size and series-id-set-cache-target-hit-rate must both be set to enable adaptive cache sizing, or both be zero to disable it")
-	ErrAdaptiveCacheSizingRequiresCacheSize = errors.New("series-id-set-cache-size must be > 0 to use adaptive cache sizing")
-	ErrAdaptiveCacheMaxSizeTooSmall         = errors.New("series-id-set-cache-max-size must be > series-id-set-cache-size")
+	ErrSeriesIDSetCacheMaxSizeNegative         = errors.New("series-id-set-cache-max-size must be non-negative")
+	ErrSeriesIDSetCacheTargetHitRateRange      = errors.New("series-id-set-cache-target-hit-rate must be in [0.0, 1.0)")
+	ErrAdaptiveCacheSizingPairing              = errors.New("series-id-set-cache-max-size and series-id-set-cache-target-hit-rate must both be set to enable adaptive cache sizing, or both be zero to disable it")
+	ErrAdaptiveCacheSizingRequiresCacheSize    = errors.New("series-id-set-cache-size must be > 0 to use adaptive cache sizing")
+	ErrAdaptiveCacheMaxSizeTooSmall            = errors.New("series-id-set-cache-max-size must be > series-id-set-cache-size")
+	ErrSeriesIDSetCacheShrinkConservatismRange = errors.New("series-id-set-cache-shrink-conservatism must be a finite value >= 0.0")
 )
 
 var SingleGenerationReasonText string = SingleGenerationReason()
@@ -210,6 +220,18 @@ type Config struct {
 	// shrinking toward it).
 	SeriesIDSetCacheTargetHitRate float64 `toml:"series-id-set-cache-target-hit-rate"`
 
+	// SeriesIDSetCacheShrinkConservatism sets the TSI series-id-set cache's
+	// adaptive shrink-gate strictness, expressed as the number of standard
+	// deviations below the at-target eviction count's mean at which the gate
+	// sits. The eviction count over an m-Get window at hit rate T is approximately
+	// Binomial(m, 1-T) with mean μ = m·(1-T) and variance σ² = m·T·(1-T); the
+	// gate admits shrink when observed evictions are below μ − conservatism·σ.
+	// Values >= 0.0 are accepted; higher values demand a wider statistical margin
+	// before shrinking (more memory-retaining, more anti-oscillation). The
+	// default is DefaultSeriesIDSetCacheShrinkConservatism (2.0). Validation
+	// rejects NaN, ±Inf, and values < 0.0.
+	SeriesIDSetCacheShrinkConservatism float64 `toml:"series-id-set-cache-shrink-conservatism"`
+
 	// SeriesFileMaxConcurrentSnapshotCompactions is the maximum number of concurrent snapshot compactions
 	// that can be running at one time across all series partitions in a database. Snapshots scheduled
 	// to run when the limit is reached are blocked until a running snaphsot completes.  Only snapshot
@@ -253,8 +275,9 @@ func NewConfig() Config {
 		MaxConcurrentCompactions: DefaultMaxConcurrentCompactions,
 		MaxConcurrentDeletes:     DefaultMaxConcurrentDeletes,
 
-		MaxIndexLogFileSize:  toml.Size(DefaultMaxIndexLogFileSize),
-		SeriesIDSetCacheSize: DefaultSeriesIDSetCacheSize,
+		MaxIndexLogFileSize:                toml.Size(DefaultMaxIndexLogFileSize),
+		SeriesIDSetCacheSize:               DefaultSeriesIDSetCacheSize,
+		SeriesIDSetCacheShrinkConservatism: DefaultSeriesIDSetCacheShrinkConservatism,
 
 		SeriesFileMaxConcurrentSnapshotCompactions: DefaultSeriesFileMaxConcurrentSnapshotCompactions,
 
@@ -288,7 +311,9 @@ func (c *Config) Validate() error {
 	if c.SeriesIDSetCacheMaxSize < 0 {
 		return ErrSeriesIDSetCacheMaxSizeNegative
 	}
-	if c.SeriesIDSetCacheTargetHitRate < 0 || c.SeriesIDSetCacheTargetHitRate >= 1 {
+	// Positive range test so NaN (for which both `<` and `>=` are false) is
+	// rejected rather than passing as if in range.
+	if !(c.SeriesIDSetCacheTargetHitRate >= 0 && c.SeriesIDSetCacheTargetHitRate < 1) {
 		return ErrSeriesIDSetCacheTargetHitRateRange
 	}
 	adaptiveMax := c.SeriesIDSetCacheMaxSize > 0
@@ -303,6 +328,11 @@ func (c *Config) Validate() error {
 		if c.SeriesIDSetCacheMaxSize <= c.SeriesIDSetCacheSize {
 			return ErrAdaptiveCacheMaxSizeTooSmall
 		}
+	}
+	// Positive-form check so NaN and ±Inf are both rejected (each comparison is
+	// false for NaN; +Inf fails the upper bound; -Inf fails the lower bound).
+	if !(c.SeriesIDSetCacheShrinkConservatism >= 0 && c.SeriesIDSetCacheShrinkConservatism < math.Inf(1)) {
+		return ErrSeriesIDSetCacheShrinkConservatismRange
 	}
 
 	if c.SeriesFileMaxConcurrentSnapshotCompactions < 0 {

--- a/tsdb/config_test.go
+++ b/tsdb/config_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/BurntSushi/toml"
 	"github.com/influxdata/influxdb/tsdb"
+	"github.com/stretchr/testify/require"
 )
 
 func TestConfig_Parse(t *testing.T) {
@@ -74,6 +75,111 @@ func TestConfig_Validate_Error(t *testing.T) {
 	c.SeriesIDSetCacheSize = -1
 	if err := c.Validate(); err == nil || err.Error() != "series-id-set-cache-size must be non-negative" {
 		t.Errorf("unexpected error: %s", err)
+	}
+}
+
+func TestConfig_Validate_AdaptiveCacheSizing(t *testing.T) {
+	base := func() tsdb.Config {
+		c := tsdb.NewConfig()
+		c.Dir = "/var/lib/influxdb/data"
+		c.WALDir = "/var/lib/influxdb/wal"
+		return c
+	}
+
+	tests := []struct {
+		name    string
+		mutate  func(c *tsdb.Config)
+		wantErr string // "" = expect success
+	}{
+		{
+			name:    "defaults are valid (adaptive disabled)",
+			mutate:  func(c *tsdb.Config) {},
+			wantErr: "",
+		},
+		{
+			name: "negative max rejected",
+			mutate: func(c *tsdb.Config) {
+				c.SeriesIDSetCacheMaxSize = -1
+			},
+			wantErr: "series-id-set-cache-max-size must be non-negative",
+		},
+		{
+			name: "negative target rate rejected",
+			mutate: func(c *tsdb.Config) {
+				c.SeriesIDSetCacheTargetHitRate = -0.1
+			},
+			wantErr: "series-id-set-cache-target-hit-rate must be in [0.0, 1.0]",
+		},
+		{
+			name: "target rate above 1 rejected",
+			mutate: func(c *tsdb.Config) {
+				c.SeriesIDSetCacheTargetHitRate = 1.01
+			},
+			wantErr: "series-id-set-cache-target-hit-rate must be in [0.0, 1.0]",
+		},
+		{
+			name: "max without target rejected",
+			mutate: func(c *tsdb.Config) {
+				c.SeriesIDSetCacheMaxSize = 200
+			},
+			wantErr: "series-id-set-cache-max-size and series-id-set-cache-target-hit-rate must both be set to enable adaptive cache sizing, or both be zero to disable it",
+		},
+		{
+			name: "target without max rejected",
+			mutate: func(c *tsdb.Config) {
+				c.SeriesIDSetCacheTargetHitRate = 0.95
+			},
+			wantErr: "series-id-set-cache-max-size and series-id-set-cache-target-hit-rate must both be set to enable adaptive cache sizing, or both be zero to disable it",
+		},
+		{
+			name: "adaptive enabled with cache disabled rejected",
+			mutate: func(c *tsdb.Config) {
+				c.SeriesIDSetCacheSize = 0
+				c.SeriesIDSetCacheMaxSize = 200
+				c.SeriesIDSetCacheTargetHitRate = 0.95
+			},
+			wantErr: "series-id-set-cache-size must be > 0 to use adaptive cache sizing",
+		},
+		{
+			name: "max < initial rejected",
+			mutate: func(c *tsdb.Config) {
+				c.SeriesIDSetCacheSize = 200
+				c.SeriesIDSetCacheMaxSize = 100
+				c.SeriesIDSetCacheTargetHitRate = 0.95
+			},
+			wantErr: "series-id-set-cache-max-size must be >= series-id-set-cache-size",
+		},
+		{
+			name: "adaptive enabled with valid configuration",
+			mutate: func(c *tsdb.Config) {
+				c.SeriesIDSetCacheSize = 100
+				c.SeriesIDSetCacheMaxSize = 1600
+				c.SeriesIDSetCacheTargetHitRate = 0.95
+			},
+			wantErr: "",
+		},
+		{
+			name: "adaptive enabled at equal min/max boundary",
+			mutate: func(c *tsdb.Config) {
+				c.SeriesIDSetCacheSize = 100
+				c.SeriesIDSetCacheMaxSize = 100
+				c.SeriesIDSetCacheTargetHitRate = 1.0
+			},
+			wantErr: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := base()
+			tt.mutate(&c)
+			err := c.Validate()
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.EqualError(t, err, tt.wantErr)
+			}
+		})
 	}
 }
 

--- a/tsdb/config_test.go
+++ b/tsdb/config_test.go
@@ -89,47 +89,47 @@ func TestConfig_Validate_AdaptiveCacheSizing(t *testing.T) {
 	tests := []struct {
 		name    string
 		mutate  func(c *tsdb.Config)
-		wantErr string // "" = expect success
+		wantErr error // nil = expect success
 	}{
 		{
 			name:    "defaults are valid (adaptive disabled)",
 			mutate:  func(c *tsdb.Config) {},
-			wantErr: "",
+			wantErr: nil,
 		},
 		{
 			name: "negative max rejected",
 			mutate: func(c *tsdb.Config) {
 				c.SeriesIDSetCacheMaxSize = -1
 			},
-			wantErr: "series-id-set-cache-max-size must be non-negative",
+			wantErr: tsdb.ErrSeriesIDSetCacheMaxSizeNegative,
 		},
 		{
 			name: "negative target rate rejected",
 			mutate: func(c *tsdb.Config) {
 				c.SeriesIDSetCacheTargetHitRate = -0.1
 			},
-			wantErr: "series-id-set-cache-target-hit-rate must be in [0.0, 1.0]",
+			wantErr: tsdb.ErrSeriesIDSetCacheTargetHitRateRange,
 		},
 		{
 			name: "target rate above 1 rejected",
 			mutate: func(c *tsdb.Config) {
 				c.SeriesIDSetCacheTargetHitRate = 1.01
 			},
-			wantErr: "series-id-set-cache-target-hit-rate must be in [0.0, 1.0]",
+			wantErr: tsdb.ErrSeriesIDSetCacheTargetHitRateRange,
 		},
 		{
 			name: "max without target rejected",
 			mutate: func(c *tsdb.Config) {
 				c.SeriesIDSetCacheMaxSize = 200
 			},
-			wantErr: "series-id-set-cache-max-size and series-id-set-cache-target-hit-rate must both be set to enable adaptive cache sizing, or both be zero to disable it",
+			wantErr: tsdb.ErrAdaptiveCacheSizingPairing,
 		},
 		{
 			name: "target without max rejected",
 			mutate: func(c *tsdb.Config) {
 				c.SeriesIDSetCacheTargetHitRate = 0.95
 			},
-			wantErr: "series-id-set-cache-max-size and series-id-set-cache-target-hit-rate must both be set to enable adaptive cache sizing, or both be zero to disable it",
+			wantErr: tsdb.ErrAdaptiveCacheSizingPairing,
 		},
 		{
 			name: "adaptive enabled with cache disabled rejected",
@@ -138,7 +138,7 @@ func TestConfig_Validate_AdaptiveCacheSizing(t *testing.T) {
 				c.SeriesIDSetCacheMaxSize = 200
 				c.SeriesIDSetCacheTargetHitRate = 0.95
 			},
-			wantErr: "series-id-set-cache-size must be > 0 to use adaptive cache sizing",
+			wantErr: tsdb.ErrAdaptiveCacheSizingRequiresCacheSize,
 		},
 		{
 			name: "max < initial rejected",
@@ -147,7 +147,16 @@ func TestConfig_Validate_AdaptiveCacheSizing(t *testing.T) {
 				c.SeriesIDSetCacheMaxSize = 100
 				c.SeriesIDSetCacheTargetHitRate = 0.95
 			},
-			wantErr: "series-id-set-cache-max-size must be >= series-id-set-cache-size",
+			wantErr: tsdb.ErrAdaptiveCacheMaxSizeTooSmall,
+		},
+		{
+			name: "max == initial rejected (adaptive cache that cannot grow)",
+			mutate: func(c *tsdb.Config) {
+				c.SeriesIDSetCacheSize = 100
+				c.SeriesIDSetCacheMaxSize = 100
+				c.SeriesIDSetCacheTargetHitRate = 1.0
+			},
+			wantErr: tsdb.ErrAdaptiveCacheMaxSizeTooSmall,
 		},
 		{
 			name: "adaptive enabled with valid configuration",
@@ -156,16 +165,16 @@ func TestConfig_Validate_AdaptiveCacheSizing(t *testing.T) {
 				c.SeriesIDSetCacheMaxSize = 1600
 				c.SeriesIDSetCacheTargetHitRate = 0.95
 			},
-			wantErr: "",
+			wantErr: nil,
 		},
 		{
-			name: "adaptive enabled at equal min/max boundary",
+			name: "adaptive enabled at minimal valid max (size+1)",
 			mutate: func(c *tsdb.Config) {
 				c.SeriesIDSetCacheSize = 100
-				c.SeriesIDSetCacheMaxSize = 100
+				c.SeriesIDSetCacheMaxSize = 101
 				c.SeriesIDSetCacheTargetHitRate = 1.0
 			},
-			wantErr: "",
+			wantErr: nil,
 		},
 	}
 
@@ -174,10 +183,10 @@ func TestConfig_Validate_AdaptiveCacheSizing(t *testing.T) {
 			c := base()
 			tt.mutate(&c)
 			err := c.Validate()
-			if tt.wantErr == "" {
+			if tt.wantErr == nil {
 				require.NoError(t, err)
 			} else {
-				require.EqualError(t, err, tt.wantErr)
+				require.ErrorIs(t, err, tt.wantErr)
 			}
 		})
 	}

--- a/tsdb/config_test.go
+++ b/tsdb/config_test.go
@@ -1,6 +1,7 @@
 package tsdb_test
 
 import (
+	"math"
 	"testing"
 	"time"
 
@@ -125,6 +126,15 @@ func TestConfig_Validate_AdaptiveCacheSizing(t *testing.T) {
 			wantErr: tsdb.ErrSeriesIDSetCacheTargetHitRateRange,
 		},
 		{
+			// NaN compares false to every bound, so it must be rejected by a
+			// positive range test rather than slipping through as "disabled".
+			name: "target rate NaN rejected",
+			mutate: func(c *tsdb.Config) {
+				c.SeriesIDSetCacheTargetHitRate = math.NaN()
+			},
+			wantErr: tsdb.ErrSeriesIDSetCacheTargetHitRateRange,
+		},
+		{
 			name: "max without target rejected",
 			mutate: func(c *tsdb.Config) {
 				c.SeriesIDSetCacheMaxSize = 200
@@ -180,6 +190,34 @@ func TestConfig_Validate_AdaptiveCacheSizing(t *testing.T) {
 				c.SeriesIDSetCacheSize = 100
 				c.SeriesIDSetCacheMaxSize = 101
 				c.SeriesIDSetCacheTargetHitRate = 0.95
+			},
+			wantErr: nil,
+		},
+		{
+			name: "negative shrink conservatism rejected",
+			mutate: func(c *tsdb.Config) {
+				c.SeriesIDSetCacheShrinkConservatism = -0.1
+			},
+			wantErr: tsdb.ErrSeriesIDSetCacheShrinkConservatismRange,
+		},
+		{
+			name: "shrink conservatism NaN rejected",
+			mutate: func(c *tsdb.Config) {
+				c.SeriesIDSetCacheShrinkConservatism = math.NaN()
+			},
+			wantErr: tsdb.ErrSeriesIDSetCacheShrinkConservatismRange,
+		},
+		{
+			name: "shrink conservatism +Inf rejected",
+			mutate: func(c *tsdb.Config) {
+				c.SeriesIDSetCacheShrinkConservatism = math.Inf(1)
+			},
+			wantErr: tsdb.ErrSeriesIDSetCacheShrinkConservatismRange,
+		},
+		{
+			name: "shrink conservatism at lower bound (0.0) accepted",
+			mutate: func(c *tsdb.Config) {
+				c.SeriesIDSetCacheShrinkConservatism = 0.0
 			},
 			wantErr: nil,
 		},

--- a/tsdb/config_test.go
+++ b/tsdb/config_test.go
@@ -118,6 +118,13 @@ func TestConfig_Validate_AdaptiveCacheSizing(t *testing.T) {
 			wantErr: tsdb.ErrSeriesIDSetCacheTargetHitRateRange,
 		},
 		{
+			name: "target rate of exactly 1 rejected (unachievable)",
+			mutate: func(c *tsdb.Config) {
+				c.SeriesIDSetCacheTargetHitRate = 1.0
+			},
+			wantErr: tsdb.ErrSeriesIDSetCacheTargetHitRateRange,
+		},
+		{
 			name: "max without target rejected",
 			mutate: func(c *tsdb.Config) {
 				c.SeriesIDSetCacheMaxSize = 200
@@ -154,7 +161,7 @@ func TestConfig_Validate_AdaptiveCacheSizing(t *testing.T) {
 			mutate: func(c *tsdb.Config) {
 				c.SeriesIDSetCacheSize = 100
 				c.SeriesIDSetCacheMaxSize = 100
-				c.SeriesIDSetCacheTargetHitRate = 1.0
+				c.SeriesIDSetCacheTargetHitRate = 0.95
 			},
 			wantErr: tsdb.ErrAdaptiveCacheMaxSizeTooSmall,
 		},
@@ -172,7 +179,7 @@ func TestConfig_Validate_AdaptiveCacheSizing(t *testing.T) {
 			mutate: func(c *tsdb.Config) {
 				c.SeriesIDSetCacheSize = 100
 				c.SeriesIDSetCacheMaxSize = 101
-				c.SeriesIDSetCacheTargetHitRate = 1.0
+				c.SeriesIDSetCacheTargetHitRate = 0.95
 			},
 			wantErr: nil,
 		},

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -760,6 +760,7 @@ func (e *Engine) Statistics(tags map[string]string) []models.Statistic {
 	if e.WALEnabled {
 		statistics = append(statistics, e.WAL.Statistics(tags)...)
 	}
+	statistics = append(statistics, e.index.Statistics(tags)...)
 	return statistics
 }
 

--- a/tsdb/engine/tsm1/engine_test.go
+++ b/tsdb/engine/tsm1/engine_test.go
@@ -2340,6 +2340,61 @@ func TestEngine_WritePointsWithStats(t *testing.T) {
 	}
 }
 
+// TestEngine_Statistics_TSI1Cache verifies that the TSI1 tag-value series-ID
+// cache is plumbed through the engine's Statistics aggregator. Counter
+// semantics are covered by TagValueSeriesIDCache unit tests; this test only
+// proves the wiring.
+func TestEngine_Statistics_TSI1Cache(t *testing.T) {
+	e := MustOpenEngine(tsdb.TSI1IndexName)
+	defer e.Close()
+
+	require.NoError(t, e.WritePointsString(
+		`cpu,host=A value=1.1 1000000000`,
+		`cpu,host=B value=1.2 2000000000`,
+	))
+
+	// Drive at least one miss followed by one hit through the cache so
+	// the wiring proves the counters move end-to-end via Statistics,
+	// not just that the keys are present.
+	itr1, err := e.index.TagValueSeriesIDIterator([]byte("cpu"), []byte("host"), []byte("A"))
+	require.NoError(t, err)
+	if itr1 != nil {
+		require.NoError(t, itr1.Close())
+	}
+	itr2, err := e.index.TagValueSeriesIDIterator([]byte("cpu"), []byte("host"), []byte("A"))
+	require.NoError(t, err)
+	if itr2 != nil {
+		require.NoError(t, itr2.Close())
+	}
+
+	stats := e.Statistics(map[string]string{"database": "db0", "id": "1"})
+
+	var found *models.Statistic
+	for i := range stats {
+		if stats[i].Name == "tsi1_cache" {
+			found = &stats[i]
+			break
+		}
+	}
+	require.NotNil(t, found, "expected a tsi1_cache statistic in engine output")
+	require.Contains(t, found.Values, "hit")
+	require.Contains(t, found.Values, "miss")
+	require.Contains(t, found.Values, "eviction")
+	require.Contains(t, found.Values, "size")
+	require.Equal(t, "db0", found.Tags["database"])
+	require.Greater(t, found.Values["hit"].(int64), int64(0), "expected at least one cache hit")
+	require.Greater(t, found.Values["miss"].(int64), int64(0), "expected at least one cache miss")
+
+	// The inmem index has no analogous cache; ensure its engine Statistics
+	// does NOT emit tsi1_cache.
+	e2 := MustOpenEngine(inmem.IndexName)
+	defer e2.Close()
+	for _, s := range e2.Statistics(map[string]string{"database": "db0", "id": "1"}) {
+		require.NotEqual(t, "tsi1_cache", s.Name,
+			"inmem engine should not emit a tsi1_cache statistic")
+	}
+}
+
 func TestEngine_WritePoints_TypeConflict(t *testing.T) {
 	os.Setenv("INFLUXDB_SERIES_TYPE_CHECK_ENABLED", "1")
 	defer os.Unsetenv("INFLUXDB_SERIES_TYPE_CHECK_ENABLED")

--- a/tsdb/engine/tsm1/engine_test.go
+++ b/tsdb/engine/tsm1/engine_test.go
@@ -2380,6 +2380,7 @@ func TestEngine_Statistics_TSI1Cache(t *testing.T) {
 	require.Contains(t, found.Values, "hit")
 	require.Contains(t, found.Values, "miss")
 	require.Contains(t, found.Values, "eviction")
+	require.Contains(t, found.Values, "shrink_eviction")
 	require.Contains(t, found.Values, "size")
 	require.Contains(t, found.Values, "capacity")
 	require.Equal(t, "db0", found.Tags["database"])

--- a/tsdb/engine/tsm1/engine_test.go
+++ b/tsdb/engine/tsm1/engine_test.go
@@ -2381,6 +2381,7 @@ func TestEngine_Statistics_TSI1Cache(t *testing.T) {
 	require.Contains(t, found.Values, "miss")
 	require.Contains(t, found.Values, "eviction")
 	require.Contains(t, found.Values, "size")
+	require.Contains(t, found.Values, "capacity")
 	require.Equal(t, "db0", found.Tags["database"])
 	require.Greater(t, found.Values["hit"].(int64), int64(0), "expected at least one cache hit")
 	require.Greater(t, found.Values["miss"].(int64), int64(0), "expected at least one cache miss")

--- a/tsdb/index.go
+++ b/tsdb/index.go
@@ -79,6 +79,9 @@ type Index interface {
 	// Bytes estimates the memory footprint of this Index, in bytes.
 	Bytes() int
 
+	// Statistics returns index statistics for periodic monitoring.
+	Statistics(tags map[string]string) []models.Statistic
+
 	// To be removed w/ tsi1.
 	SetFieldName(measurement []byte, name string)
 

--- a/tsdb/index/inmem/inmem.go
+++ b/tsdb/index/inmem/inmem.go
@@ -117,6 +117,10 @@ func (i *Index) Type() string      { return IndexName }
 func (i *Index) Open() (err error) { return nil }
 func (i *Index) Close() error      { return nil }
 
+// Statistics returns statistics for periodic monitoring. The inmem index has
+// no caches of its own to report, so this is a no-op.
+func (i *Index) Statistics(tags map[string]string) []models.Statistic { return nil }
+
 func (i *Index) WithLogger(*zap.Logger) {}
 
 // Database returns the name of the database the index was initialized with.

--- a/tsdb/index/tsi1/cache.go
+++ b/tsdb/index/tsi1/cache.go
@@ -159,10 +159,12 @@ func NewTagValueSeriesIDCache(c int) *TagValueSeriesIDCache {
 // deviations below the at-target eviction mean at which the shrink eviction gate
 // sits; see the doc on SeriesIDSetCacheShrinkConservatism in tsdb.Config.
 //
-// If any argument is invalid, the error is logged and a fixed-size (non-adaptive)
-// cache from NewTagValueSeriesIDCache is returned in place of the adaptive one,
-// so misconfiguration degrades to a working cache rather than crashing the
-// process. The fallback uses initial when it is itself valid (>0), otherwise
+// Every argument is validated; each invalid one is logged separately (so a
+// misconfiguration with several bad values surfaces all of them at once rather
+// than one error per restart), and a fixed-size (non-adaptive) cache from
+// NewTagValueSeriesIDCache is returned in place of the adaptive one, so
+// misconfiguration degrades to a working cache rather than crashing the process.
+// The fallback uses initial when it is itself valid (>0), otherwise
 // tsdb.DefaultSeriesIDSetCacheSize. Invalid arguments are: initial <= 0; max <=
 // initial (an adaptive cache that cannot grow is a misconfiguration — use
 // NewTagValueSeriesIDCache directly for a fixed cache); target not in (0, 1)
@@ -173,40 +175,50 @@ func NewAdaptiveTagValueSeriesIDCache(initial, max int, target, shrinkConservati
 		logger = zap.NewNop()
 	}
 
-	// fallback builds the non-adaptive replacement: a fixed-size cache sized to
-	// initial when valid, otherwise tsdb.DefaultSeriesIDSetCacheSize, with the
-	// caller's logger attached so the error log line and the fallback share a
-	// destination. Safe to set the logger directly because the cache has not
-	// yet been shared with other goroutines.
-	fallback := func(reason string, fields ...zap.Field) *TagValueSeriesIDCache {
-		size := initial
-		if size <= 0 {
-			size = tsdb.DefaultSeriesIDSetCacheSize
-		}
-		logger.Error("NewAdaptiveTagValueSeriesIDCache: "+reason+"; falling back to fixed-size cache",
-			append(fields, zap.Int("fallback_size", size))...)
-		c := NewTagValueSeriesIDCache(size)
-		c.SetLogger(logger)
-		return c
-	}
+	// Validate every argument before deciding, logging each problem and setting
+	// useFallback, rather than returning on the first failure. A misconfiguration
+	// with several bad values then reports all of them in one pass.
+	const logPrefix = "NewAdaptiveTagValueSeriesIDCache: "
+	useFallback := false
 
 	if initial <= 0 {
-		return fallback("initial must be > 0", zap.Int("initial", initial))
+		logger.Error(logPrefix+"initial must be > 0", zap.Int("initial", initial))
+		useFallback = true
 	}
 	if max <= initial {
-		return fallback("max must be > initial", zap.Int("initial", initial), zap.Int("max", max))
+		logger.Error(logPrefix+"max must be > initial", zap.Int("initial", initial), zap.Int("max", max))
+		useFallback = true
 	}
 	// Positive range test so NaN (for which both `<` and `>` are false) is
 	// rejected rather than slipping through.
 	if !(target > 0 && target < 1) {
-		return fallback("target must be in (0, 1)", zap.Float64("target", target))
+		logger.Error(logPrefix+"target must be in (0, 1)", zap.Float64("target", target))
+		useFallback = true
 	}
 	// Same positive-form trick rejects NaN and ±Inf for the conservatism.
 	if !(shrinkConservatism >= 0 && shrinkConservatism < math.Inf(1)) {
-		return fallback("shrinkConservatism must be a finite value >= 0", zap.Float64("shrink_conservatism", shrinkConservatism))
+		logger.Error(logPrefix+"shrinkConservatism must be a finite value >= 0", zap.Float64("shrink_conservatism", shrinkConservatism))
+		useFallback = true
 	}
 	if minSamples < 0 {
-		return fallback("minSamples must be >= 0", zap.Int("min_samples", minSamples))
+		logger.Error(logPrefix+"minSamples must be >= 0", zap.Int("min_samples", minSamples))
+		useFallback = true
+	}
+
+	if useFallback {
+		// Build the non-adaptive replacement: a fixed-size cache sized to initial
+		// when valid, otherwise tsdb.DefaultSeriesIDSetCacheSize, with the caller's
+		// logger attached so the error log lines and the fallback share a
+		// destination. Safe to set the logger directly because the cache has not
+		// yet been shared with other goroutines.
+		size := initial
+		if size <= 0 {
+			size = tsdb.DefaultSeriesIDSetCacheSize
+		}
+		logger.Error(logPrefix+"falling back to fixed-size cache", zap.Int("fallback_size", size))
+		c := NewTagValueSeriesIDCache(size)
+		c.SetLogger(logger)
+		return c
 	}
 
 	cache := &TagValueSeriesIDCache{

--- a/tsdb/index/tsi1/cache.go
+++ b/tsdb/index/tsi1/cache.go
@@ -26,21 +26,36 @@ const logMsgCacheCapacityDecreased = "tsi cache capacity decreased"
 
 // Statistic field names for the tag value series ID cache.
 const (
-	statTagValueCacheHit      = "hit"
-	statTagValueCacheMiss     = "miss"
-	statTagValueCacheEviction = "eviction"
-	statTagValueCacheSize     = "size"
-	statTagValueCacheCapacity = "capacity"
+	statTagValueCacheHit            = "hit"
+	statTagValueCacheMiss           = "miss"
+	statTagValueCacheEviction       = "eviction"
+	statTagValueCacheShrinkEviction = "shrink_eviction"
+	statTagValueCacheSize           = "size"
+	statTagValueCacheCapacity       = "capacity"
 )
+
+// maxShrinkEvictPerEvent caps the number of LRU-tail entries shed in a single
+// shrink event. The per-event bound limits how long the write lock is held
+// during a shrink trim; further decay continues over subsequent windows. The
+// other per-event bound is size/2 (applied in decideColdTail).
+const maxShrinkEvictPerEvent = 1024
 
 // TagValueSeriesIDCacheStatistics holds counters describing the behavior of a
 // TagValueSeriesIDCache. Fields are read and written with sync/atomic so that
 // Statistics can be sampled without acquiring the cache lock.
+//
+// Evictions counts entries forced out under write pressure (a Put on a full
+// cache); ShrinkEvictions counts entries shed by the adaptive shrink policy.
+// They are tracked separately because only Evictions is the binomial signal
+// the shrink eviction-gate is derived against (Bernoulli "miss on full cache
+// → forced eviction"), and operators often want to distinguish "the cache is
+// under pressure" from "the cache is voluntarily releasing memory."
 type TagValueSeriesIDCacheStatistics struct {
-	Hits      int64
-	Misses    int64
-	Evictions int64
-	Size      int64
+	Hits            int64
+	Misses          int64
+	Evictions       int64
+	ShrinkEvictions int64
+	Size            int64
 }
 
 // resizeEvent describes a single capacity-change event (grow or shrink).
@@ -207,11 +222,12 @@ func (c *TagValueSeriesIDCache) Statistics(tags map[string]string) []models.Stat
 		Name: statTagValueCacheMeasurement,
 		Tags: tags,
 		Values: map[string]interface{}{
-			statTagValueCacheHit:      atomic.LoadInt64(&c.stats.Hits),
-			statTagValueCacheMiss:     atomic.LoadInt64(&c.stats.Misses),
-			statTagValueCacheEviction: atomic.LoadInt64(&c.stats.Evictions),
-			statTagValueCacheSize:     atomic.LoadInt64(&c.stats.Size),
-			statTagValueCacheCapacity: atomic.LoadInt64(&c.capacity),
+			statTagValueCacheHit:            atomic.LoadInt64(&c.stats.Hits),
+			statTagValueCacheMiss:           atomic.LoadInt64(&c.stats.Misses),
+			statTagValueCacheEviction:       atomic.LoadInt64(&c.stats.Evictions),
+			statTagValueCacheShrinkEviction: atomic.LoadInt64(&c.stats.ShrinkEvictions),
+			statTagValueCacheSize:           atomic.LoadInt64(&c.stats.Size),
+			statTagValueCacheCapacity:       atomic.LoadInt64(&c.capacity),
 		},
 	}}
 }
@@ -220,11 +236,11 @@ func (c *TagValueSeriesIDCache) Statistics(tags map[string]string) []models.Stat
 // exists.
 func (c *TagValueSeriesIDCache) Get(name, key, value []byte) *tsdb.SeriesIDSet {
 	c.Lock()
-	ss := c.get(name, key, value)
+	ss, hit := c.get(name, key, value)
 	// Drive the adaptive shrink check from the read path: the grow check is
 	// eviction-driven and is blind when the cache is quiet (exactly when a
 	// shrink may be warranted). Log after releasing the lock, like Put.
-	event, shrank := c.checkShrink()
+	event, shrank := c.checkShrink(hit)
 	c.Unlock()
 	if shrank {
 		c.logShrink(event)
@@ -232,7 +248,7 @@ func (c *TagValueSeriesIDCache) Get(name, key, value []byte) *tsdb.SeriesIDSet {
 	return ss
 }
 
-func (c *TagValueSeriesIDCache) get(name, key, value []byte) *tsdb.SeriesIDSet {
+func (c *TagValueSeriesIDCache) get(name, key, value []byte) (*tsdb.SeriesIDSet, bool) {
 	if mmap, ok := c.cache[string(name)]; ok {
 		if tkmap, ok := mmap[string(key)]; ok {
 			if ele, ok := tkmap[string(value)]; ok {
@@ -243,12 +259,12 @@ func (c *TagValueSeriesIDCache) get(name, key, value []byte) *tsdb.SeriesIDSet {
 				}
 				c.evictor.MoveToFront(ele) // This now becomes most recently used.
 				atomic.AddInt64(&c.stats.Hits, 1)
-				return ele.Value.(*seriesIDCacheElement).SeriesIDSet
+				return ele.Value.(*seriesIDCacheElement).SeriesIDSet, true
 			}
 		}
 	}
 	atomic.AddInt64(&c.stats.Misses, 1)
-	return nil
+	return nil, false
 }
 
 // trackTouchLocked maintains deepestTouched — the back-most element of the warm
@@ -387,11 +403,13 @@ func (c *TagValueSeriesIDCache) delete(name, key, value []byte, x uint64) {
 }
 
 // checkEviction checks if the cache is too big, and evicts the least
-// recently used item if it is. When adaptive sizing is enabled and the
-// cache has just turned over (i.e. accumulated `capacity` evictions since
-// the last policy firing), it samples the windowed hit rate and may grow
-// the capacity. The optional resizeEvent return carries the snapshot the
-// caller should use to emit a log line after releasing the write lock;
+// recently used item if it is. The eviction is a forced eviction (driven by
+// write pressure) — distinct from the voluntary evictions performed by the
+// shrink trim — so it bumps stats.Evictions. When adaptive sizing is enabled
+// and the cache has just turned over (i.e. accumulated `capacity` evictions
+// since the last policy firing), it samples the windowed hit rate and may
+// grow the capacity. The optional resizeEvent return carries the snapshot
+// the caller should use to emit a log line after releasing the write lock;
 // the bool is true iff a resize occurred.
 func (c *TagValueSeriesIDCache) checkEviction() (resizeEvent, bool) {
 	if int64(c.evictor.Len()) <= atomic.LoadInt64(&c.capacity) {
@@ -400,6 +418,7 @@ func (c *TagValueSeriesIDCache) checkEviction() (resizeEvent, bool) {
 	if !c.evictLRULocked() {
 		return resizeEvent{}, false
 	}
+	atomic.AddInt64(&c.stats.Evictions, 1)
 
 	// Adaptive sizing: skip entirely when disabled to keep the hot path
 	// free of per-eviction tracking work.
@@ -415,10 +434,12 @@ func (c *TagValueSeriesIDCache) checkEviction() (resizeEvent, bool) {
 	return c.maybeResizeLocked()
 }
 
-// evictLRULocked removes the least-recently-used entry (the back of the evictor
-// list) from the eviction list, the cache maps, and the size/eviction counters.
-// Returns false if the cache is empty. Must be called under the write lock.
-// Shared by the grow path (checkEviction) and the shrink trim.
+// evictLRULocked removes the least-recently-used entry (the back of the
+// evictor list) from the eviction list, the cache maps, and the size counter.
+// Returns false if the cache is empty. Does NOT bump Evictions or
+// ShrinkEvictions — callers do that with the appropriate counter, since they
+// know whether the eviction was forced (Put under pressure) or voluntary
+// (shrink trim). Must be called under the write lock.
 func (c *TagValueSeriesIDCache) evictLRULocked() bool {
 	e := c.evictor.Back() // Least recently used item.
 	if e == nil {
@@ -429,16 +450,21 @@ func (c *TagValueSeriesIDCache) evictLRULocked() bool {
 	key := listElement.key
 	value := listElement.value
 
-	// Drop the shrink footprint boundary if it points at the element being
-	// evicted (only possible via the grow path on an all-warm cache). Avoids a
-	// dangling pointer; such a window has evictionsW > 0 and is gated out anyway.
+	// If the boundary points at the element being evicted, recede it to the
+	// new back. This case fires only via the Put path on an all-warm cache
+	// (the LRU is the boundary iff every entry was touched this window). Put
+	// is reached after a Get miss, so the new front element is itself warm;
+	// the warm set is then the cache minus the evicted entry, and the new
+	// back-most warm element is e.Prev() at the moment of the call. Using
+	// Prev() (rather than nil-ing) preserves the touched-front-prefix
+	// invariant the warm-count walk relies on. Prev() is nil only when the
+	// cache held exactly one element; nil-ing is then correct (empty cache).
 	if e == c.deepestTouched {
-		c.deepestTouched = nil
+		c.deepestTouched = e.Prev()
 	}
 
 	c.evictor.Remove(e)               // Remove from evictor
 	delete(c.cache[name][key], value) // Remove from hashmap of items.
-	atomic.AddInt64(&c.stats.Evictions, 1)
 	atomic.AddInt64(&c.stats.Size, -1)
 
 	// Check if there are no more tag values for the tag key.
@@ -555,7 +581,9 @@ func (c *TagValueSeriesIDCache) logResize(e resizeEvent) {
 // the write lock and returns a resizeEvent the caller should log after releasing
 // the lock (the bool is true iff a shrink occurred). When adaptive sizing is
 // disabled it does nothing, keeping the read path free of shrink bookkeeping.
-func (c *TagValueSeriesIDCache) checkShrink() (resizeEvent, bool) {
+// hit reports whether the Get that triggered this call was a cache hit, so the
+// new-window baselines can snapshot the pre-Get counter state.
+func (c *TagValueSeriesIDCache) checkShrink(hit bool) (resizeEvent, bool) {
 	if c.maxCapacity == 0 {
 		return resizeEvent{}, false
 	}
@@ -567,13 +595,19 @@ func (c *TagValueSeriesIDCache) checkShrink() (resizeEvent, bool) {
 
 	// Start a window if none is active (first ever, or just completed). The
 	// window length is recomputed from current occupancy each time. The current
-	// Get's hit was already folded into deepestTouched by get(), so the boundary
-	// is reset only at window completion, never here.
+	// Get's hit was already folded into deepestTouched by get() and is also
+	// counted in getsSinceShrinkCheck below; rewind the hit/miss baseline by one
+	// so the same Get is folded into hitsW/missesW for the new window.
 	if c.shrinkWindowGets == 0 {
 		c.shrinkWindowGets = adaptiveWindowLen(int64(c.evictor.Len()), c.minSamples, c.targetHitRate)
 		c.getsSinceShrinkCheck = 0
 		c.shrinkBaseHits = atomic.LoadInt64(&c.stats.Hits)
 		c.shrinkBaseMisses = atomic.LoadInt64(&c.stats.Misses)
+		if hit {
+			c.shrinkBaseHits--
+		} else {
+			c.shrinkBaseMisses--
+		}
 		c.shrinkBaseEvictions = atomic.LoadInt64(&c.stats.Evictions)
 		if c.shrinkWindowGets == 0 {
 			// Cache too small (n < 2) to evaluate. Clear the boundary so a
@@ -638,6 +672,7 @@ func (c *TagValueSeriesIDCache) maybeShrinkLocked() (resizeEvent, bool) {
 		for evicted < evict && c.evictLRULocked() {
 			evicted++
 		}
+		atomic.AddInt64(&c.stats.ShrinkEvictions, evicted)
 		// Derive the new capacity from what was actually evicted so the
 		// invariant size <= capacity holds even if the list emptied early.
 		newCap = size - evicted
@@ -845,10 +880,13 @@ func decideShrinkPre(hitsW, missesW, evictionsW, capacity, size, floor int64, ta
 	return capacity, false, true
 }
 
-// decideColdTail trims a full cache to the warm footprint, clamped at floor and
-// bounded to half the cache per event so the write lock is not held long.
-// Returns the new capacity, the number of LRU-tail entries to evict to reach it,
-// and whether a shrink should occur.
+// decideColdTail trims a full cache to the warm footprint, clamped at floor
+// and bounded per event so the write lock is not held long: both to half the
+// cache (proportional) and to maxShrinkEvictPerEvent (absolute, so a single
+// shrink on a multi-million-entry cache cannot park readers for an unbounded
+// time). Decay continues over later windows. Returns the new capacity, the
+// number of LRU-tail entries to evict to reach it, and whether a shrink
+// should occur.
 func decideColdTail(size, warmCount, floor int64) (newCap, evict int64, shrink bool) {
 	targetCap := warmCount
 	if targetCap < floor {
@@ -859,7 +897,10 @@ func decideColdTail(size, warmCount, floor int64) (newCap, evict int64, shrink b
 	}
 	evict = size - targetCap
 	if maxEvict := size / 2; evict > maxEvict {
-		evict = maxEvict // bound per-event eviction; decay continues over later windows
+		evict = maxEvict
+	}
+	if evict > maxShrinkEvictPerEvent {
+		evict = maxShrinkEvictPerEvent
 	}
 	return size - evict, evict, true
 }

--- a/tsdb/index/tsi1/cache.go
+++ b/tsdb/index/tsi1/cache.go
@@ -288,7 +288,9 @@ func (c *TagValueSeriesIDCache) get(name, key, value []byte) (*tsdb.SeriesIDSet,
 			if ele, ok := tkmap[string(value)]; ok {
 				// Track the LRU access footprint for the shrink policy before
 				// MoveToFront moves the element (the rule reads ele.Prev()).
-				if c.maxCapacity != 0 {
+				// Only bother when a shrink is actually reachable (capacity above
+				// the floor); at the floor a shrink can never fire, so skip it.
+				if c.maxCapacity != 0 && c.capacity.Load() > c.minCapacity {
 					c.trackTouchLocked(ele)
 				}
 				c.evictor.MoveToFront(ele) // This now becomes most recently used.
@@ -380,6 +382,10 @@ func (c *TagValueSeriesIDCache) innerLockingPut(name, key, value []byte, ss *tsd
 		return resizeEvent{}, false
 	}
 
+	// Update stats.Size after the element added and any evictions.
+	defer func() {
+		c.stats.Size.Store(int64(c.evictor.Len()))
+	}()
 	// Ensure our SeriesIDSet is go heap backed.
 	if ss != nil {
 		ss = ss.Clone()
@@ -392,7 +398,6 @@ func (c *TagValueSeriesIDCache) innerLockingPut(name, key, value []byte, ss *tsd
 		value:       valueStr,
 		SeriesIDSet: ss,
 	})
-	c.stats.Size.Add(1)
 
 	// Add the listElement to the set of items. The tuple cannot already
 	// exist here: the exists() check at the top of Put returns early if it
@@ -447,7 +452,7 @@ func (c *TagValueSeriesIDCache) delete(name, key, value []byte, x uint64) {
 // since the last policy firing), it samples the windowed hit rate and may
 // grow the capacity. The optional resizeEvent return carries the snapshot
 // the caller should use to emit a log line after releasing the write lock;
-// the bool is true iff a resize occurred.
+// the bool is true iff a resize occurred. Does not update stats.Size; its caller must
 func (c *TagValueSeriesIDCache) checkEviction() (resizeEvent, bool) {
 	if int64(c.evictor.Len()) <= c.capacity.Load() {
 		return resizeEvent{}, false
@@ -472,11 +477,12 @@ func (c *TagValueSeriesIDCache) checkEviction() (resizeEvent, bool) {
 }
 
 // evictLRULocked removes the least-recently-used entry (the back of the
-// evictor list) from the eviction list, the cache maps, and the size counter.
+// evictor list) from the eviction list and the cache maps
 // Returns false if the cache is empty. Does NOT bump Evictions or
 // ShrinkEvictions — callers do that with the appropriate counter, since they
 // know whether the eviction was forced (Put under pressure) or voluntary
-// (shrink trim). Must be called under the write lock.
+// (shrink trim). Must be called under the write lock.  It does not
+// decrement Size; callers must do that.
 func (c *TagValueSeriesIDCache) evictLRULocked() bool {
 	e := c.evictor.Back() // Least recently used item.
 	if e == nil {
@@ -502,7 +508,6 @@ func (c *TagValueSeriesIDCache) evictLRULocked() bool {
 
 	c.evictor.Remove(e)               // Remove from evictor
 	delete(c.cache[name][key], value) // Remove from hashmap of items.
-	c.stats.Size.Add(-1)
 
 	// Check if there are no more tag values for the tag key.
 	if len(c.cache[name][key]) == 0 {
@@ -625,6 +630,19 @@ func (c *TagValueSeriesIDCache) checkShrink(hit bool) (resizeEvent, bool) {
 		return resizeEvent{}, false
 	}
 
+	// At the floor a shrink can never fire: decideShrinkPre's slack branch floors
+	// newCap at the current capacity, and decideColdTail's targetCap floors at
+	// capacity == size, so both no-op. Skip all window bookkeeping while at the
+	// floor. State is already clean here — a prior shrink-to-floor reset
+	// shrinkWindowGets and deepestTouched, and a freshly constructed cache starts
+	// at the floor with zero-valued state — so a fresh window simply starts on the
+	// next Get once a Put grows the cache back above the floor. The cooldown need
+	// not tick here: a grow resets it (maybeResizeLocked). Growth is driven from
+	// the Put/eviction path and is unaffected by this early return.
+	if c.capacity.Load() <= c.minCapacity {
+		return resizeEvent{}, false
+	}
+
 	// One Get elapsed; tick down the post-resize cooldown.
 	if c.cooldownGets > 0 {
 		c.cooldownGets--
@@ -709,6 +727,7 @@ func (c *TagValueSeriesIDCache) maybeShrinkLocked() (resizeEvent, bool) {
 		for evicted < evict && c.evictLRULocked() {
 			evicted++
 		}
+		c.stats.Size.Store(int64(c.evictor.Len()))
 		c.stats.ShrinkEvictions.Add(evicted)
 		// Derive the new capacity from what was actually evicted so the
 		// invariant size <= capacity holds even if the list emptied early.
@@ -813,7 +832,11 @@ func adaptiveWindowLen(n, minWindow int64, target float64) int64 {
 		return 0
 	}
 	// window = ceil( ln(1-target) / ln((n-1)/n) ); both logs are finite and negative.
-	wf := math.Ceil(math.Log(1-target) / math.Log(float64(n-1)/float64(n)))
+	// The denominator is ln(1 - 1/n); compute it with Log1p rather than
+	// Log(float64(n-1)/float64(n)) so the tiny 1/n term is not lost when the ratio
+	// rounds to a double near 1.0 (catastrophic for very large n). Log1p is also
+	// implemented in portable Go, so the result is identical on amd64 and arm64.
+	wf := math.Ceil(math.Log(1-target) / math.Log1p(-1.0/float64(n)))
 	if wf >= float64(math.MaxInt64) { // huge finite window (target very close to 1)
 		return math.MaxInt64
 	}
@@ -856,11 +879,21 @@ func atTargetEvictionGateLimit(gets int64, target, z float64) int64 {
 	m := float64(gets)
 	mu := m * (1 - target)
 	sigma := math.Sqrt(m * target * (1 - target))
-	limit := int64(mu - z*sigma)
-	if limit < 1 {
-		limit = 1
+	limit := mu - z*sigma
+	// Clamp in float space before converting. Converting an out-of-range float to
+	// int64 is implementation-defined in Go and differs by architecture: amd64
+	// (CVTTSD2SI) yields MinInt64 for any out-of-range value, but arm64 (FCVTZS)
+	// saturates, so a large-positive overflow becomes MaxInt64 — which would slip
+	// past a post-conversion `< 1` check and invert the fail-safe. Guarding the
+	// float first (the `!(limit >= 1)` form also rejects NaN and -Inf) keeps the value
+	// fed to int64() provably in [1, 2^63), so the result is identical on both.
+	if !(limit >= 1) {
+		return 1
+	} else if limit >= float64(math.MaxInt64) { // out-of-range high (only at unreachable gets)
+		return math.MaxInt64
+	} else {
+		return int64(limit)
 	}
-	return limit
 }
 
 // decideShrinkPre evaluates everything that does not require the access footprint:

--- a/tsdb/index/tsi1/cache.go
+++ b/tsdb/index/tsi1/cache.go
@@ -3,6 +3,7 @@ package tsi1
 import (
 	"container/list"
 	"fmt"
+	"math"
 	"sync"
 	"sync/atomic"
 
@@ -18,6 +19,16 @@ const statTagValueCacheMeasurement = "tsi1_cache"
 // logMsgCacheCapacityIncreased is the message logged when adaptive sizing
 // grows the cache. Shared with tests so the assertion tracks the source.
 const logMsgCacheCapacityIncreased = "tsi cache capacity increased"
+
+// logMsgCacheCapacityDecreased is the message logged when adaptive sizing
+// shrinks the cache. Shared with tests so the assertion tracks the source.
+const logMsgCacheCapacityDecreased = "tsi cache capacity decreased"
+
+// shrinkCooldownWindows is the number of shrink-evaluation windows for which
+// shrink is suppressed after any capacity change (grow or shrink). It prevents
+// grow⇄shrink oscillation; only shrink respects it (grow always reacts to real
+// eviction pressure immediately).
+const shrinkCooldownWindows = 3
 
 // Statistic field names for the tag value series ID cache.
 const (
@@ -38,12 +49,13 @@ type TagValueSeriesIDCacheStatistics struct {
 	Size      int64
 }
 
-// resizeEvent describes a single capacity-growth event. Snapshot fields are
-// captured under the cache write lock so the log line can be emitted by the
-// caller after releasing the lock.
+// resizeEvent describes a single capacity-change event (grow or shrink).
+// Snapshot fields are captured under the cache write lock so the log line can be
+// emitted by the caller after releasing the lock. evicted is set only for shrink
+// events (entries shed to reach the new capacity); it is 0 for grow.
 type resizeEvent struct {
-	oldCap, newCap, gets int64
-	rate                 float64
+	oldCap, newCap, gets, evicted int64
+	rate                          float64
 }
 
 // TagValueSeriesIDCache is an LRU cache for series id sets associated with
@@ -92,6 +104,24 @@ type TagValueSeriesIDCache struct {
 	evictionsSinceCheck int64
 	lastHits            int64
 	lastMisses          int64
+
+	// Shrink (capacity-decay) state. Written only under the write lock; not
+	// accessed atomically, so placement is unconstrained. minCapacity is the
+	// floor (the configured initial size); capacity never shrinks below it.
+	// A window spans getsSinceShrinkCheck Gets up to shrinkWindowGets (0 means
+	// no active window — recompute from current occupancy on the next Get). The
+	// shrinkBase* fields snapshot the stats counters at window start so deltas
+	// can be measured. deepestTouched marks the back of the warm front-prefix
+	// observed this window (the LRU access footprint). cooldownRemaining gates
+	// shrink for a few windows after any capacity change.
+	minCapacity          int64
+	getsSinceShrinkCheck int64
+	shrinkWindowGets     int64
+	shrinkBaseHits       int64
+	shrinkBaseMisses     int64
+	shrinkBaseEvictions  int64
+	cooldownRemaining    int64
+	deepestTouched       *list.Element
 }
 
 // NewTagValueSeriesIDCache returns a TagValueSeriesIDCache with fixed
@@ -115,7 +145,8 @@ func NewTagValueSeriesIDCache(c int) *TagValueSeriesIDCache {
 // floor the rate is treated as too noisy to react to. Panics on invalid
 // arguments: initial must be > 0, max > initial (an adaptive cache that
 // cannot grow is a misconfiguration — use NewTagValueSeriesIDCache for a
-// fixed cache), target in (0, 1], minSamples >= 0.
+// fixed cache), target in (0, 1) (1.0 is unachievable and is rejected by config
+// validation), minSamples >= 0.
 func NewAdaptiveTagValueSeriesIDCache(initial, max int, target float64, minSamples int, logger *zap.Logger) *TagValueSeriesIDCache {
 	if initial <= 0 {
 		panic(fmt.Sprintf("NewAdaptiveTagValueSeriesIDCache: initial must be > 0, got %d", initial))
@@ -123,8 +154,8 @@ func NewAdaptiveTagValueSeriesIDCache(initial, max int, target float64, minSampl
 	if max <= initial {
 		panic(fmt.Sprintf("NewAdaptiveTagValueSeriesIDCache: max (%d) must be > initial (%d)", max, initial))
 	}
-	if target <= 0 || target > 1 {
-		panic(fmt.Sprintf("NewAdaptiveTagValueSeriesIDCache: target must be in (0, 1], got %v", target))
+	if target <= 0 || target >= 1 {
+		panic(fmt.Sprintf("NewAdaptiveTagValueSeriesIDCache: target must be in (0, 1), got %v", target))
 	}
 	if minSamples < 0 {
 		panic(fmt.Sprintf("NewAdaptiveTagValueSeriesIDCache: minSamples must be >= 0, got %d", minSamples))
@@ -136,6 +167,7 @@ func NewAdaptiveTagValueSeriesIDCache(initial, max int, target float64, minSampl
 		cache:         map[string]map[string]map[string]*list.Element{},
 		evictor:       list.New(),
 		capacity:      int64(initial),
+		minCapacity:   int64(initial),
 		maxCapacity:   int64(max),
 		targetHitRate: target,
 		minSamples:    int64(minSamples),
@@ -173,14 +205,27 @@ func (c *TagValueSeriesIDCache) Statistics(tags map[string]string) []models.Stat
 // exists.
 func (c *TagValueSeriesIDCache) Get(name, key, value []byte) *tsdb.SeriesIDSet {
 	c.Lock()
-	defer c.Unlock()
-	return c.get(name, key, value)
+	ss := c.get(name, key, value)
+	// Drive the adaptive shrink check from the read path: the grow check is
+	// eviction-driven and is blind when the cache is quiet (exactly when a
+	// shrink may be warranted). Log after releasing the lock, like Put.
+	event, shrank := c.checkShrink()
+	c.Unlock()
+	if shrank {
+		c.logShrink(event)
+	}
+	return ss
 }
 
 func (c *TagValueSeriesIDCache) get(name, key, value []byte) *tsdb.SeriesIDSet {
 	if mmap, ok := c.cache[string(name)]; ok {
 		if tkmap, ok := mmap[string(key)]; ok {
 			if ele, ok := tkmap[string(value)]; ok {
+				// Track the LRU access footprint for the shrink policy before
+				// MoveToFront moves the element (the rule reads ele.Prev()).
+				if c.maxCapacity != 0 {
+					c.trackTouchLocked(ele)
+				}
 				c.evictor.MoveToFront(ele) // This now becomes most recently used.
 				atomic.AddInt64(&c.stats.Hits, 1)
 				return ele.Value.(*seriesIDCacheElement).SeriesIDSet
@@ -189,6 +234,26 @@ func (c *TagValueSeriesIDCache) get(name, key, value []byte) *tsdb.SeriesIDSet {
 	}
 	atomic.AddInt64(&c.stats.Misses, 1)
 	return nil
+}
+
+// trackTouchLocked maintains deepestTouched — the back-most element of the warm
+// front-prefix (the deepest element touched this window). Called on a hit before
+// MoveToFront. Invariant: touched elements form a contiguous front-prefix, so the
+// boundary only recedes (toward the front) when the boundary element is itself
+// re-touched (it is about to jump to the front); touching a cold or non-deepest
+// warm element leaves the boundary unchanged. Must be called under the write lock.
+func (c *TagValueSeriesIDCache) trackTouchLocked(e *list.Element) {
+	switch {
+	case c.deepestTouched == nil:
+		c.deepestTouched = e
+	case e == c.deepestTouched:
+		// Re-touching the boundary moves it to the front; its predecessor (still
+		// warm) becomes the new boundary. Keep e if it is already at the front
+		// (warm set is the single element {e}).
+		if p := e.Prev(); p != nil {
+			c.deepestTouched = p
+		}
+	}
 }
 
 // exists returns true if the item exists for the tuple {name, key, value}.
@@ -317,26 +382,8 @@ func (c *TagValueSeriesIDCache) checkEviction() (resizeEvent, bool) {
 	if int64(c.evictor.Len()) <= atomic.LoadInt64(&c.capacity) {
 		return resizeEvent{}, false
 	}
-
-	e := c.evictor.Back() // Least recently used item.
-	listElement := e.Value.(*seriesIDCacheElement)
-	name := listElement.name
-	key := listElement.key
-	value := listElement.value
-
-	c.evictor.Remove(e)                                       // Remove from evictor
-	delete(c.cache[string(name)][string(key)], string(value)) // Remove from hashmap of items.
-	atomic.AddInt64(&c.stats.Evictions, 1)
-	atomic.AddInt64(&c.stats.Size, -1)
-
-	// Check if there are no more tag values for the tag key.
-	if len(c.cache[string(name)][string(key)]) == 0 {
-		delete(c.cache[string(name)], string(key))
-	}
-
-	// Check there are no more tag keys for the measurement.
-	if len(c.cache[string(name)]) == 0 {
-		delete(c.cache, string(name))
+	if !c.evictLRULocked() {
+		return resizeEvent{}, false
 	}
 
 	// Adaptive sizing: skip entirely when disabled to keep the hot path
@@ -351,6 +398,44 @@ func (c *TagValueSeriesIDCache) checkEviction() (resizeEvent, bool) {
 	}
 	c.evictionsSinceCheck = 0
 	return c.maybeResizeLocked()
+}
+
+// evictLRULocked removes the least-recently-used entry (the back of the evictor
+// list) from the eviction list, the cache maps, and the size/eviction counters.
+// Returns false if the cache is empty. Must be called under the write lock.
+// Shared by the grow path (checkEviction) and the shrink trim.
+func (c *TagValueSeriesIDCache) evictLRULocked() bool {
+	e := c.evictor.Back() // Least recently used item.
+	if e == nil {
+		return false
+	}
+	listElement := e.Value.(*seriesIDCacheElement)
+	name := listElement.name
+	key := listElement.key
+	value := listElement.value
+
+	// Drop the shrink footprint boundary if it points at the element being
+	// evicted (only possible via the grow path on an all-warm cache). Avoids a
+	// dangling pointer; such a window has evictionsW > 0 and is gated out anyway.
+	if e == c.deepestTouched {
+		c.deepestTouched = nil
+	}
+
+	c.evictor.Remove(e)               // Remove from evictor
+	delete(c.cache[name][key], value) // Remove from hashmap of items.
+	atomic.AddInt64(&c.stats.Evictions, 1)
+	atomic.AddInt64(&c.stats.Size, -1)
+
+	// Check if there are no more tag values for the tag key.
+	if len(c.cache[name][key]) == 0 {
+		delete(c.cache[name], key)
+	}
+
+	// Check there are no more tag keys for the measurement.
+	if len(c.cache[name]) == 0 {
+		delete(c.cache, name)
+	}
+	return true
 }
 
 // maybeResizeLocked samples the windowed hit rate, calls the pure policy
@@ -377,6 +462,9 @@ func (c *TagValueSeriesIDCache) maybeResizeLocked() (resizeEvent, bool) {
 	}
 
 	atomic.StoreInt64(&c.capacity, newCap)
+	// Suppress shrink for a few windows after a grow so a freshly-grown cache
+	// (occupancy ~50% of the new capacity) isn't immediately clawed back.
+	c.cooldownRemaining = shrinkCooldownWindows
 	return resizeEvent{
 		oldCap: curCap,
 		newCap: newCap,
@@ -438,6 +526,238 @@ func (c *TagValueSeriesIDCache) logResize(e resizeEvent) {
 		zap.Float64("target", c.targetHitRate),
 		zap.Int64("gets_window", e.gets),
 	)
+}
+
+// checkShrink advances the Get-driven shrink window and, when a window
+// completes, evaluates whether to shrink the cache. It is called from Get under
+// the write lock and returns a resizeEvent the caller should log after releasing
+// the lock (the bool is true iff a shrink occurred). When adaptive sizing is
+// disabled it does nothing, keeping the read path free of shrink bookkeeping.
+func (c *TagValueSeriesIDCache) checkShrink() (resizeEvent, bool) {
+	if c.maxCapacity == 0 {
+		return resizeEvent{}, false
+	}
+
+	// Start a window if none is active (first ever, or just completed). The
+	// window length is recomputed from current occupancy each time. The current
+	// Get's hit was already folded into deepestTouched by get(), so the boundary
+	// is reset only at window completion, never here.
+	if c.shrinkWindowGets == 0 {
+		c.shrinkWindowGets = shrinkWindowLen(int64(c.evictor.Len()), c.minSamples, c.targetHitRate)
+		c.getsSinceShrinkCheck = 0
+		c.shrinkBaseHits = atomic.LoadInt64(&c.stats.Hits)
+		c.shrinkBaseMisses = atomic.LoadInt64(&c.stats.Misses)
+		c.shrinkBaseEvictions = atomic.LoadInt64(&c.stats.Evictions)
+		if c.shrinkWindowGets == 0 {
+			// Cache too small (n < 2) to evaluate. Clear the boundary so a
+			// warm-up touch can't carry into the first real window.
+			c.deepestTouched = nil
+			return resizeEvent{}, false
+		}
+	}
+
+	c.getsSinceShrinkCheck++
+	if c.getsSinceShrinkCheck < c.shrinkWindowGets {
+		return resizeEvent{}, false
+	}
+
+	// Window complete. Evaluate unless a recent capacity change is cooling down.
+	var event resizeEvent
+	var shrank bool
+	if c.cooldownRemaining > 0 {
+		c.cooldownRemaining--
+	} else if e, ok := c.maybeShrinkLocked(); ok {
+		event, shrank = e, true
+		c.cooldownRemaining = shrinkCooldownWindows
+	}
+
+	// End the window: a fresh one (with a recomputed length) starts on the next
+	// Get, and the footprint resets so the next window measures cleanly.
+	c.shrinkWindowGets = 0
+	c.deepestTouched = nil
+	return event, shrank
+}
+
+// maybeShrinkLocked measures the completed window, consults the shrink policy,
+// and applies the result: it evicts up to the bounded number of LRU-tail entries
+// and lowers capacity. The O(size) footprint walk (warmCountLocked) is performed
+// only when the gates pass, the slack branch does not apply, and there is in fact
+// an untouched tail — so gated-out and slack windows stay O(1). Must be called
+// under the write lock.
+func (c *TagValueSeriesIDCache) maybeShrinkLocked() (resizeEvent, bool) {
+	hitsW := atomic.LoadInt64(&c.stats.Hits) - c.shrinkBaseHits
+	missesW := atomic.LoadInt64(&c.stats.Misses) - c.shrinkBaseMisses
+	evictionsW := atomic.LoadInt64(&c.stats.Evictions) - c.shrinkBaseEvictions
+
+	curCap := atomic.LoadInt64(&c.capacity)
+	size := int64(c.evictor.Len())
+
+	newCap, shrink, coldTail := decideShrinkPre(hitsW, missesW, evictionsW, curCap, size, c.minCapacity, c.targetHitRate)
+
+	var evicted int64
+	if coldTail {
+		// The cache is full and the gates passed. Short-circuit the footprint
+		// walk when the whole cache was touched this window (the boundary is at
+		// the LRU tail) or nothing was touched: there is no cold tail to shed.
+		if c.deepestTouched == nil || c.deepestTouched == c.evictor.Back() {
+			return resizeEvent{}, false
+		}
+		var evict int64
+		newCap, evict, shrink = decideColdTail(size, c.warmCountLocked(), c.minCapacity)
+		if !shrink {
+			return resizeEvent{}, false
+		}
+		for evicted < evict && c.evictLRULocked() {
+			evicted++
+		}
+		// Derive the new capacity from what was actually evicted so the
+		// invariant size <= capacity holds even if the list emptied early.
+		newCap = size - evicted
+	} else if !shrink {
+		return resizeEvent{}, false
+	}
+
+	atomic.StoreInt64(&c.capacity, newCap)
+
+	gets := hitsW + missesW
+	var rate float64
+	if gets > 0 {
+		rate = float64(hitsW) / float64(gets)
+	}
+	return resizeEvent{oldCap: curCap, newCap: newCap, gets: gets, evicted: evicted, rate: rate}, true
+}
+
+// warmCountLocked returns the number of entries in the warm front-prefix
+// (Front() through deepestTouched, inclusive) = the distinct entries touched
+// this window. Must be called under the write lock.
+func (c *TagValueSeriesIDCache) warmCountLocked() int64 {
+	if c.deepestTouched == nil {
+		return 0
+	}
+	var n int64
+	for e := c.evictor.Front(); e != nil; e = e.Next() {
+		n++
+		if e == c.deepestTouched {
+			break
+		}
+	}
+	return n
+}
+
+// logShrink emits a single INFO log line describing a capacity-shrink event.
+// Called by Get after releasing the cache write lock.
+func (c *TagValueSeriesIDCache) logShrink(e resizeEvent) {
+	c.logger.Info(logMsgCacheCapacityDecreased,
+		zap.Int64("old_capacity", e.oldCap),
+		zap.Int64("new_capacity", e.newCap),
+		zap.Int64("min_capacity", c.minCapacity),
+		zap.Int64("evicted", e.evicted),
+		zap.Float64("hit_rate", e.rate),
+		zap.Int64("gets_window", e.gets),
+	)
+}
+
+// shrinkWindowLen returns how many Gets to observe before evaluating a shrink,
+// sized so that under ~uniform random access over n cached items the expected
+// fraction left untouched is <= (1-target). An entry still untouched after a
+// full window is therefore genuinely cold, not merely unsampled. The length
+// scales ~linearly with n (≈ 3n at target 0.95). minWindow floors the result so
+// tiny caches don't act on noisy windows. Returns 0 when n < 2 (too small to
+// evaluate). Precondition: target < 1 (config validation rejects target >= 1).
+// As defense, a target that rounds to 1 makes the window infinite; rather than
+// overflow the float->int64 conversion, that degenerate case returns MaxInt64
+// ("effectively never shrink"), which is the correct behavior for an
+// unachievable target.
+func shrinkWindowLen(n, minWindow int64, target float64) int64 {
+	if n < 2 {
+		return 0
+	}
+	// window = ceil( ln(1-target) / ln((n-1)/n) ); both logs are negative.
+	wf := math.Ceil(math.Log(1-target) / math.Log(float64(n-1)/float64(n)))
+	if wf >= float64(math.MaxInt64) { // +Inf (target rounds to 1) or out of range
+		return math.MaxInt64
+	}
+	w := int64(wf)
+	if w < minWindow {
+		w = minWindow
+	}
+	return w
+}
+
+// decideShrink implements the full capacity-decay policy as a pure function of
+// the window's counters, the current occupancy, and the observed access
+// footprint. It mirrors decideResize so the policy can be exercised with integer
+// literals. It composes decideShrinkPre and decideColdTail; production code calls
+// those two directly so the O(size) footprint walk that produces warmCount is
+// only performed when the cold-tail branch is actually reached (see
+// maybeShrinkLocked).
+//
+// Gates (all required): at least one read, zero evictions this window (the cache
+// is not under capacity pressure), and a windowed hit rate >= target (the cache
+// is serving its working set well). When gated through, one of two branches fires:
+//   - slack: capacity exceeds occupancy -> drop the unused headroom (no eviction).
+//   - cold-tail: cache is full -> shed the LRU tail that went untouched this
+//     window, down to the warm footprint (warmCount), clamped at floor, and
+//     bounded to half the cache per event so the write lock is not held long.
+//
+// The evicted entries are always within the untouched cold tail, so warm entries
+// are never shed.
+func decideShrink(hitsW, missesW, evictionsW, capacity, size, warmCount, floor int64, target float64) (newCap, evict int64, shrink bool) {
+	newCap, shrink, coldTail := decideShrinkPre(hitsW, missesW, evictionsW, capacity, size, floor, target)
+	if coldTail {
+		return decideColdTail(size, warmCount, floor)
+	}
+	return newCap, 0, shrink
+}
+
+// decideShrinkPre evaluates everything that does not require the access footprint:
+// the gates and the slack branch. It returns the slack result (newCap/shrink), or
+// coldTail=true to signal that the cache is full and the caller must measure the
+// warm footprint and consult decideColdTail. When coldTail is true, newCap/shrink
+// are not meaningful.
+func decideShrinkPre(hitsW, missesW, evictionsW, capacity, size, floor int64, target float64) (newCap int64, shrink, coldTail bool) {
+	gets := hitsW + missesW
+	if gets <= 0 || evictionsW != 0 {
+		return capacity, false, false
+	}
+	if float64(hitsW)/float64(gets) < target {
+		return capacity, false, false
+	}
+
+	// Slack branch: capacity above occupancy. Drop the unused headroom; no
+	// eviction is needed because occupancy already fits the smaller capacity.
+	if capacity > size {
+		newCap = size
+		if newCap < floor {
+			newCap = floor
+		}
+		if newCap >= capacity {
+			return capacity, false, false
+		}
+		return newCap, true, false
+	}
+
+	// Cache is full (capacity == size): the decision needs the footprint.
+	return capacity, false, true
+}
+
+// decideColdTail trims a full cache to the warm footprint, clamped at floor and
+// bounded to half the cache per event so the write lock is not held long.
+// Returns the new capacity, the number of LRU-tail entries to evict to reach it,
+// and whether a shrink should occur.
+func decideColdTail(size, warmCount, floor int64) (newCap, evict int64, shrink bool) {
+	targetCap := warmCount
+	if targetCap < floor {
+		targetCap = floor
+	}
+	if targetCap >= size {
+		return size, 0, false // nothing cold to shed
+	}
+	evict = size - targetCap
+	if maxEvict := size / 2; evict > maxEvict {
+		evict = maxEvict // bound per-event eviction; decay continues over later windows
+	}
+	return size - evict, evict, true
 }
 
 // seriesIDCacheElement is an item stored within a cache.

--- a/tsdb/index/tsi1/cache.go
+++ b/tsdb/index/tsi1/cache.go
@@ -40,8 +40,8 @@ const (
 const maxShrinkEvictPerEvent = 1024
 
 // TagValueSeriesIDCacheStatistics holds counters describing the behavior of a
-// TagValueSeriesIDCache. Fields are read and written with sync/atomic so that
-// Statistics can be sampled without acquiring the cache lock.
+// TagValueSeriesIDCache. Fields are atomic.Int64 so that Statistics can be
+// sampled without acquiring the cache lock.
 //
 // Evictions counts entries forced out under write pressure (a Put on a full
 // cache); ShrinkEvictions counts entries shed by the adaptive shrink policy.
@@ -50,11 +50,11 @@ const maxShrinkEvictPerEvent = 1024
 // → forced eviction"), and operators often want to distinguish "the cache is
 // under pressure" from "the cache is voluntarily releasing memory."
 type TagValueSeriesIDCacheStatistics struct {
-	Hits            int64
-	Misses          int64
-	Evictions       int64
-	ShrinkEvictions int64
-	Size            int64
+	Hits            atomic.Int64
+	Misses          atomic.Int64
+	Evictions       atomic.Int64
+	ShrinkEvictions atomic.Int64
+	Size            atomic.Int64
 }
 
 // resizeEvent describes a single capacity-change event (grow or shrink).
@@ -79,20 +79,13 @@ type resizeEvent struct {
 // order by which items should be evicted from the cache, and a hashmap implementation
 // to provide constant time retrievals of items from the cache.
 type TagValueSeriesIDCache struct {
-	// Due to a bug in atomic, 64-bit words accessed with sync/atomic must be
-	// 64-bit aligned, and the first word of an allocated struct is the only
-	// position guaranteed to be 8-byte aligned on 32-bit platforms. Keep all
-	// atomically-accessed int64 fields (capacity and the stats counters)
-	// contiguous at the top of the struct, ahead of every other field.
-	// See: https://golang.org/pkg/sync/atomic/#pkg-note-BUG
+	// capacity is the current cache capacity. Read with capacity.Load()
+	// (lockless reads from Statistics); written with capacity.Store() under
+	// the cache write lock when the adaptive policy grows it. It is an
+	// atomic.Int64, which aligns itself, so its placement is unconstrained.
+	capacity atomic.Int64
 
-	// capacity is the current cache capacity. Read with atomic.LoadInt64
-	// (lockless reads from Statistics); written with atomic.StoreInt64 under
-	// the cache write lock when the adaptive policy grows it.
-	capacity int64
-
-	// stats holds the atomically-accessed counters. Its int64 fields stay
-	// 8-byte aligned because capacity above is exactly one 64-bit word.
+	// stats holds the atomically-accessed counters.
 	stats TagValueSeriesIDCacheStatistics
 
 	sync.RWMutex
@@ -138,12 +131,13 @@ type TagValueSeriesIDCache struct {
 // NewTagValueSeriesIDCache returns a TagValueSeriesIDCache with fixed
 // capacity c. Adaptive sizing is disabled; the cache will evict at c.
 func NewTagValueSeriesIDCache(c int) *TagValueSeriesIDCache {
-	return &TagValueSeriesIDCache{
-		cache:    map[string]map[string]map[string]*list.Element{},
-		evictor:  list.New(),
-		capacity: int64(c),
-		logger:   zap.NewNop(),
+	cache := &TagValueSeriesIDCache{
+		cache:   map[string]map[string]map[string]*list.Element{},
+		evictor: list.New(),
+		logger:  zap.NewNop(),
 	}
+	cache.capacity.Store(int64(c))
+	return cache
 }
 
 // NewAdaptiveTagValueSeriesIDCache returns a TagValueSeriesIDCache that sizes
@@ -215,10 +209,9 @@ func NewAdaptiveTagValueSeriesIDCache(initial, max int, target, shrinkConservati
 		return fallback("minSamples must be >= 0", zap.Int("min_samples", minSamples))
 	}
 
-	return &TagValueSeriesIDCache{
+	cache := &TagValueSeriesIDCache{
 		cache:              map[string]map[string]map[string]*list.Element{},
 		evictor:            list.New(),
-		capacity:           int64(initial),
 		minCapacity:        int64(initial),
 		maxCapacity:        int64(max),
 		targetHitRate:      target,
@@ -226,6 +219,8 @@ func NewAdaptiveTagValueSeriesIDCache(initial, max int, target, shrinkConservati
 		minSamples:         int64(minSamples),
 		logger:             logger,
 	}
+	cache.capacity.Store(int64(initial))
+	return cache
 }
 
 // SetLogger replaces the cache's logger. Intended for callers that
@@ -245,12 +240,12 @@ func (c *TagValueSeriesIDCache) Statistics(tags map[string]string) []models.Stat
 		Name: statTagValueCacheMeasurement,
 		Tags: tags,
 		Values: map[string]interface{}{
-			statTagValueCacheHit:            atomic.LoadInt64(&c.stats.Hits),
-			statTagValueCacheMiss:           atomic.LoadInt64(&c.stats.Misses),
-			statTagValueCacheEviction:       atomic.LoadInt64(&c.stats.Evictions),
-			statTagValueCacheShrinkEviction: atomic.LoadInt64(&c.stats.ShrinkEvictions),
-			statTagValueCacheSize:           atomic.LoadInt64(&c.stats.Size),
-			statTagValueCacheCapacity:       atomic.LoadInt64(&c.capacity),
+			statTagValueCacheHit:            c.stats.Hits.Load(),
+			statTagValueCacheMiss:           c.stats.Misses.Load(),
+			statTagValueCacheEviction:       c.stats.Evictions.Load(),
+			statTagValueCacheShrinkEviction: c.stats.ShrinkEvictions.Load(),
+			statTagValueCacheSize:           c.stats.Size.Load(),
+			statTagValueCacheCapacity:       c.capacity.Load(),
 		},
 	}}
 }
@@ -285,12 +280,12 @@ func (c *TagValueSeriesIDCache) get(name, key, value []byte) (*tsdb.SeriesIDSet,
 					c.trackTouchLocked(ele)
 				}
 				c.evictor.MoveToFront(ele) // This now becomes most recently used.
-				atomic.AddInt64(&c.stats.Hits, 1)
+				c.stats.Hits.Add(1)
 				return ele.Value.(*seriesIDCacheElement).SeriesIDSet, true
 			}
 		}
 	}
-	atomic.AddInt64(&c.stats.Misses, 1)
+	c.stats.Misses.Add(1)
 	return nil, false
 }
 
@@ -385,7 +380,7 @@ func (c *TagValueSeriesIDCache) innerLockingPut(name, key, value []byte, ss *tsd
 		value:       valueStr,
 		SeriesIDSet: ss,
 	})
-	atomic.AddInt64(&c.stats.Size, 1)
+	c.stats.Size.Add(1)
 
 	// Add the listElement to the set of items. The tuple cannot already
 	// exist here: the exists() check at the top of Put returns early if it
@@ -442,13 +437,13 @@ func (c *TagValueSeriesIDCache) delete(name, key, value []byte, x uint64) {
 // the caller should use to emit a log line after releasing the write lock;
 // the bool is true iff a resize occurred.
 func (c *TagValueSeriesIDCache) checkEviction() (resizeEvent, bool) {
-	if int64(c.evictor.Len()) <= atomic.LoadInt64(&c.capacity) {
+	if int64(c.evictor.Len()) <= c.capacity.Load() {
 		return resizeEvent{}, false
 	}
 	if !c.evictLRULocked() {
 		return resizeEvent{}, false
 	}
-	atomic.AddInt64(&c.stats.Evictions, 1)
+	c.stats.Evictions.Add(1)
 
 	// Adaptive sizing: skip entirely when disabled to keep the hot path
 	// free of per-eviction tracking work.
@@ -457,7 +452,7 @@ func (c *TagValueSeriesIDCache) checkEviction() (resizeEvent, bool) {
 	}
 
 	c.evictionsSinceCheck++
-	if c.evictionsSinceCheck < atomic.LoadInt64(&c.capacity) {
+	if c.evictionsSinceCheck < c.capacity.Load() {
 		return resizeEvent{}, false
 	}
 	c.evictionsSinceCheck = 0
@@ -495,7 +490,7 @@ func (c *TagValueSeriesIDCache) evictLRULocked() bool {
 
 	c.evictor.Remove(e)               // Remove from evictor
 	delete(c.cache[name][key], value) // Remove from hashmap of items.
-	atomic.AddInt64(&c.stats.Size, -1)
+	c.stats.Size.Add(-1)
 
 	// Check if there are no more tag values for the tag key.
 	if len(c.cache[name][key]) == 0 {
@@ -514,9 +509,9 @@ func (c *TagValueSeriesIDCache) evictLRULocked() bool {
 // new capacity if growth is warranted. Must be called under the write
 // lock.
 func (c *TagValueSeriesIDCache) maybeResizeLocked() (resizeEvent, bool) {
-	hits := atomic.LoadInt64(&c.stats.Hits)
-	misses := atomic.LoadInt64(&c.stats.Misses)
-	curCap := atomic.LoadInt64(&c.capacity)
+	hits := c.stats.Hits.Load()
+	misses := c.stats.Misses.Load()
+	curCap := c.capacity.Load()
 
 	newCap, gets, rate, grow := decideResize(
 		hits, misses, c.lastHits, c.lastMisses,
@@ -532,7 +527,7 @@ func (c *TagValueSeriesIDCache) maybeResizeLocked() (resizeEvent, bool) {
 		return resizeEvent{}, false
 	}
 
-	atomic.StoreInt64(&c.capacity, newCap)
+	c.capacity.Store(newCap)
 	// Suppress shrink until the freshly-grown cache (occupancy ~50% of the new
 	// capacity) has been exercised: a full observation window sized to the new
 	// capacity, so the cooldown scales with the grown size rather than the
@@ -631,14 +626,14 @@ func (c *TagValueSeriesIDCache) checkShrink(hit bool) (resizeEvent, bool) {
 	if c.shrinkWindowGets == 0 {
 		c.shrinkWindowGets = adaptiveWindowLen(int64(c.evictor.Len()), c.minSamples, c.targetHitRate)
 		c.getsSinceShrinkCheck = 0
-		c.shrinkBaseHits = atomic.LoadInt64(&c.stats.Hits)
-		c.shrinkBaseMisses = atomic.LoadInt64(&c.stats.Misses)
+		c.shrinkBaseHits = c.stats.Hits.Load()
+		c.shrinkBaseMisses = c.stats.Misses.Load()
 		if hit {
 			c.shrinkBaseHits--
 		} else {
 			c.shrinkBaseMisses--
 		}
-		c.shrinkBaseEvictions = atomic.LoadInt64(&c.stats.Evictions)
+		c.shrinkBaseEvictions = c.stats.Evictions.Load()
 		if c.shrinkWindowGets == 0 {
 			// Cache too small (n < 2) to evaluate. Clear the boundary so a
 			// warm-up touch can't carry into the first real window.
@@ -677,11 +672,11 @@ func (c *TagValueSeriesIDCache) checkShrink(hit bool) (resizeEvent, bool) {
 // an untouched tail — so gated-out and slack windows stay O(1). Must be called
 // under the write lock.
 func (c *TagValueSeriesIDCache) maybeShrinkLocked() (resizeEvent, bool) {
-	hitsW := atomic.LoadInt64(&c.stats.Hits) - c.shrinkBaseHits
-	missesW := atomic.LoadInt64(&c.stats.Misses) - c.shrinkBaseMisses
-	evictionsW := atomic.LoadInt64(&c.stats.Evictions) - c.shrinkBaseEvictions
+	hitsW := c.stats.Hits.Load() - c.shrinkBaseHits
+	missesW := c.stats.Misses.Load() - c.shrinkBaseMisses
+	evictionsW := c.stats.Evictions.Load() - c.shrinkBaseEvictions
 
-	curCap := atomic.LoadInt64(&c.capacity)
+	curCap := c.capacity.Load()
 	size := int64(c.evictor.Len())
 
 	newCap, shrink, coldTail := decideShrinkPre(hitsW, missesW, evictionsW, curCap, size, c.minCapacity, c.targetHitRate, c.shrinkConservatism)
@@ -702,7 +697,7 @@ func (c *TagValueSeriesIDCache) maybeShrinkLocked() (resizeEvent, bool) {
 		for evicted < evict && c.evictLRULocked() {
 			evicted++
 		}
-		atomic.AddInt64(&c.stats.ShrinkEvictions, evicted)
+		c.stats.ShrinkEvictions.Add(evicted)
 		// Derive the new capacity from what was actually evicted so the
 		// invariant size <= capacity holds even if the list emptied early.
 		newCap = size - evicted
@@ -710,7 +705,7 @@ func (c *TagValueSeriesIDCache) maybeShrinkLocked() (resizeEvent, bool) {
 		return resizeEvent{}, false
 	}
 
-	atomic.StoreInt64(&c.capacity, newCap)
+	c.capacity.Store(newCap)
 
 	// Capacity shrank: reset the grow policy's per-window state so the next
 	// forced eviction measures a fresh post-shrink turnover. Without this,
@@ -718,8 +713,8 @@ func (c *TagValueSeriesIDCache) maybeShrinkLocked() (resizeEvent, bool) {
 	// smaller capacity) could immediately fire maybeResizeLocked against
 	// pre-shrink hit/miss baselines, mixing pre- and post-shrink samples.
 	c.evictionsSinceCheck = 0
-	c.lastHits = atomic.LoadInt64(&c.stats.Hits)
-	c.lastMisses = atomic.LoadInt64(&c.stats.Misses)
+	c.lastHits = c.stats.Hits.Load()
+	c.lastMisses = c.stats.Misses.Load()
 
 	gets := hitsW + missesW
 	var rate float64

--- a/tsdb/index/tsi1/cache.go
+++ b/tsdb/index/tsi1/cache.go
@@ -11,7 +11,15 @@ import (
 	"go.uber.org/zap"
 )
 
-// Statistic names for the tag value series ID cache.
+// statTagValueCacheMeasurement is the measurement name under which the tag
+// value series ID cache reports its statistics.
+const statTagValueCacheMeasurement = "tsi1_cache"
+
+// logMsgCacheCapacityIncreased is the message logged when adaptive sizing
+// grows the cache. Shared with tests so the assertion tracks the source.
+const logMsgCacheCapacityIncreased = "tsi cache capacity increased"
+
+// Statistic field names for the tag value series ID cache.
 const (
 	statTagValueCacheHit      = "hit"
 	statTagValueCacheMiss     = "miss"
@@ -94,14 +102,15 @@ func NewTagValueSeriesIDCache(c int) *TagValueSeriesIDCache {
 // never shrinks. minSamples is a floor on the number of Get operations
 // observed in a window before the policy is allowed to act; below this
 // floor the rate is treated as too noisy to react to. Panics on invalid
-// arguments: initial must be > 0, max >= initial, target in (0, 1],
-// minSamples >= 0.
+// arguments: initial must be > 0, max > initial (an adaptive cache that
+// cannot grow is a misconfiguration — use NewTagValueSeriesIDCache for a
+// fixed cache), target in (0, 1], minSamples >= 0.
 func NewAdaptiveTagValueSeriesIDCache(initial, max int, target float64, minSamples int, logger *zap.Logger) *TagValueSeriesIDCache {
 	if initial <= 0 {
 		panic(fmt.Sprintf("NewAdaptiveTagValueSeriesIDCache: initial must be > 0, got %d", initial))
 	}
-	if max < initial {
-		panic(fmt.Sprintf("NewAdaptiveTagValueSeriesIDCache: max (%d) must be >= initial (%d)", max, initial))
+	if max <= initial {
+		panic(fmt.Sprintf("NewAdaptiveTagValueSeriesIDCache: max (%d) must be > initial (%d)", max, initial))
 	}
 	if target <= 0 || target > 1 {
 		panic(fmt.Sprintf("NewAdaptiveTagValueSeriesIDCache: target must be in (0, 1], got %v", target))
@@ -137,7 +146,7 @@ func (c *TagValueSeriesIDCache) SetLogger(logger *zap.Logger) {
 // Statistics returns statistics for periodic monitoring.
 func (c *TagValueSeriesIDCache) Statistics(tags map[string]string) []models.Statistic {
 	return []models.Statistic{{
-		Name: "tsi1_cache",
+		Name: statTagValueCacheMeasurement,
 		Tags: tags,
 		Values: map[string]interface{}{
 			statTagValueCacheHit:      atomic.LoadInt64(&c.stats.Hits),
@@ -237,13 +246,11 @@ func (c *TagValueSeriesIDCache) Put(name, key, value []byte, ss *tsdb.SeriesIDSe
 	})
 	atomic.AddInt64(&c.stats.Size, 1)
 
-	// Add the listElement to the set of items.
+	// Add the listElement to the set of items. The tuple cannot already
+	// exist here: the exists() check at the top of Put returns early if it
+	// does, and nothing inserts into c.cache between that check and here.
 	if mmap, ok := c.cache[nameStr]; ok {
 		if tkmap, ok := mmap[keyStr]; ok {
-			if _, ok := tkmap[valueStr]; ok {
-				goto EVICT
-			}
-
 			// Add the set to the map
 			tkmap[valueStr] = listElement
 			goto EVICT
@@ -409,7 +416,7 @@ func decideResize(hits, misses, lastHits, lastMisses, capacity, maxCapacity, min
 // c.maxCapacity and c.targetHitRate directly — both are set at
 // construction and never mutated.
 func (c *TagValueSeriesIDCache) logResize(e resizeEvent) {
-	c.logger.Info("tsi cache capacity increased",
+	c.logger.Info(logMsgCacheCapacityIncreased,
 		zap.Int64("old_capacity", e.oldCap),
 		zap.Int64("new_capacity", e.newCap),
 		zap.Int64("max_capacity", c.maxCapacity),

--- a/tsdb/index/tsi1/cache.go
+++ b/tsdb/index/tsi1/cache.go
@@ -2,10 +2,41 @@ package tsi1
 
 import (
 	"container/list"
+	"fmt"
 	"sync"
+	"sync/atomic"
 
+	"github.com/influxdata/influxdb/models"
 	"github.com/influxdata/influxdb/tsdb"
+	"go.uber.org/zap"
 )
+
+// Statistic names for the tag value series ID cache.
+const (
+	statTagValueCacheHit      = "hit"
+	statTagValueCacheMiss     = "miss"
+	statTagValueCacheEviction = "eviction"
+	statTagValueCacheSize     = "size"
+	statTagValueCacheCapacity = "capacity"
+)
+
+// TagValueSeriesIDCacheStatistics holds counters describing the behavior of a
+// TagValueSeriesIDCache. Fields are read and written with sync/atomic so that
+// Statistics can be sampled without acquiring the cache lock.
+type TagValueSeriesIDCacheStatistics struct {
+	Hits      int64
+	Misses    int64
+	Evictions int64
+	Size      int64
+}
+
+// resizeEvent describes a single capacity-growth event. Snapshot fields are
+// captured under the cache write lock so the log line can be emitted by the
+// caller after releasing the lock.
+type resizeEvent struct {
+	oldCap, newCap, gets int64
+	rate                 float64
+}
 
 // TagValueSeriesIDCache is an LRU cache for series id sets associated with
 // name -> key -> value mappings. The purpose of the cache is to provide
@@ -24,16 +55,98 @@ type TagValueSeriesIDCache struct {
 	cache   map[string]map[string]map[string]*list.Element
 	evictor *list.List
 
-	capacity int
+	// capacity is the current cache capacity. Read with atomic.LoadInt64
+	// (lockless reads from Statistics); written with atomic.StoreInt64 under
+	// the cache write lock when the adaptive policy grows it.
+	capacity int64
+
+	// Adaptive sizing fields. maxCapacity == 0 means adaptive sizing is
+	// disabled and none of the other fields below are consulted. When
+	// enabled, lastHits/lastMisses/evictionsSinceCheck are read and written
+	// only under the write lock (checkEviction always holds it).
+	maxCapacity         int64
+	targetHitRate       float64
+	minSamples          int64
+	logger              *zap.Logger
+	evictionsSinceCheck int64
+	lastHits            int64
+	lastMisses          int64
+
+	stats TagValueSeriesIDCacheStatistics
 }
 
-// NewTagValueSeriesIDCache returns a TagValueSeriesIDCache with capacity c.
+// NewTagValueSeriesIDCache returns a TagValueSeriesIDCache with fixed
+// capacity c. Adaptive sizing is disabled; the cache will evict at c.
 func NewTagValueSeriesIDCache(c int) *TagValueSeriesIDCache {
 	return &TagValueSeriesIDCache{
 		cache:    map[string]map[string]map[string]*list.Element{},
 		evictor:  list.New(),
-		capacity: c,
+		capacity: int64(c),
+		logger:   zap.NewNop(),
 	}
+}
+
+// NewAdaptiveTagValueSeriesIDCache returns a TagValueSeriesIDCache that
+// starts at the given initial capacity and grows (doubling) up to max as
+// the observed Get hit rate falls below target. Resizes are driven from
+// the eviction path: after every `capacity` evictions, the cache samples
+// its windowed hit rate and grows once if the policy fires. The cache
+// never shrinks. minSamples is a floor on the number of Get operations
+// observed in a window before the policy is allowed to act; below this
+// floor the rate is treated as too noisy to react to. Panics on invalid
+// arguments: initial must be > 0, max >= initial, target in (0, 1],
+// minSamples >= 0.
+func NewAdaptiveTagValueSeriesIDCache(initial, max int, target float64, minSamples int, logger *zap.Logger) *TagValueSeriesIDCache {
+	if initial <= 0 {
+		panic(fmt.Sprintf("NewAdaptiveTagValueSeriesIDCache: initial must be > 0, got %d", initial))
+	}
+	if max < initial {
+		panic(fmt.Sprintf("NewAdaptiveTagValueSeriesIDCache: max (%d) must be >= initial (%d)", max, initial))
+	}
+	if target <= 0 || target > 1 {
+		panic(fmt.Sprintf("NewAdaptiveTagValueSeriesIDCache: target must be in (0, 1], got %v", target))
+	}
+	if minSamples < 0 {
+		panic(fmt.Sprintf("NewAdaptiveTagValueSeriesIDCache: minSamples must be >= 0, got %d", minSamples))
+	}
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	return &TagValueSeriesIDCache{
+		cache:         map[string]map[string]map[string]*list.Element{},
+		evictor:       list.New(),
+		capacity:      int64(initial),
+		maxCapacity:   int64(max),
+		targetHitRate: target,
+		minSamples:    int64(minSamples),
+		logger:        logger,
+	}
+}
+
+// SetLogger replaces the cache's logger. Intended for callers that
+// construct the cache before a logger is available (and for tests that
+// need to observe resize log lines). Not safe for concurrent use; call
+// before the cache is shared with other goroutines.
+func (c *TagValueSeriesIDCache) SetLogger(logger *zap.Logger) {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+	c.logger = logger
+}
+
+// Statistics returns statistics for periodic monitoring.
+func (c *TagValueSeriesIDCache) Statistics(tags map[string]string) []models.Statistic {
+	return []models.Statistic{{
+		Name: "tsi1_cache",
+		Tags: tags,
+		Values: map[string]interface{}{
+			statTagValueCacheHit:      atomic.LoadInt64(&c.stats.Hits),
+			statTagValueCacheMiss:     atomic.LoadInt64(&c.stats.Misses),
+			statTagValueCacheEviction: atomic.LoadInt64(&c.stats.Evictions),
+			statTagValueCacheSize:     atomic.LoadInt64(&c.stats.Size),
+			statTagValueCacheCapacity: atomic.LoadInt64(&c.capacity),
+		},
+	}}
 }
 
 // Get returns the SeriesIDSet associated with the {name, key, value} tuple if it
@@ -49,10 +162,12 @@ func (c *TagValueSeriesIDCache) get(name, key, value []byte) *tsdb.SeriesIDSet {
 		if tkmap, ok := mmap[string(key)]; ok {
 			if ele, ok := tkmap[string(value)]; ok {
 				c.evictor.MoveToFront(ele) // This now becomes most recently used.
+				atomic.AddInt64(&c.stats.Hits, 1)
 				return ele.Value.(*seriesIDCacheElement).SeriesIDSet
 			}
 		}
 	}
+	atomic.AddInt64(&c.stats.Misses, 1)
 	return nil
 }
 
@@ -107,7 +222,6 @@ func (c *TagValueSeriesIDCache) Put(name, key, value []byte, ss *tsdb.SeriesIDSe
 		c.Unlock()
 		return
 	}
-	defer c.Unlock()
 
 	// Ensure our SeriesIDSet is go heap backed.
 	if ss != nil {
@@ -121,6 +235,7 @@ func (c *TagValueSeriesIDCache) Put(name, key, value []byte, ss *tsdb.SeriesIDSe
 		value:       valueStr,
 		SeriesIDSet: ss,
 	})
+	atomic.AddInt64(&c.stats.Size, 1)
 
 	// Add the listElement to the set of items.
 	if mmap, ok := c.cache[nameStr]; ok {
@@ -145,7 +260,11 @@ func (c *TagValueSeriesIDCache) Put(name, key, value []byte, ss *tsdb.SeriesIDSe
 	}
 
 EVICT:
-	c.checkEviction()
+	event, grew := c.checkEviction()
+	c.Unlock()
+	if grew {
+		c.logResize(event)
+	}
 }
 
 // Delete removes x from the tuple {name, key, value} if it exists.
@@ -169,11 +288,16 @@ func (c *TagValueSeriesIDCache) delete(name, key, value []byte, x uint64) {
 	}
 }
 
-// checkEviction checks if the cache is too big, and evicts the least recently used
-// item if it is.
-func (c *TagValueSeriesIDCache) checkEviction() {
-	if c.evictor.Len() <= c.capacity {
-		return
+// checkEviction checks if the cache is too big, and evicts the least
+// recently used item if it is. When adaptive sizing is enabled and the
+// cache has just turned over (i.e. accumulated `capacity` evictions since
+// the last policy firing), it samples the windowed hit rate and may grow
+// the capacity. The optional resizeEvent return carries the snapshot the
+// caller should use to emit a log line after releasing the write lock;
+// the bool is true iff a resize occurred.
+func (c *TagValueSeriesIDCache) checkEviction() (resizeEvent, bool) {
+	if int64(c.evictor.Len()) <= atomic.LoadInt64(&c.capacity) {
+		return resizeEvent{}, false
 	}
 
 	e := c.evictor.Back() // Least recently used item.
@@ -184,6 +308,8 @@ func (c *TagValueSeriesIDCache) checkEviction() {
 
 	c.evictor.Remove(e)                                       // Remove from evictor
 	delete(c.cache[string(name)][string(key)], string(value)) // Remove from hashmap of items.
+	atomic.AddInt64(&c.stats.Evictions, 1)
+	atomic.AddInt64(&c.stats.Size, -1)
 
 	// Check if there are no more tag values for the tag key.
 	if len(c.cache[string(name)][string(key)]) == 0 {
@@ -194,6 +320,103 @@ func (c *TagValueSeriesIDCache) checkEviction() {
 	if len(c.cache[string(name)]) == 0 {
 		delete(c.cache, string(name))
 	}
+
+	// Adaptive sizing: skip entirely when disabled to keep the hot path
+	// free of per-eviction tracking work.
+	if c.maxCapacity == 0 {
+		return resizeEvent{}, false
+	}
+
+	c.evictionsSinceCheck++
+	if c.evictionsSinceCheck < atomic.LoadInt64(&c.capacity) {
+		return resizeEvent{}, false
+	}
+	c.evictionsSinceCheck = 0
+	return c.maybeResizeLocked()
+}
+
+// maybeResizeLocked samples the windowed hit rate, calls the pure policy
+// helper, advances the per-window snapshot, and atomically applies the
+// new capacity if growth is warranted. Must be called under the write
+// lock.
+func (c *TagValueSeriesIDCache) maybeResizeLocked() (resizeEvent, bool) {
+	hits := atomic.LoadInt64(&c.stats.Hits)
+	misses := atomic.LoadInt64(&c.stats.Misses)
+	curCap := atomic.LoadInt64(&c.capacity)
+
+	newCap, gets, rate, grow := decideResize(
+		hits, misses, c.lastHits, c.lastMisses,
+		curCap, c.maxCapacity, c.minSamples, c.targetHitRate,
+	)
+
+	// Always advance the snapshot so each firing measures the next
+	// window, regardless of whether we grew.
+	c.lastHits = hits
+	c.lastMisses = misses
+
+	if !grow {
+		return resizeEvent{}, false
+	}
+
+	atomic.StoreInt64(&c.capacity, newCap)
+	return resizeEvent{
+		oldCap: curCap,
+		newCap: newCap,
+		gets:   gets,
+		rate:   rate,
+	}, true
+}
+
+// decideResize implements the adaptive-sizing policy as a pure function
+// of the cache's counters and configuration. Kept as a free function so
+// the policy table can be exercised with integer literals, without
+// configuring a *TagValueSeriesIDCache instance for every row.
+func decideResize(hits, misses, lastHits, lastMisses, capacity, maxCapacity, minSamples int64, target float64) (newCap, gets int64, rate float64, grow bool) {
+	hitsW := hits - lastHits
+	missesW := misses - lastMisses
+	gets = hitsW + missesW
+
+	// Compute rate up-front when there is at least one read so the
+	// returned rate is always meaningful when gets > 0, regardless of
+	// which branch the policy takes.
+	if gets > 0 {
+		rate = float64(hitsW) / float64(gets)
+	}
+
+	// Floor on sample size: too few reads since the last firing makes
+	// any rate observation noisy. Also covers pure-write workloads
+	// (gets == 0).
+	if gets < minSamples {
+		return capacity, gets, rate, false
+	}
+
+	if rate >= target {
+		return capacity, gets, rate, false
+	}
+	if capacity >= maxCapacity {
+		return capacity, gets, rate, false
+	}
+
+	newCap = capacity * 2
+	if newCap > maxCapacity {
+		newCap = maxCapacity
+	}
+	return newCap, gets, rate, true
+}
+
+// logResize emits a single INFO log line describing a capacity-growth
+// event. Called by Put after releasing the cache write lock. Reads
+// c.maxCapacity and c.targetHitRate directly — both are set at
+// construction and never mutated.
+func (c *TagValueSeriesIDCache) logResize(e resizeEvent) {
+	c.logger.Info("tsi cache capacity increased",
+		zap.Int64("old_capacity", e.oldCap),
+		zap.Int64("new_capacity", e.newCap),
+		zap.Int64("max_capacity", c.maxCapacity),
+		zap.Float64("hit_rate", e.rate),
+		zap.Float64("target", c.targetHitRate),
+		zap.Int64("gets_window", e.gets),
+	)
 }
 
 // seriesIDCacheElement is an item stored within a cache.

--- a/tsdb/index/tsi1/cache.go
+++ b/tsdb/index/tsi1/cache.go
@@ -682,6 +682,15 @@ func (c *TagValueSeriesIDCache) maybeShrinkLocked() (resizeEvent, bool) {
 
 	atomic.StoreInt64(&c.capacity, newCap)
 
+	// Capacity shrank: reset the grow policy's per-window state so the next
+	// forced eviction measures a fresh post-shrink turnover. Without this,
+	// the stale evictionsSinceCheck (potentially near or above the new
+	// smaller capacity) could immediately fire maybeResizeLocked against
+	// pre-shrink hit/miss baselines, mixing pre- and post-shrink samples.
+	c.evictionsSinceCheck = 0
+	c.lastHits = atomic.LoadInt64(&c.stats.Hits)
+	c.lastMisses = atomic.LoadInt64(&c.stats.Misses)
+
 	gets := hitsW + missesW
 	var rate float64
 	if gets > 0 {

--- a/tsdb/index/tsi1/cache.go
+++ b/tsdb/index/tsi1/cache.go
@@ -415,9 +415,12 @@ func decideResize(hits, misses, lastHits, lastMisses, capacity, maxCapacity, min
 		return capacity, gets, rate, false
 	}
 
-	newCap = capacity * 2
-	if newCap > maxCapacity {
+	// Clamp before doubling so large valid int64 capacities cannot
+	// overflow when applying the adaptive growth policy.
+	if capacity > maxCapacity/2 {
 		newCap = maxCapacity
+	} else {
+		newCap = capacity * 2
 	}
 	return newCap, gets, rate, true
 }

--- a/tsdb/index/tsi1/cache.go
+++ b/tsdb/index/tsi1/cache.go
@@ -24,12 +24,6 @@ const logMsgCacheCapacityIncreased = "tsi cache capacity increased"
 // shrinks the cache. Shared with tests so the assertion tracks the source.
 const logMsgCacheCapacityDecreased = "tsi cache capacity decreased"
 
-// shrinkCooldownWindows is the number of shrink-evaluation windows for which
-// shrink is suppressed after any capacity change (grow or shrink). It prevents
-// grow⇄shrink oscillation; only shrink respects it (grow always reacts to real
-// eviction pressure immediately).
-const shrinkCooldownWindows = 3
-
 // Statistic field names for the tag value series ID cache.
 const (
 	statTagValueCacheHit      = "hit"
@@ -99,6 +93,7 @@ type TagValueSeriesIDCache struct {
 	// unconstrained.
 	maxCapacity         int64
 	targetHitRate       float64
+	shrinkConservatism  float64 // sigmas below the at-target eviction mean for the shrink gate; >= 0.0
 	minSamples          int64
 	logger              *zap.Logger
 	evictionsSinceCheck int64
@@ -112,15 +107,17 @@ type TagValueSeriesIDCache struct {
 	// no active window — recompute from current occupancy on the next Get). The
 	// shrinkBase* fields snapshot the stats counters at window start so deltas
 	// can be measured. deepestTouched marks the back of the warm front-prefix
-	// observed this window (the LRU access footprint). cooldownRemaining gates
-	// shrink for a few windows after any capacity change.
+	// observed this window (the LRU access footprint). cooldownGets is the number
+	// of Gets for which shrink stays suppressed after any capacity change, sized
+	// to the new capacity so a freshly-resized cache is exercised before the next
+	// shrink decision.
 	minCapacity          int64
 	getsSinceShrinkCheck int64
 	shrinkWindowGets     int64
 	shrinkBaseHits       int64
 	shrinkBaseMisses     int64
 	shrinkBaseEvictions  int64
-	cooldownRemaining    int64
+	cooldownGets         int64
 	deepestTouched       *list.Element
 }
 
@@ -135,27 +132,44 @@ func NewTagValueSeriesIDCache(c int) *TagValueSeriesIDCache {
 	}
 }
 
-// NewAdaptiveTagValueSeriesIDCache returns a TagValueSeriesIDCache that
-// starts at the given initial capacity and grows (doubling) up to max as
-// the observed Get hit rate falls below target. Resizes are driven from
-// the eviction path: after every `capacity` evictions, the cache samples
-// its windowed hit rate and grows once if the policy fires. The cache
-// never shrinks. minSamples is a floor on the number of Get operations
-// observed in a window before the policy is allowed to act; below this
-// floor the rate is treated as too noisy to react to. Panics on invalid
-// arguments: initial must be > 0, max > initial (an adaptive cache that
-// cannot grow is a misconfiguration — use NewTagValueSeriesIDCache for a
+// NewAdaptiveTagValueSeriesIDCache returns a TagValueSeriesIDCache that sizes
+// itself between initial and max as the workload changes; capacity is not a
+// fixed high-water mark and callers must not rely on it staying at any value.
+//
+// It grows by doubling toward max when the observed Get hit rate falls below
+// target while under eviction pressure (driven from the eviction path: after
+// every `capacity` evictions it samples the windowed hit rate and grows once if
+// the policy fires). It also shrinks: driven from the read path, after a
+// self-tuning window of Gets, a cache that is quiet (no evictions) and serving
+// at/above target trims capacity toward its observed working set, shedding only
+// least-recently-used entries left untouched over the window, never below
+// initial. A cooldown between resizes prevents grow/shrink oscillation.
+//
+// minSamples is a floor on the number of Get operations observed in a window
+// before the grow policy is allowed to act; below this floor the rate is treated
+// as too noisy to react to. shrinkConservatism (>= 0.0) is the number of standard
+// deviations below the at-target eviction mean at which the shrink eviction gate
+// sits; see the doc on SeriesIDSetCacheShrinkConservatism in tsdb.Config. Panics
+// on invalid arguments: initial must be > 0, max > initial (an adaptive cache
+// that cannot grow is a misconfiguration — use NewTagValueSeriesIDCache for a
 // fixed cache), target in (0, 1) (1.0 is unachievable and is rejected by config
-// validation), minSamples >= 0.
-func NewAdaptiveTagValueSeriesIDCache(initial, max int, target float64, minSamples int, logger *zap.Logger) *TagValueSeriesIDCache {
+// validation; NaN is rejected), shrinkConservatism finite and >= 0.0 (NaN/±Inf
+// rejected), minSamples >= 0.
+func NewAdaptiveTagValueSeriesIDCache(initial, max int, target, shrinkConservatism float64, minSamples int, logger *zap.Logger) *TagValueSeriesIDCache {
 	if initial <= 0 {
 		panic(fmt.Sprintf("NewAdaptiveTagValueSeriesIDCache: initial must be > 0, got %d", initial))
 	}
 	if max <= initial {
 		panic(fmt.Sprintf("NewAdaptiveTagValueSeriesIDCache: max (%d) must be > initial (%d)", max, initial))
 	}
-	if target <= 0 || target >= 1 {
+	// Positive range test so NaN (for which both `<` and `>` are false) is
+	// rejected rather than slipping through.
+	if !(target > 0 && target < 1) {
 		panic(fmt.Sprintf("NewAdaptiveTagValueSeriesIDCache: target must be in (0, 1), got %v", target))
+	}
+	// Same positive-form trick rejects NaN and ±Inf for the conservatism.
+	if !(shrinkConservatism >= 0 && shrinkConservatism < math.Inf(1)) {
+		panic(fmt.Sprintf("NewAdaptiveTagValueSeriesIDCache: shrinkConservatism must be a finite value >= 0, got %v", shrinkConservatism))
 	}
 	if minSamples < 0 {
 		panic(fmt.Sprintf("NewAdaptiveTagValueSeriesIDCache: minSamples must be >= 0, got %d", minSamples))
@@ -164,14 +178,15 @@ func NewAdaptiveTagValueSeriesIDCache(initial, max int, target float64, minSampl
 		logger = zap.NewNop()
 	}
 	return &TagValueSeriesIDCache{
-		cache:         map[string]map[string]map[string]*list.Element{},
-		evictor:       list.New(),
-		capacity:      int64(initial),
-		minCapacity:   int64(initial),
-		maxCapacity:   int64(max),
-		targetHitRate: target,
-		minSamples:    int64(minSamples),
-		logger:        logger,
+		cache:              map[string]map[string]map[string]*list.Element{},
+		evictor:            list.New(),
+		capacity:           int64(initial),
+		minCapacity:        int64(initial),
+		maxCapacity:        int64(max),
+		targetHitRate:      target,
+		shrinkConservatism: shrinkConservatism,
+		minSamples:         int64(minSamples),
+		logger:             logger,
 	}
 }
 
@@ -462,9 +477,11 @@ func (c *TagValueSeriesIDCache) maybeResizeLocked() (resizeEvent, bool) {
 	}
 
 	atomic.StoreInt64(&c.capacity, newCap)
-	// Suppress shrink for a few windows after a grow so a freshly-grown cache
-	// (occupancy ~50% of the new capacity) isn't immediately clawed back.
-	c.cooldownRemaining = shrinkCooldownWindows
+	// Suppress shrink until the freshly-grown cache (occupancy ~50% of the new
+	// capacity) has been exercised: a full observation window sized to the new
+	// capacity, so the cooldown scales with the grown size rather than the
+	// half-full occupancy.
+	c.cooldownGets = adaptiveWindowLen(newCap, c.minSamples, c.targetHitRate)
 	return resizeEvent{
 		oldCap: curCap,
 		newCap: newCap,
@@ -538,12 +555,17 @@ func (c *TagValueSeriesIDCache) checkShrink() (resizeEvent, bool) {
 		return resizeEvent{}, false
 	}
 
+	// One Get elapsed; tick down the post-resize cooldown.
+	if c.cooldownGets > 0 {
+		c.cooldownGets--
+	}
+
 	// Start a window if none is active (first ever, or just completed). The
 	// window length is recomputed from current occupancy each time. The current
 	// Get's hit was already folded into deepestTouched by get(), so the boundary
 	// is reset only at window completion, never here.
 	if c.shrinkWindowGets == 0 {
-		c.shrinkWindowGets = shrinkWindowLen(int64(c.evictor.Len()), c.minSamples, c.targetHitRate)
+		c.shrinkWindowGets = adaptiveWindowLen(int64(c.evictor.Len()), c.minSamples, c.targetHitRate)
 		c.getsSinceShrinkCheck = 0
 		c.shrinkBaseHits = atomic.LoadInt64(&c.stats.Hits)
 		c.shrinkBaseMisses = atomic.LoadInt64(&c.stats.Misses)
@@ -564,11 +586,12 @@ func (c *TagValueSeriesIDCache) checkShrink() (resizeEvent, bool) {
 	// Window complete. Evaluate unless a recent capacity change is cooling down.
 	var event resizeEvent
 	var shrank bool
-	if c.cooldownRemaining > 0 {
-		c.cooldownRemaining--
-	} else if e, ok := c.maybeShrinkLocked(); ok {
-		event, shrank = e, true
-		c.cooldownRemaining = shrinkCooldownWindows
+	if c.cooldownGets == 0 {
+		if e, ok := c.maybeShrinkLocked(); ok {
+			event, shrank = e, true
+			// Cool down for a window sized to the new (smaller) capacity.
+			c.cooldownGets = adaptiveWindowLen(e.newCap, c.minSamples, c.targetHitRate)
+		}
 	}
 
 	// End the window: a fresh one (with a recomputed length) starts on the next
@@ -592,7 +615,7 @@ func (c *TagValueSeriesIDCache) maybeShrinkLocked() (resizeEvent, bool) {
 	curCap := atomic.LoadInt64(&c.capacity)
 	size := int64(c.evictor.Len())
 
-	newCap, shrink, coldTail := decideShrinkPre(hitsW, missesW, evictionsW, curCap, size, c.minCapacity, c.targetHitRate)
+	newCap, shrink, coldTail := decideShrinkPre(hitsW, missesW, evictionsW, curCap, size, c.minCapacity, c.targetHitRate, c.shrinkConservatism)
 
 	var evicted int64
 	if coldTail {
@@ -657,31 +680,101 @@ func (c *TagValueSeriesIDCache) logShrink(e resizeEvent) {
 	)
 }
 
-// shrinkWindowLen returns how many Gets to observe before evaluating a shrink,
-// sized so that under ~uniform random access over n cached items the expected
-// fraction left untouched is <= (1-target). An entry still untouched after a
-// full window is therefore genuinely cold, not merely unsampled. The length
-// scales ~linearly with n (≈ 3n at target 0.95). minWindow floors the result so
-// tiny caches don't act on noisy windows. Returns 0 when n < 2 (too small to
-// evaluate). Precondition: target < 1 (config validation rejects target >= 1).
-// As defense, a target that rounds to 1 makes the window infinite; rather than
-// overflow the float->int64 conversion, that degenerate case returns MaxInt64
-// ("effectively never shrink"), which is the correct behavior for an
-// unachievable target.
-func shrinkWindowLen(n, minWindow int64, target float64) int64 {
+// adaptiveWindowLen returns how many Gets to observe before making an adaptive
+// sizing decision over a population of n items — either a shrink evaluation
+// (n = current occupancy) or the quiet period after a resize (n = the new
+// capacity). It is sized so that under ~uniform random access over n items the
+// expected fraction left untouched is <= (1-target), so an item still untouched
+// after a full window is genuinely cold, not merely unsampled. The result is
+// floored at n (always sample at least as many times as there are items) and at
+// minWindow (a noise floor for tiny caches), so it is ~max(3n at target 0.95, n,
+// minWindow). Returns 0 when n < 2 (too small to evaluate). target must be in
+// (0, 1) (enforced by config validation and the constructor); as defense, any
+// out-of-range target — including NaN or a value rounding to 0 or 1 — is rejected
+// up front and returns MaxInt64 ("effectively never"), so the logarithms below
+// cannot produce NaN, ±Inf, or an overflowing window.
+//
+// Derivation. Model each Get as an independent draw landing uniformly on one of
+// the n items. The chance a given item is not the one accessed by a single Get
+// is (n-1)/n, so after k independent Gets the chance it is still untouched is
+// ((n-1)/n)^k. By linearity of expectation that is also the expected fraction of
+// all n items left untouched after k Gets. We want a window long enough that
+// this expected untouched fraction is at most (1-target):
+//
+//	((n-1)/n)^k <= 1 - target
+//
+// Take natural logs. Since (n-1)/n < 1, ln((n-1)/n) is negative, so dividing by
+// it flips the inequality:
+//
+//	k * ln((n-1)/n) <= ln(1 - target)
+//	k >= ln(1 - target) / ln((n-1)/n)
+//
+// Both logs are negative, so the ratio is positive; take the ceiling for a whole
+// number of Gets. For large n, ln((n-1)/n) = ln(1 - 1/n) ~= -1/n, so the window
+// is ~ n * ln(1/(1-target)): linear in n with a multiplier set only by target
+// (e.g. ln(20) ~= 3.0 at target 0.95, hence ~3n; ln(2) ~= 0.69 at target 0.5,
+// which is below n and is why the result is floored at n).
+func adaptiveWindowLen(n, minWindow int64, target float64) int64 {
+	// Defensive argument range check: callers pass target in (0, 1) (enforced by
+	// config validation and the constructor). Reject anything else up front —
+	// including NaN and values rounding to 0 or 1 — so the logarithms below cannot
+	// yield NaN, ±Inf, or an overflowing/negative window; an out-of-range target
+	// disables sizing decisions, the safe choice for a bad input.
+	if !(target > 0 && target < 1) {
+		return math.MaxInt64
+	}
 	if n < 2 {
 		return 0
 	}
-	// window = ceil( ln(1-target) / ln((n-1)/n) ); both logs are negative.
+	// window = ceil( ln(1-target) / ln((n-1)/n) ); both logs are finite and negative.
 	wf := math.Ceil(math.Log(1-target) / math.Log(float64(n-1)/float64(n)))
-	if wf >= float64(math.MaxInt64) { // +Inf (target rounds to 1) or out of range
+	if wf >= float64(math.MaxInt64) { // huge finite window (target very close to 1)
 		return math.MaxInt64
 	}
 	w := int64(wf)
+	if w < n { // sample at least as many times as there are items
+		w = n
+	}
 	if w < minWindow {
 		w = minWindow
 	}
 	return w
+}
+
+// atTargetEvictionGateLimit returns the shrink eviction-gate threshold using a
+// lower confidence bound on the at-target eviction count distribution.
+//
+// Derivation. On a full cache a miss generally produces one eviction, so over a
+// window of m Gets at hit rate T the eviction count is approximately
+// Binomial(m, 1-T), with mean μ = m·(1-T) and variance σ² = m·T·(1-T). The gate
+// admits shrink only when the observed evictions sit below μ − z·σ, the lower
+// edge of the at-target distribution's z-sigma confidence band. Tying the
+// threshold to the distribution itself yields a scale-adaptive margin: as the
+// window m grows, σ grows like √m while μ grows like m, so the relative slack
+// the gate demands shrinks naturally — a 1M-Get window admits a smaller relative
+// margin than a 100-Get one because the rate estimate is correspondingly
+// tighter. Higher z demands the cache outperform target by more standard
+// deviations (more conservative); z = 0 admits at the median (μ). Floored at 1
+// so a single stray eviction never blocks shrink. Out-of-range inputs (gets<1,
+// target outside (0,1), z not in [0, +Inf)) return 1 (fail-safe: gates on any
+// eviction).
+//
+// Note: the binomial assumes independent Bernoulli misses; real cache access
+// is correlated (locality, Zipfian skew), so the true distribution is wider
+// than σ here, and the bound is optimistic in that sense. Operators concerned
+// about workload skew can compensate by raising z.
+func atTargetEvictionGateLimit(gets int64, target, z float64) int64 {
+	if gets < 1 || !(target > 0 && target < 1) || !(z >= 0 && z < math.Inf(1)) {
+		return 1
+	}
+	m := float64(gets)
+	mu := m * (1 - target)
+	sigma := math.Sqrt(m * target * (1 - target))
+	limit := int64(mu - z*sigma)
+	if limit < 1 {
+		limit = 1
+	}
+	return limit
 }
 
 // decideShrink implements the full capacity-decay policy as a pure function of
@@ -692,9 +785,10 @@ func shrinkWindowLen(n, minWindow int64, target float64) int64 {
 // only performed when the cold-tail branch is actually reached (see
 // maybeShrinkLocked).
 //
-// Gates (all required): at least one read, zero evictions this window (the cache
-// is not under capacity pressure), and a windowed hit rate >= target (the cache
-// is serving its working set well). When gated through, one of two branches fires:
+// Gates (all required): at least one read; window evictions at or below the
+// scaled at-target expectation (see atTargetEvictionGateLimit); and a windowed
+// hit rate >= target (the cache is serving its working set well). When gated
+// through, one of two branches fires:
 //   - slack: capacity exceeds occupancy -> drop the unused headroom (no eviction).
 //   - cold-tail: cache is full -> shed the LRU tail that went untouched this
 //     window, down to the warm footprint (warmCount), clamped at floor, and
@@ -702,8 +796,8 @@ func shrinkWindowLen(n, minWindow int64, target float64) int64 {
 //
 // The evicted entries are always within the untouched cold tail, so warm entries
 // are never shed.
-func decideShrink(hitsW, missesW, evictionsW, capacity, size, warmCount, floor int64, target float64) (newCap, evict int64, shrink bool) {
-	newCap, shrink, coldTail := decideShrinkPre(hitsW, missesW, evictionsW, capacity, size, floor, target)
+func decideShrink(hitsW, missesW, evictionsW, capacity, size, warmCount, floor int64, target, conservatism float64) (newCap, evict int64, shrink bool) {
+	newCap, shrink, coldTail := decideShrinkPre(hitsW, missesW, evictionsW, capacity, size, floor, target, conservatism)
 	if coldTail {
 		return decideColdTail(size, warmCount, floor)
 	}
@@ -714,10 +808,15 @@ func decideShrink(hitsW, missesW, evictionsW, capacity, size, warmCount, floor i
 // the gates and the slack branch. It returns the slack result (newCap/shrink), or
 // coldTail=true to signal that the cache is full and the caller must measure the
 // warm footprint and consult decideColdTail. When coldTail is true, newCap/shrink
-// are not meaningful.
-func decideShrinkPre(hitsW, missesW, evictionsW, capacity, size, floor int64, target float64) (newCap int64, shrink, coldTail bool) {
+// are not meaningful. The eviction gate threshold is produced by
+// atTargetEvictionGateLimit (see its doc for derivation). The hit-rate gate is
+// kept for defense.
+func decideShrinkPre(hitsW, missesW, evictionsW, capacity, size, floor int64, target, conservatism float64) (newCap int64, shrink, coldTail bool) {
 	gets := hitsW + missesW
-	if gets <= 0 || evictionsW != 0 {
+	if gets <= 0 {
+		return capacity, false, false
+	}
+	if evictionsW > atTargetEvictionGateLimit(gets, target, conservatism) {
 		return capacity, false, false
 	}
 	if float64(hitsW)/float64(gets) < target {

--- a/tsdb/index/tsi1/cache.go
+++ b/tsdb/index/tsi1/cache.go
@@ -2,7 +2,6 @@ package tsi1
 
 import (
 	"container/list"
-	"fmt"
 	"math"
 	"sync"
 	"sync/atomic"
@@ -164,34 +163,58 @@ func NewTagValueSeriesIDCache(c int) *TagValueSeriesIDCache {
 // before the grow policy is allowed to act; below this floor the rate is treated
 // as too noisy to react to. shrinkConservatism (>= 0.0) is the number of standard
 // deviations below the at-target eviction mean at which the shrink eviction gate
-// sits; see the doc on SeriesIDSetCacheShrinkConservatism in tsdb.Config. Panics
-// on invalid arguments: initial must be > 0, max > initial (an adaptive cache
-// that cannot grow is a misconfiguration — use NewTagValueSeriesIDCache for a
-// fixed cache), target in (0, 1) (1.0 is unachievable and is rejected by config
-// validation; NaN is rejected), shrinkConservatism finite and >= 0.0 (NaN/±Inf
-// rejected), minSamples >= 0.
+// sits; see the doc on SeriesIDSetCacheShrinkConservatism in tsdb.Config.
+//
+// If any argument is invalid, the error is logged and a fixed-size (non-adaptive)
+// cache from NewTagValueSeriesIDCache is returned in place of the adaptive one,
+// so misconfiguration degrades to a working cache rather than crashing the
+// process. The fallback uses initial when it is itself valid (>0), otherwise
+// tsdb.DefaultSeriesIDSetCacheSize. Invalid arguments are: initial <= 0; max <=
+// initial (an adaptive cache that cannot grow is a misconfiguration — use
+// NewTagValueSeriesIDCache directly for a fixed cache); target not in (0, 1)
+// (1.0 is unachievable and is rejected by config validation; NaN is rejected);
+// shrinkConservatism not in [0, +Inf) (NaN/±Inf rejected); minSamples < 0.
 func NewAdaptiveTagValueSeriesIDCache(initial, max int, target, shrinkConservatism float64, minSamples int, logger *zap.Logger) *TagValueSeriesIDCache {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+
+	// fallback builds the non-adaptive replacement: a fixed-size cache sized to
+	// initial when valid, otherwise tsdb.DefaultSeriesIDSetCacheSize, with the
+	// caller's logger attached so the error log line and the fallback share a
+	// destination. Safe to set the logger directly because the cache has not
+	// yet been shared with other goroutines.
+	fallback := func(reason string, fields ...zap.Field) *TagValueSeriesIDCache {
+		size := initial
+		if size <= 0 {
+			size = tsdb.DefaultSeriesIDSetCacheSize
+		}
+		logger.Error("NewAdaptiveTagValueSeriesIDCache: "+reason+"; falling back to fixed-size cache",
+			append(fields, zap.Int("fallback_size", size))...)
+		c := NewTagValueSeriesIDCache(size)
+		c.SetLogger(logger)
+		return c
+	}
+
 	if initial <= 0 {
-		panic(fmt.Sprintf("NewAdaptiveTagValueSeriesIDCache: initial must be > 0, got %d", initial))
+		return fallback("initial must be > 0", zap.Int("initial", initial))
 	}
 	if max <= initial {
-		panic(fmt.Sprintf("NewAdaptiveTagValueSeriesIDCache: max (%d) must be > initial (%d)", max, initial))
+		return fallback("max must be > initial", zap.Int("initial", initial), zap.Int("max", max))
 	}
 	// Positive range test so NaN (for which both `<` and `>` are false) is
 	// rejected rather than slipping through.
 	if !(target > 0 && target < 1) {
-		panic(fmt.Sprintf("NewAdaptiveTagValueSeriesIDCache: target must be in (0, 1), got %v", target))
+		return fallback("target must be in (0, 1)", zap.Float64("target", target))
 	}
 	// Same positive-form trick rejects NaN and ±Inf for the conservatism.
 	if !(shrinkConservatism >= 0 && shrinkConservatism < math.Inf(1)) {
-		panic(fmt.Sprintf("NewAdaptiveTagValueSeriesIDCache: shrinkConservatism must be a finite value >= 0, got %v", shrinkConservatism))
+		return fallback("shrinkConservatism must be a finite value >= 0", zap.Float64("shrink_conservatism", shrinkConservatism))
 	}
 	if minSamples < 0 {
-		panic(fmt.Sprintf("NewAdaptiveTagValueSeriesIDCache: minSamples must be >= 0, got %d", minSamples))
+		return fallback("minSamples must be >= 0", zap.Int("min_samples", minSamples))
 	}
-	if logger == nil {
-		logger = zap.NewNop()
-	}
+
 	return &TagValueSeriesIDCache{
 		cache:              map[string]map[string]map[string]*list.Element{},
 		evictor:            list.New(),
@@ -235,13 +258,17 @@ func (c *TagValueSeriesIDCache) Statistics(tags map[string]string) []models.Stat
 // Get returns the SeriesIDSet associated with the {name, key, value} tuple if it
 // exists.
 func (c *TagValueSeriesIDCache) Get(name, key, value []byte) *tsdb.SeriesIDSet {
-	c.Lock()
-	ss, hit := c.get(name, key, value)
-	// Drive the adaptive shrink check from the read path: the grow check is
-	// eviction-driven and is blind when the cache is quiet (exactly when a
-	// shrink may be warranted). Log after releasing the lock, like Put.
-	event, shrank := c.checkShrink(hit)
-	c.Unlock()
+	ss, event, shrank := func() (*tsdb.SeriesIDSet, resizeEvent, bool) {
+		c.Lock()
+		defer c.Unlock()
+		ss, hit := c.get(name, key, value)
+		// Drive the adaptive shrink check from the read path: the grow check is
+		// eviction-driven and is blind when the cache is quiet (exactly when a
+		// shrink may be warranted). Log after releasing the lock, like Put.
+		event, shrank := c.checkShrink(hit)
+		return ss, event, shrank
+	}()
+
 	if shrank {
 		c.logShrink(event)
 	}
@@ -327,7 +354,15 @@ func (c *TagValueSeriesIDCache) measurementContainsSets(name []byte) bool {
 // Put adds the SeriesIDSet to the cache under the tuple {name, key, value}. If
 // the cache is at its limit, then the least recently used item is evicted.
 func (c *TagValueSeriesIDCache) Put(name, key, value []byte, ss *tsdb.SeriesIDSet) {
+	event, grew := c.innerLockingPut(name, key, value, ss)
+	if grew {
+		c.logResize(event)
+	}
+}
+
+func (c *TagValueSeriesIDCache) innerLockingPut(name, key, value []byte, ss *tsdb.SeriesIDSet) (resizeEvent, bool) {
 	c.Lock()
+	defer c.Unlock()
 	// Convert once; the same string backing array is shared between
 	// the cache element (used during eviction) and the map keys.
 	nameStr := string(name)
@@ -335,8 +370,7 @@ func (c *TagValueSeriesIDCache) Put(name, key, value []byte, ss *tsdb.SeriesIDSe
 	valueStr := string(value)
 	// Check under the write lock if the relevant item is now in the cache.
 	if c.exists(nameStr, keyStr, valueStr) {
-		c.Unlock()
-		return
+		return resizeEvent{}, false
 	}
 
 	// Ensure our SeriesIDSet is go heap backed.
@@ -374,11 +408,7 @@ func (c *TagValueSeriesIDCache) Put(name, key, value []byte, ss *tsdb.SeriesIDSe
 	}
 
 EVICT:
-	event, grew := c.checkEviction()
-	c.Unlock()
-	if grew {
-		c.logResize(event)
-	}
+	return c.checkEviction()
 }
 
 // Delete removes x from the tuple {name, key, value} if it exists.

--- a/tsdb/index/tsi1/cache.go
+++ b/tsdb/index/tsi1/cache.go
@@ -59,19 +59,32 @@ type resizeEvent struct {
 // order by which items should be evicted from the cache, and a hashmap implementation
 // to provide constant time retrievals of items from the cache.
 type TagValueSeriesIDCache struct {
-	sync.RWMutex
-	cache   map[string]map[string]map[string]*list.Element
-	evictor *list.List
+	// Due to a bug in atomic, 64-bit words accessed with sync/atomic must be
+	// 64-bit aligned, and the first word of an allocated struct is the only
+	// position guaranteed to be 8-byte aligned on 32-bit platforms. Keep all
+	// atomically-accessed int64 fields (capacity and the stats counters)
+	// contiguous at the top of the struct, ahead of every other field.
+	// See: https://golang.org/pkg/sync/atomic/#pkg-note-BUG
 
 	// capacity is the current cache capacity. Read with atomic.LoadInt64
 	// (lockless reads from Statistics); written with atomic.StoreInt64 under
 	// the cache write lock when the adaptive policy grows it.
 	capacity int64
 
+	// stats holds the atomically-accessed counters. Its int64 fields stay
+	// 8-byte aligned because capacity above is exactly one 64-bit word.
+	stats TagValueSeriesIDCacheStatistics
+
+	sync.RWMutex
+	cache   map[string]map[string]map[string]*list.Element
+	evictor *list.List
+
 	// Adaptive sizing fields. maxCapacity == 0 means adaptive sizing is
 	// disabled and none of the other fields below are consulted. When
 	// enabled, lastHits/lastMisses/evictionsSinceCheck are read and written
-	// only under the write lock (checkEviction always holds it).
+	// only under the write lock (checkEviction always holds it). None of
+	// these int64 fields are accessed atomically, so their placement is
+	// unconstrained.
 	maxCapacity         int64
 	targetHitRate       float64
 	minSamples          int64
@@ -79,8 +92,6 @@ type TagValueSeriesIDCache struct {
 	evictionsSinceCheck int64
 	lastHits            int64
 	lastMisses          int64
-
-	stats TagValueSeriesIDCacheStatistics
 }
 
 // NewTagValueSeriesIDCache returns a TagValueSeriesIDCache with fixed

--- a/tsdb/index/tsi1/cache.go
+++ b/tsdb/index/tsi1/cache.go
@@ -506,9 +506,14 @@ func decideResize(hits, misses, lastHits, lastMisses, capacity, maxCapacity, min
 		rate = float64(hitsW) / float64(gets)
 	}
 
-	// Floor on sample size: too few reads since the last firing makes
-	// any rate observation noisy. Also covers pure-write workloads
-	// (gets == 0).
+	// Explicitly gate the zero-reads window first: with no Gets there is no
+	// evidence to act on, and the rate would be the zero-init 0.0 (looking
+	// like a 0% hit rate, triggering growth on a pure-write workload). The
+	// minSamples floor below is a configurable noise floor for tiny windows;
+	// it can be 0, so it does not subsume the gets == 0 check.
+	if gets == 0 {
+		return capacity, gets, rate, false
+	}
 	if gets < minSamples {
 		return capacity, gets, rate, false
 	}

--- a/tsdb/index/tsi1/cache.go
+++ b/tsdb/index/tsi1/cache.go
@@ -155,7 +155,7 @@ func NewTagValueSeriesIDCache(c int) *TagValueSeriesIDCache {
 // target while under eviction pressure (driven from the eviction path: after
 // every `capacity` evictions it samples the windowed hit rate and grows once if
 // the policy fires). It also shrinks: driven from the read path, after a
-// self-tuning window of Gets, a cache that is quiet (no evictions) and serving
+// self-tuning window of Gets, a cache that is quiet (few evictions) and serving
 // at/above target trims capacity toward its observed working set, shedding only
 // least-recently-used entries left untouched over the window, never below
 // initial. A cooldown between resizes prevents grow/shrink oscillation.
@@ -824,33 +824,6 @@ func atTargetEvictionGateLimit(gets int64, target, z float64) int64 {
 		limit = 1
 	}
 	return limit
-}
-
-// decideShrink implements the full capacity-decay policy as a pure function of
-// the window's counters, the current occupancy, and the observed access
-// footprint. It mirrors decideResize so the policy can be exercised with integer
-// literals. It composes decideShrinkPre and decideColdTail; production code calls
-// those two directly so the O(size) footprint walk that produces warmCount is
-// only performed when the cold-tail branch is actually reached (see
-// maybeShrinkLocked).
-//
-// Gates (all required): at least one read; window evictions at or below the
-// scaled at-target expectation (see atTargetEvictionGateLimit); and a windowed
-// hit rate >= target (the cache is serving its working set well). When gated
-// through, one of two branches fires:
-//   - slack: capacity exceeds occupancy -> drop the unused headroom (no eviction).
-//   - cold-tail: cache is full -> shed the LRU tail that went untouched this
-//     window, down to the warm footprint (warmCount), clamped at floor, and
-//     bounded to half the cache per event so the write lock is not held long.
-//
-// The evicted entries are always within the untouched cold tail, so warm entries
-// are never shed.
-func decideShrink(hitsW, missesW, evictionsW, capacity, size, warmCount, floor int64, target, conservatism float64) (newCap, evict int64, shrink bool) {
-	newCap, shrink, coldTail := decideShrinkPre(hitsW, missesW, evictionsW, capacity, size, floor, target, conservatism)
-	if coldTail {
-		return decideColdTail(size, warmCount, floor)
-	}
-	return newCap, 0, shrink
 }
 
 // decideShrinkPre evaluates everything that does not require the access footprint:

--- a/tsdb/index/tsi1/cache.go
+++ b/tsdb/index/tsi1/cache.go
@@ -277,7 +277,7 @@ func (c *TagValueSeriesIDCache) Get(name, key, value []byte) *tsdb.SeriesIDSet {
 	}()
 
 	if shrank {
-		c.logShrink(event)
+		c.logResize(event)
 	}
 	return ss
 }
@@ -603,15 +603,28 @@ func decideResize(hits, misses, lastHits, lastMisses, capacity, maxCapacity, min
 	return newCap, gets, rate, true
 }
 
-// logResize emits a single INFO log line describing a capacity-growth
-// event. Called by Put after releasing the cache write lock. Reads
-// c.maxCapacity and c.targetHitRate directly — both are set at
-// construction and never mutated.
+// logResize emits a single INFO log line describing a capacity-change event,
+// either a grow (driven from Put) or a shrink (driven from Get). The direction
+// is taken from the event: newCap > oldCap is a grow, otherwise a shrink. Both
+// callers invoke this only after an actual capacity change, and grow strictly
+// increases capacity while shrink strictly decreases it, so the comparison is
+// unambiguous and selects only the log message. Every metric is logged on both
+// lines so the field set is uniform regardless of direction: evicted is 0 for a
+// grow, and min_capacity/max_capacity/target are the configured bounds in either
+// case. c.minCapacity, c.maxCapacity, and c.targetHitRate are read directly — all
+// set at construction and never mutated. Called after releasing the cache write
+// lock.
 func (c *TagValueSeriesIDCache) logResize(e resizeEvent) {
-	c.logger.Info(logMsgCacheCapacityIncreased,
+	msg := logMsgCacheCapacityIncreased
+	if e.newCap <= e.oldCap {
+		msg = logMsgCacheCapacityDecreased
+	}
+	c.logger.Info(msg,
 		zap.Int64("old_capacity", e.oldCap),
 		zap.Int64("new_capacity", e.newCap),
+		zap.Int64("min_capacity", c.minCapacity),
 		zap.Int64("max_capacity", c.maxCapacity),
+		zap.Int64("evicted", e.evicted),
 		zap.Float64("hit_rate", e.rate),
 		zap.Float64("target", c.targetHitRate),
 		zap.Int64("gets_window", e.gets),
@@ -770,19 +783,6 @@ func (c *TagValueSeriesIDCache) warmCountLocked() int64 {
 		}
 	}
 	return n
-}
-
-// logShrink emits a single INFO log line describing a capacity-shrink event.
-// Called by Get after releasing the cache write lock.
-func (c *TagValueSeriesIDCache) logShrink(e resizeEvent) {
-	c.logger.Info(logMsgCacheCapacityDecreased,
-		zap.Int64("old_capacity", e.oldCap),
-		zap.Int64("new_capacity", e.newCap),
-		zap.Int64("min_capacity", c.minCapacity),
-		zap.Int64("evicted", e.evicted),
-		zap.Float64("hit_rate", e.rate),
-		zap.Int64("gets_window", e.gets),
-	)
 }
 
 // adaptiveWindowLen returns how many Gets to observe before making an adaptive

--- a/tsdb/index/tsi1/cache_test.go
+++ b/tsdb/index/tsi1/cache_test.go
@@ -1,6 +1,7 @@
 package tsi1
 
 import (
+	"math"
 	"math/rand"
 	"sync"
 	"sync/atomic"
@@ -603,4 +604,320 @@ func TestIndex_WithLogger_PropagatesToAdaptiveCache(t *testing.T) {
 	require.Equal(t, int64(4), atomic.LoadInt64(&cache.capacity), "cache should have grown after policy fired")
 	require.Equal(t, 1, logs.Len(), "resize event must be emitted to the logger propagated by WithLogger")
 	require.Equal(t, logMsgCacheCapacityIncreased, logs.All()[0].Message)
+}
+
+func TestShrinkWindowLen(t *testing.T) {
+	tests := []struct {
+		name         string
+		n, minWindow int64
+		target       float64
+		want         int64
+	}{
+		{name: "typical 100 @ 0.95 ≈ 3n", n: 100, minWindow: 1, target: 0.95, want: 299},
+		{name: "typical 1000 @ 0.95 ≈ 3n", n: 1000, minWindow: 1, target: 0.95, want: 2995},
+		{name: "floored for tiny cache", n: 2, minWindow: 100, target: 0.95, want: 100},
+		{name: "n=1 too small", n: 1, minWindow: 100, target: 0.95, want: 0},
+		{name: "n=0 too small", n: 0, minWindow: 100, target: 0.95, want: 0},
+		// 1.0 - SmallestNonzeroFloat64 rounds to exactly 1.0; config rejects this
+		// target, but the helper must not overflow — it returns the MaxInt64
+		// sentinel ("effectively never shrink").
+		{name: "degenerate target rounding to 1 returns sentinel", n: 100, minWindow: 1, target: 1.0 - math.SmallestNonzeroFloat64, want: math.MaxInt64},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, shrinkWindowLen(tt.n, tt.minWindow, tt.target))
+		})
+	}
+}
+
+func TestDecideShrink_PolicyTable(t *testing.T) {
+	const target = 0.95
+	tests := []struct {
+		name                             string
+		hitsW, missesW, evictionsW       int64
+		capacity, size, warmCount, floor int64
+		wantNewCap, wantEvict            int64
+		wantShrink                       bool
+	}{
+		{
+			name:  "no reads does not shrink",
+			hitsW: 0, missesW: 0, evictionsW: 0,
+			capacity: 100, size: 100, warmCount: 0, floor: 10,
+			wantNewCap: 100, wantEvict: 0, wantShrink: false,
+		},
+		{
+			name:  "evictions in window (under pressure) does not shrink",
+			hitsW: 1000, missesW: 0, evictionsW: 5,
+			capacity: 100, size: 100, warmCount: 20, floor: 10,
+			wantNewCap: 100, wantEvict: 0, wantShrink: false,
+		},
+		{
+			name:  "hit rate below target does not shrink",
+			hitsW: 50, missesW: 50, evictionsW: 0,
+			capacity: 100, size: 100, warmCount: 20, floor: 10,
+			wantNewCap: 100, wantEvict: 0, wantShrink: false,
+		},
+		{
+			name:  "slack: capacity above occupancy trims to size, no eviction",
+			hitsW: 1000, missesW: 0, evictionsW: 0,
+			capacity: 200, size: 100, warmCount: 80, floor: 50,
+			wantNewCap: 100, wantEvict: 0, wantShrink: true,
+		},
+		{
+			name:  "slack clamped to floor",
+			hitsW: 1000, missesW: 0, evictionsW: 0,
+			capacity: 200, size: 30, warmCount: 10, floor: 50,
+			wantNewCap: 50, wantEvict: 0, wantShrink: true,
+		},
+		{
+			name:  "slack no-op when size already at/below floor and capacity==floor",
+			hitsW: 1000, missesW: 0, evictionsW: 0,
+			capacity: 50, size: 30, warmCount: 10, floor: 50,
+			wantNewCap: 50, wantEvict: 0, wantShrink: false,
+		},
+		{
+			name:  "cold-tail bounded to half the cache",
+			hitsW: 1000, missesW: 0, evictionsW: 0,
+			capacity: 100, size: 100, warmCount: 20, floor: 10,
+			wantNewCap: 50, wantEvict: 50, wantShrink: true,
+		},
+		{
+			name:  "cold-tail sheds exactly the cold tail when under half",
+			hitsW: 1000, missesW: 0, evictionsW: 0,
+			capacity: 100, size: 100, warmCount: 60, floor: 10,
+			wantNewCap: 60, wantEvict: 40, wantShrink: true,
+		},
+		{
+			name:  "cold-tail clamped at floor",
+			hitsW: 1000, missesW: 0, evictionsW: 0,
+			capacity: 100, size: 100, warmCount: 5, floor: 30,
+			wantNewCap: 50, wantEvict: 50, wantShrink: true,
+		},
+		{
+			name:  "cold-tail no-op when everything was touched",
+			hitsW: 1000, missesW: 0, evictionsW: 0,
+			capacity: 100, size: 100, warmCount: 100, floor: 10,
+			wantNewCap: 100, wantEvict: 0, wantShrink: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			newCap, evict, shrink := decideShrink(
+				tt.hitsW, tt.missesW, tt.evictionsW,
+				tt.capacity, tt.size, tt.warmCount, tt.floor, target,
+			)
+			require.Equal(t, tt.wantShrink, shrink, "shrink")
+			require.Equal(t, tt.wantNewCap, newCap, "newCap")
+			require.Equal(t, tt.wantEvict, evict, "evict")
+		})
+	}
+}
+
+// newFullAdaptiveCache returns an adaptive cache forced to the given capacity
+// and filled with that many entries (values 0..capacity-1). The floor is 2, so
+// shrink has room to act. Adaptive growth is not exercised (no evictions occur
+// during setup), so the forced capacity stands in for a previously-grown cache.
+func newFullAdaptiveCache(t *testing.T, capacity, minSamples int, target float64) *TagValueSeriesIDCache {
+	t.Helper()
+	c := NewAdaptiveTagValueSeriesIDCache(2, 1024, target, minSamples, zap.NewNop())
+	atomic.StoreInt64(&c.capacity, int64(capacity))
+	for i := 0; i < capacity; i++ {
+		c.Put([]byte("m"), []byte("k"), []byte{byte(i)}, tsdb.NewSeriesIDSet(uint64(i)))
+	}
+	require.Equal(t, int64(capacity), atomic.LoadInt64(&c.stats.Size), "setup occupancy")
+	return c
+}
+
+func getVal(c *TagValueSeriesIDCache, v int) *tsdb.SeriesIDSet {
+	return c.Get([]byte("m"), []byte("k"), []byte{byte(v)})
+}
+
+func existsVal(c *TagValueSeriesIDCache, v int) bool {
+	c.Lock()
+	defer c.Unlock()
+	return c.exists("m", "k", string([]byte{byte(v)}))
+}
+
+func TestTagValueSeriesIDCache_ShrinkColdTail(t *testing.T) {
+	// Full cache of 10; touch only {0,1,2} for one window. The window
+	// (floored at minSamples=8 for this size) completes; with a 100% hit
+	// rate and zero evictions, capacity trims toward the warm footprint,
+	// bounded to half the cache per event. Verifies the RIGHT (deepest,
+	// untouched) entries are shed and the warm set + recently-inserted cold
+	// entries survive.
+	cache := newFullAdaptiveCache(t, 10, 8, 0.5)
+
+	for i := 0; i < 8; i++ { // window == 8 for n=10
+		require.NotNil(t, getVal(cache, i%3))
+	}
+
+	require.Equal(t, int64(5), atomic.LoadInt64(&cache.capacity), "capacity = size - min(coldTail, size/2) = 10-5")
+	require.Equal(t, int64(5), atomic.LoadInt64(&cache.stats.Size))
+
+	// Warm {0,1,2} survive; the deepest untouched {3,4,5,6,7} are evicted;
+	// the most-recently-inserted cold {8,9} survive (they are above the LRU tail).
+	for _, v := range []int{0, 1, 2, 8, 9} {
+		require.True(t, existsVal(cache, v), "expected value %d to survive", v)
+	}
+	for _, v := range []int{3, 4, 5, 6, 7} {
+		require.False(t, existsVal(cache, v), "expected value %d to be evicted", v)
+	}
+}
+
+func TestTagValueSeriesIDCache_ShrinkSlack(t *testing.T) {
+	// Capacity 10 but only 4 entries (slack). A quiet, all-hit window trims
+	// capacity down to the occupancy with no eviction.
+	cache := NewAdaptiveTagValueSeriesIDCache(2, 1024, 0.5, 8, zap.NewNop())
+	atomic.StoreInt64(&cache.capacity, 10)
+	for i := 0; i < 4; i++ {
+		cache.Put([]byte("m"), []byte("k"), []byte{byte(i)}, tsdb.NewSeriesIDSet(uint64(i)))
+	}
+
+	for i := 0; i < 8; i++ { // window == 8 for n=4
+		require.NotNil(t, getVal(cache, i%4))
+	}
+
+	require.Equal(t, int64(4), atomic.LoadInt64(&cache.capacity), "slack branch trims capacity to occupancy")
+	require.Equal(t, int64(4), atomic.LoadInt64(&cache.stats.Size), "no eviction in the slack branch")
+	for v := 0; v < 4; v++ {
+		require.True(t, existsVal(cache, v), "value %d must survive a slack trim", v)
+	}
+}
+
+func TestTagValueSeriesIDCache_NoShrinkWhenAllTouched(t *testing.T) {
+	// Full cache; touch every entry within the window. warmCount == size, so
+	// there is no cold tail and capacity is unchanged.
+	cache := newFullAdaptiveCache(t, 10, 16, 0.5) // window == 16, enough to touch all 10
+
+	for i := 0; i < 16; i++ {
+		require.NotNil(t, getVal(cache, i%10))
+	}
+
+	require.Equal(t, int64(10), atomic.LoadInt64(&cache.capacity), "capacity must not shrink when the whole cache is in use")
+	require.Equal(t, int64(10), atomic.LoadInt64(&cache.stats.Size))
+}
+
+func TestTagValueSeriesIDCache_ShrinkCooldown(t *testing.T) {
+	// A capacity change sets a cooldown that suppresses shrink for a few
+	// windows. Seed the cooldown directly and verify shrink is gated until it
+	// elapses, then fires.
+	cache := newFullAdaptiveCache(t, 10, 8, 0.5)
+	cache.cooldownRemaining = 2
+
+	drive := func() {
+		for i := 0; i < 8; i++ { // one window (n stays 10 while no shrink)
+			getVal(cache, i%3)
+		}
+	}
+
+	drive() // window 1: cooldown 2 -> 1, no shrink
+	require.Equal(t, int64(10), atomic.LoadInt64(&cache.capacity), "shrink suppressed during cooldown (window 1)")
+	drive() // window 2: cooldown 1 -> 0, no shrink
+	require.Equal(t, int64(10), atomic.LoadInt64(&cache.capacity), "shrink suppressed during cooldown (window 2)")
+	drive() // window 3: cooldown 0 -> shrink fires
+	require.Equal(t, int64(5), atomic.LoadInt64(&cache.capacity), "shrink fires once the cooldown elapses")
+}
+
+func TestTagValueSeriesIDCache_ShrinkBoundaryReTouch(t *testing.T) {
+	// Re-touching the deepest warm element must recede the boundary to its
+	// predecessor, keeping warmCount equal to the true distinct-touched count.
+	// A large minSamples keeps the window open so we can inspect mid-window.
+	cache := NewAdaptiveTagValueSeriesIDCache(2, 1024, 0.5, 1000, zap.NewNop())
+	atomic.StoreInt64(&cache.capacity, 5)
+	for i := 0; i < 5; i++ {
+		cache.Put([]byte("m"), []byte("k"), []byte{byte(i)}, tsdb.NewSeriesIDSet(uint64(i)))
+	}
+
+	// Touch 0,1,2 (warm set {0,1,2}, deepest=0), then re-touch 0 (the boundary).
+	for _, v := range []int{0, 1, 2, 0} {
+		require.NotNil(t, getVal(cache, v))
+	}
+
+	cache.Lock()
+	got := cache.warmCountLocked()
+	cache.Unlock()
+	require.Equal(t, int64(3), got, "warmCount must equal distinct-touched (3), not collapse on boundary re-touch")
+}
+
+func TestTagValueSeriesIDCache_ShrinkGrowCooldownStamp(t *testing.T) {
+	// A grow stamps the shared cooldown so a freshly-grown cache is not
+	// immediately shrunk. Drive a grow and assert the cooldown is armed.
+	cache := NewAdaptiveTagValueSeriesIDCache(2, 16, 0.99, 4, zap.NewNop())
+	insert := func(seq int) {
+		v := []byte{byte(seq)}
+		require.Nil(t, cache.Get([]byte("m"), []byte("k"), v))
+		cache.Put([]byte("m"), []byte("k"), v, tsdb.NewSeriesIDSet(uint64(seq)))
+	}
+	for i := 1; i <= 4; i++ { // drives one doubling (2 -> 4)
+		insert(i)
+	}
+	require.Equal(t, int64(4), atomic.LoadInt64(&cache.capacity), "precondition: grow occurred")
+	cache.Lock()
+	cd := cache.cooldownRemaining
+	cache.Unlock()
+	require.Equal(t, int64(shrinkCooldownWindows), cd, "grow must arm the shrink cooldown")
+}
+
+// TestTagValueSeriesIDCache_Adaptive_Concurrent exercises the adaptive grow and
+// shrink paths (and the lockless Statistics reader) under concurrency so the
+// race detector validates the new shrink bookkeeping. The keyspace is small
+// enough to generate both hits (boundary tracking) and eviction pressure
+// (growth), and reads outnumber writes so shrink windows can fire.
+func TestTagValueSeriesIDCache_Adaptive_Concurrent(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping long test")
+	}
+
+	cache := NewAdaptiveTagValueSeriesIDCache(8, 256, 0.9, 16, zap.NewNop())
+
+	const (
+		writers = 4
+		readers = 8
+		iters   = 50000
+		keys    = 40 // > initial capacity, so writes create eviction pressure
+	)
+	key := func(i int) []byte { return []byte{byte(i % keys)} }
+
+	// Start all goroutines simultaneously to maximize contention (per the
+	// project's concurrency-test pattern): each acquires the read lock at the
+	// start and blocks until the write lock is released.
+	var start sync.RWMutex
+	var concurrency, maxConcurrency atomic.Int64
+	var wg sync.WaitGroup
+	start.Lock()
+
+	run := func(body func(i int)) {
+		wg.Add(1)
+		go func() {
+			start.RLock()
+			defer start.RUnlock()
+			defer wg.Done()
+			c := concurrency.Add(1)
+			if old := maxConcurrency.Load(); c > old {
+				maxConcurrency.CompareAndSwap(old, c)
+			}
+			for i := 0; i < iters; i++ {
+				body(i)
+			}
+			concurrency.Add(-1)
+		}()
+	}
+
+	for w := 0; w < writers; w++ {
+		run(func(i int) { cache.Put([]byte("m"), []byte("k"), key(i), tsdb.NewSeriesIDSet(uint64(i))) })
+	}
+	for r := 0; r < readers; r++ {
+		run(func(i int) { _ = cache.Get([]byte("m"), []byte("k"), key(i)) })
+	}
+	// A lockless Statistics sampler races against the atomic counters.
+	run(func(int) { _ = cache.Statistics(nil) })
+
+	start.Unlock() // release all goroutines at once
+	wg.Wait()
+	t.Logf("max concurrency: %d", maxConcurrency.Load())
+
+	finalCap := atomic.LoadInt64(&cache.capacity)
+	require.GreaterOrEqual(t, finalCap, int64(8), "capacity must never drop below the floor")
+	require.LessOrEqual(t, finalCap, int64(256), "capacity must never exceed the max")
+	require.Equal(t, int64(cache.evictor.Len()), atomic.LoadInt64(&cache.stats.Size), "size counter must track the evictor list")
 }

--- a/tsdb/index/tsi1/cache_test.go
+++ b/tsdb/index/tsi1/cache_test.go
@@ -551,3 +551,43 @@ func TestTagValueSeriesIDCache_AdaptiveDisabled_NoLogNoGrowth(t *testing.T) {
 	require.Equal(t, int64(2), atomic.LoadInt64(&cache.capacity), "capacity must not change when adaptive sizing is disabled")
 	require.Equal(t, 0, logs.Len(), "no log lines must be emitted when adaptive sizing is disabled")
 }
+
+// TestIndex_WithLogger_PropagatesToAdaptiveCache verifies that WithLogger,
+// called after the adaptive cache has already been constructed in NewIndex
+// (with the index's initial no-op logger), re-points the cache at the real
+// logger so resize events are actually emitted. Regression test: previously
+// WithLogger only updated i.logger and the cache kept its no-op logger.
+func TestIndex_WithLogger_PropagatesToAdaptiveCache(t *testing.T) {
+	const minSamples = tsdb.DefaultAdaptiveCacheMinSamples
+
+	idx := NewIndex(nil, "db0",
+		WithSeriesIDCacheSize(2),
+		WithSeriesIDCacheMaxSize(16),
+		WithSeriesIDCacheTargetHitRate(0.99),
+	)
+
+	core, logs := observer.New(zap.InfoLevel)
+	idx.WithLogger(zap.New(core))
+
+	cache := idx.tagValueCache
+
+	// Fill the cache to capacity (2).
+	cache.Put([]byte("m"), []byte("k"), []byte{0}, tsdb.NewSeriesIDSet(0))
+	cache.Put([]byte("m"), []byte("k"), []byte{1}, tsdb.NewSeriesIDSet(1))
+
+	// Bank enough misses to clear the per-window sample floor without
+	// triggering evictions (Get never evicts).
+	for i := 0; i < minSamples; i++ {
+		require.Nil(t, cache.Get([]byte("m"), []byte("absent"), []byte{byte(i)}))
+	}
+
+	// Two more inserts of new keys cause two evictions; the second is the
+	// `capacity`-th eviction, firing the policy. The window hit rate is
+	// 0 (< 0.99 target) over >= minSamples gets, so the cache must grow.
+	cache.Put([]byte("m"), []byte("k"), []byte{2}, tsdb.NewSeriesIDSet(2))
+	cache.Put([]byte("m"), []byte("k"), []byte{3}, tsdb.NewSeriesIDSet(3))
+
+	require.Equal(t, int64(4), atomic.LoadInt64(&cache.capacity), "cache should have grown after policy fired")
+	require.Equal(t, 1, logs.Len(), "resize event must be emitted to the logger propagated by WithLogger")
+	require.Equal(t, "tsi cache capacity increased", logs.All()[0].Message)
+}

--- a/tsdb/index/tsi1/cache_test.go
+++ b/tsdb/index/tsi1/cache_test.go
@@ -463,7 +463,7 @@ func TestTagValueSeriesIDCache_AdaptiveGrowth_TriggersOnTurnover(t *testing.T) {
 	// preceded by one miss; every Put past the cache's current size
 	// causes one eviction.
 	logger := zap.NewNop()
-	cache := NewAdaptiveTagValueSeriesIDCache(2, 16, 0.99, 4, logger)
+	cache := NewAdaptiveTagValueSeriesIDCache(2, 16, 0.99, tsdb.DefaultSeriesIDSetCacheShrinkConservatism, 4, logger)
 
 	require.Equal(t, int64(2), atomic.LoadInt64(&cache.capacity))
 
@@ -514,7 +514,7 @@ func TestTagValueSeriesIDCache_AdaptiveGrowth_NoOpAtTarget(t *testing.T) {
 	// evictions while also generating hits, so the windowed hit rate
 	// stays comfortably above target and capacity must not grow.
 	logger := zap.NewNop()
-	cache := NewAdaptiveTagValueSeriesIDCache(2, 16, 0.01, 4, logger)
+	cache := NewAdaptiveTagValueSeriesIDCache(2, 16, 0.01, tsdb.DefaultSeriesIDSetCacheShrinkConservatism, 4, logger)
 
 	insertedSeqs := []int{}
 	insert := func(seq int) {
@@ -606,7 +606,7 @@ func TestIndex_WithLogger_PropagatesToAdaptiveCache(t *testing.T) {
 	require.Equal(t, logMsgCacheCapacityIncreased, logs.All()[0].Message)
 }
 
-func TestShrinkWindowLen(t *testing.T) {
+func TestAdaptiveWindowLen(t *testing.T) {
 	tests := []struct {
 		name         string
 		n, minWindow int64
@@ -615,23 +615,64 @@ func TestShrinkWindowLen(t *testing.T) {
 	}{
 		{name: "typical 100 @ 0.95 ≈ 3n", n: 100, minWindow: 1, target: 0.95, want: 299},
 		{name: "typical 1000 @ 0.95 ≈ 3n", n: 1000, minWindow: 1, target: 0.95, want: 2995},
-		{name: "floored for tiny cache", n: 2, minWindow: 100, target: 0.95, want: 100},
+		// At a low target the computed window (~0.69n) is below n; the n floor
+		// raises it so we always sample at least as many times as there are items.
+		{name: "n floor binds at low target", n: 100, minWindow: 1, target: 0.5, want: 100},
+		{name: "minWindow floor binds for tiny cache", n: 2, minWindow: 100, target: 0.95, want: 100},
 		{name: "n=1 too small", n: 1, minWindow: 100, target: 0.95, want: 0},
 		{name: "n=0 too small", n: 0, minWindow: 100, target: 0.95, want: 0},
 		// 1.0 - SmallestNonzeroFloat64 rounds to exactly 1.0; config rejects this
 		// target, but the helper must not overflow — it returns the MaxInt64
-		// sentinel ("effectively never shrink").
+		// sentinel ("effectively never").
 		{name: "degenerate target rounding to 1 returns sentinel", n: 100, minWindow: 1, target: 1.0 - math.SmallestNonzeroFloat64, want: math.MaxInt64},
+		// Out-of-range targets are rejected by the argument guard before the
+		// logarithms run, returning the sentinel rather than NaN/±Inf/overflow.
+		{name: "NaN target returns sentinel", n: 100, minWindow: 1, target: math.NaN(), want: math.MaxInt64},
+		{name: "target above 1 returns sentinel", n: 100, minWindow: 1, target: 1.5, want: math.MaxInt64},
+		{name: "zero target returns sentinel", n: 100, minWindow: 1, target: 0, want: math.MaxInt64},
+		{name: "negative target returns sentinel", n: 100, minWindow: 1, target: -0.1, want: math.MaxInt64},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.want, shrinkWindowLen(tt.n, tt.minWindow, tt.target))
+			require.Equal(t, tt.want, adaptiveWindowLen(tt.n, tt.minWindow, tt.target))
 		})
 	}
 }
 
+func TestNewAdaptiveTagValueSeriesIDCache_RejectsInvalidArguments(t *testing.T) {
+	// NaN and out-of-range targets must panic; a NaN target would otherwise make
+	// the grow/shrink rate comparisons behave unpredictably.
+	for _, target := range []float64{math.NaN(), 0, 1, -0.1, 1.5} {
+		require.Panics(t, func() {
+			NewAdaptiveTagValueSeriesIDCache(2, 16, target, tsdb.DefaultSeriesIDSetCacheShrinkConservatism, 4, zap.NewNop())
+		}, "target %v must be rejected", target)
+	}
+	// NaN, ±Inf and negative conservatism values must panic; the valid range is
+	// [0, +Inf), so 0 and small positive values are accepted (covered separately).
+	for _, c := range []float64{math.NaN(), math.Inf(1), math.Inf(-1), -1, -0.0001} {
+		require.Panics(t, func() {
+			NewAdaptiveTagValueSeriesIDCache(2, 16, 0.95, c, 4, zap.NewNop())
+		}, "conservatism %v must be rejected", c)
+	}
+	// Conservatism boundary values (0 = median admit; small positive) must NOT panic.
+	for _, c := range []float64{0, 0.5, 1, 2.0, 10} {
+		require.NotPanics(t, func() {
+			NewAdaptiveTagValueSeriesIDCache(2, 16, 0.95, c, 4, zap.NewNop())
+		}, "conservatism %v must be accepted", c)
+	}
+}
+
 func TestDecideShrink_PolicyTable(t *testing.T) {
-	const target = 0.95
+	const (
+		target       = 0.95
+		conservatism = tsdb.DefaultSeriesIDSetCacheShrinkConservatism
+		// The eviction-gate rows below all use this window length (hitsW+missesW).
+		rowGets = int64(1000)
+	)
+	// Derive the eviction-gate threshold from the same helper production uses,
+	// so changing the conservatism constant doesn't require rewriting hardcoded
+	// numbers. Eviction-gate test rows below use evictionsW relative to this.
+	limit := atTargetEvictionGateLimit(rowGets, target, conservatism)
 	tests := []struct {
 		name                             string
 		hitsW, missesW, evictionsW       int64
@@ -646,10 +687,20 @@ func TestDecideShrink_PolicyTable(t *testing.T) {
 			wantNewCap: 100, wantEvict: 0, wantShrink: false,
 		},
 		{
-			name:  "evictions in window (under pressure) does not shrink",
-			hitsW: 1000, missesW: 0, evictionsW: 5,
+			// Evictions one above the gate limit must block shrink.
+			name:  "evictions above gate limit blocks shrink",
+			hitsW: rowGets, missesW: 0, evictionsW: limit + 1,
 			capacity: 100, size: 100, warmCount: 20, floor: 10,
 			wantNewCap: 100, wantEvict: 0, wantShrink: false,
+		},
+		{
+			// Evictions exactly at the gate limit must NOT block shrink: the
+			// cache is performing at/above the at-target − z·σ bound and has a
+			// cold tail to shed.
+			name:  "evictions at the gate limit passes through to shrink",
+			hitsW: rowGets, missesW: 0, evictionsW: limit,
+			capacity: 100, size: 100, warmCount: 20, floor: 10,
+			wantNewCap: 50, wantEvict: 50, wantShrink: true,
 		},
 		{
 			name:  "hit rate below target does not shrink",
@@ -704,7 +755,7 @@ func TestDecideShrink_PolicyTable(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			newCap, evict, shrink := decideShrink(
 				tt.hitsW, tt.missesW, tt.evictionsW,
-				tt.capacity, tt.size, tt.warmCount, tt.floor, target,
+				tt.capacity, tt.size, tt.warmCount, tt.floor, target, conservatism,
 			)
 			require.Equal(t, tt.wantShrink, shrink, "shrink")
 			require.Equal(t, tt.wantNewCap, newCap, "newCap")
@@ -719,7 +770,7 @@ func TestDecideShrink_PolicyTable(t *testing.T) {
 // during setup), so the forced capacity stands in for a previously-grown cache.
 func newFullAdaptiveCache(t *testing.T, capacity, minSamples int, target float64) *TagValueSeriesIDCache {
 	t.Helper()
-	c := NewAdaptiveTagValueSeriesIDCache(2, 1024, target, minSamples, zap.NewNop())
+	c := NewAdaptiveTagValueSeriesIDCache(2, 1024, target, tsdb.DefaultSeriesIDSetCacheShrinkConservatism, minSamples, zap.NewNop())
 	atomic.StoreInt64(&c.capacity, int64(capacity))
 	for i := 0; i < capacity; i++ {
 		c.Put([]byte("m"), []byte("k"), []byte{byte(i)}, tsdb.NewSeriesIDSet(uint64(i)))
@@ -739,16 +790,16 @@ func existsVal(c *TagValueSeriesIDCache, v int) bool {
 }
 
 func TestTagValueSeriesIDCache_ShrinkColdTail(t *testing.T) {
-	// Full cache of 10; touch only {0,1,2} for one window. The window
-	// (floored at minSamples=8 for this size) completes; with a 100% hit
-	// rate and zero evictions, capacity trims toward the warm footprint,
-	// bounded to half the cache per event. Verifies the RIGHT (deepest,
+	// Full cache of 10; touch only {0,1,2} for one window. The window completes;
+	// with a 100% hit rate and zero evictions, capacity trims toward the warm
+	// footprint, bounded to half the cache per event. Verifies the RIGHT (deepest,
 	// untouched) entries are shed and the warm set + recently-inserted cold
 	// entries survive.
 	cache := newFullAdaptiveCache(t, 10, 8, 0.5)
 
-	for i := 0; i < 8; i++ { // window == 8 for n=10
-		require.NotNil(t, getVal(cache, i%3))
+	w := adaptiveWindowLen(10, 8, 0.5)
+	for i := int64(0); i < w; i++ {
+		require.NotNil(t, getVal(cache, int(i%3)))
 	}
 
 	require.Equal(t, int64(5), atomic.LoadInt64(&cache.capacity), "capacity = size - min(coldTail, size/2) = 10-5")
@@ -767,14 +818,15 @@ func TestTagValueSeriesIDCache_ShrinkColdTail(t *testing.T) {
 func TestTagValueSeriesIDCache_ShrinkSlack(t *testing.T) {
 	// Capacity 10 but only 4 entries (slack). A quiet, all-hit window trims
 	// capacity down to the occupancy with no eviction.
-	cache := NewAdaptiveTagValueSeriesIDCache(2, 1024, 0.5, 8, zap.NewNop())
+	cache := NewAdaptiveTagValueSeriesIDCache(2, 1024, 0.5, tsdb.DefaultSeriesIDSetCacheShrinkConservatism, 8, zap.NewNop())
 	atomic.StoreInt64(&cache.capacity, 10)
 	for i := 0; i < 4; i++ {
 		cache.Put([]byte("m"), []byte("k"), []byte{byte(i)}, tsdb.NewSeriesIDSet(uint64(i)))
 	}
 
-	for i := 0; i < 8; i++ { // window == 8 for n=4
-		require.NotNil(t, getVal(cache, i%4))
+	w := adaptiveWindowLen(4, 8, 0.5)
+	for i := int64(0); i < w; i++ {
+		require.NotNil(t, getVal(cache, int(i%4)))
 	}
 
 	require.Equal(t, int64(4), atomic.LoadInt64(&cache.capacity), "slack branch trims capacity to occupancy")
@@ -787,10 +839,11 @@ func TestTagValueSeriesIDCache_ShrinkSlack(t *testing.T) {
 func TestTagValueSeriesIDCache_NoShrinkWhenAllTouched(t *testing.T) {
 	// Full cache; touch every entry within the window. warmCount == size, so
 	// there is no cold tail and capacity is unchanged.
-	cache := newFullAdaptiveCache(t, 10, 16, 0.5) // window == 16, enough to touch all 10
+	cache := newFullAdaptiveCache(t, 10, 16, 0.5) // window >= 16, enough to touch all 10
 
-	for i := 0; i < 16; i++ {
-		require.NotNil(t, getVal(cache, i%10))
+	w := adaptiveWindowLen(10, 16, 0.5)
+	for i := int64(0); i < w; i++ {
+		require.NotNil(t, getVal(cache, int(i%10)))
 	}
 
 	require.Equal(t, int64(10), atomic.LoadInt64(&cache.capacity), "capacity must not shrink when the whole cache is in use")
@@ -798,23 +851,28 @@ func TestTagValueSeriesIDCache_NoShrinkWhenAllTouched(t *testing.T) {
 }
 
 func TestTagValueSeriesIDCache_ShrinkCooldown(t *testing.T) {
-	// A capacity change sets a cooldown that suppresses shrink for a few
-	// windows. Seed the cooldown directly and verify shrink is gated until it
-	// elapses, then fires.
+	// A capacity change sets a Gets-based cooldown that suppresses shrink until
+	// it elapses. Seed a long cooldown and verify shrink is gated across several
+	// windows, then clear it and confirm the next completed window shrinks.
 	cache := newFullAdaptiveCache(t, 10, 8, 0.5)
-	cache.cooldownRemaining = 2
+	w := adaptiveWindowLen(10, 8, 0.5)
+	cache.cooldownGets = 1000 // spans the windows driven below
 
 	drive := func() {
-		for i := 0; i < 8; i++ { // one window (n stays 10 while no shrink)
-			getVal(cache, i%3)
+		for i := int64(0); i < w; i++ { // one window (n stays 10 while no shrink)
+			getVal(cache, int(i%3))
 		}
 	}
 
-	drive() // window 1: cooldown 2 -> 1, no shrink
-	require.Equal(t, int64(10), atomic.LoadInt64(&cache.capacity), "shrink suppressed during cooldown (window 1)")
-	drive() // window 2: cooldown 1 -> 0, no shrink
-	require.Equal(t, int64(10), atomic.LoadInt64(&cache.capacity), "shrink suppressed during cooldown (window 2)")
-	drive() // window 3: cooldown 0 -> shrink fires
+	drive()
+	drive()
+	drive()
+	require.Equal(t, int64(10), atomic.LoadInt64(&cache.capacity), "shrink suppressed while cooling down")
+
+	cache.Lock()
+	cache.cooldownGets = 0
+	cache.Unlock()
+	drive()
 	require.Equal(t, int64(5), atomic.LoadInt64(&cache.capacity), "shrink fires once the cooldown elapses")
 }
 
@@ -822,7 +880,7 @@ func TestTagValueSeriesIDCache_ShrinkBoundaryReTouch(t *testing.T) {
 	// Re-touching the deepest warm element must recede the boundary to its
 	// predecessor, keeping warmCount equal to the true distinct-touched count.
 	// A large minSamples keeps the window open so we can inspect mid-window.
-	cache := NewAdaptiveTagValueSeriesIDCache(2, 1024, 0.5, 1000, zap.NewNop())
+	cache := NewAdaptiveTagValueSeriesIDCache(2, 1024, 0.5, tsdb.DefaultSeriesIDSetCacheShrinkConservatism, 1000, zap.NewNop())
 	atomic.StoreInt64(&cache.capacity, 5)
 	for i := 0; i < 5; i++ {
 		cache.Put([]byte("m"), []byte("k"), []byte{byte(i)}, tsdb.NewSeriesIDSet(uint64(i)))
@@ -840,9 +898,10 @@ func TestTagValueSeriesIDCache_ShrinkBoundaryReTouch(t *testing.T) {
 }
 
 func TestTagValueSeriesIDCache_ShrinkGrowCooldownStamp(t *testing.T) {
-	// A grow stamps the shared cooldown so a freshly-grown cache is not
-	// immediately shrunk. Drive a grow and assert the cooldown is armed.
-	cache := NewAdaptiveTagValueSeriesIDCache(2, 16, 0.99, 4, zap.NewNop())
+	// A grow stamps the cooldown so a freshly-grown cache is not immediately
+	// shrunk; the cooldown is sized to the new capacity, not the half-full
+	// occupancy. Drive a grow and assert the cooldown matches.
+	cache := NewAdaptiveTagValueSeriesIDCache(2, 16, 0.99, tsdb.DefaultSeriesIDSetCacheShrinkConservatism, 4, zap.NewNop())
 	insert := func(seq int) {
 		v := []byte{byte(seq)}
 		require.Nil(t, cache.Get([]byte("m"), []byte("k"), v))
@@ -853,9 +912,9 @@ func TestTagValueSeriesIDCache_ShrinkGrowCooldownStamp(t *testing.T) {
 	}
 	require.Equal(t, int64(4), atomic.LoadInt64(&cache.capacity), "precondition: grow occurred")
 	cache.Lock()
-	cd := cache.cooldownRemaining
+	cd := cache.cooldownGets
 	cache.Unlock()
-	require.Equal(t, int64(shrinkCooldownWindows), cd, "grow must arm the shrink cooldown")
+	require.Equal(t, adaptiveWindowLen(4, 4, 0.99), cd, "grow arms a cooldown sized to the new capacity")
 }
 
 // TestTagValueSeriesIDCache_Adaptive_Concurrent exercises the adaptive grow and
@@ -868,7 +927,7 @@ func TestTagValueSeriesIDCache_Adaptive_Concurrent(t *testing.T) {
 		t.Skip("Skipping long test")
 	}
 
-	cache := NewAdaptiveTagValueSeriesIDCache(8, 256, 0.9, 16, zap.NewNop())
+	cache := NewAdaptiveTagValueSeriesIDCache(8, 256, 0.9, tsdb.DefaultSeriesIDSetCacheShrinkConservatism, 16, zap.NewNop())
 
 	const (
 		writers = 4

--- a/tsdb/index/tsi1/cache_test.go
+++ b/tsdb/index/tsi1/cache_test.go
@@ -660,25 +660,54 @@ func TestAdaptiveWindowLen(t *testing.T) {
 }
 
 func TestNewAdaptiveTagValueSeriesIDCache_RejectsInvalidArguments(t *testing.T) {
-	// NaN and out-of-range targets must panic; a NaN target would otherwise make
-	// the grow/shrink rate comparisons behave unpredictably.
-	for _, target := range []float64{math.NaN(), 0, 1, -0.1, 1.5} {
-		require.Panics(t, func() {
-			NewAdaptiveTagValueSeriesIDCache(2, 16, target, tsdb.DefaultSeriesIDSetCacheShrinkConservatism, 4, zap.NewNop())
-		}, "target %v must be rejected", target)
+	// Invalid arguments must NOT panic; the constructor logs the error and
+	// returns a fixed-size (non-adaptive) cache so misconfiguration degrades to
+	// a working cache. A non-adaptive cache is identified by maxCapacity == 0.
+	const defaultC = tsdb.DefaultSeriesIDSetCacheShrinkConservatism
+	cases := []struct {
+		name             string
+		initial, max     int
+		target, cons     float64
+		minSamples       int
+		wantLogSubstring string
+		wantFallbackSize int64 // size NewTagValueSeriesIDCache was called with
+	}{
+		{"initial zero", 0, 16, 0.95, defaultC, 4, "initial must be > 0", int64(tsdb.DefaultSeriesIDSetCacheSize)},
+		{"initial negative", -1, 16, 0.95, defaultC, 4, "initial must be > 0", int64(tsdb.DefaultSeriesIDSetCacheSize)},
+		{"max equal to initial", 2, 2, 0.95, defaultC, 4, "max must be > initial", 2},
+		{"max less than initial", 2, 1, 0.95, defaultC, 4, "max must be > initial", 2},
+		{"target NaN", 2, 16, math.NaN(), defaultC, 4, "target must be in (0, 1)", 2},
+		{"target zero", 2, 16, 0, defaultC, 4, "target must be in (0, 1)", 2},
+		{"target one", 2, 16, 1, defaultC, 4, "target must be in (0, 1)", 2},
+		{"target negative", 2, 16, -0.1, defaultC, 4, "target must be in (0, 1)", 2},
+		{"target above 1", 2, 16, 1.5, defaultC, 4, "target must be in (0, 1)", 2},
+		{"conservatism NaN", 2, 16, 0.95, math.NaN(), 4, "shrinkConservatism", 2},
+		{"conservatism +Inf", 2, 16, 0.95, math.Inf(1), 4, "shrinkConservatism", 2},
+		{"conservatism -Inf", 2, 16, 0.95, math.Inf(-1), 4, "shrinkConservatism", 2},
+		{"conservatism negative", 2, 16, 0.95, -1, 4, "shrinkConservatism", 2},
+		{"minSamples negative", 2, 16, 0.95, defaultC, -1, "minSamples must be >= 0", 2},
 	}
-	// NaN, ±Inf and negative conservatism values must panic; the valid range is
-	// [0, +Inf), so 0 and small positive values are accepted (covered separately).
-	for _, c := range []float64{math.NaN(), math.Inf(1), math.Inf(-1), -1, -0.0001} {
-		require.Panics(t, func() {
-			NewAdaptiveTagValueSeriesIDCache(2, 16, 0.95, c, 4, zap.NewNop())
-		}, "conservatism %v must be rejected", c)
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			core, logs := observer.New(zap.ErrorLevel)
+			c := NewAdaptiveTagValueSeriesIDCache(tt.initial, tt.max, tt.target, tt.cons, tt.minSamples, zap.New(core))
+			require.NotNil(t, c)
+			require.Equal(t, int64(0), c.maxCapacity, "fallback must be non-adaptive (maxCapacity == 0)")
+			require.Equal(t, tt.wantFallbackSize, atomic.LoadInt64(&c.capacity), "fallback capacity")
+			entries := logs.All()
+			require.Len(t, entries, 1, "expected exactly one error log")
+			require.Contains(t, entries[0].Message, tt.wantLogSubstring)
+		})
 	}
-	// Conservatism boundary values (0 = median admit; small positive) must NOT panic.
-	for _, c := range []float64{0, 0.5, 1, 2.0, 10} {
-		require.NotPanics(t, func() {
-			NewAdaptiveTagValueSeriesIDCache(2, 16, 0.95, c, 4, zap.NewNop())
-		}, "conservatism %v must be accepted", c)
+
+	// Valid conservatism boundary values (0 = median admit; small positive)
+	// must produce an adaptive cache and log nothing.
+	for _, cons := range []float64{0, 0.5, 1, 2.0, 10} {
+		core, logs := observer.New(zap.ErrorLevel)
+		cache := NewAdaptiveTagValueSeriesIDCache(2, 16, 0.95, cons, 4, zap.New(core))
+		require.NotNil(t, cache)
+		require.Equal(t, int64(16), cache.maxCapacity, "valid args must produce adaptive cache, conservatism=%v", cons)
+		require.Empty(t, logs.All(), "valid args must not log, conservatism=%v", cons)
 	}
 }
 
@@ -818,6 +847,92 @@ func decideShrink(hitsW, missesW, evictionsW, capacity, size, warmCount, floor i
 		return decideColdTail(size, warmCount, floor)
 	}
 	return newCap, 0, shrink
+}
+
+// TestAtTargetEvictionGateLimit_Table exercises the gate-threshold helper across
+// a range of z (conservatism) values — including a mid-(0,1) z and a z>3 — that
+// the constructor's NotPanics check accepts but no behavior test exercises. With
+// gets=1000 and target=0.95, mu = 1000*0.05 = 50 and sigma = sqrt(1000*0.95*0.05)
+// ~= 6.8920, so the int64 floor of mu - z*sigma is computable to one count.
+func TestAtTargetEvictionGateLimit_Table(t *testing.T) {
+	tests := []struct {
+		name      string
+		gets      int64
+		target, z float64
+		want      int64
+	}{
+		// z=0 admits at the mean; covers the median-admit case the doc calls out.
+		{name: "z=0 admits at the mean", gets: 1000, target: 0.95, z: 0, want: 50},
+		// z in (0, 1): small relaxation below the mean. 50 - 0.5*6.892 = 46.554.
+		{name: "z=0.5 (in (0,1)) lowers limit below mean", gets: 1000, target: 0.95, z: 0.5, want: 46},
+		// Default production conservatism: 50 - 2.5*6.892 = 32.770.
+		{name: "z=2.5 (default) lowers limit further", gets: 1000, target: 0.95, z: 2.5, want: 32},
+		// z>3 deep below the mean drives the result negative; the floor at 1 binds.
+		{name: "z=10 (>3) floors at 1", gets: 1000, target: 0.95, z: 10, want: 1},
+		// Different targets shift the mean: T=0.5 -> mu=500; T=0.99 -> mu=10.
+		{name: "target=0.5 widens the mean", gets: 1000, target: 0.5, z: 0, want: 500},
+		{name: "target=0.99 narrows the mean", gets: 1000, target: 0.99, z: 0, want: 10},
+		// Tiny window where mu < 1: the floor binds even at z=0.
+		{name: "gets=1 floors at 1", gets: 1, target: 0.95, z: 0, want: 1},
+		// Out-of-range inputs return 1 (fail-safe: gate any eviction).
+		{name: "gets=0 fail-safe", gets: 0, target: 0.95, z: 0, want: 1},
+		{name: "gets=-1 fail-safe", gets: -1, target: 0.95, z: 0, want: 1},
+		{name: "target=0 fail-safe", gets: 1000, target: 0, z: 0, want: 1},
+		{name: "target=1 fail-safe", gets: 1000, target: 1, z: 0, want: 1},
+		{name: "target=NaN fail-safe", gets: 1000, target: math.NaN(), z: 0, want: 1},
+		{name: "z=-0.1 fail-safe", gets: 1000, target: 0.95, z: -0.1, want: 1},
+		{name: "z=NaN fail-safe", gets: 1000, target: 0.95, z: math.NaN(), want: 1},
+		{name: "z=+Inf fail-safe", gets: 1000, target: 0.95, z: math.Inf(1), want: 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, atTargetEvictionGateLimit(tt.gets, tt.target, tt.z))
+		})
+	}
+}
+
+// TestDecideShrink_ConservatismVariation locks in the scale-adaptive margin the
+// gate provides: with the same window evictions, raising z lowers the admission
+// threshold and flips the gate from pass to block. TestDecideShrink_PolicyTable
+// only exercises the default z (2.5); this test exercises z values in (0, 1) and
+// z > 3 to confirm both ends of the legal range affect shrink behavior.
+func TestDecideShrink_ConservatismVariation(t *testing.T) {
+	const (
+		target  = 0.95
+		rowGets = int64(1000)
+	)
+	// At target=0.95 and gets=1000, mu=50. The cold-tail shape mirrors a row
+	// from TestDecideShrink_PolicyTable: full cache (size=capacity=100), warm
+	// prefix of 20, hit rate 1.0 so the hit-rate gate always passes.
+	tests := []struct {
+		name         string
+		conservatism float64
+		evictionsW   int64
+		wantShrink   bool
+	}{
+		// z=0 admits at the mean (limit=50). evictionsW=50 is NOT > 50, gate
+		// passes, cold-tail branch shrinks. Documents the median-admit boundary.
+		{name: "z=0 admits at the median", conservatism: 0, evictionsW: 50, wantShrink: true},
+		// z=0.5 (in (0,1)) lowers limit to 46; evictionsW=50 > 46 blocks. Proves
+		// a small in-range z already tightens the gate.
+		{name: "z=0.5 (in (0,1)) blocks above lowered limit", conservatism: 0.5, evictionsW: 50, wantShrink: false},
+		// z=10 (>3) drives the limit to the floor (1); evictionsW=50 > 1 blocks
+		// hard. Proves a very conservative operator setting suppresses shrink
+		// under normal eviction pressure.
+		{name: "z=10 (>3) blocks above the floored limit", conservatism: 10, evictionsW: 50, wantShrink: false},
+		// z=10 still admits when evictions sit at the floor: 1 > 1 is false, so
+		// even a very conservative cache can shrink when traffic is genuinely quiet.
+		{name: "z=10 (>3) admits at the floor", conservatism: 10, evictionsW: 1, wantShrink: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, shrink := decideShrink(
+				rowGets, 0, tt.evictionsW,
+				100, 100, 20, 10, target, tt.conservatism,
+			)
+			require.Equal(t, tt.wantShrink, shrink)
+		})
+	}
 }
 
 // newFullAdaptiveCache returns an adaptive cache forced to the given capacity

--- a/tsdb/index/tsi1/cache_test.go
+++ b/tsdb/index/tsi1/cache_test.go
@@ -1331,3 +1331,111 @@ func TestTagValueSeriesIDCache_Adaptive_Concurrent(t *testing.T) {
 	require.LessOrEqual(t, finalCap, int64(256), "capacity must never exceed the max")
 	require.Equal(t, int64(cache.evictor.Len()), cache.stats.Size.Load(), "size counter must track the evictor list")
 }
+
+// TestTagValueSeriesIDCache_AtFloor_SkipsShrinkBookkeeping verifies that while
+// the cache sits at its floor (capacity == minCapacity) a shrink can never fire,
+// so the read path skips all shrink window bookkeeping: it tracks no footprint
+// and starts no window. Regression guard for the floor gate — without it, the
+// first hit would start a window and set deepestTouched.
+func TestTagValueSeriesIDCache_AtFloor_SkipsShrinkBookkeeping(t *testing.T) {
+	const floor = 8
+	cache := NewAdaptiveTagValueSeriesIDCache(floor, 64, 0.5, tsdb.DefaultSeriesIDSetCacheShrinkConservatism, 4, zap.NewNop())
+	require.Equal(t, int64(floor), cache.capacity.Load())
+	require.Equal(t, int64(floor), cache.minCapacity)
+
+	// Fill exactly to the floor (full, no eviction).
+	for i := 0; i < floor; i++ {
+		cache.Put([]byte("m"), []byte("k"), []byte{byte(i)}, tsdb.NewSeriesIDSet(uint64(i)))
+	}
+	require.Equal(t, int64(floor), cache.stats.Size.Load())
+
+	// A handful of hits on a subset — fewer than one window. Without the gate this
+	// would already have a live window and a tracked footprint.
+	for i := 0; i < 3; i++ {
+		require.NotNil(t, getVal(cache, i%3))
+	}
+	cache.Lock()
+	window, gets, deepest := cache.shrinkWindowGets, cache.getsSinceShrinkCheck, cache.deepestTouched
+	cache.Unlock()
+	require.Zero(t, window, "no shrink window may start at the floor")
+	require.Zero(t, gets, "no window gets may accumulate at the floor")
+	require.Nil(t, deepest, "no footprint may be tracked at the floor")
+
+	// Over many more would-be windows, nothing is ever shed and capacity holds.
+	for i := 0; i < 500; i++ {
+		require.NotNil(t, getVal(cache, i%3))
+	}
+	require.Equal(t, int64(floor), cache.capacity.Load(), "capacity must stay at the floor")
+	require.Equal(t, int64(floor), cache.stats.Size.Load(), "nothing may be evicted at the floor")
+	require.Zero(t, cache.stats.ShrinkEvictions.Load(), "no shrink evictions at the floor")
+}
+
+// TestTagValueSeriesIDCache_FloorGateReopensAfterGrowth proves the floor gate is
+// not a one-way latch: growth from the floor is unaffected (it runs on the Put
+// path), and once capacity rises above the floor the read path resumes shrink
+// bookkeeping so the cache can shrink again.
+func TestTagValueSeriesIDCache_FloorGateReopensAfterGrowth(t *testing.T) {
+	const floor = 4
+	cache := NewAdaptiveTagValueSeriesIDCache(floor, 64, 0.5, tsdb.DefaultSeriesIDSetCacheShrinkConservatism, 4, zap.NewNop())
+	require.Equal(t, int64(floor), cache.capacity.Load())
+
+	// Get-miss then Put each distinct key, driving evictions that grow capacity.
+	insert := func(seq int) {
+		v := []byte{byte(seq)}
+		require.Nil(t, cache.Get([]byte("m"), []byte("k"), v))
+		cache.Put([]byte("m"), []byte("k"), v, tsdb.NewSeriesIDSet(uint64(seq)))
+	}
+	for i := 0; i < 60; i++ {
+		insert(i)
+	}
+	peak := cache.capacity.Load()
+	require.Greater(t, peak, int64(floor), "growth must not be blocked by the floor gate")
+
+	// Repeatedly hit a tiny, most-recently-inserted (still-resident) warm set.
+	// Once the post-grow cooldown drains and a pure-hit window completes, the cold
+	// tail is shed — which can only happen if the gate reopened above the floor.
+	warm := []int{57, 58, 59}
+	var shrank bool
+	for round := 0; round < 5000 && !shrank; round++ {
+		for _, v := range warm {
+			getVal(cache, v)
+		}
+		shrank = cache.capacity.Load() < peak && cache.stats.ShrinkEvictions.Load() > 0
+	}
+	require.True(t, shrank, "cache must shrink after growth (floor gate must reopen)")
+	require.GreaterOrEqual(t, cache.capacity.Load(), int64(floor), "must never shrink below the floor")
+}
+
+// benchmarkGetHit measures the cost of a cache hit with adaptive sizing enabled,
+// for a cache forced to `capacity` with floor `floor`. When capacity == floor the
+// floor gate skips the per-hit footprint tracking and the shrink window
+// machinery; when capacity > floor that bookkeeping runs. The working set is the
+// whole cache so the above-floor case never actually shrinks (warmCount == size),
+// keeping the two benchmarks an apples-to-apples comparison of the overhead the
+// gate removes.
+func benchmarkGetHit(b *testing.B, capacity, floor int) {
+	cache := NewAdaptiveTagValueSeriesIDCache(floor, 1<<20, 0.5, tsdb.DefaultSeriesIDSetCacheShrinkConservatism, tsdb.DefaultAdaptiveCacheMinSamples, zap.NewNop())
+	cache.capacity.Store(int64(capacity))
+	for i := 0; i < capacity; i++ {
+		cache.Put([]byte("m"), []byte("k"), []byte{byte(i)}, tsdb.NewSeriesIDSet(uint64(i)))
+	}
+	name, key := []byte("m"), []byte("k")
+	val := []byte{0}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		val[0] = byte(i % capacity)
+		cache.Get(name, key, val)
+	}
+}
+
+// At the floor (capacity == minCapacity): the shrink bookkeeping is skipped.
+func BenchmarkTagValueSeriesIDCache_GetHit_AtFloor(b *testing.B) {
+	benchmarkGetHit(b, 64, 64)
+}
+
+// Above the floor (capacity > minCapacity): the shrink bookkeeping runs.
+func BenchmarkTagValueSeriesIDCache_GetHit_AboveFloor(b *testing.B) {
+	benchmarkGetHit(b, 64, 2)
+}

--- a/tsdb/index/tsi1/cache_test.go
+++ b/tsdb/index/tsi1/cache_test.go
@@ -793,6 +793,33 @@ func TestDecideShrink_PolicyTable(t *testing.T) {
 	}
 }
 
+// decideShrink implements the full capacity-decay policy as a pure function of
+// the window's counters, the current occupancy, and the observed access
+// footprint. It mirrors decideResize so the policy can be exercised with integer
+// literals. It composes decideShrinkPre and decideColdTail; production code calls
+// those two directly so the O(size) footprint walk that produces warmCount is
+// only performed when the cold-tail branch is actually reached (see
+// maybeShrinkLocked).
+//
+// Gates (all required): at least one read; window evictions at or below the
+// scaled at-target expectation (see atTargetEvictionGateLimit); and a windowed
+// hit rate >= target (the cache is serving its working set well). When gated
+// through, one of two branches fires:
+//   - slack: capacity exceeds occupancy -> drop the unused headroom (no eviction).
+//   - cold-tail: cache is full -> shed the LRU tail that went untouched this
+//     window, down to the warm footprint (warmCount), clamped at floor, and
+//     bounded to half the cache per event so the write lock is not held long.
+//
+// The evicted entries are always within the untouched cold tail, so warm entries
+// are never shed.
+func decideShrink(hitsW, missesW, evictionsW, capacity, size, warmCount, floor int64, target, conservatism float64) (newCap, evict int64, shrink bool) {
+	newCap, shrink, coldTail := decideShrinkPre(hitsW, missesW, evictionsW, capacity, size, floor, target, conservatism)
+	if coldTail {
+		return decideColdTail(size, warmCount, floor)
+	}
+	return newCap, 0, shrink
+}
+
 // newFullAdaptiveCache returns an adaptive cache forced to the given capacity
 // and filled with that many entries (values 0..capacity-1). The floor is 2, so
 // shrink has room to act. Adaptive growth is not exercised (no evictions occur

--- a/tsdb/index/tsi1/cache_test.go
+++ b/tsdb/index/tsi1/cache_test.go
@@ -1084,6 +1084,40 @@ func TestTagValueSeriesIDCache_ShrinkGrowCooldownStamp(t *testing.T) {
 	require.Equal(t, adaptiveWindowLen(4, 4, 0.99), cd, "grow arms a cooldown sized to the new capacity")
 }
 
+func TestTagValueSeriesIDCache_ShrinkResetsGrowWindow(t *testing.T) {
+	// After a shrink, the grow policy's per-window state still describes the
+	// pre-shrink window. If evictionsSinceCheck happens to be near or above the
+	// new smaller capacity, the next forced eviction would fire
+	// maybeResizeLocked immediately against stale hit/miss baselines. A shrink
+	// must reset all three so the grow window restarts post-shrink.
+	cache := newFullAdaptiveCache(t, 10, 8, 0.5)
+
+	// Pre-seed the grow-window state to look "almost ready to fire", with
+	// baselines from a moment that predates the shrink window.
+	cache.Lock()
+	cache.evictionsSinceCheck = 7
+	cache.lastHits = 99
+	cache.lastMisses = 99
+	cache.Unlock()
+
+	// Drive a window of all hits on a warm subset of 3 to trigger a shrink.
+	w := adaptiveWindowLen(10, 8, 0.5)
+	for i := int64(0); i < w; i++ {
+		require.NotNil(t, getVal(cache, int(i%3)))
+	}
+	require.Less(t, atomic.LoadInt64(&cache.capacity), int64(10),
+		"precondition: shrink should have fired")
+
+	cache.Lock()
+	defer cache.Unlock()
+	require.Equal(t, int64(0), cache.evictionsSinceCheck,
+		"evictionsSinceCheck must reset so the next forced eviction starts a fresh grow window")
+	require.Equal(t, atomic.LoadInt64(&cache.stats.Hits), cache.lastHits,
+		"lastHits must snap to the current hit count after shrink")
+	require.Equal(t, atomic.LoadInt64(&cache.stats.Misses), cache.lastMisses,
+		"lastMisses must snap to the current miss count after shrink")
+}
+
 // TestTagValueSeriesIDCache_Adaptive_Concurrent exercises the adaptive grow and
 // shrink paths (and the lockless Statistics reader) under concurrency so the
 // race detector validates the new shrink bookkeeping. The keyspace is small

--- a/tsdb/index/tsi1/cache_test.go
+++ b/tsdb/index/tsi1/cache_test.go
@@ -682,10 +682,31 @@ func TestNewAdaptiveTagValueSeriesIDCache_RejectsInvalidArguments(t *testing.T) 
 			require.Equal(t, int64(0), c.maxCapacity, "fallback must be non-adaptive (maxCapacity == 0)")
 			require.Equal(t, tt.wantFallbackSize, c.capacity.Load(), "fallback capacity")
 			entries := logs.All()
-			require.Len(t, entries, 1, "expected exactly one error log")
+			require.Len(t, entries, 2, "expected the specific error plus the fallback log")
 			require.Contains(t, entries[0].Message, tt.wantLogSubstring)
+			require.Contains(t, entries[1].Message, "falling back to fixed-size cache")
 		})
 	}
+
+	// All invalid arguments are reported in a single construction: validation
+	// does not stop at the first failure. Every argument here is invalid, so each
+	// produces its own error log, followed by the fallback summary.
+	t.Run("all invalid arguments reported", func(t *testing.T) {
+		core, logs := observer.New(zap.ErrorLevel)
+		c := NewAdaptiveTagValueSeriesIDCache(-1, -2, math.NaN(), math.Inf(1), -3, zap.New(core))
+		require.NotNil(t, c)
+		require.Equal(t, int64(0), c.maxCapacity, "fallback must be non-adaptive (maxCapacity == 0)")
+		require.Equal(t, int64(tsdb.DefaultSeriesIDSetCacheSize), c.capacity.Load(), "fallback capacity")
+
+		entries := logs.All()
+		require.Len(t, entries, 6, "five argument errors plus the fallback summary")
+		require.Contains(t, entries[0].Message, "initial must be > 0")
+		require.Contains(t, entries[1].Message, "max must be > initial")
+		require.Contains(t, entries[2].Message, "target must be in (0, 1)")
+		require.Contains(t, entries[3].Message, "shrinkConservatism")
+		require.Contains(t, entries[4].Message, "minSamples must be >= 0")
+		require.Contains(t, entries[5].Message, "falling back to fixed-size cache")
+	})
 
 	// Valid conservatism boundary values (0 = median admit; small positive)
 	// must produce an adaptive cache and log nothing.

--- a/tsdb/index/tsi1/cache_test.go
+++ b/tsdb/index/tsi1/cache_test.go
@@ -7,7 +7,6 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
-	"unsafe"
 
 	"github.com/influxdata/influxdb/tsdb"
 	"github.com/stretchr/testify/require"
@@ -250,18 +249,6 @@ func (c TestCache) PutByString(name, key, value string, ss *tsdb.SeriesIDSet) {
 	c.Put([]byte(name), []byte(key), []byte(value), ss)
 }
 
-// TestTagValueSeriesIDCache_AtomicFieldAlignment guards the struct layout:
-// fields accessed with sync/atomic (capacity and the stats counters) must be
-// 64-bit aligned, or atomic ops panic on 32-bit platforms. The allocation
-// base is guaranteed 8-byte aligned, so it suffices that these fields sit at
-// 8-byte-multiple offsets. The leading layout has no sub-8-byte fields, so
-// the offsets observed here (on any host) match those on 32-bit.
-func TestTagValueSeriesIDCache_AtomicFieldAlignment(t *testing.T) {
-	var c TagValueSeriesIDCache
-	require.Zero(t, unsafe.Offsetof(c.capacity)%8, "capacity must be 8-byte aligned")
-	require.Zero(t, unsafe.Offsetof(c.stats)%8, "stats counters must be 8-byte aligned")
-}
-
 func TestTagValueSeriesIDCache_Statistics(t *testing.T) {
 	statValues := func(cache *TagValueSeriesIDCache) map[string]interface{} {
 		stats := cache.Statistics(nil)
@@ -485,7 +472,7 @@ func TestTagValueSeriesIDCache_AdaptiveGrowth_TriggersOnTurnover(t *testing.T) {
 	logger := zap.NewNop()
 	cache := NewAdaptiveTagValueSeriesIDCache(2, 16, 0.99, tsdb.DefaultSeriesIDSetCacheShrinkConservatism, 4, logger)
 
-	require.Equal(t, int64(2), atomic.LoadInt64(&cache.capacity))
+	require.Equal(t, int64(2), cache.capacity.Load())
 
 	insert := func(seq int) {
 		v := []byte{byte(seq)}
@@ -501,7 +488,7 @@ func TestTagValueSeriesIDCache_AdaptiveGrowth_TriggersOnTurnover(t *testing.T) {
 	for i := 1; i <= 4; i++ {
 		insert(i)
 	}
-	require.Equal(t, int64(4), atomic.LoadInt64(&cache.capacity), "after first turnover, capacity=4")
+	require.Equal(t, int64(4), cache.capacity.Load(), "after first turnover, capacity=4")
 
 	// After grow to 4, two free slots. Need to refill before evicting:
 	//   insert 5: size 2→3
@@ -510,7 +497,7 @@ func TestTagValueSeriesIDCache_AdaptiveGrowth_TriggersOnTurnover(t *testing.T) {
 	for i := 5; i <= 10; i++ {
 		insert(i)
 	}
-	require.Equal(t, int64(8), atomic.LoadInt64(&cache.capacity), "after second turnover, capacity=8")
+	require.Equal(t, int64(8), cache.capacity.Load(), "after second turnover, capacity=8")
 
 	// After grow to 8, four free slots. Refill then 8 evictions:
 	//   insert 11..14: fill to size=8
@@ -518,7 +505,7 @@ func TestTagValueSeriesIDCache_AdaptiveGrowth_TriggersOnTurnover(t *testing.T) {
 	for i := 11; i <= 22; i++ {
 		insert(i)
 	}
-	require.Equal(t, int64(16), atomic.LoadInt64(&cache.capacity), "after third turnover, capacity=16 (= max)")
+	require.Equal(t, int64(16), cache.capacity.Load(), "after third turnover, capacity=16 (= max)")
 
 	// Further evictions do not grow past max.
 	// After grow to 16, eight free slots. Fill them, then drive enough
@@ -526,7 +513,7 @@ func TestTagValueSeriesIDCache_AdaptiveGrowth_TriggersOnTurnover(t *testing.T) {
 	for i := 23; i <= 50; i++ {
 		insert(i)
 	}
-	require.Equal(t, int64(16), atomic.LoadInt64(&cache.capacity), "capacity stays at max")
+	require.Equal(t, int64(16), cache.capacity.Load(), "capacity stays at max")
 }
 
 func TestTagValueSeriesIDCache_AdaptiveGrowth_NoOpAtTarget(t *testing.T) {
@@ -565,7 +552,7 @@ func TestTagValueSeriesIDCache_AdaptiveGrowth_NoOpAtTarget(t *testing.T) {
 		hitOnSurvivors()
 		insert(i)
 	}
-	require.Equal(t, int64(2), atomic.LoadInt64(&cache.capacity), "capacity must stay at 2 when target is met")
+	require.Equal(t, int64(2), cache.capacity.Load(), "capacity must stay at 2 when target is met")
 }
 
 func TestTagValueSeriesIDCache_AdaptiveDisabled_NoLogNoGrowth(t *testing.T) {
@@ -582,7 +569,7 @@ func TestTagValueSeriesIDCache_AdaptiveDisabled_NoLogNoGrowth(t *testing.T) {
 		cache.Put([]byte("m"), []byte("k"), v, tsdb.NewSeriesIDSet(uint64(i)))
 	}
 
-	require.Equal(t, int64(2), atomic.LoadInt64(&cache.capacity), "capacity must not change when adaptive sizing is disabled")
+	require.Equal(t, int64(2), cache.capacity.Load(), "capacity must not change when adaptive sizing is disabled")
 	require.Equal(t, 0, logs.Len(), "no log lines must be emitted when adaptive sizing is disabled")
 }
 
@@ -621,7 +608,7 @@ func TestIndex_WithLogger_PropagatesToAdaptiveCache(t *testing.T) {
 	cache.Put([]byte("m"), []byte("k"), []byte{2}, tsdb.NewSeriesIDSet(2))
 	cache.Put([]byte("m"), []byte("k"), []byte{3}, tsdb.NewSeriesIDSet(3))
 
-	require.Equal(t, int64(4), atomic.LoadInt64(&cache.capacity), "cache should have grown after policy fired")
+	require.Equal(t, int64(4), cache.capacity.Load(), "cache should have grown after policy fired")
 	require.Equal(t, 1, logs.Len(), "resize event must be emitted to the logger propagated by WithLogger")
 	require.Equal(t, logMsgCacheCapacityIncreased, logs.All()[0].Message)
 }
@@ -693,7 +680,7 @@ func TestNewAdaptiveTagValueSeriesIDCache_RejectsInvalidArguments(t *testing.T) 
 			c := NewAdaptiveTagValueSeriesIDCache(tt.initial, tt.max, tt.target, tt.cons, tt.minSamples, zap.New(core))
 			require.NotNil(t, c)
 			require.Equal(t, int64(0), c.maxCapacity, "fallback must be non-adaptive (maxCapacity == 0)")
-			require.Equal(t, tt.wantFallbackSize, atomic.LoadInt64(&c.capacity), "fallback capacity")
+			require.Equal(t, tt.wantFallbackSize, c.capacity.Load(), "fallback capacity")
 			entries := logs.All()
 			require.Len(t, entries, 1, "expected exactly one error log")
 			require.Contains(t, entries[0].Message, tt.wantLogSubstring)
@@ -942,11 +929,11 @@ func TestDecideShrink_ConservatismVariation(t *testing.T) {
 func newFullAdaptiveCache(t *testing.T, capacity, minSamples int, target float64) *TagValueSeriesIDCache {
 	t.Helper()
 	c := NewAdaptiveTagValueSeriesIDCache(2, 1024, target, tsdb.DefaultSeriesIDSetCacheShrinkConservatism, minSamples, zap.NewNop())
-	atomic.StoreInt64(&c.capacity, int64(capacity))
+	c.capacity.Store(int64(capacity))
 	for i := 0; i < capacity; i++ {
 		c.Put([]byte("m"), []byte("k"), []byte{byte(i)}, tsdb.NewSeriesIDSet(uint64(i)))
 	}
-	require.Equal(t, int64(capacity), atomic.LoadInt64(&c.stats.Size), "setup occupancy")
+	require.Equal(t, int64(capacity), c.stats.Size.Load(), "setup occupancy")
 	return c
 }
 
@@ -973,8 +960,8 @@ func TestTagValueSeriesIDCache_ShrinkColdTail(t *testing.T) {
 		require.NotNil(t, getVal(cache, int(i%3)))
 	}
 
-	require.Equal(t, int64(5), atomic.LoadInt64(&cache.capacity), "capacity = size - min(coldTail, size/2) = 10-5")
-	require.Equal(t, int64(5), atomic.LoadInt64(&cache.stats.Size))
+	require.Equal(t, int64(5), cache.capacity.Load(), "capacity = size - min(coldTail, size/2) = 10-5")
+	require.Equal(t, int64(5), cache.stats.Size.Load())
 
 	// Warm {0,1,2} survive; the deepest untouched {3,4,5,6,7} are evicted;
 	// the most-recently-inserted cold {8,9} survive (they are above the LRU tail).
@@ -990,7 +977,7 @@ func TestTagValueSeriesIDCache_ShrinkSlack(t *testing.T) {
 	// Capacity 10 but only 4 entries (slack). A quiet, all-hit window trims
 	// capacity down to the occupancy with no eviction.
 	cache := NewAdaptiveTagValueSeriesIDCache(2, 1024, 0.5, tsdb.DefaultSeriesIDSetCacheShrinkConservatism, 8, zap.NewNop())
-	atomic.StoreInt64(&cache.capacity, 10)
+	cache.capacity.Store(10)
 	for i := 0; i < 4; i++ {
 		cache.Put([]byte("m"), []byte("k"), []byte{byte(i)}, tsdb.NewSeriesIDSet(uint64(i)))
 	}
@@ -1000,8 +987,8 @@ func TestTagValueSeriesIDCache_ShrinkSlack(t *testing.T) {
 		require.NotNil(t, getVal(cache, int(i%4)))
 	}
 
-	require.Equal(t, int64(4), atomic.LoadInt64(&cache.capacity), "slack branch trims capacity to occupancy")
-	require.Equal(t, int64(4), atomic.LoadInt64(&cache.stats.Size), "no eviction in the slack branch")
+	require.Equal(t, int64(4), cache.capacity.Load(), "slack branch trims capacity to occupancy")
+	require.Equal(t, int64(4), cache.stats.Size.Load(), "no eviction in the slack branch")
 	for v := 0; v < 4; v++ {
 		require.True(t, existsVal(cache, v), "value %d must survive a slack trim", v)
 	}
@@ -1017,8 +1004,8 @@ func TestTagValueSeriesIDCache_NoShrinkWhenAllTouched(t *testing.T) {
 		require.NotNil(t, getVal(cache, int(i%10)))
 	}
 
-	require.Equal(t, int64(10), atomic.LoadInt64(&cache.capacity), "capacity must not shrink when the whole cache is in use")
-	require.Equal(t, int64(10), atomic.LoadInt64(&cache.stats.Size))
+	require.Equal(t, int64(10), cache.capacity.Load(), "capacity must not shrink when the whole cache is in use")
+	require.Equal(t, int64(10), cache.stats.Size.Load())
 }
 
 // TestTagValueSeriesIDCache_ShrinkRepeatsWhenCapped verifies that when the
@@ -1042,7 +1029,7 @@ func TestTagValueSeriesIDCache_ShrinkRepeatsWhenCapped(t *testing.T) {
 		samples = 8
 	)
 	cache := NewAdaptiveTagValueSeriesIDCache(2, 4096, target, tsdb.DefaultSeriesIDSetCacheShrinkConservatism, samples, zap.NewNop())
-	atomic.StoreInt64(&cache.capacity, size)
+	cache.capacity.Store(size)
 
 	// 2-byte values give a unique key per i in [0, 65536); the single-byte
 	// values used by newFullAdaptiveCache would collide past 255.
@@ -1051,7 +1038,7 @@ func TestTagValueSeriesIDCache_ShrinkRepeatsWhenCapped(t *testing.T) {
 		keys[i] = []byte{byte(i >> 8), byte(i & 0xFF)}
 		cache.Put([]byte("m"), []byte("k"), keys[i], tsdb.NewSeriesIDSet(uint64(i)))
 	}
-	require.Equal(t, int64(size), atomic.LoadInt64(&cache.stats.Size), "setup occupancy")
+	require.Equal(t, int64(size), cache.stats.Size.Load(), "setup occupancy")
 
 	drive := func(w int64) {
 		for i := int64(0); i < w; i++ {
@@ -1062,18 +1049,18 @@ func TestTagValueSeriesIDCache_ShrinkRepeatsWhenCapped(t *testing.T) {
 	// Window 1: cap clamps the first shrink at maxShrinkEvictPerEvent.
 	drive(adaptiveWindowLen(size, samples, target))
 	afterFirst := int64(size - maxShrinkEvictPerEvent)
-	require.Equal(t, int64(maxShrinkEvictPerEvent), atomic.LoadInt64(&cache.stats.ShrinkEvictions),
+	require.Equal(t, int64(maxShrinkEvictPerEvent), cache.stats.ShrinkEvictions.Load(),
 		"first shrink should hit maxShrinkEvictPerEvent exactly")
-	require.Equal(t, afterFirst, atomic.LoadInt64(&cache.capacity),
+	require.Equal(t, afterFirst, cache.capacity.Load(),
 		"capacity reflects the capped shed")
 
 	// Window 2: same workload after the cooldown elapses; cap clamps again.
 	// ShrinkEvictions accumulates, so the second shrink is visible as a second
 	// 1024 increment.
 	drive(adaptiveWindowLen(afterFirst, samples, target))
-	require.Equal(t, int64(2*maxShrinkEvictPerEvent), atomic.LoadInt64(&cache.stats.ShrinkEvictions),
+	require.Equal(t, int64(2*maxShrinkEvictPerEvent), cache.stats.ShrinkEvictions.Load(),
 		"second shrink should add another maxShrinkEvictPerEvent — decay continues")
-	require.Equal(t, afterFirst-int64(maxShrinkEvictPerEvent), atomic.LoadInt64(&cache.capacity),
+	require.Equal(t, afterFirst-int64(maxShrinkEvictPerEvent), cache.capacity.Load(),
 		"capacity drops by the cap on each successive event")
 }
 
@@ -1114,11 +1101,11 @@ func TestTagValueSeriesIDCache_ShrinkAfterPutEvictsBoundary(t *testing.T) {
 		require.NotNil(t, getVal(cache, 4))
 	}
 
-	require.Equal(t, int64(5), atomic.LoadInt64(&cache.capacity),
+	require.Equal(t, int64(5), cache.capacity.Load(),
 		"capacity must not shrink: post Put-evict the cache is full-warm")
-	require.Equal(t, int64(0), atomic.LoadInt64(&cache.stats.ShrinkEvictions),
+	require.Equal(t, int64(0), cache.stats.ShrinkEvictions.Load(),
 		"no shrink trim should have run")
-	require.Equal(t, int64(1), atomic.LoadInt64(&cache.stats.Evictions),
+	require.Equal(t, int64(1), cache.stats.Evictions.Load(),
 		"the Put-induced eviction lands in Evictions, not ShrinkEvictions")
 
 	require.False(t, existsVal(cache, 0), "entry 0 was evicted by the Put")
@@ -1144,13 +1131,13 @@ func TestTagValueSeriesIDCache_ShrinkCooldown(t *testing.T) {
 	drive()
 	drive()
 	drive()
-	require.Equal(t, int64(10), atomic.LoadInt64(&cache.capacity), "shrink suppressed while cooling down")
+	require.Equal(t, int64(10), cache.capacity.Load(), "shrink suppressed while cooling down")
 
 	cache.Lock()
 	cache.cooldownGets = 0
 	cache.Unlock()
 	drive()
-	require.Equal(t, int64(5), atomic.LoadInt64(&cache.capacity), "shrink fires once the cooldown elapses")
+	require.Equal(t, int64(5), cache.capacity.Load(), "shrink fires once the cooldown elapses")
 }
 
 func TestTagValueSeriesIDCache_ShrinkBoundaryReTouch(t *testing.T) {
@@ -1158,7 +1145,7 @@ func TestTagValueSeriesIDCache_ShrinkBoundaryReTouch(t *testing.T) {
 	// predecessor, keeping warmCount equal to the true distinct-touched count.
 	// A large minSamples keeps the window open so we can inspect mid-window.
 	cache := NewAdaptiveTagValueSeriesIDCache(2, 1024, 0.5, tsdb.DefaultSeriesIDSetCacheShrinkConservatism, 1000, zap.NewNop())
-	atomic.StoreInt64(&cache.capacity, 5)
+	cache.capacity.Store(5)
 	for i := 0; i < 5; i++ {
 		cache.Put([]byte("m"), []byte("k"), []byte{byte(i)}, tsdb.NewSeriesIDSet(uint64(i)))
 	}
@@ -1182,7 +1169,7 @@ func TestTagValueSeriesIDCache_ShrinkWindowFirstGetCountsInRate(t *testing.T) {
 	// fails to block a spurious shrink.
 	const target = 0.95
 	cache := NewAdaptiveTagValueSeriesIDCache(2, 1024, target, tsdb.DefaultSeriesIDSetCacheShrinkConservatism, 8, zap.NewNop())
-	atomic.StoreInt64(&cache.capacity, 10)
+	cache.capacity.Store(10)
 	for i := 0; i < 4; i++ {
 		cache.Put([]byte("m"), []byte("k"), []byte{byte(i)}, tsdb.NewSeriesIDSet(uint64(i)))
 	}
@@ -1202,7 +1189,7 @@ func TestTagValueSeriesIDCache_ShrinkWindowFirstGetCountsInRate(t *testing.T) {
 
 	// Pre-fix, the opening miss was excluded from missesW, so the window looked
 	// like 100% hit rate and the slack branch trimmed capacity to size (4).
-	require.Equal(t, int64(10), atomic.LoadInt64(&cache.capacity),
+	require.Equal(t, int64(10), cache.capacity.Load(),
 		"rate gate must block shrink when the window-opening miss is counted")
 }
 
@@ -1219,7 +1206,7 @@ func TestTagValueSeriesIDCache_ShrinkGrowCooldownStamp(t *testing.T) {
 	for i := 1; i <= 4; i++ { // drives one doubling (2 -> 4)
 		insert(i)
 	}
-	require.Equal(t, int64(4), atomic.LoadInt64(&cache.capacity), "precondition: grow occurred")
+	require.Equal(t, int64(4), cache.capacity.Load(), "precondition: grow occurred")
 	cache.Lock()
 	cd := cache.cooldownGets
 	cache.Unlock()
@@ -1247,16 +1234,16 @@ func TestTagValueSeriesIDCache_ShrinkResetsGrowWindow(t *testing.T) {
 	for i := int64(0); i < w; i++ {
 		require.NotNil(t, getVal(cache, int(i%3)))
 	}
-	require.Less(t, atomic.LoadInt64(&cache.capacity), int64(10),
+	require.Less(t, cache.capacity.Load(), int64(10),
 		"precondition: shrink should have fired")
 
 	cache.Lock()
 	defer cache.Unlock()
 	require.Equal(t, int64(0), cache.evictionsSinceCheck,
 		"evictionsSinceCheck must reset so the next forced eviction starts a fresh grow window")
-	require.Equal(t, atomic.LoadInt64(&cache.stats.Hits), cache.lastHits,
+	require.Equal(t, cache.stats.Hits.Load(), cache.lastHits,
 		"lastHits must snap to the current hit count after shrink")
-	require.Equal(t, atomic.LoadInt64(&cache.stats.Misses), cache.lastMisses,
+	require.Equal(t, cache.stats.Misses.Load(), cache.lastMisses,
 		"lastMisses must snap to the current miss count after shrink")
 }
 
@@ -1318,8 +1305,8 @@ func TestTagValueSeriesIDCache_Adaptive_Concurrent(t *testing.T) {
 	wg.Wait()
 	t.Logf("max concurrency: %d", maxConcurrency.Load())
 
-	finalCap := atomic.LoadInt64(&cache.capacity)
+	finalCap := cache.capacity.Load()
 	require.GreaterOrEqual(t, finalCap, int64(8), "capacity must never drop below the floor")
 	require.LessOrEqual(t, finalCap, int64(256), "capacity must never exceed the max")
-	require.Equal(t, int64(cache.evictor.Len()), atomic.LoadInt64(&cache.stats.Size), "size counter must track the evictor list")
+	require.Equal(t, int64(cache.evictor.Len()), cache.stats.Size.Load(), "size counter must track the evictor list")
 }

--- a/tsdb/index/tsi1/cache_test.go
+++ b/tsdb/index/tsi1/cache_test.go
@@ -252,7 +252,7 @@ func TestTagValueSeriesIDCache_Statistics(t *testing.T) {
 	statValues := func(cache *TagValueSeriesIDCache) map[string]interface{} {
 		stats := cache.Statistics(nil)
 		require.Len(t, stats, 1)
-		require.Equal(t, "tsi1_cache", stats[0].Name)
+		require.Equal(t, statTagValueCacheMeasurement, stats[0].Name)
 		return stats[0].Values
 	}
 
@@ -589,5 +589,5 @@ func TestIndex_WithLogger_PropagatesToAdaptiveCache(t *testing.T) {
 
 	require.Equal(t, int64(4), atomic.LoadInt64(&cache.capacity), "cache should have grown after policy fired")
 	require.Equal(t, 1, logs.Len(), "resize event must be emitted to the logger propagated by WithLogger")
-	require.Equal(t, "tsi cache capacity increased", logs.All()[0].Message)
+	require.Equal(t, logMsgCacheCapacityIncreased, logs.All()[0].Message)
 }

--- a/tsdb/index/tsi1/cache_test.go
+++ b/tsdb/index/tsi1/cache_test.go
@@ -3,10 +3,14 @@ package tsi1
 import (
 	"math/rand"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/influxdata/influxdb/tsdb"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 // This function is used to log the components of disk size when DiskSizeBytes fails
@@ -242,4 +246,308 @@ func (c TestCache) GetByString(name, key, value string) *tsdb.SeriesIDSet {
 
 func (c TestCache) PutByString(name, key, value string, ss *tsdb.SeriesIDSet) {
 	c.Put([]byte(name), []byte(key), []byte(value), ss)
+}
+
+func TestTagValueSeriesIDCache_Statistics(t *testing.T) {
+	statValues := func(cache *TagValueSeriesIDCache) map[string]interface{} {
+		stats := cache.Statistics(nil)
+		require.Len(t, stats, 1)
+		require.Equal(t, "tsi1_cache", stats[0].Name)
+		return stats[0].Values
+	}
+
+	cache := NewTagValueSeriesIDCache(2)
+
+	// Initial state: all counters zero.
+	require.Equal(t, map[string]interface{}{
+		statTagValueCacheHit:      int64(0),
+		statTagValueCacheMiss:     int64(0),
+		statTagValueCacheEviction: int64(0),
+		statTagValueCacheSize:     int64(0),
+		statTagValueCacheCapacity: int64(2),
+	}, statValues(cache))
+
+	// Miss on absent key.
+	require.Nil(t, cache.Get([]byte("m0"), []byte("k0"), []byte("v0")))
+	require.Equal(t, map[string]interface{}{
+		statTagValueCacheHit:      int64(0),
+		statTagValueCacheMiss:     int64(1),
+		statTagValueCacheEviction: int64(0),
+		statTagValueCacheSize:     int64(0),
+		statTagValueCacheCapacity: int64(2),
+	}, statValues(cache))
+
+	// Put, then Get the same key → one hit, size 1.
+	s0 := tsdb.NewSeriesIDSet(1)
+	cache.Put([]byte("m0"), []byte("k0"), []byte("v0"), s0)
+	require.True(t, cache.Get([]byte("m0"), []byte("k0"), []byte("v0")).Equals(s0))
+	require.Equal(t, map[string]interface{}{
+		statTagValueCacheHit:      int64(1),
+		statTagValueCacheMiss:     int64(1),
+		statTagValueCacheEviction: int64(0),
+		statTagValueCacheSize:     int64(1),
+		statTagValueCacheCapacity: int64(2),
+	}, statValues(cache))
+
+	// Add a second entry to fill the cache.
+	s1 := tsdb.NewSeriesIDSet(2)
+	cache.Put([]byte("m0"), []byte("k0"), []byte("v1"), s1)
+	require.Equal(t, int64(2), statValues(cache)[statTagValueCacheSize])
+	require.Equal(t, int64(0), statValues(cache)[statTagValueCacheEviction])
+
+	// Adding a third distinct entry must evict the least-recently-used.
+	// LRU at this point is v0: it was Put first, Get-promoted to MRU, then
+	// v1 was Put (making v1 MRU and v0 LRU).
+	s2 := tsdb.NewSeriesIDSet(3)
+	cache.Put([]byte("m0"), []byte("k0"), []byte("v2"), s2)
+	require.Equal(t, map[string]interface{}{
+		statTagValueCacheHit:      int64(1),
+		statTagValueCacheMiss:     int64(1),
+		statTagValueCacheEviction: int64(1),
+		statTagValueCacheSize:     int64(2),
+		statTagValueCacheCapacity: int64(2),
+	}, statValues(cache))
+	// v0 was evicted; v1 and v2 must survive.
+	require.Nil(t, cache.get([]byte("m0"), []byte("k0"), []byte("v0")))
+	require.True(t, cache.get([]byte("m0"), []byte("k0"), []byte("v1")).Equals(s1))
+	require.True(t, cache.get([]byte("m0"), []byte("k0"), []byte("v2")).Equals(s2))
+}
+
+func TestTagValueSeriesIDCache_Statistics_EvictsTrueLRU(t *testing.T) {
+	// Verifies that a Get on an existing entry promotes it to MRU, so a
+	// subsequent insertion evicts the previously-second-oldest entry rather
+	// than the just-touched one.
+	cache := NewTagValueSeriesIDCache(2)
+
+	s0 := tsdb.NewSeriesIDSet(1)
+	s1 := tsdb.NewSeriesIDSet(2)
+	s2 := tsdb.NewSeriesIDSet(3)
+
+	cache.Put([]byte("m"), []byte("k"), []byte("v0"), s0)
+	cache.Put([]byte("m"), []byte("k"), []byte("v1"), s1)
+
+	// Touch v0 so it becomes MRU; v1 is now LRU.
+	require.True(t, cache.Get([]byte("m"), []byte("k"), []byte("v0")).Equals(s0))
+
+	// Inserting v2 must evict v1, not v0.
+	cache.Put([]byte("m"), []byte("k"), []byte("v2"), s2)
+
+	require.True(t, cache.get([]byte("m"), []byte("k"), []byte("v0")).Equals(s0),
+		"recently-touched key v0 should not have been evicted")
+	require.Nil(t, cache.get([]byte("m"), []byte("k"), []byte("v1")),
+		"true LRU key v1 should have been evicted")
+	require.True(t, cache.get([]byte("m"), []byte("k"), []byte("v2")).Equals(s2),
+		"newly inserted key v2 should be present")
+
+	stats := cache.Statistics(nil)
+	require.Equal(t, int64(1), stats[0].Values[statTagValueCacheEviction])
+	require.Equal(t, int64(2), stats[0].Values[statTagValueCacheSize])
+}
+
+func TestTagValueSeriesIDCache_Statistics_Tags(t *testing.T) {
+	cache := NewTagValueSeriesIDCache(1)
+	tags := map[string]string{"database": "db0", "id": "42"}
+	stats := cache.Statistics(tags)
+	require.Len(t, stats, 1)
+	require.Equal(t, tags, stats[0].Tags)
+}
+
+func TestDecideResize_PolicyTable(t *testing.T) {
+	const (
+		initialCap = int64(100)
+		maxCap     = int64(800)
+		minSamples = int64(100)
+		target     = 0.95
+	)
+	// Counter offsets to simulate a fresh window for each row: each
+	// row chooses (hitsW, missesW); we feed hits = hitsW, misses =
+	// missesW with lastHits = lastMisses = 0.
+	tests := []struct {
+		name              string
+		hits, misses      int64
+		capacity, maxCap  int64
+		minSamples        int64
+		target            float64
+		wantNewCap        int64
+		wantGrow          bool
+		wantGetsApprox    int64   // sanity check on the gets return
+		wantRateBelowOnly float64 // 0 means don't check; otherwise rate must be < this
+	}{
+		{
+			name: "below target with adequate samples grows (doubles)",
+			hits: 800, misses: 200, capacity: initialCap, maxCap: maxCap,
+			minSamples: minSamples, target: target,
+			wantNewCap: initialCap * 2, wantGrow: true, wantGetsApprox: 1000,
+			wantRateBelowOnly: target,
+		},
+		{
+			name: "below target with adequate samples but at max does not grow",
+			hits: 800, misses: 200, capacity: maxCap, maxCap: maxCap,
+			minSamples: minSamples, target: target,
+			wantNewCap: maxCap, wantGrow: false,
+		},
+		{
+			name: "above target does not grow",
+			hits: 1000, misses: 0, capacity: initialCap, maxCap: maxCap,
+			minSamples: minSamples, target: target,
+			wantNewCap: initialCap, wantGrow: false,
+		},
+		{
+			name: "at target does not grow",
+			hits: 950, misses: 50, capacity: initialCap, maxCap: maxCap,
+			minSamples: minSamples, target: target,
+			wantNewCap: initialCap, wantGrow: false,
+		},
+		{
+			name: "below floor (any rate) does not grow",
+			hits: 5, misses: 50, capacity: initialCap, maxCap: maxCap,
+			minSamples: minSamples, target: target,
+			wantNewCap: initialCap, wantGrow: false,
+		},
+		{
+			name: "pure-write zero-reads window does not grow (no divide by zero)",
+			hits: 0, misses: 0, capacity: initialCap, maxCap: maxCap,
+			minSamples: minSamples, target: target,
+			wantNewCap: initialCap, wantGrow: false,
+		},
+		{
+			name: "grow capped at max when doubling would overshoot",
+			hits: 100, misses: 900, capacity: 600, maxCap: maxCap,
+			minSamples: minSamples, target: target,
+			wantNewCap: maxCap, wantGrow: true,
+		},
+		{
+			name: "tiny window at floor grows correctly when rate is below target",
+			hits: 50, misses: 50, capacity: initialCap, maxCap: maxCap,
+			minSamples: 100, target: target,
+			wantNewCap: initialCap * 2, wantGrow: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			newCap, gets, rate, grow := decideResize(
+				tt.hits, tt.misses, 0, 0,
+				tt.capacity, tt.maxCap, tt.minSamples, tt.target,
+			)
+			require.Equal(t, tt.wantGrow, grow, "grow")
+			require.Equal(t, tt.wantNewCap, newCap, "newCap")
+			if tt.wantGetsApprox > 0 {
+				require.Equal(t, tt.wantGetsApprox, gets, "gets")
+			}
+			if tt.wantRateBelowOnly > 0 {
+				require.Less(t, rate, tt.wantRateBelowOnly, "observed rate")
+			}
+		})
+	}
+}
+
+func TestTagValueSeriesIDCache_AdaptiveGrowth_TriggersOnTurnover(t *testing.T) {
+	// Tiny initial/max so the test runs in a handful of operations.
+	// minSamples is also small so the floor is cleared by the test
+	// traffic. We Get-then-Put each absent key, so every Put is
+	// preceded by one miss; every Put past the cache's current size
+	// causes one eviction.
+	logger := zap.NewNop()
+	cache := NewAdaptiveTagValueSeriesIDCache(2, 16, 0.99, 4, logger)
+
+	require.Equal(t, int64(2), atomic.LoadInt64(&cache.capacity))
+
+	insert := func(seq int) {
+		v := []byte{byte(seq)}
+		require.Nil(t, cache.Get([]byte("m"), []byte("k"), v))
+		cache.Put([]byte("m"), []byte("k"), v, tsdb.NewSeriesIDSet(uint64(seq)))
+	}
+
+	// Trace:
+	//   insert 1: size 0→1
+	//   insert 2: size 1→2 (cache full at cap=2)
+	//   insert 3: size 2→2 (1 eviction)
+	//   insert 4: size 2→2 (2 evictions → fires → cap doubles to 4)
+	for i := 1; i <= 4; i++ {
+		insert(i)
+	}
+	require.Equal(t, int64(4), atomic.LoadInt64(&cache.capacity), "after first turnover, capacity=4")
+
+	// After grow to 4, two free slots. Need to refill before evicting:
+	//   insert 5: size 2→3
+	//   insert 6: size 3→4 (cache full at cap=4)
+	//   insert 7..10: each evicts once. 4 evictions → fires → cap=8
+	for i := 5; i <= 10; i++ {
+		insert(i)
+	}
+	require.Equal(t, int64(8), atomic.LoadInt64(&cache.capacity), "after second turnover, capacity=8")
+
+	// After grow to 8, four free slots. Refill then 8 evictions:
+	//   insert 11..14: fill to size=8
+	//   insert 15..22: 8 evictions → fires → cap=16 (= max)
+	for i := 11; i <= 22; i++ {
+		insert(i)
+	}
+	require.Equal(t, int64(16), atomic.LoadInt64(&cache.capacity), "after third turnover, capacity=16 (= max)")
+
+	// Further evictions do not grow past max.
+	// After grow to 16, eight free slots. Fill them, then drive enough
+	// evictions to trigger another firing — which must not grow.
+	for i := 23; i <= 50; i++ {
+		insert(i)
+	}
+	require.Equal(t, int64(16), atomic.LoadInt64(&cache.capacity), "capacity stays at max")
+}
+
+func TestTagValueSeriesIDCache_AdaptiveGrowth_NoOpAtTarget(t *testing.T) {
+	// Target so low that any nonzero hit rate satisfies it. We drive
+	// evictions while also generating hits, so the windowed hit rate
+	// stays comfortably above target and capacity must not grow.
+	logger := zap.NewNop()
+	cache := NewAdaptiveTagValueSeriesIDCache(2, 16, 0.01, 4, logger)
+
+	insertedSeqs := []int{}
+	insert := func(seq int) {
+		insertedSeqs = append(insertedSeqs, seq)
+		v := []byte{byte(seq)}
+		cache.Put([]byte("m"), []byte("k"), v, tsdb.NewSeriesIDSet(uint64(seq)))
+	}
+	hitOnSurvivors := func() {
+		// Issue a Get on each key currently in the cache to bank hits.
+		// Use the most-recent fixed-size window of recent inserts.
+		start := len(insertedSeqs) - 2
+		if start < 0 {
+			start = 0
+		}
+		for _, seq := range insertedSeqs[start:] {
+			cache.Get([]byte("m"), []byte("k"), []byte{byte(seq)})
+		}
+	}
+
+	// Fill cache.
+	for i := 1; i <= 2; i++ {
+		insert(i)
+	}
+	// Force enough evictions to reach the trigger, but bank hits
+	// between each Put so the window's hit rate is >= target=0.01.
+	for i := 3; i <= 20; i++ {
+		hitOnSurvivors()
+		hitOnSurvivors()
+		insert(i)
+	}
+	require.Equal(t, int64(2), atomic.LoadInt64(&cache.capacity), "capacity must stay at 2 when target is met")
+}
+
+func TestTagValueSeriesIDCache_AdaptiveDisabled_NoLogNoGrowth(t *testing.T) {
+	core, logs := observer.New(zap.DebugLevel)
+	logger := zap.New(core)
+
+	// Legacy constructor → adaptive sizing disabled. We splice in the
+	// observer logger so any unexpected log call is detected.
+	cache := NewTagValueSeriesIDCache(2)
+	cache.SetLogger(logger)
+
+	for i := 1; i <= 30; i++ {
+		v := []byte{byte(i)}
+		cache.Put([]byte("m"), []byte("k"), v, tsdb.NewSeriesIDSet(uint64(i)))
+	}
+
+	require.Equal(t, int64(2), atomic.LoadInt64(&cache.capacity), "capacity must not change when adaptive sizing is disabled")
+	require.Equal(t, 0, logs.Len(), "no log lines must be emitted when adaptive sizing is disabled")
 }

--- a/tsdb/index/tsi1/cache_test.go
+++ b/tsdb/index/tsi1/cache_test.go
@@ -425,6 +425,16 @@ func TestDecideResize_PolicyTable(t *testing.T) {
 			wantNewCap: initialCap, wantGrow: false,
 		},
 		{
+			// Regression: with minSamples == 0 the gets<minSamples floor does
+			// not fire on a pure-write window, so the policy must independently
+			// gate gets == 0 — otherwise rate stays 0.0 and we grow with no
+			// evidence.
+			name: "pure-write zero-reads with minSamples=0 does not grow",
+			hits: 0, misses: 0, capacity: initialCap, maxCap: maxCap,
+			minSamples: 0, target: target,
+			wantNewCap: initialCap, wantGrow: false,
+		},
+		{
 			name: "grow capped at max when doubling would overshoot",
 			hits: 100, misses: 900, capacity: 600, maxCap: maxCap,
 			minSamples: minSamples, target: target,

--- a/tsdb/index/tsi1/cache_test.go
+++ b/tsdb/index/tsi1/cache_test.go
@@ -274,21 +274,23 @@ func TestTagValueSeriesIDCache_Statistics(t *testing.T) {
 
 	// Initial state: all counters zero.
 	require.Equal(t, map[string]interface{}{
-		statTagValueCacheHit:      int64(0),
-		statTagValueCacheMiss:     int64(0),
-		statTagValueCacheEviction: int64(0),
-		statTagValueCacheSize:     int64(0),
-		statTagValueCacheCapacity: int64(2),
+		statTagValueCacheHit:            int64(0),
+		statTagValueCacheMiss:           int64(0),
+		statTagValueCacheEviction:       int64(0),
+		statTagValueCacheShrinkEviction: int64(0),
+		statTagValueCacheSize:           int64(0),
+		statTagValueCacheCapacity:       int64(2),
 	}, statValues(cache))
 
 	// Miss on absent key.
 	require.Nil(t, cache.Get([]byte("m0"), []byte("k0"), []byte("v0")))
 	require.Equal(t, map[string]interface{}{
-		statTagValueCacheHit:      int64(0),
-		statTagValueCacheMiss:     int64(1),
-		statTagValueCacheEviction: int64(0),
-		statTagValueCacheSize:     int64(0),
-		statTagValueCacheCapacity: int64(2),
+		statTagValueCacheHit:            int64(0),
+		statTagValueCacheMiss:           int64(1),
+		statTagValueCacheEviction:       int64(0),
+		statTagValueCacheShrinkEviction: int64(0),
+		statTagValueCacheSize:           int64(0),
+		statTagValueCacheCapacity:       int64(2),
 	}, statValues(cache))
 
 	// Put, then Get the same key → one hit, size 1.
@@ -296,11 +298,12 @@ func TestTagValueSeriesIDCache_Statistics(t *testing.T) {
 	cache.Put([]byte("m0"), []byte("k0"), []byte("v0"), s0)
 	require.True(t, cache.Get([]byte("m0"), []byte("k0"), []byte("v0")).Equals(s0))
 	require.Equal(t, map[string]interface{}{
-		statTagValueCacheHit:      int64(1),
-		statTagValueCacheMiss:     int64(1),
-		statTagValueCacheEviction: int64(0),
-		statTagValueCacheSize:     int64(1),
-		statTagValueCacheCapacity: int64(2),
+		statTagValueCacheHit:            int64(1),
+		statTagValueCacheMiss:           int64(1),
+		statTagValueCacheEviction:       int64(0),
+		statTagValueCacheShrinkEviction: int64(0),
+		statTagValueCacheSize:           int64(1),
+		statTagValueCacheCapacity:       int64(2),
 	}, statValues(cache))
 
 	// Add a second entry to fill the cache.
@@ -308,23 +311,30 @@ func TestTagValueSeriesIDCache_Statistics(t *testing.T) {
 	cache.Put([]byte("m0"), []byte("k0"), []byte("v1"), s1)
 	require.Equal(t, int64(2), statValues(cache)[statTagValueCacheSize])
 	require.Equal(t, int64(0), statValues(cache)[statTagValueCacheEviction])
+	require.Equal(t, int64(0), statValues(cache)[statTagValueCacheShrinkEviction])
 
 	// Adding a third distinct entry must evict the least-recently-used.
 	// LRU at this point is v0: it was Put first, Get-promoted to MRU, then
-	// v1 was Put (making v1 MRU and v0 LRU).
+	// v1 was Put (making v1 MRU and v0 LRU). The eviction is a forced
+	// eviction (write pressure on a full cache), so it lands in Evictions
+	// rather than ShrinkEvictions.
 	s2 := tsdb.NewSeriesIDSet(3)
 	cache.Put([]byte("m0"), []byte("k0"), []byte("v2"), s2)
 	require.Equal(t, map[string]interface{}{
-		statTagValueCacheHit:      int64(1),
-		statTagValueCacheMiss:     int64(1),
-		statTagValueCacheEviction: int64(1),
-		statTagValueCacheSize:     int64(2),
-		statTagValueCacheCapacity: int64(2),
+		statTagValueCacheHit:            int64(1),
+		statTagValueCacheMiss:           int64(1),
+		statTagValueCacheEviction:       int64(1),
+		statTagValueCacheShrinkEviction: int64(0),
+		statTagValueCacheSize:           int64(2),
+		statTagValueCacheCapacity:       int64(2),
 	}, statValues(cache))
 	// v0 was evicted; v1 and v2 must survive.
-	require.Nil(t, cache.get([]byte("m0"), []byte("k0"), []byte("v0")))
-	require.True(t, cache.get([]byte("m0"), []byte("k0"), []byte("v1")).Equals(s1))
-	require.True(t, cache.get([]byte("m0"), []byte("k0"), []byte("v2")).Equals(s2))
+	got0, _ := cache.get([]byte("m0"), []byte("k0"), []byte("v0"))
+	require.Nil(t, got0)
+	got1, _ := cache.get([]byte("m0"), []byte("k0"), []byte("v1"))
+	require.True(t, got1.Equals(s1))
+	got2, _ := cache.get([]byte("m0"), []byte("k0"), []byte("v2"))
+	require.True(t, got2.Equals(s2))
 }
 
 func TestTagValueSeriesIDCache_Statistics_EvictsTrueLRU(t *testing.T) {
@@ -346,12 +356,12 @@ func TestTagValueSeriesIDCache_Statistics_EvictsTrueLRU(t *testing.T) {
 	// Inserting v2 must evict v1, not v0.
 	cache.Put([]byte("m"), []byte("k"), []byte("v2"), s2)
 
-	require.True(t, cache.get([]byte("m"), []byte("k"), []byte("v0")).Equals(s0),
-		"recently-touched key v0 should not have been evicted")
-	require.Nil(t, cache.get([]byte("m"), []byte("k"), []byte("v1")),
-		"true LRU key v1 should have been evicted")
-	require.True(t, cache.get([]byte("m"), []byte("k"), []byte("v2")).Equals(s2),
-		"newly inserted key v2 should be present")
+	got0, _ := cache.get([]byte("m"), []byte("k"), []byte("v0"))
+	require.True(t, got0.Equals(s0), "recently-touched key v0 should not have been evicted")
+	got1, _ := cache.get([]byte("m"), []byte("k"), []byte("v1"))
+	require.Nil(t, got1, "true LRU key v1 should have been evicted")
+	got2, _ := cache.get([]byte("m"), []byte("k"), []byte("v2"))
+	require.True(t, got2.Equals(s2), "newly inserted key v2 should be present")
 
 	stats := cache.Statistics(nil)
 	require.Equal(t, int64(1), stats[0].Values[statTagValueCacheEviction])
@@ -743,6 +753,15 @@ func TestDecideShrink_PolicyTable(t *testing.T) {
 			wantNewCap: 50, wantEvict: 50, wantShrink: true,
 		},
 		{
+			// Cold tail of 4900 (and size/2 of 2500) both exceed the per-event
+			// cap, so the absolute bound is the binding one. Decay continues over
+			// later windows (covered by TestTagValueSeriesIDCache_ShrinkRepeatsWhenCapped).
+			name:  "cold-tail bounded by maxShrinkEvictPerEvent",
+			hitsW: 1000, missesW: 0, evictionsW: 0,
+			capacity: 5000, size: 5000, warmCount: 100, floor: 10,
+			wantNewCap: 5000 - maxShrinkEvictPerEvent, wantEvict: maxShrinkEvictPerEvent, wantShrink: true,
+		},
+		{
 			name:  "cold-tail sheds exactly the cold tail when under half",
 			hitsW: 1000, missesW: 0, evictionsW: 0,
 			capacity: 100, size: 100, warmCount: 60, floor: 10,
@@ -860,6 +879,112 @@ func TestTagValueSeriesIDCache_NoShrinkWhenAllTouched(t *testing.T) {
 	require.Equal(t, int64(10), atomic.LoadInt64(&cache.stats.Size))
 }
 
+// TestTagValueSeriesIDCache_ShrinkRepeatsWhenCapped verifies that when the
+// unbounded cold-tail shed would exceed maxShrinkEvictPerEvent, a single event
+// sheds exactly the cap and subsequent windows continue the decay — the claim
+// made by decideColdTail's doc comment.
+//
+// Cache size 3074 with a warm set of 10 and floor 2:
+//   - Window 1: unbounded shed 3064 → size/2 bound 1537 → cap 1024. New cap 2050.
+//   - Window 2: unbounded shed 2040 → size/2 bound 1025 → cap 1024. New cap 1026.
+//
+// The post-shrink cooldown is adaptiveWindowLen(newCap, samples, target), which
+// matches the next window's length, so the cooldown elapses exactly when window 2
+// ends — no manual cooldown reset is needed (and the natural cycle is itself
+// useful coverage).
+func TestTagValueSeriesIDCache_ShrinkRepeatsWhenCapped(t *testing.T) {
+	const (
+		target  = 0.5
+		size    = 3074
+		warm    = 10
+		samples = 8
+	)
+	cache := NewAdaptiveTagValueSeriesIDCache(2, 4096, target, tsdb.DefaultSeriesIDSetCacheShrinkConservatism, samples, zap.NewNop())
+	atomic.StoreInt64(&cache.capacity, size)
+
+	// 2-byte values give a unique key per i in [0, 65536); the single-byte
+	// values used by newFullAdaptiveCache would collide past 255.
+	keys := make([][]byte, size)
+	for i := 0; i < size; i++ {
+		keys[i] = []byte{byte(i >> 8), byte(i & 0xFF)}
+		cache.Put([]byte("m"), []byte("k"), keys[i], tsdb.NewSeriesIDSet(uint64(i)))
+	}
+	require.Equal(t, int64(size), atomic.LoadInt64(&cache.stats.Size), "setup occupancy")
+
+	drive := func(w int64) {
+		for i := int64(0); i < w; i++ {
+			require.NotNil(t, cache.Get([]byte("m"), []byte("k"), keys[int(i)%warm]))
+		}
+	}
+
+	// Window 1: cap clamps the first shrink at maxShrinkEvictPerEvent.
+	drive(adaptiveWindowLen(size, samples, target))
+	afterFirst := int64(size - maxShrinkEvictPerEvent)
+	require.Equal(t, int64(maxShrinkEvictPerEvent), atomic.LoadInt64(&cache.stats.ShrinkEvictions),
+		"first shrink should hit maxShrinkEvictPerEvent exactly")
+	require.Equal(t, afterFirst, atomic.LoadInt64(&cache.capacity),
+		"capacity reflects the capped shed")
+
+	// Window 2: same workload after the cooldown elapses; cap clamps again.
+	// ShrinkEvictions accumulates, so the second shrink is visible as a second
+	// 1024 increment.
+	drive(adaptiveWindowLen(afterFirst, samples, target))
+	require.Equal(t, int64(2*maxShrinkEvictPerEvent), atomic.LoadInt64(&cache.stats.ShrinkEvictions),
+		"second shrink should add another maxShrinkEvictPerEvent — decay continues")
+	require.Equal(t, afterFirst-int64(maxShrinkEvictPerEvent), atomic.LoadInt64(&cache.capacity),
+		"capacity drops by the cap on each successive event")
+}
+
+// TestTagValueSeriesIDCache_ShrinkAfterPutEvictsBoundary is a regression
+// test for a bug where a Put during an in-progress shrink window evicted
+// the LRU boundary on an all-warm cache and nil-ed deepestTouched. A
+// subsequent narrow Get re-seeded deepestTouched at the touched element
+// (now at the front), so the warm-count walk gave warmCount=1 and
+// decideColdTail trimmed the cache, evicting entries that HAD been
+// touched this window. The fix recedes deepestTouched to e.Prev() (the
+// new back of the now-smaller list, still warm) instead of nil-ing it:
+// Put is reached after a Get miss so the new front element is itself
+// warm, the warm set after the Put is the entire (now smaller) cache,
+// and the existing "boundary == Back" short-circuit then prevents shrink.
+func TestTagValueSeriesIDCache_ShrinkAfterPutEvictsBoundary(t *testing.T) {
+	// minSamples=1 so the rate-floor doesn't block; target=0.95 so the
+	// eviction-gate threshold stays at the 1-eviction floor for w=14.
+	cache := newFullAdaptiveCache(t, 5, 1, 0.95)
+
+	// Touch every entry: cache is fully warm, boundary = LRU.
+	for i := 0; i < 5; i++ {
+		require.NotNil(t, getVal(cache, i))
+	}
+
+	// Put a new key. The LRU IS the boundary; the Put-induced eviction
+	// would have nil-ed deepestTouched pre-fix. With the fix, it recedes
+	// to the new back (still warm).
+	cache.Put([]byte("m"), []byte("k"), []byte{99}, tsdb.NewSeriesIDSet(99))
+
+	// Narrow post-Put access: touch ONLY entry 4 (already at the front),
+	// driving the window to completion without disturbing the new boundary.
+	// Pre-fix, the first such Get re-seeded deepestTouched at 4 and the
+	// walk gave warmCount=1, triggering a shrink to ~size/2 that evicted
+	// warm entries 1 and 2. Post-fix, deepestTouched stays at the new
+	// back, the "boundary == Back" short-circuit fires, and no shrink runs.
+	w := adaptiveWindowLen(5, 1, 0.95)
+	for i := int64(0); i < w; i++ {
+		require.NotNil(t, getVal(cache, 4))
+	}
+
+	require.Equal(t, int64(5), atomic.LoadInt64(&cache.capacity),
+		"capacity must not shrink: post Put-evict the cache is full-warm")
+	require.Equal(t, int64(0), atomic.LoadInt64(&cache.stats.ShrinkEvictions),
+		"no shrink trim should have run")
+	require.Equal(t, int64(1), atomic.LoadInt64(&cache.stats.Evictions),
+		"the Put-induced eviction lands in Evictions, not ShrinkEvictions")
+
+	require.False(t, existsVal(cache, 0), "entry 0 was evicted by the Put")
+	for _, v := range []int{1, 2, 3, 4, 99} {
+		require.True(t, existsVal(cache, v), "entry %d must survive", v)
+	}
+}
+
 func TestTagValueSeriesIDCache_ShrinkCooldown(t *testing.T) {
 	// A capacity change sets a Gets-based cooldown that suppresses shrink until
 	// it elapses. Seed a long cooldown and verify shrink is gated across several
@@ -905,6 +1030,38 @@ func TestTagValueSeriesIDCache_ShrinkBoundaryReTouch(t *testing.T) {
 	got := cache.warmCountLocked()
 	cache.Unlock()
 	require.Equal(t, int64(3), got, "warmCount must equal distinct-touched (3), not collapse on boundary re-touch")
+}
+
+func TestTagValueSeriesIDCache_ShrinkWindowFirstGetCountsInRate(t *testing.T) {
+	// Regression: a shrink window opened on a Get must include that Get's
+	// hit/miss in hitsW/missesW, matching its inclusion in getsSinceShrinkCheck
+	// and deepestTouched. Otherwise a window opened by a miss looks like 100%
+	// hit rate (the only miss is excluded from the baseline) and the rate gate
+	// fails to block a spurious shrink.
+	const target = 0.95
+	cache := NewAdaptiveTagValueSeriesIDCache(2, 1024, target, tsdb.DefaultSeriesIDSetCacheShrinkConservatism, 8, zap.NewNop())
+	atomic.StoreInt64(&cache.capacity, 10)
+	for i := 0; i < 4; i++ {
+		cache.Put([]byte("m"), []byte("k"), []byte{byte(i)}, tsdb.NewSeriesIDSet(uint64(i)))
+	}
+
+	w := adaptiveWindowLen(4, 8, target)
+	// True rate (w-1)/w must be < target for the gate to block a shrink; any w
+	// in [2, 19] satisfies this for target=0.95. Guard against future tuning.
+	require.Greater(t, w, int64(1), "precondition: window must span >1 Get")
+	require.Less(t, float64(w-1)/float64(w), target, "precondition: true rate < target")
+
+	// First Get of the new window: absent key (a miss). Then fill the rest of
+	// the window with hits on existing keys.
+	require.Nil(t, getVal(cache, 99))
+	for i := int64(1); i < w; i++ {
+		require.NotNil(t, getVal(cache, int(i%4)))
+	}
+
+	// Pre-fix, the opening miss was excluded from missesW, so the window looked
+	// like 100% hit rate and the slack branch trimmed capacity to size (4).
+	require.Equal(t, int64(10), atomic.LoadInt64(&cache.capacity),
+		"rate gate must block shrink when the window-opening miss is counted")
 }
 
 func TestTagValueSeriesIDCache_ShrinkGrowCooldownStamp(t *testing.T) {

--- a/tsdb/index/tsi1/cache_test.go
+++ b/tsdb/index/tsi1/cache_test.go
@@ -6,6 +6,7 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+	"unsafe"
 
 	"github.com/influxdata/influxdb/tsdb"
 	"github.com/stretchr/testify/require"
@@ -246,6 +247,18 @@ func (c TestCache) GetByString(name, key, value string) *tsdb.SeriesIDSet {
 
 func (c TestCache) PutByString(name, key, value string, ss *tsdb.SeriesIDSet) {
 	c.Put([]byte(name), []byte(key), []byte(value), ss)
+}
+
+// TestTagValueSeriesIDCache_AtomicFieldAlignment guards the struct layout:
+// fields accessed with sync/atomic (capacity and the stats counters) must be
+// 64-bit aligned, or atomic ops panic on 32-bit platforms. The allocation
+// base is guaranteed 8-byte aligned, so it suffices that these fields sit at
+// 8-byte-multiple offsets. The leading layout has no sub-8-byte fields, so
+// the offsets observed here (on any host) match those on 32-bit.
+func TestTagValueSeriesIDCache_AtomicFieldAlignment(t *testing.T) {
+	var c TagValueSeriesIDCache
+	require.Zero(t, unsafe.Offsetof(c.capacity)%8, "capacity must be 8-byte aligned")
+	require.Zero(t, unsafe.Offsetof(c.stats)%8, "stats counters must be 8-byte aligned")
 }
 
 func TestTagValueSeriesIDCache_Statistics(t *testing.T) {

--- a/tsdb/index/tsi1/index.go
+++ b/tsdb/index/tsi1/index.go
@@ -274,6 +274,12 @@ func (i *Index) WithLogger(l *zap.Logger) {
 	i.mu.Lock()
 	defer i.mu.Unlock()
 	i.logger = l.With(zap.String("index", "tsi"))
+	// The cache is constructed in NewIndex with the index's initial
+	// (no-op) logger; propagate the real logger so adaptive resize
+	// events are emitted to it.
+	if i.tagValueCache != nil {
+		i.tagValueCache.SetLogger(i.logger)
+	}
 }
 
 // Type returns the type of Index this is.

--- a/tsdb/index/tsi1/index.go
+++ b/tsdb/index/tsi1/index.go
@@ -51,6 +51,7 @@ func init() {
 			WithSeriesIDCacheSize(opt.Config.SeriesIDSetCacheSize),
 			WithSeriesIDCacheMaxSize(opt.Config.SeriesIDSetCacheMaxSize),
 			WithSeriesIDCacheTargetHitRate(opt.Config.SeriesIDSetCacheTargetHitRate),
+			WithSeriesIDCacheShrinkConservatism(opt.Config.SeriesIDSetCacheShrinkConservatism),
 		)
 		return idx
 	})
@@ -151,16 +152,26 @@ var WithSeriesIDCacheTargetHitRate = func(rate float64) IndexOption {
 	}
 }
 
+// WithSeriesIDCacheShrinkConservatism sets the number of standard deviations
+// below the at-target eviction mean at which the shrink eviction gate sits.
+// Higher values (>= 0.0) make the cache more reluctant to shrink. See tsdb.Config.
+var WithSeriesIDCacheShrinkConservatism = func(c float64) IndexOption {
+	return func(i *Index) {
+		i.tagValueCacheShrinkConservatism = c
+	}
+}
+
 // Index represents a collection of layered index files and WAL.
 type Index struct {
 	mu         sync.RWMutex
 	partitions []*Partition
 	opened     bool
 
-	tagValueCache              *TagValueSeriesIDCache
-	tagValueCacheSize          int
-	tagValueCacheMaxSize       int     // 0 = adaptive sizing disabled
-	tagValueCacheTargetHitRate float64 // 0 = adaptive sizing disabled
+	tagValueCache                   *TagValueSeriesIDCache
+	tagValueCacheSize               int
+	tagValueCacheMaxSize            int     // 0 = adaptive sizing disabled
+	tagValueCacheTargetHitRate      float64 // 0 = adaptive sizing disabled
+	tagValueCacheShrinkConservatism float64 // sigmas below the at-target eviction mean for the shrink gate; validated by Config to be >= 0.0
 
 	// The following may be set when initializing an Index.
 	path               string        // Root directory of the index partitions.
@@ -193,18 +204,19 @@ func (i *Index) UniqueReferenceID() uintptr {
 // NewIndex returns a new instance of Index.
 func NewIndex(sfile *tsdb.SeriesFile, database string, options ...IndexOption) *Index {
 	idx := &Index{
-		tagValueCacheSize: tsdb.DefaultSeriesIDSetCacheSize,
-		maxLogFileSize:    tsdb.DefaultMaxIndexLogFileSize,
-		maxLogFileAge:     tsdb.DefaultCompactFullWriteColdDuration,
-		logger:            zap.NewNop(),
-		version:           Version,
-		sfile:             sfile,
-		database:          database,
-		mSketch:           hll.NewDefaultPlus(),
-		mTSketch:          hll.NewDefaultPlus(),
-		sSketch:           hll.NewDefaultPlus(),
-		sTSketch:          hll.NewDefaultPlus(),
-		PartitionN:        DefaultPartitionN,
+		tagValueCacheSize:               tsdb.DefaultSeriesIDSetCacheSize,
+		tagValueCacheShrinkConservatism: tsdb.DefaultSeriesIDSetCacheShrinkConservatism,
+		maxLogFileSize:                  tsdb.DefaultMaxIndexLogFileSize,
+		maxLogFileAge:                   tsdb.DefaultCompactFullWriteColdDuration,
+		logger:                          zap.NewNop(),
+		version:                         Version,
+		sfile:                           sfile,
+		database:                        database,
+		mSketch:                         hll.NewDefaultPlus(),
+		mTSketch:                        hll.NewDefaultPlus(),
+		sSketch:                         hll.NewDefaultPlus(),
+		sTSketch:                        hll.NewDefaultPlus(),
+		PartitionN:                      DefaultPartitionN,
 	}
 
 	for _, option := range options {
@@ -216,6 +228,7 @@ func NewIndex(sfile *tsdb.SeriesFile, database string, options ...IndexOption) *
 			idx.tagValueCacheSize,
 			idx.tagValueCacheMaxSize,
 			idx.tagValueCacheTargetHitRate,
+			idx.tagValueCacheShrinkConservatism,
 			tsdb.DefaultAdaptiveCacheMinSamples,
 			idx.logger,
 		)

--- a/tsdb/index/tsi1/index.go
+++ b/tsdb/index/tsi1/index.go
@@ -49,6 +49,8 @@ func init() {
 			WithMaximumLogFileSize(int64(opt.Config.MaxIndexLogFileSize)),
 			WithMaximumLogFileAge(time.Duration(opt.Config.CompactFullWriteColdDuration)),
 			WithSeriesIDCacheSize(opt.Config.SeriesIDSetCacheSize),
+			WithSeriesIDCacheMaxSize(opt.Config.SeriesIDSetCacheMaxSize),
+			WithSeriesIDCacheTargetHitRate(opt.Config.SeriesIDSetCacheTargetHitRate),
 		)
 		return idx
 	})
@@ -131,14 +133,34 @@ var WithSeriesIDCacheSize = func(sz int) IndexOption {
 	}
 }
 
+// WithSeriesIDCacheMaxSize sets the upper bound on adaptive growth of
+// the series id set cache. A value of 0 disables adaptive sizing. Must
+// be paired with WithSeriesIDCacheTargetHitRate.
+var WithSeriesIDCacheMaxSize = func(sz int) IndexOption {
+	return func(i *Index) {
+		i.tagValueCacheMaxSize = sz
+	}
+}
+
+// WithSeriesIDCacheTargetHitRate sets the target Get hit rate used to
+// drive adaptive cache growth. A value of 0 disables adaptive sizing.
+// Must be paired with WithSeriesIDCacheMaxSize.
+var WithSeriesIDCacheTargetHitRate = func(rate float64) IndexOption {
+	return func(i *Index) {
+		i.tagValueCacheTargetHitRate = rate
+	}
+}
+
 // Index represents a collection of layered index files and WAL.
 type Index struct {
 	mu         sync.RWMutex
 	partitions []*Partition
 	opened     bool
 
-	tagValueCache     *TagValueSeriesIDCache
-	tagValueCacheSize int
+	tagValueCache              *TagValueSeriesIDCache
+	tagValueCacheSize          int
+	tagValueCacheMaxSize       int     // 0 = adaptive sizing disabled
+	tagValueCacheTargetHitRate float64 // 0 = adaptive sizing disabled
 
 	// The following may be set when initializing an Index.
 	path               string        // Root directory of the index partitions.
@@ -189,7 +211,17 @@ func NewIndex(sfile *tsdb.SeriesFile, database string, options ...IndexOption) *
 		option(idx)
 	}
 
-	idx.tagValueCache = NewTagValueSeriesIDCache(idx.tagValueCacheSize)
+	if idx.tagValueCacheMaxSize > 0 && idx.tagValueCacheTargetHitRate > 0 {
+		idx.tagValueCache = NewAdaptiveTagValueSeriesIDCache(
+			idx.tagValueCacheSize,
+			idx.tagValueCacheMaxSize,
+			idx.tagValueCacheTargetHitRate,
+			tsdb.DefaultAdaptiveCacheMinSamples,
+			idx.logger,
+		)
+	} else {
+		idx.tagValueCache = NewTagValueSeriesIDCache(idx.tagValueCacheSize)
+	}
 	return idx
 }
 
@@ -224,6 +256,14 @@ func (i *Index) Bytes() int {
 // Database returns the name of the database the index was initialized with.
 func (i *Index) Database() string {
 	return i.database
+}
+
+// Statistics returns statistics for periodic monitoring.
+func (i *Index) Statistics(tags map[string]string) []models.Statistic {
+	if i.tagValueCache == nil {
+		return nil
+	}
+	return i.tagValueCache.Statistics(tags)
 }
 
 // WithLogger sets the logger on the index after it's been created.


### PR DESCRIPTION
Add statistics for hits and misses and cache 
capacity to TagValueSeriesIDCache to permit 
adaptive cache growth up to a configured 
max capacity when hit rate is below a 
configured target.

Includes new configuration parameters and tests

Closes https://github.com/influxdata/influxdb/issues/27479
