### PR TITLE
fix: remove per-shard Prometheus series when a shard is deleted

### DIFF
--- a/kit/prom/promtest/promtest.go
+++ b/kit/prom/promtest/promtest.go
@@ -132,6 +132,31 @@ func findMetric(mfs []*dto.MetricFamily, name string, labels map[string]string) 
 	return fam, nil
 }
 
+// CountMetricsByLabel gathers from g and returns, keyed by metric family name,
+// the number of series in each family that carry the given label name=value.
+// Families with no matching series are omitted, so the returned map is empty
+// when nothing matches.
+//
+// This is useful for asserting that a whole set of series sharing one label
+// (e.g. all of a single shard's series, keyed by its unique "path" label) is
+// either present or fully removed across many metric families at once. Unlike
+// FindMetric, it matches on a single label rather than an exact full label set.
+func CountMetricsByLabel(tb testing.TB, g prometheus.Gatherer, label, value string) map[string]int {
+	tb.Helper()
+
+	out := make(map[string]int)
+	for _, mf := range MustGather(tb, g) {
+		for _, m := range mf.GetMetric() {
+			for _, lp := range m.GetLabel() {
+				if lp.GetName() == label && lp.GetValue() == value {
+					out[mf.GetName()]++
+				}
+			}
+		}
+	}
+	return out
+}
+
 // MustGather calls g.Gather and calls tb.Fatal if there was an error.
 func MustGather(tb testing.TB, g prometheus.Gatherer) []*dto.MetricFamily {
 	tb.Helper()

--- a/kit/prom/promtest/promtest_test.go
+++ b/kit/prom/promtest/promtest_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/influxdata/influxdb/v2/kit/prom/promtest"
 	"github.com/prometheus/client_golang/prometheus"
 	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
 )
 
@@ -145,6 +146,42 @@ func TestMustFindMetric(t *testing.T) {
 	if !strings.Contains(logged, `"label1": "one"`) || !strings.Contains(logged, `"label2": "two"`) {
 		t.Fatalf("did not log the available label names. message: %s", logged)
 	}
+}
+
+func TestCountMetricsByLabel(t *testing.T) {
+	gv := prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Namespace: "my",
+		Subsystem: "random",
+		Name:      "countbylabel",
+		Help:      "Just a random gauge vector.",
+	}, []string{"shared", "unique"})
+	// Two series share shared="x"; one has shared="y".
+	gv.WithLabelValues("x", "a").Set(1)
+	gv.WithLabelValues("x", "b").Set(1)
+	gv.WithLabelValues("y", "c").Set(1)
+
+	// A family that does not carry the shared label at all.
+	c := prometheus.NewCounter(prometheus.CounterOpts{
+		Namespace: "my",
+		Subsystem: "random",
+		Name:      "countbylabel_total",
+		Help:      "A counter without the shared label.",
+	})
+	c.Inc()
+
+	reg := prometheus.NewRegistry()
+	reg.MustRegister(gv, c)
+
+	// Counts the matching series, grouped by family; the counter family is omitted.
+	require.Equal(t, map[string]int{"my_random_countbylabel": 2},
+		promtest.CountMetricsByLabel(t, reg, "shared", "x"))
+
+	// A label value present on exactly one series.
+	require.Equal(t, map[string]int{"my_random_countbylabel": 1},
+		promtest.CountMetricsByLabel(t, reg, "shared", "y"))
+
+	// No series carries this value: an empty (non-nil) map.
+	require.Empty(t, promtest.CountMetricsByLabel(t, reg, "shared", "missing"))
 }
 
 func TestMustGather(t *testing.T) {

--- a/tsdb/engine.go
+++ b/tsdb/engine.go
@@ -79,6 +79,12 @@ type Engine interface {
 	IsIdle() (bool, string)
 	Free() error
 
+	// RemoveMetrics deletes the engine's per-shard Prometheus child series from
+	// their global vectors. It must be called after Close, so the engine's
+	// background goroutines (which re-create their series on each tick) have
+	// stopped, and only when the shard is being permanently removed.
+	RemoveMetrics()
+
 	Reindex() error
 
 	io.WriterTo

--- a/tsdb/engine/tsm1/cache.go
+++ b/tsdb/engine/tsm1/cache.go
@@ -215,6 +215,9 @@ type allCacheMetrics struct {
 }
 
 type cacheMetrics struct {
+	// labels are retained so this shard's children can be deleted from the
+	// global vectors when the shard is permanently removed.
+	labels       prometheus.Labels
 	MemBytes     prometheus.Gauge
 	DiskBytes    prometheus.Gauge
 	LastSnapshot prometheus.Gauge
@@ -279,6 +282,7 @@ func CacheCollectors() []prometheus.Collector {
 func newCacheMetrics(tags tsdb.EngineTags) *cacheMetrics {
 	labels := tags.GetLabels()
 	return &cacheMetrics{
+		labels:       labels,
 		MemBytes:     globalCacheMetrics.MemBytes.With(labels),
 		DiskBytes:    globalCacheMetrics.DiskBytes.With(labels),
 		LastSnapshot: globalCacheMetrics.LastSnapshot.With(labels),
@@ -286,6 +290,18 @@ func newCacheMetrics(tags tsdb.EngineTags) *cacheMetrics {
 		WriteErr:     globalCacheMetrics.WriteErr.With(labels),
 		WriteDropped: globalCacheMetrics.WriteDropped.With(labels),
 	}
+}
+
+// remove deletes this shard's child series from the global cache vectors. It is
+// called when the shard is permanently removed so the series stop being
+// exported and their cardinality is reclaimed.
+func (m *cacheMetrics) remove() {
+	globalCacheMetrics.MemBytes.Delete(m.labels)
+	globalCacheMetrics.DiskBytes.Delete(m.labels)
+	globalCacheMetrics.LastSnapshot.Delete(m.labels)
+	globalCacheMetrics.Writes.Delete(m.labels)
+	globalCacheMetrics.WriteErr.Delete(m.labels)
+	globalCacheMetrics.WriteDropped.Delete(m.labels)
 }
 
 // init initializes the cache and allocates the underlying store.  Once initialized,

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -726,19 +726,60 @@ func (c *compactionCounter) countForLevel(l int) *int64 {
 
 // engineMetrics holds statistics across all instantiated engines
 type compactionMetrics struct {
-	Duration prometheus.ObserverVec
-	Active   *prometheus.GaugeVec
-	Queued   *prometheus.GaugeVec
-	Failed   *prometheus.CounterVec
+	// engineLabels are this engine's labels (without the per-level "level"
+	// label). They are retained so this shard's children can be deleted from
+	// the global vectors when the shard is permanently removed.
+	engineLabels prometheus.Labels
+	Duration     prometheus.ObserverVec
+	Active       *prometheus.GaugeVec
+	Queued       *prometheus.GaugeVec
+	Failed       *prometheus.CounterVec
 }
 
 func newEngineMetrics(tags tsdb.EngineTags) *compactionMetrics {
 	engineLabels := tags.GetLabels()
 	return &compactionMetrics{
-		Duration: globalCompactionMetrics.Duration.MustCurryWith(engineLabels),
-		Active:   globalCompactionMetrics.Active.MustCurryWith(engineLabels),
-		Failed:   globalCompactionMetrics.Failed.MustCurryWith(engineLabels),
-		Queued:   globalCompactionMetrics.Queued.MustCurryWith(engineLabels),
+		engineLabels: engineLabels,
+		Duration:     globalCompactionMetrics.Duration.MustCurryWith(engineLabels),
+		Active:       globalCompactionMetrics.Active.MustCurryWith(engineLabels),
+		Failed:       globalCompactionMetrics.Failed.MustCurryWith(engineLabels),
+		Queued:       globalCompactionMetrics.Queued.MustCurryWith(engineLabels),
+	}
+}
+
+// remove deletes this shard's compaction child series from the global vectors.
+// The global vectors carry an extra "level" label, so one shard owns several
+// children; DeletePartialMatch on the engine-label subset removes every level
+// variant. The curried vecs held on this struct do not support deletion, so the
+// underlying global vectors are used directly.
+func (m *compactionMetrics) remove() {
+	if hv, ok := globalCompactionMetrics.Duration.(*prometheus.HistogramVec); ok {
+		hv.DeletePartialMatch(m.engineLabels)
+	}
+	globalCompactionMetrics.Active.DeletePartialMatch(m.engineLabels)
+	globalCompactionMetrics.Queued.DeletePartialMatch(m.engineLabels)
+	globalCompactionMetrics.Failed.DeletePartialMatch(m.engineLabels)
+}
+
+// RemoveMetrics deletes all of this engine's per-shard Prometheus child series
+// (cache, WAL, file store, and compaction families) from their global vectors.
+// It must be called after Close has stopped the engine's background compaction
+// goroutines; those goroutines re-create their child series via With() on every
+// tick (e.g. PlanCompactions, compactCache), so removing earlier would race with
+// them and leak the resurrected series. It is invoked only when the shard is
+// permanently removed; a transient close/reopen must not call it.
+func (e *Engine) RemoveMetrics() {
+	if e.Cache != nil && e.Cache.stats != nil {
+		e.Cache.stats.remove()
+	}
+	if e.WAL != nil && e.WAL.stats != nil {
+		e.WAL.stats.remove()
+	}
+	if e.FileStore != nil && e.FileStore.stats != nil {
+		e.FileStore.stats.remove()
+	}
+	if e.Stats != nil {
+		e.Stats.remove()
 	}
 }
 

--- a/tsdb/engine/tsm1/file_store.go
+++ b/tsdb/engine/tsm1/file_store.go
@@ -336,6 +336,9 @@ type allFileStoreMetrics struct {
 }
 
 type fileStoreMetrics struct {
+	// labels are retained so this shard's children can be deleted from the
+	// global vectors when the shard is permanently removed.
+	labels     prometheus.Labels
 	files      prometheus.Gauge
 	size       prometheus.Gauge
 	sizeAtomic int64
@@ -383,9 +386,18 @@ func FileStoreCollectors() []prometheus.Collector {
 func newFileStoreMetrics(tags tsdb.EngineTags) *fileStoreMetrics {
 	labels := tags.GetLabels()
 	return &fileStoreMetrics{
-		files: globalFileStoreMetrics.files.With(labels),
-		size:  globalFileStoreMetrics.size.With(labels),
+		labels: labels,
+		files:  globalFileStoreMetrics.files.With(labels),
+		size:   globalFileStoreMetrics.size.With(labels),
 	}
+}
+
+// remove deletes this shard's child series from the global file store vectors.
+// It is called when the shard is permanently removed so the series stop being
+// exported and their cardinality is reclaimed.
+func (f *fileStoreMetrics) remove() {
+	globalFileStoreMetrics.files.Delete(f.labels)
+	globalFileStoreMetrics.size.Delete(f.labels)
 }
 
 // Count returns the number of TSM files currently loaded.

--- a/tsdb/engine/tsm1/metrics_test.go
+++ b/tsdb/engine/tsm1/metrics_test.go
@@ -1,0 +1,98 @@
+package tsm1
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+
+	"github.com/influxdata/influxdb/v2/kit/prom/promtest"
+	"github.com/influxdata/influxdb/v2/tsdb"
+)
+
+// TestTSM1Metrics_remove verifies that each tsm1 metric family's remove()
+// deletes that shard's child series from its global vectors. It covers the
+// compaction family specifically, whose curried per-level children must be
+// removed from the underlying global vectors via DeletePartialMatch.
+func TestTSM1Metrics_remove(t *testing.T) {
+	// A unique path isolates this test's series from those left in the
+	// process-global vectors by other engines/tests.
+	const uniquePath = "tsm1-metrics-remove-test-path"
+	tags := tsdb.EngineTags{
+		Path:          uniquePath,
+		WalPath:       uniquePath + "-wal",
+		Id:            "987654",
+		Bucket:        "bkt",
+		EngineVersion: "tsm1",
+	}
+
+	cm := newCacheMetrics(tags)
+	wm := newWALMetrics(tags)
+	fm := newFileStoreMetrics(tags)
+	em := newEngineMetrics(tags)
+
+	// The compaction children are created lazily per level, so observe a few
+	// distinct levels to populate them.
+	em.Active.With(labelForLevel(1)).Set(1)
+	em.Queued.With(labelForLevel(2)).Set(1)
+	em.Failed.With(labelForLevel(3)).Inc()
+	em.Duration.With(labelForLevel(1)).Observe(1)
+
+	reg := prometheus.NewRegistry()
+	// PrometheusCollectors includes the cache, WAL, file store, and compaction
+	// families.
+	reg.MustRegister(PrometheusCollectors()...)
+
+	require.NotEmpty(t, promtest.CountMetricsByLabel(t, reg, "path", uniquePath),
+		"expected child series for the shard before removal")
+
+	cm.remove()
+	wm.remove()
+	fm.remove()
+	em.remove()
+
+	require.Empty(t, promtest.CountMetricsByLabel(t, reg, "path", uniquePath),
+		"expected all tsm1 child series (including every compaction level) to be removed")
+}
+
+// TestCompactionMetrics_resurrectsAfterRemove is a regression guard for the
+// ordering of metric removal relative to engine close. The compaction update
+// path resolves each child via With() on every call (e.g. PlanCompactions,
+// compactCache), so a compaction tick that lands after remove() re-creates the
+// deleted series. This is why an engine's metrics must be removed only after
+// Close has stopped its compaction goroutines: removing while they still run
+// would leak the resurrected series. The test pins that hazard so a change that
+// reintroduces remove-before-close is caught.
+func TestCompactionMetrics_resurrectsAfterRemove(t *testing.T) {
+	const uniquePath = "tsm1-compaction-resurrect-test-path"
+	tags := tsdb.EngineTags{
+		Path:          uniquePath,
+		WalPath:       uniquePath + "-wal",
+		Id:            "123456",
+		Bucket:        "bkt",
+		EngineVersion: "tsm1",
+	}
+	em := newEngineMetrics(tags)
+
+	reg := prometheus.NewRegistry()
+	reg.MustRegister(PrometheusCollectors()...)
+
+	// Populate a compaction child the way the compaction loop does.
+	em.Queued.With(labelForLevel(1)).Set(1)
+	require.NotEmpty(t, promtest.CountMetricsByLabel(t, reg, "path", uniquePath),
+		"expected the compaction child series before removal")
+
+	em.remove()
+	require.Empty(t, promtest.CountMetricsByLabel(t, reg, "path", uniquePath),
+		"remove() should delete every compaction child for the shard")
+
+	// A compaction-loop tick after remove() resurrects the series, because the
+	// update path goes through With(). The engine must therefore be closed (its
+	// goroutines stopped) before remove() is called.
+	em.Queued.With(labelForLevel(1)).Set(1)
+	require.NotEmpty(t, promtest.CountMetricsByLabel(t, reg, "path", uniquePath),
+		"a post-remove update resurrects the compaction series; removal must happen after the engine is closed")
+
+	// Leave no series behind in the process-global vectors.
+	em.remove()
+}

--- a/tsdb/engine/tsm1/wal.go
+++ b/tsdb/engine/tsm1/wal.go
@@ -188,6 +188,9 @@ type allWALMetrics struct {
 }
 
 type walMetrics struct {
+	// labels are retained so this shard's children can be deleted from the
+	// global vectors when the shard is permanently removed.
+	labels prometheus.Labels
 	// size should never be updated directly, only through SetSize/AddSize
 	size prometheus.Gauge
 	// sizeAtomic should never be updated directly, only through SetSize/AddSize
@@ -241,10 +244,20 @@ func WALCollectors() []prometheus.Collector {
 func newWALMetrics(tags tsdb.EngineTags) *walMetrics {
 	labels := tags.GetLabels()
 	return &walMetrics{
+		labels:    labels,
 		size:      globalWALMetrics.size.With(labels),
 		writes:    globalWALMetrics.writes.With(labels),
 		writesErr: globalWALMetrics.writesErr.With(labels),
 	}
+}
+
+// remove deletes this shard's child series from the global WAL vectors. It is
+// called when the shard is permanently removed so the series stop being
+// exported and their cardinality is reclaimed.
+func (f *walMetrics) remove() {
+	globalWALMetrics.size.Delete(f.labels)
+	globalWALMetrics.writes.Delete(f.labels)
+	globalWALMetrics.writesErr.Delete(f.labels)
 }
 
 // Path returns the directory the log was initialized with.

--- a/tsdb/shard.go
+++ b/tsdb/shard.go
@@ -284,6 +284,9 @@ type allShardMetrics struct {
 }
 
 type ShardMetrics struct {
+	// labels are retained so this shard's children can be deleted from the
+	// global vectors when the shard is permanently removed.
+	labels        prometheus.Labels
 	writes        prometheus.Observer
 	writesErr     prometheus.Observer
 	writesDropped prometheus.Counter
@@ -365,6 +368,7 @@ func ShardCollectors() []prometheus.Collector {
 func newShardMetrics(tags EngineTags) *ShardMetrics {
 	labels := tags.GetLabels()
 	return &ShardMetrics{
+		labels: labels,
 		writes: twoCounterObserver{
 			count: globalShardMetrics.writes.With(labels),
 			sum:   globalShardMetrics.writesSum.With(labels),
@@ -378,6 +382,20 @@ func newShardMetrics(tags EngineTags) *ShardMetrics {
 		diskSize:      globalShardMetrics.diskSize.With(labels),
 		series:        globalShardMetrics.series.With(labels),
 	}
+}
+
+// remove deletes this shard's child series from the global shard vectors. It is
+// called when the shard is permanently removed so the series stop being
+// exported and their cardinality is reclaimed.
+func (m *ShardMetrics) remove() {
+	globalShardMetrics.writes.Delete(m.labels)
+	globalShardMetrics.writesSum.Delete(m.labels)
+	globalShardMetrics.writesErr.Delete(m.labels)
+	globalShardMetrics.writesErrSum.Delete(m.labels)
+	globalShardMetrics.writesDropped.Delete(m.labels)
+	globalShardMetrics.fieldsCreated.Delete(m.labels)
+	globalShardMetrics.diskSize.Delete(m.labels)
+	globalShardMetrics.series.Delete(m.labels)
 }
 
 // ticker runs fn periodically, and stops when Stop() is called
@@ -545,6 +563,51 @@ func (s *Shard) closeAndWait(flush bool) error {
 // Close shuts down the shard's store.
 func (s *Shard) Close() error {
 	return s.closeAndWait(false)
+}
+
+// CloseAndRemoveMetrics permanently closes the shard and then deletes its
+// per-shard Prometheus child series from their global vectors, across all metric
+// families (shard, cache, WAL, file store, and compaction). Removal happens
+// after Close so the engine's background compaction goroutines — which re-create
+// their child series via With() on every tick — have fully exited and cannot
+// resurrect a removed series. It is intended to be called only when the shard is
+// being permanently removed (e.g. DeleteShard, DeleteDatabase,
+// DeleteRetentionPolicy); a transient close/reopen must use Close, which reuses
+// the same labels and preserves the metrics.
+func (s *Shard) CloseAndRemoveMetrics() error {
+	// Capture the engine reference before closeNoLock clears it, so the engine's
+	// metric families can be removed once its goroutines have stopped.
+	engine, err := func() (Engine, error) {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		engine := s._engine
+		return engine, s.closeNoLock(false)
+	}()
+	// Make sure not to hold a lock while waiting for close to finish.
+	werr := s.closeWait()
+
+	// The shard's background goroutines have now exited, so deleting the metric
+	// series cannot race with an update that would re-create them.
+	s.removeMetrics(engine)
+
+	if err != nil {
+		return err
+	}
+	return werr
+}
+
+// removeMetrics deletes this shard's child series from every metric family. The
+// engine argument carries the cache, WAL, file store, and compaction families
+// and may be nil if the shard was never opened. It must only be called once the
+// shard's background goroutines have stopped, otherwise a concurrent update can
+// re-create a deleted series.
+func (s *Shard) removeMetrics(engine Engine) {
+	if s.stats != nil {
+		s.stats.remove()
+	}
+	if engine != nil {
+		engine.RemoveMetrics()
+	}
 }
 
 // closeNoLock closes the shard an removes reference to the shard from associated

--- a/tsdb/shard_metrics_test.go
+++ b/tsdb/shard_metrics_test.go
@@ -1,0 +1,117 @@
+package tsdb_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/require"
+
+	"github.com/influxdata/influxdb/v2/kit/prom/promtest"
+	"github.com/influxdata/influxdb/v2/tsdb"
+	"github.com/influxdata/influxdb/v2/tsdb/engine/tsm1"
+)
+
+// metricsRegistry returns a registry holding every per-shard collector family
+// (shard, cache, WAL, file store, and compaction).
+func metricsRegistry(t *testing.T) *prometheus.Registry {
+	t.Helper()
+	reg := prometheus.NewRegistry()
+	reg.MustRegister(tsdb.ShardCollectors()...)
+	// PrometheusCollectors includes the cache, WAL, file store, and compaction
+	// families.
+	reg.MustRegister(tsm1.PrometheusCollectors()...)
+	return reg
+}
+
+// TestStore_DeleteShard_RemovesMetrics verifies that permanently removing a
+// shard deletes its child series from every metric family.
+func TestStore_DeleteShard_RemovesMetrics(t *testing.T) {
+	for _, index := range tsdb.RegisteredIndexes() {
+		t.Run(index, func(t *testing.T) {
+			s := MustOpenStore(t, index)
+			defer s.CloseStore(t, index)
+
+			require.NoError(t, s.CreateShard(context.Background(), "db0", "rp0", 1, true))
+			sh := s.Shard(1)
+			require.NotNil(t, sh)
+			s.MustWriteToShardString(1, "cpu,server=a v=1")
+
+			reg := metricsRegistry(t)
+			path := sh.Path()
+
+			before := promtest.CountMetricsByLabel(t, reg, "path", path)
+			// These three families register their children at engine open, so
+			// they must be present before deletion.
+			require.Contains(t, before, "storage_shard_series")
+			require.Contains(t, before, "storage_cache_inuse_bytes")
+			require.Contains(t, before, "storage_tsm_files_total")
+
+			require.NoError(t, s.DeleteShard(1))
+
+			after := promtest.CountMetricsByLabel(t, reg, "path", path)
+			require.Empty(t, after,
+				"expected all metric families for the deleted shard to be removed, still present: %v", after)
+		})
+	}
+}
+
+// TestShard_CloseAndRemoveMetrics verifies that permanent removal closes the
+// shard before deleting its metric series. Closing first stops the engine's
+// background compaction goroutines, which re-create their child series via
+// With() on every tick; removing only after they have stopped is what prevents
+// a stray tick from resurrecting a deleted series.
+func TestShard_CloseAndRemoveMetrics(t *testing.T) {
+	for _, index := range tsdb.RegisteredIndexes() {
+		t.Run(index, func(t *testing.T) {
+			s := MustOpenStore(t, index)
+			defer s.CloseStore(t, index)
+
+			require.NoError(t, s.CreateShard(context.Background(), "db0", "rp0", 1, true))
+			sh := s.Shard(1)
+			require.NotNil(t, sh)
+			s.MustWriteToShardString(1, "cpu,server=a v=1")
+
+			reg := metricsRegistry(t)
+			path := sh.Path()
+			require.NotEmpty(t, promtest.CountMetricsByLabel(t, reg, "path", path))
+
+			require.NoError(t, sh.CloseAndRemoveMetrics())
+
+			// The engine must be closed once removal has run, so its compaction
+			// goroutines have stopped and cannot resurrect a removed series.
+			_, err := sh.Engine()
+			require.Error(t, err, "engine should be closed after CloseAndRemoveMetrics")
+
+			require.Empty(t, promtest.CountMetricsByLabel(t, reg, "path", path),
+				"all metric families for the removed shard must be deleted")
+		})
+	}
+}
+
+// TestStore_ReopenShard_KeepsMetrics verifies that a transient close/reopen
+// (which reuses the same Shard object and labels) does NOT remove the shard's
+// metric series.
+func TestStore_ReopenShard_KeepsMetrics(t *testing.T) {
+	for _, index := range tsdb.RegisteredIndexes() {
+		t.Run(index, func(t *testing.T) {
+			s := MustOpenStore(t, index)
+			defer s.CloseStore(t, index)
+
+			require.NoError(t, s.CreateShard(context.Background(), "db0", "rp0", 1, true))
+			sh := s.Shard(1)
+			require.NotNil(t, sh)
+			s.MustWriteToShardString(1, "cpu,server=a v=1")
+
+			reg := metricsRegistry(t)
+			path := sh.Path()
+			require.NotEmpty(t, promtest.CountMetricsByLabel(t, reg, "path", path))
+
+			require.NoError(t, s.ReopenShard(context.Background(), 1, false))
+
+			after := promtest.CountMetricsByLabel(t, reg, "path", path)
+			require.Contains(t, after, "storage_shard_series",
+				"transient reopen must not remove the shard's metric series")
+		})
+	}
+}

--- a/tsdb/store.go
+++ b/tsdb/store.go
@@ -1122,8 +1122,9 @@ func (s *Store) DeleteShard(shardID uint64) error {
 		}
 	}
 
-	// Close the shard.
-	if err := sh.Close(); err != nil {
+	// The shard is being permanently removed. Close it first so the engine's
+	// background compaction goroutines stop, then delete its Prometheus series.
+	if err := sh.CloseAndRemoveMetrics(); err != nil {
 		return err
 	}
 
@@ -1157,7 +1158,10 @@ func (s *Store) DeleteDatabase(name string) error {
 			return nil
 		}
 
-		return sh.Close()
+		// The shard is being permanently removed. Close it first so the
+		// engine's background compaction goroutines stop, then delete its
+		// Prometheus series.
+		return sh.CloseAndRemoveMetrics()
 	}); err != nil {
 		return err
 	}
@@ -1221,7 +1225,10 @@ func (s *Store) DeleteRetentionPolicy(database, name string) error {
 			return nil
 		}
 
-		return sh.Close()
+		// The shard is being permanently removed. Close it first so the
+		// engine's background compaction goroutines stop, then delete its
+		// Prometheus series.
+		return sh.CloseAndRemoveMetrics()
 	}); err != nil {
 		return err
 	}


### PR DESCRIPTION
Permanently deleting a shard left its per-shard child series (shard, cache, WAL, file store, and compaction families) registered in the global metric vectors, leaking cardinality for the life of the process. Each metric struct now retains its labels and exposes removal, and shards are closed before their series are deleted so the engine's background compaction goroutines, which re-create their children via With() on every tick, have stopped and cannot resurrect a removed series; transient close/reopen still preserves the metrics.

Closes https://github.com/influxdata/influxdb/issues/24094