### PR TITLE
chore: sync 2026-06-10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,7 +444,7 @@ dependencies = [
 
 [[package]]
 name = "arrow_util"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -541,7 +541,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "authz"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -655,7 +655,7 @@ dependencies = [
 
 [[package]]
 name = "backoff"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "rand 0.9.4",
  "snafu 0.9.0",
@@ -1078,7 +1078,7 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "catalog_cache"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "bytes",
  "criterion 0.8.2",
@@ -1222,14 +1222,14 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli_types"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "tokio",
 ]
 
 [[package]]
 name = "client_util"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "http 1.4.0",
  "iox_http_util",
@@ -1832,7 +1832,7 @@ dependencies = [
 
 [[package]]
 name = "data_types"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -2566,7 +2566,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion_util"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -2661,7 +2661,7 @@ dependencies = [
 
 [[package]]
 name = "dml"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "arrow_util",
  "data_types",
@@ -2773,7 +2773,7 @@ dependencies = [
 
 [[package]]
 name = "error_reporting"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "datafusion",
  "snafu 0.9.0",
@@ -2803,7 +2803,7 @@ dependencies = [
 
 [[package]]
 name = "executor"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "futures",
  "metric",
@@ -2884,7 +2884,7 @@ dependencies = [
 
 [[package]]
 name = "flightsql"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -3091,7 +3091,7 @@ dependencies = [
 
 [[package]]
 name = "futures_test_utils"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "clap",
  "futures",
@@ -3102,7 +3102,7 @@ dependencies = [
 
 [[package]]
 name = "generated_types"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "bytes",
  "pbjson",
@@ -3756,7 +3756,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb2_client"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "bytes",
  "futures",
@@ -3775,7 +3775,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3867,7 +3867,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_authz"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "async-trait",
  "authz",
@@ -3885,7 +3885,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_cache"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3920,7 +3920,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_catalog"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "ahash 0.8.12",
  "anyhow",
@@ -3977,7 +3977,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_clap_blocks"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4014,7 +4014,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_client"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "bytes",
  "flate2",
@@ -4035,7 +4035,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_commands"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4062,7 +4062,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_id"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "criterion 0.5.1",
  "indexmap 2.14.0",
@@ -4074,7 +4074,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_internal_api"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4095,7 +4095,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_load_generator"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4125,7 +4125,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_process"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "iox_time",
  "uuid",
@@ -4133,7 +4133,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_processing_engine"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4176,7 +4176,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_py_api"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -4204,7 +4204,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_query_executor"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4255,7 +4255,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_server"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4342,7 +4342,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_shutdown"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "futures",
  "futures-util",
@@ -4357,14 +4357,14 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_startup"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "chrono",
 ]
 
 [[package]]
 name = "influxdb3_sys_events"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4383,7 +4383,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_system_tables"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4415,7 +4415,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_telemetry"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "futures",
  "futures-util",
@@ -4436,7 +4436,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_test_helpers"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4449,7 +4449,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_types"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4469,7 +4469,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_wal"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "async-trait",
  "bitcode",
@@ -4498,7 +4498,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_write"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4568,7 +4568,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb_influxql_parser"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "assert_matches",
  "chrono",
@@ -4585,7 +4585,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb_iox_client"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -4614,7 +4614,7 @@ dependencies = [
 
 [[package]]
 name = "ingester_query_grpc"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "base64 0.22.1",
  "data_types",
@@ -4680,7 +4680,7 @@ checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
 
 [[package]]
 name = "iox_http"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -4700,7 +4700,7 @@ dependencies = [
 
 [[package]]
 name = "iox_http_util"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "futures",
  "http 1.4.0",
@@ -4711,7 +4711,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "arrow",
  "arrow_util",
@@ -4760,7 +4760,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query_influxql"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "arrow",
  "assert_matches",
@@ -4787,7 +4787,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query_influxql_rewrite"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "influxdb_influxql_parser",
  "thiserror 2.0.18",
@@ -4795,7 +4795,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query_params"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "arrow",
  "assert_matches",
@@ -4809,7 +4809,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query_udf"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "datafusion-udf-wasm-host",
  "datafusion-udf-wasm-query",
@@ -4820,7 +4820,7 @@ dependencies = [
 
 [[package]]
 name = "iox_system_tables"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4830,7 +4830,7 @@ dependencies = [
 
 [[package]]
 name = "iox_time"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "chrono",
  "parking_lot",
@@ -4839,7 +4839,7 @@ dependencies = [
 
 [[package]]
 name = "iox_v1_query_api"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4953,7 +4953,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jemalloc_pprof_http"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "http-body-util",
  "hyper 1.9.0",
@@ -4966,7 +4966,7 @@ dependencies = [
 
 [[package]]
 name = "jemalloc_stats"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "futures",
  "snafu 0.9.0",
@@ -5159,7 +5159,7 @@ dependencies = [
 
 [[package]]
 name = "linear_buffer"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 
 [[package]]
 name = "linux-raw-sys"
@@ -5203,7 +5203,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "logfmt"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "humantime",
  "parking_lot",
@@ -5302,14 +5302,14 @@ dependencies = [
 
 [[package]]
 name = "metric"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "parking_lot",
 ]
 
 [[package]]
 name = "metric_exporters"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "metric",
  "mockito",
@@ -5434,7 +5434,7 @@ checksum = "9252111cf132ba0929b6f8e030cac2a24b507f3a4d6db6fb2896f27b354c714b"
 
 [[package]]
 name = "mutable_batch"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "arrow",
  "arrow_util",
@@ -5452,7 +5452,7 @@ dependencies = [
 
 [[package]]
 name = "mutable_batch_lp"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "arrow_util",
  "assert_matches",
@@ -5468,7 +5468,7 @@ dependencies = [
 
 [[package]]
 name = "mutable_batch_pb"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "arrow_util",
  "criterion 0.8.2",
@@ -5706,7 +5706,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_limit"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5718,7 +5718,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_mem_cache"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5746,7 +5746,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_metrics"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "async-trait",
  "bloom2",
@@ -5771,7 +5771,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_mock"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5785,7 +5785,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_size_hinting"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "chrono",
  "http 1.4.0",
@@ -5795,7 +5795,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_utils"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "async-trait",
  "backon",
@@ -5809,7 +5809,7 @@ dependencies = [
 
 [[package]]
 name = "observability_deps"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "tracing",
 ]
@@ -5874,7 +5874,7 @@ dependencies = [
 
 [[package]]
 name = "panic_logging"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "metric",
  "test_helpers",
@@ -5949,7 +5949,7 @@ dependencies = [
 
 [[package]]
 name = "parquet_file"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "arrow",
  "arrow_util",
@@ -5980,7 +5980,7 @@ dependencies = [
 
 [[package]]
 name = "partition"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "arrow",
  "assert_matches",
@@ -6277,7 +6277,7 @@ dependencies = [
 
 [[package]]
 name = "predicate"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6621,7 +6621,7 @@ dependencies = [
 
 [[package]]
 name = "query_functions"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "arrow",
  "chrono",
@@ -7331,7 +7331,7 @@ dependencies = [
 
 [[package]]
 name = "schema"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "arrow",
  "base64 0.22.1",
@@ -7514,7 +7514,7 @@ dependencies = [
 
 [[package]]
 name = "service_common"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -7528,7 +7528,7 @@ dependencies = [
 
 [[package]]
 name = "service_grpc_flight"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -7604,7 +7604,7 @@ dependencies = [
 
 [[package]]
 name = "sharder"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "criterion 0.8.2",
  "data_types",
@@ -8126,7 +8126,7 @@ dependencies = [
 
 [[package]]
 name = "table_batch"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "arrow_util",
  "bitvec",
@@ -8222,7 +8222,7 @@ dependencies = [
 
 [[package]]
 name = "test_helpers"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "async-trait",
  "dotenvy",
@@ -8241,7 +8241,7 @@ dependencies = [
 
 [[package]]
 name = "test_helpers_authz"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "futures",
  "generated_types",
@@ -8514,7 +8514,7 @@ dependencies = [
 
 [[package]]
 name = "tokio_metrics_bridge"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "metric",
  "parking_lot",
@@ -8523,7 +8523,7 @@ dependencies = [
 
 [[package]]
 name = "tokio_watchdog"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "metric",
  "test_helpers",
@@ -8746,7 +8746,7 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tower_trailer"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "futures",
  "http 1.4.0",
@@ -8758,7 +8758,7 @@ dependencies = [
 
 [[package]]
 name = "trace"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "chrono",
  "parking_lot",
@@ -8768,7 +8768,7 @@ dependencies = [
 
 [[package]]
 name = "trace_exporters"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8785,7 +8785,7 @@ dependencies = [
 
 [[package]]
 name = "trace_http"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "bytes",
  "futures",
@@ -8880,7 +8880,7 @@ dependencies = [
 
 [[package]]
 name = "tracker"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "futures",
  "hashbrown 0.14.5",
@@ -8900,7 +8900,7 @@ dependencies = [
 
 [[package]]
 name = "trogging"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-nightly"
 dependencies = [
  "clap",
  "logfmt",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,7 +444,7 @@ dependencies = [
 
 [[package]]
 name = "arrow_util"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -541,7 +541,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "authz"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -655,7 +655,7 @@ dependencies = [
 
 [[package]]
 name = "backoff"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "rand 0.9.4",
  "snafu 0.9.0",
@@ -1078,7 +1078,7 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "catalog_cache"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "bytes",
  "criterion 0.8.2",
@@ -1222,14 +1222,14 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli_types"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "tokio",
 ]
 
 [[package]]
 name = "client_util"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "http 1.4.0",
  "iox_http_util",
@@ -1832,7 +1832,7 @@ dependencies = [
 
 [[package]]
 name = "data_types"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -2566,7 +2566,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion_util"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -2661,7 +2661,7 @@ dependencies = [
 
 [[package]]
 name = "dml"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "arrow_util",
  "data_types",
@@ -2773,7 +2773,7 @@ dependencies = [
 
 [[package]]
 name = "error_reporting"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "datafusion",
  "snafu 0.9.0",
@@ -2803,7 +2803,7 @@ dependencies = [
 
 [[package]]
 name = "executor"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "futures",
  "metric",
@@ -2884,7 +2884,7 @@ dependencies = [
 
 [[package]]
 name = "flightsql"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -3091,7 +3091,7 @@ dependencies = [
 
 [[package]]
 name = "futures_test_utils"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "clap",
  "futures",
@@ -3102,7 +3102,7 @@ dependencies = [
 
 [[package]]
 name = "generated_types"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "bytes",
  "pbjson",
@@ -3756,7 +3756,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb2_client"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "bytes",
  "futures",
@@ -3775,7 +3775,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3867,7 +3867,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_authz"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "async-trait",
  "authz",
@@ -3885,7 +3885,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_cache"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3920,7 +3920,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_catalog"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "ahash 0.8.12",
  "anyhow",
@@ -3977,7 +3977,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_clap_blocks"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4014,7 +4014,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_client"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "bytes",
  "flate2",
@@ -4035,7 +4035,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_commands"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4062,7 +4062,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_id"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "criterion 0.5.1",
  "indexmap 2.14.0",
@@ -4074,7 +4074,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_internal_api"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4095,7 +4095,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_load_generator"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4125,7 +4125,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_process"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "iox_time",
  "uuid",
@@ -4133,7 +4133,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_processing_engine"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4176,7 +4176,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_py_api"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -4204,7 +4204,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_query_executor"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4255,7 +4255,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_server"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4342,7 +4342,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_shutdown"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "futures",
  "futures-util",
@@ -4357,14 +4357,14 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_startup"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "chrono",
 ]
 
 [[package]]
 name = "influxdb3_sys_events"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4383,7 +4383,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_system_tables"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4415,7 +4415,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_telemetry"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "futures",
  "futures-util",
@@ -4436,7 +4436,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_test_helpers"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4449,7 +4449,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_types"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4469,7 +4469,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_wal"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "async-trait",
  "bitcode",
@@ -4498,7 +4498,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_write"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4568,7 +4568,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb_influxql_parser"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "assert_matches",
  "chrono",
@@ -4585,7 +4585,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb_iox_client"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -4614,7 +4614,7 @@ dependencies = [
 
 [[package]]
 name = "ingester_query_grpc"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "base64 0.22.1",
  "data_types",
@@ -4680,7 +4680,7 @@ checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
 
 [[package]]
 name = "iox_http"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -4700,7 +4700,7 @@ dependencies = [
 
 [[package]]
 name = "iox_http_util"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "futures",
  "http 1.4.0",
@@ -4711,7 +4711,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "arrow",
  "arrow_util",
@@ -4760,7 +4760,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query_influxql"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "arrow",
  "assert_matches",
@@ -4787,7 +4787,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query_influxql_rewrite"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "influxdb_influxql_parser",
  "thiserror 2.0.18",
@@ -4795,7 +4795,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query_params"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "arrow",
  "assert_matches",
@@ -4809,7 +4809,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query_udf"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "datafusion-udf-wasm-host",
  "datafusion-udf-wasm-query",
@@ -4820,7 +4820,7 @@ dependencies = [
 
 [[package]]
 name = "iox_system_tables"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4830,7 +4830,7 @@ dependencies = [
 
 [[package]]
 name = "iox_time"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "chrono",
  "parking_lot",
@@ -4839,7 +4839,7 @@ dependencies = [
 
 [[package]]
 name = "iox_v1_query_api"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4953,7 +4953,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jemalloc_pprof_http"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "http-body-util",
  "hyper 1.9.0",
@@ -4966,7 +4966,7 @@ dependencies = [
 
 [[package]]
 name = "jemalloc_stats"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "futures",
  "snafu 0.9.0",
@@ -5159,7 +5159,7 @@ dependencies = [
 
 [[package]]
 name = "linear_buffer"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 
 [[package]]
 name = "linux-raw-sys"
@@ -5203,7 +5203,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "logfmt"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "humantime",
  "parking_lot",
@@ -5302,14 +5302,14 @@ dependencies = [
 
 [[package]]
 name = "metric"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "parking_lot",
 ]
 
 [[package]]
 name = "metric_exporters"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "metric",
  "mockito",
@@ -5434,7 +5434,7 @@ checksum = "9252111cf132ba0929b6f8e030cac2a24b507f3a4d6db6fb2896f27b354c714b"
 
 [[package]]
 name = "mutable_batch"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "arrow",
  "arrow_util",
@@ -5452,7 +5452,7 @@ dependencies = [
 
 [[package]]
 name = "mutable_batch_lp"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "arrow_util",
  "assert_matches",
@@ -5468,7 +5468,7 @@ dependencies = [
 
 [[package]]
 name = "mutable_batch_pb"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "arrow_util",
  "criterion 0.8.2",
@@ -5706,7 +5706,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_limit"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5718,7 +5718,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_mem_cache"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5746,7 +5746,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_metrics"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "async-trait",
  "bloom2",
@@ -5771,7 +5771,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_mock"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5785,7 +5785,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_size_hinting"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "chrono",
  "http 1.4.0",
@@ -5795,7 +5795,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_utils"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "async-trait",
  "backon",
@@ -5809,7 +5809,7 @@ dependencies = [
 
 [[package]]
 name = "observability_deps"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "tracing",
 ]
@@ -5874,7 +5874,7 @@ dependencies = [
 
 [[package]]
 name = "panic_logging"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "metric",
  "test_helpers",
@@ -5949,7 +5949,7 @@ dependencies = [
 
 [[package]]
 name = "parquet_file"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "arrow",
  "arrow_util",
@@ -5980,7 +5980,7 @@ dependencies = [
 
 [[package]]
 name = "partition"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "arrow",
  "assert_matches",
@@ -6277,7 +6277,7 @@ dependencies = [
 
 [[package]]
 name = "predicate"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6621,7 +6621,7 @@ dependencies = [
 
 [[package]]
 name = "query_functions"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "arrow",
  "chrono",
@@ -7331,7 +7331,7 @@ dependencies = [
 
 [[package]]
 name = "schema"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "arrow",
  "base64 0.22.1",
@@ -7514,7 +7514,7 @@ dependencies = [
 
 [[package]]
 name = "service_common"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -7528,7 +7528,7 @@ dependencies = [
 
 [[package]]
 name = "service_grpc_flight"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -7604,7 +7604,7 @@ dependencies = [
 
 [[package]]
 name = "sharder"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "criterion 0.8.2",
  "data_types",
@@ -8126,7 +8126,7 @@ dependencies = [
 
 [[package]]
 name = "table_batch"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "arrow_util",
  "bitvec",
@@ -8222,7 +8222,7 @@ dependencies = [
 
 [[package]]
 name = "test_helpers"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "async-trait",
  "dotenvy",
@@ -8241,7 +8241,7 @@ dependencies = [
 
 [[package]]
 name = "test_helpers_authz"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "futures",
  "generated_types",
@@ -8514,7 +8514,7 @@ dependencies = [
 
 [[package]]
 name = "tokio_metrics_bridge"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "metric",
  "parking_lot",
@@ -8523,7 +8523,7 @@ dependencies = [
 
 [[package]]
 name = "tokio_watchdog"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "metric",
  "test_helpers",
@@ -8746,7 +8746,7 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tower_trailer"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "futures",
  "http 1.4.0",
@@ -8758,7 +8758,7 @@ dependencies = [
 
 [[package]]
 name = "trace"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "chrono",
  "parking_lot",
@@ -8768,7 +8768,7 @@ dependencies = [
 
 [[package]]
 name = "trace_exporters"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8785,7 +8785,7 @@ dependencies = [
 
 [[package]]
 name = "trace_http"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "bytes",
  "futures",
@@ -8880,7 +8880,7 @@ dependencies = [
 
 [[package]]
 name = "tracker"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "futures",
  "hashbrown 0.14.5",
@@ -8900,7 +8900,7 @@ dependencies = [
 
 [[package]]
 name = "trogging"
-version = "3.10.0-nightly"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "clap",
  "logfmt",

--- a/influxdb3_catalog/src/catalog/versions/v3/catalog.rs
+++ b/influxdb3_catalog/src/catalog/versions/v3/catalog.rs
@@ -127,7 +127,7 @@ use crate::format::records::types::ResourceIdentifier as WireResourceIdentifier;
 use crate::format::records::types::ResourceType as WireResourceType;
 use crate::format::records::types::RetentionPeriod as WireRetentionPeriod;
 use crate::object_store::PersistCatalogResult;
-use crate::object_store::versions::v3::ObjectStoreCatalog;
+use crate::object_store::versions::v3::{CatalogLoad, ObjectStoreCatalog};
 use crate::resource::CatalogResource;
 use crate::{CatalogError, Result};
 use influxdb3_wal::CatalogSnapshotObserver;
@@ -609,7 +609,7 @@ impl Catalog {
         };
         let catalog_id: Arc<str> = catalog_id.into();
         let store = ObjectStoreCatalog::new(catalog_id, store, StorageMode::default());
-        let inner = store.load_or_create_catalog().await?;
+        let inner = store.load_or_create_catalog().await?.inner;
         Ok(Self::from_parts(
             inner,
             store,
@@ -690,7 +690,10 @@ impl Catalog {
 
         let store = ObjectStoreCatalog::new(catalog_id, store, args.storage_mode)
             .with_catalog_snapshot_observer(catalog_snapshot_observer);
-        let inner = store.load_or_create_catalog().await?;
+        let CatalogLoad {
+            inner,
+            snapshot_needs_rewrite,
+        } = store.load_or_create_catalog().await?;
 
         let local = derive_feature_level();
         let committed = inner.committed_feature_level;
@@ -714,6 +717,25 @@ impl Catalog {
             CheckpointPolicy::default(),
             limits,
         );
+
+        // Snapshots in a non-current layout — legacy multi-group, or the
+        // indexless flat form that pre-flat readers reject — still load, but
+        // the file itself should not linger on object store: rewrite it in
+        // the current single-group format now rather than waiting for the
+        // next organic checkpoint. `force_checkpoint` snapshots the live
+        // state, so any log files replayed on top of the snapshot are folded
+        // in as well. Failure is non-fatal — startup proceeds and the next
+        // checkpoint retires the file instead.
+        if snapshot_needs_rewrite {
+            match catalog.force_checkpoint().await {
+                Ok(()) => info!("rewrote catalog snapshot in current format"),
+                Err(error) => warn!(
+                    ?error,
+                    "failed to rewrite non-current catalog snapshot at startup; \
+                     it will be retired by the next checkpoint"
+                ),
+            }
+        }
 
         // Mirror v2: ensure the `_internal` system database exists. v2
         // calls `create_internal_db` from every public constructor; v3
@@ -3531,13 +3553,14 @@ async fn promote_core_catalog_to_cluster_prefix(
         Arc::clone(&store),
         storage_mode,
     );
-    if let Some(mut inner) = v3_core
+    if let Some(load) = v3_core
         .load_catalog()
         .await
         .map_err(|e| CatalogError::Internal {
             details: format!("loading v3 core catalog from {current_node_id}: {e}"),
         })?
     {
+        let mut inner = load.inner;
         inner.catalog_id = Arc::clone(&cluster_id);
         let _ = v3_cluster
             .initialize_snapshot(inner.create_snapshot())

--- a/influxdb3_catalog/src/catalog/versions/v3/catalog/tests.rs
+++ b/influxdb3_catalog/src/catalog/versions/v3/catalog/tests.rs
@@ -1334,6 +1334,268 @@ mod checkpointing {
 }
 
 // ---------------------------------------------------------------------------
+// Legacy grouped snapshot rewrite at startup
+// ---------------------------------------------------------------------------
+
+mod startup_snapshot_rewrite {
+    use std::io::Cursor;
+
+    use super::*;
+    use crate::format::records::{CreateDatabase, CreateTable, RegisterNode};
+    use crate::format::{CatalogFile, FeatureLevel, Header, MakeRecord, Record, file_flags};
+    use crate::object_store::CatalogFilePath;
+
+    /// Byte length of one legacy group-index entry.
+    const LEGACY_ENTRY_SIZE: usize = 24;
+
+    /// Encode one legacy group-index entry: group_type, group_key,
+    /// record_count, and byte_length as u32 LE, then byte_offset as u64 LE.
+    fn legacy_index_entry(
+        group_type: u32,
+        group_key: u32,
+        record_count: u32,
+        byte_length: u32,
+        byte_offset: u64,
+    ) -> [u8; LEGACY_ENTRY_SIZE] {
+        let mut entry = [0u8; LEGACY_ENTRY_SIZE];
+        entry[0..4].copy_from_slice(&group_type.to_le_bytes());
+        entry[4..8].copy_from_slice(&group_key.to_le_bytes());
+        entry[8..12].copy_from_slice(&record_count.to_le_bytes());
+        entry[12..16].copy_from_slice(&byte_length.to_le_bytes());
+        entry[16..24].copy_from_slice(&byte_offset.to_le_bytes());
+        entry
+    }
+
+    /// Hand-build a legacy multi-group snapshot file: header, then one
+    /// 24-byte index entry per (group, records) pair — Global first — then
+    /// the record bytes of every group concatenated in order.
+    fn build_legacy_grouped_snapshot(
+        sequence_number: u64,
+        groups: &[(u32, u32, &[Record])],
+    ) -> Vec<u8> {
+        let mut index = Vec::new();
+        let mut record_bytes = Vec::new();
+        let mut record_count = 0u32;
+        for (group_type, group_key, records) in groups {
+            let byte_offset = record_bytes.len() as u64;
+            for record in *records {
+                record_bytes.extend_from_slice(&record.to_bytes());
+            }
+            index.extend_from_slice(&legacy_index_entry(
+                *group_type,
+                *group_key,
+                records.len() as u32,
+                (record_bytes.len() as u64 - byte_offset) as u32,
+                byte_offset,
+            ));
+            record_count += records.len() as u32;
+        }
+        let payload: Vec<u8> = index.into_iter().chain(record_bytes).collect();
+        let header = Header {
+            format_version: Header::CURRENT_VERSION,
+            flags: file_flags::SNAPSHOT,
+            catalog_uuid: Uuid::nil().as_u128(),
+            sequence_number,
+            record_count,
+            group_count: groups.len() as u32,
+            payload_len: payload.len() as u64,
+            payload_crc: crc32fast::hash(&payload),
+        };
+        let mut file = Vec::with_capacity(Header::SIZE + payload.len());
+        file.extend_from_slice(&header.to_bytes());
+        file.extend_from_slice(&payload);
+        file
+    }
+
+    /// Hand-build an indexless flat snapshot file as written between
+    /// #4026 and the compat-entry writer: header with `group_count: 0`,
+    /// then the record bytes with no index.
+    fn build_flat_indexless_snapshot(sequence_number: u64, records: &[Record]) -> Vec<u8> {
+        let mut payload = Vec::new();
+        for record in records {
+            payload.extend_from_slice(&record.to_bytes());
+        }
+        let header = Header {
+            format_version: Header::CURRENT_VERSION,
+            flags: file_flags::SNAPSHOT,
+            catalog_uuid: Uuid::nil().as_u128(),
+            sequence_number,
+            record_count: records.len() as u32,
+            group_count: 0,
+            payload_len: payload.len() as u64,
+            payload_crc: crc32fast::hash(&payload),
+        };
+        let mut file = Vec::with_capacity(Header::SIZE + payload.len());
+        file.extend_from_slice(&header.to_bytes());
+        file.extend_from_slice(&payload);
+        file
+    }
+
+    /// Three records — register-node, create-database, create-table — used
+    /// to populate the hand-built snapshot fixtures.
+    fn sample_records() -> [Record; 3] {
+        let register = RegisterNode {
+            node_catalog_id: 1,
+            node_id: "node-a".to_string(),
+            instance_id: "inst-1".to_string(),
+            registered_time_ns: 1000,
+            core_count: 4,
+            mode: vec![crate::format::records::types::NodeMode::Core],
+            process_uuid: [0u8; 16],
+            conn_info: None,
+            cli_params: None,
+            row_delete_predicate_version: 0,
+            feature_level: FeatureLevel::ZERO,
+        }
+        .make_record(1);
+        let create_db = CreateDatabase {
+            database_id: 10,
+            database_name: "db-10".to_string(),
+            retention_period: crate::format::records::types::RetentionPeriod::Indefinite,
+        }
+        .make_record(2);
+        let create_table = CreateTable {
+            database_id: 10,
+            database_name: "db-10".to_string(),
+            table_name: "table-100".to_string(),
+            table_id: 100,
+            retention_period: crate::format::records::types::RetentionPeriod::Indefinite,
+            field_family_mode: crate::format::records::types::FieldFamilyMode::Auto,
+        }
+        .make_record(3);
+        [register, create_db, create_table]
+    }
+
+    async fn read_stored_snapshot(
+        store: &Arc<dyn object_store::ObjectStore>,
+        prefix: &str,
+    ) -> CatalogFile {
+        let bytes = store
+            .get(&CatalogFilePath::snapshot(prefix))
+            .await
+            .expect("snapshot object present")
+            .bytes()
+            .await
+            .unwrap();
+        let mut cursor = Cursor::new(bytes.as_ref());
+        CatalogFile::read_from(&mut cursor).expect("parse stored snapshot")
+    }
+
+    #[tokio::test]
+    async fn legacy_grouped_snapshot_rewritten_at_startup() {
+        let shared: Arc<dyn object_store::ObjectStore> = Arc::new(InMemory::new());
+
+        // Hand-build a legacy multi-group snapshot: Global group with a
+        // register-node and a create-database record, plus a per-database
+        // group holding the create-table record.
+        let [register, create_db, create_table] = sample_records();
+
+        let bytes = build_legacy_grouped_snapshot(
+            3,
+            &[
+                (0, 0, &[register, create_db]), // Global group
+                (1, 10, &[create_table]),       // Database group for db 10
+            ],
+        );
+        shared
+            .put(&CatalogFilePath::snapshot("p"), bytes.into())
+            .await
+            .unwrap();
+        assert_eq!(
+            read_stored_snapshot(&shared, "p").await.header.group_count,
+            2
+        );
+
+        let catalog = test_load_or_create("p", Arc::clone(&shared)).await.unwrap();
+
+        // The loaded state contains the db + table from the legacy file.
+        let db = catalog.db_schema("db-10").expect("db loaded");
+        assert!(db.tables.get_by_name("table-100").is_some());
+
+        // The stored snapshot was rewritten in the current single-group
+        // form, preserving record count and sequence.
+        let snapshot = read_stored_snapshot(&shared, "p").await;
+        assert_eq!(snapshot.header.group_count, 1);
+        assert_eq!(snapshot.header.sequence_number, 3);
+        assert_eq!(snapshot.record_count(), 3);
+    }
+
+    #[tokio::test]
+    async fn flat_indexless_snapshot_rewritten_at_startup() {
+        let shared: Arc<dyn object_store::ObjectStore> = Arc::new(InMemory::new());
+
+        // Hand-build a flat indexless snapshot (group_count == 0) as written
+        // between #4026 and the compat-entry writer. Pre-flat readers reject
+        // this layout, so startup must rewrite it even though this binary
+        // reads it fine.
+        let records = sample_records();
+        let bytes = build_flat_indexless_snapshot(3, &records);
+        shared
+            .put(&CatalogFilePath::snapshot("p"), bytes.into())
+            .await
+            .unwrap();
+        assert_eq!(
+            read_stored_snapshot(&shared, "p").await.header.group_count,
+            0
+        );
+
+        let catalog = test_load_or_create("p", Arc::clone(&shared)).await.unwrap();
+
+        // The loaded state contains the db + table from the flat file.
+        let db = catalog.db_schema("db-10").expect("db loaded");
+        assert!(db.tables.get_by_name("table-100").is_some());
+
+        // The stored snapshot was rewritten in the current single-group
+        // form, preserving record count and sequence.
+        let snapshot = read_stored_snapshot(&shared, "p").await;
+        assert_eq!(snapshot.header.group_count, 1);
+        assert_eq!(snapshot.header.sequence_number, 3);
+        assert_eq!(snapshot.record_count(), 3);
+    }
+
+    #[tokio::test]
+    async fn current_snapshot_not_rewritten_at_startup() {
+        let shared: Arc<dyn object_store::ObjectStore> = Arc::new(InMemory::new());
+        {
+            let catalog = test_load_or_create("p", Arc::clone(&shared)).await.unwrap();
+            catalog.create_database("db").await.unwrap();
+            catalog.force_checkpoint().await.unwrap();
+        }
+        let path = CatalogFilePath::snapshot("p");
+        let before = shared.head(&path).await.unwrap();
+        assert_eq!(
+            read_stored_snapshot(&shared, "p").await.header.group_count,
+            1
+        );
+
+        let reloaded = test_load_or_create("p", Arc::clone(&shared)).await.unwrap();
+        assert!(reloaded.db_schema("db").is_some());
+
+        // A single-group snapshot is already the target form; startup must
+        // not write it again.
+        let after = shared.head(&path).await.unwrap();
+        assert_eq!(before.e_tag, after.e_tag);
+        assert_eq!(before.last_modified, after.last_modified);
+    }
+
+    #[tokio::test]
+    async fn fresh_catalog_writes_only_initial_snapshot() {
+        let shared: Arc<dyn object_store::ObjectStore> = Arc::new(InMemory::new());
+        let catalog = test_load_or_create("p", Arc::clone(&shared)).await.unwrap();
+
+        // Pin the existing fresh-boot behavior: initialization writes an
+        // initial single-group snapshot at sequence 0 holding only the
+        // SetStorageMode record. No rewrite runs — the `_internal` database
+        // created after init lands in a log file, not the snapshot.
+        let snapshot = read_stored_snapshot(&shared, "p").await;
+        assert_eq!(snapshot.header.group_count, 1);
+        assert_eq!(snapshot.header.sequence_number, 0);
+        assert_eq!(snapshot.record_count(), 1);
+        assert!(catalog.db_schema("_internal").is_some());
+    }
+}
+
+// ---------------------------------------------------------------------------
 // DDL CreateTable field families
 // ---------------------------------------------------------------------------
 

--- a/influxdb3_catalog/src/format/apply.rs
+++ b/influxdb3_catalog/src/format/apply.rs
@@ -45,6 +45,7 @@ use crate::format::records::RestoreCatalog;
 use crate::object_store::versions::v3::ObjectStoreCatalog;
 use crate::repository::RepositoryError;
 
+use super::reader::LEGACY_GROUP_INDEX_ENTRY_SIZE;
 use super::{
     CatalogFile, Decode, FormatError, Header, REGISTRY, Record, file_flags, record_ids,
     validate_record_flags,
@@ -75,6 +76,7 @@ fn make_file_bytes(
     sequence_number: u64,
     payload: Vec<u8>,
     record_count: u32,
+    group_count: u32,
     flags: u16,
 ) -> Bytes {
     let payload_crc = crc32fast::hash(&payload);
@@ -84,6 +86,7 @@ fn make_file_bytes(
         catalog_uuid: catalog_uuid.as_u128(),
         sequence_number,
         record_count,
+        group_count,
         payload_len: payload.len() as u64,
         payload_crc,
     };
@@ -110,13 +113,21 @@ pub fn serialize_log_file(catalog_uuid: Uuid, sequence_number: u64, records: &[R
         sequence_number,
         serialize_records(records),
         u32::try_from(records.len()).expect("record count overflow"),
+        0,
         file_flags::NONE,
     )
 }
 
-/// Serialize a snapshot file: header (SNAPSHOT flag set) followed by all
-/// records concatenated in slice (application) order — the same payload
-/// shape as a log file.
+/// Serialize a snapshot file: header (SNAPSHOT flag set), one
+/// backward-compatibility group-index entry, then all records concatenated
+/// in slice (application) order.
+///
+/// The index entry declares a single Global group spanning every record.
+/// Readers deployed before the flat layout require a snapshot's group index
+/// to be present, start with a Global group, and account for every record;
+/// this one entry keeps snapshots written here readable on those binaries —
+/// and correctly ordered, since flattening a single group is the identity.
+/// Current readers skip the entry (see `read_records`).
 ///
 /// Each record is written verbatim, preserving its original per-record
 /// sequence — snapshots collect records across many log sequences and that
@@ -126,11 +137,27 @@ pub fn serialize_snapshot_file(
     sequence_number: u64,
     records: &[Record],
 ) -> Bytes {
+    let record_bytes = serialize_records(records);
+    let record_count = u32::try_from(records.len()).expect("record count overflow");
+    let byte_length = u32::try_from(record_bytes.len()).expect("record bytes overflow");
+
+    // The legacy `GroupIndexEntry` wire layout: group_type and group_key
+    // (Global = 0, 0), record_count and byte_length as u32 LE, then
+    // byte_offset as u64 LE.
+    let mut payload = Vec::with_capacity(LEGACY_GROUP_INDEX_ENTRY_SIZE + record_bytes.len());
+    payload.extend_from_slice(&0u32.to_le_bytes());
+    payload.extend_from_slice(&0u32.to_le_bytes());
+    payload.extend_from_slice(&record_count.to_le_bytes());
+    payload.extend_from_slice(&byte_length.to_le_bytes());
+    payload.extend_from_slice(&0u64.to_le_bytes());
+    payload.extend_from_slice(&record_bytes);
+
     make_file_bytes(
         catalog_uuid,
         sequence_number,
-        serialize_records(records),
-        u32::try_from(records.len()).expect("record count overflow"),
+        payload,
+        record_count,
+        1,
         file_flags::SNAPSHOT,
     )
 }

--- a/influxdb3_catalog/src/format/apply/tests.rs
+++ b/influxdb3_catalog/src/format/apply/tests.rs
@@ -264,24 +264,27 @@ fn sample_create_table(database_id: u32, table_id: u32, sequence: u64) -> Record
 }
 
 #[test]
-fn serialize_snapshot_empty_catalog_writes_empty_payload() {
-    // An empty catalog snapshots to a header-only file: SNAPSHOT flag set,
-    // zero records, empty payload.
+fn serialize_snapshot_empty_catalog_writes_compat_entry_only() {
+    // An empty catalog snapshots to a header plus the single
+    // backward-compatibility group-index entry: SNAPSHOT flag set, zero
+    // records, all-zero entry (Global, zero records, zero bytes).
     let catalog = test_catalog();
     let bytes = catalog.create_snapshot();
     let mut cursor = Cursor::new(bytes.as_ref());
     let header = Header::read_from(&mut cursor).expect("valid header");
     assert_eq!(header.flags & file_flags::SNAPSHOT, file_flags::SNAPSHOT);
     assert_eq!(header.record_count, 0);
-    assert_eq!(header.payload_len, 0);
-    assert_eq!(bytes.len(), Header::SIZE);
+    assert_eq!(header.group_count, 1);
+    assert_eq!(header.payload_len, 24);
+    assert_eq!(bytes.len(), Header::SIZE + 24);
+    assert_eq!(&bytes.as_ref()[Header::SIZE..], &[0u8; 24]);
 }
 
 #[test]
-fn create_snapshot_byte_layout_is_flat() {
+fn create_snapshot_byte_layout_compat_entry_then_flat_records() {
     // Apply records spanning several databases, then inspect the snapshot
-    // bytes: records begin directly at the payload start (no index), in
-    // application order, with original sequences preserved.
+    // bytes: one Global group-index entry spanning all records, then the
+    // records in application order with original sequences preserved.
     let mut catalog = test_catalog();
 
     let r_node = sample_register_node().make_record(1);
@@ -305,16 +308,29 @@ fn create_snapshot_byte_layout_is_flat() {
 
     assert_eq!(header.flags & file_flags::SNAPSHOT, file_flags::SNAPSHOT);
     assert_eq!(header.record_count, 5);
+    assert_eq!(header.group_count, 1);
 
-    // payload_len covers exactly the concatenated records.
+    // payload_len covers the compat index entry plus the concatenated
+    // records.
     let records_len: u64 = input
         .iter()
         .map(|r| (RECORD_HEADER_SIZE + r.data.len()) as u64)
         .sum();
-    assert_eq!(header.payload_len, records_len);
+    assert_eq!(header.payload_len, 24 + records_len);
 
-    // The first record's header begins at the payload start, verbatim.
-    let first = &bytes.as_ref()[Header::SIZE..Header::SIZE + RECORD_HEADER_SIZE];
+    // The compat entry declares one Global group spanning every record.
+    let entry = &bytes.as_ref()[Header::SIZE..Header::SIZE + 24];
+    assert_eq!(u32::from_le_bytes(entry[0..4].try_into().unwrap()), 0); // group_type Global
+    assert_eq!(u32::from_le_bytes(entry[4..8].try_into().unwrap()), 0); // group_key
+    assert_eq!(u32::from_le_bytes(entry[8..12].try_into().unwrap()), 5); // record_count
+    assert_eq!(
+        u32::from_le_bytes(entry[12..16].try_into().unwrap()) as u64,
+        records_len,
+    );
+    assert_eq!(u64::from_le_bytes(entry[16..24].try_into().unwrap()), 0); // byte_offset
+
+    // The first record's header begins right after the entry, verbatim.
+    let first = &bytes.as_ref()[Header::SIZE + 24..Header::SIZE + 24 + RECORD_HEADER_SIZE];
     assert_eq!(
         u16::from_le_bytes(first[0..2].try_into().unwrap()),
         input[0].id(),

--- a/influxdb3_catalog/src/format/header.rs
+++ b/influxdb3_catalog/src/format/header.rs
@@ -14,7 +14,7 @@
 //! | 0x10   | 16   | `[u8; 16]` | catalog_uuid    | Unique catalog instance ID                      |
 //! | 0x20   | 8    | `u64`      | sequence_number | Catalog sequence for this file                  |
 //! | 0x28   | 4    | `u32`      | record_count    | Total number of records in payload               |
-//! | 0x2C   | 4    | N/A        | reserved        | Zeros                                           |
+//! | 0x2C   | 4    | `u32`      | group_count     | Group-index entry count: `0` for logs, `1` for current snapshots (compat entry), per-group pre-#4026 |
 //! | 0x30   | 8    | `u64`      | payload_len     | Byte length of payload                           |
 //! | 0x38   | 4    | `u32`      | payload_crc     | CRC32 of the payload bytes                       |
 //! | 0x3C   | 4    | N/A        | reserved        | Zeros                                           |
@@ -49,6 +49,14 @@ pub struct Header {
     pub sequence_number: u64,
     /// Number of records in the file.
     pub record_count: u32,
+    /// Group-index entry count at offset 0x2C.
+    ///
+    /// Snapshots prefix their record payload with a group index of
+    /// `group_count` fixed-size entries — one per group in files written
+    /// before influxdb_pro#4026, a single backward-compatibility entry in
+    /// snapshots written since. The records that follow are in application
+    /// order, so the reader skips the index. Logs set this to `0`.
+    pub group_count: u32,
     /// Length of the record payload in bytes.
     pub payload_len: u64,
     /// CRC32 of the record payload.
@@ -110,10 +118,13 @@ impl Header {
         let catalog_uuid = reader.get_u128_le();
         let sequence_number = reader.get_u64_le();
         let record_count = reader.get_u32_le();
-        let reserved = reader.get_u32_le();
-        if reserved != 0 {
+        // 0x2C holds the legacy group-index entry count. Pre-#4026 snapshots
+        // set it nonzero; logs and post-#4026 files set it to 0. Only a
+        // snapshot may carry a group index — reject a nonzero count on a log.
+        let group_count = reader.get_u32_le();
+        if group_count != 0 && flags & file_flags::SNAPSHOT == 0 {
             return Err(FormatError::InvalidHeader {
-                reason: "reserved field at 0x2C is nonzero",
+                reason: "log file has nonzero group_count at 0x2C",
             });
         }
         let payload_len = reader.get_u64_le();
@@ -126,6 +137,7 @@ impl Header {
             catalog_uuid,
             sequence_number,
             record_count,
+            group_count,
             payload_len,
             payload_crc,
         })
@@ -149,7 +161,8 @@ impl Header {
         buf[0x20..0x28].copy_from_slice(&self.sequence_number.to_le_bytes());
         // Record count (0x28)
         buf[0x28..0x2C].copy_from_slice(&self.record_count.to_le_bytes());
-        // Reserved (0x2C) — already zero
+        // Group count (0x2C) — 0 for logs, 1 for snapshots (compat entry)
+        buf[0x2C..0x30].copy_from_slice(&self.group_count.to_le_bytes());
         // Payload length (0x30)
         buf[0x30..0x38].copy_from_slice(&self.payload_len.to_le_bytes());
         // Payload CRC (0x38)

--- a/influxdb3_catalog/src/format/header/tests.rs
+++ b/influxdb3_catalog/src/format/header/tests.rs
@@ -8,6 +8,7 @@ fn header_round_trip() {
         catalog_uuid: 0x0102030405060708090a0b0c0d0e0f10,
         sequence_number: 12345,
         record_count: 100,
+        group_count: 0,
         payload_crc: 0xDEADBEEF,
         payload_len: 50000,
     };
@@ -34,6 +35,7 @@ fn snapshot_header_round_trip() {
         catalog_uuid: 0,
         sequence_number: 500,
         record_count: 10000,
+        group_count: 0,
         payload_crc: 0x12345678,
         payload_len: 1_000_000,
     };
@@ -46,21 +48,43 @@ fn snapshot_header_round_trip() {
 }
 
 #[test]
-fn nonzero_reserved_field_rejected() {
-    // The reserved u32 at 0x2C must be zero; a nonzero value (e.g. a file
-    // written by a stale pre-release format) is rejected loudly.
+fn legacy_snapshot_group_count_accepted() {
+    // Snapshots written before #4026 carry a nonzero group_count at 0x2C. The
+    // reader must accept and round-trip it so old catalogs remain loadable.
     let header = Header {
         format_version: 1,
         flags: file_flags::SNAPSHOT,
         catalog_uuid: 0,
         sequence_number: 1,
         record_count: 0,
+        group_count: 3,
+        payload_crc: 0,
+        payload_len: 0,
+    };
+    let bytes = header.to_bytes();
+    let mut cursor = Cursor::new(bytes);
+    let parsed = Header::read_from(&mut cursor).unwrap();
+    assert_eq!(parsed.group_count, 3);
+    assert!(parsed.is_snapshot());
+}
+
+#[test]
+fn nonzero_group_count_on_log_rejected() {
+    // A log file must never carry a group index; a nonzero 0x2C on a
+    // non-snapshot file is corruption and is rejected loudly.
+    let header = Header {
+        format_version: 1,
+        flags: file_flags::NONE,
+        catalog_uuid: 0,
+        sequence_number: 1,
+        record_count: 0,
+        group_count: 0,
         payload_crc: 0,
         payload_len: 0,
     };
     let mut bytes = header.to_bytes();
     bytes[0x2C..0x30].copy_from_slice(&1u32.to_le_bytes());
-    // Recompute the header CRC so only the reserved-field check can fail.
+    // Recompute the header CRC so only the group_count check can fail.
     let crc = crc32fast::hash(&bytes[0x0C..Header::SIZE]);
     bytes[0x08..0x0C].copy_from_slice(&crc.to_le_bytes());
 
@@ -102,6 +126,7 @@ fn header_crc_mismatch_rejected() {
         catalog_uuid: 0,
         sequence_number: 1,
         record_count: 1,
+        group_count: 0,
         payload_crc: 0,
         payload_len: 0,
     };
@@ -129,7 +154,7 @@ fn header_alignment() {
         (0x10, "catalog_uuid"),
         (0x20, "sequence_number"),
         (0x28, "record_count"),
-        (0x2C, "reserved"),
+        (0x2C, "group_count"),
         (0x30, "payload_len"),
         (0x38, "payload_crc"),
         (0x3C, "reserved"),

--- a/influxdb3_catalog/src/format/reader.rs
+++ b/influxdb3_catalog/src/format/reader.rs
@@ -6,6 +6,13 @@ use std::io::Cursor;
 
 use super::{FormatError, Header, RECORD_HEADER_SIZE, Record};
 
+/// On-disk size of a group-index entry: the legacy `GroupIndexEntry` —
+/// group_type, group_key, record_count and byte_length (4 bytes each) plus
+/// byte_offset (8). Pre-#4026 snapshots wrote one entry per group; snapshots
+/// written since carry a single backward-compatibility entry (see
+/// `serialize_snapshot_file`). The reader skips them either way.
+pub(crate) const LEGACY_GROUP_INDEX_ENTRY_SIZE: usize = 24;
+
 /// A parsed catalog file: header plus records.
 ///
 /// Logs and snapshots share the same payload shape — records back-to-back in
@@ -80,7 +87,20 @@ fn read_records<T: AsRef<[u8]>>(
     cursor: &mut Cursor<T>,
     header: &Header,
 ) -> Result<Vec<Record>, FormatError> {
-    let max_possible = header.payload_len as usize / RECORD_HEADER_SIZE;
+    // Snapshots prefix the record payload with a group index of `group_count`
+    // fixed-size entries — one per group in files written before #4026, a
+    // single backward-compatibility entry in files written since. The records
+    // that follow are contiguous and in application order (the pre-#4026
+    // writer emitted the Global group first, then databases ascending), so
+    // skip the index and read the records flat. Log files set group_count to
+    // 0, making this a no-op.
+    let index_len = header.group_count as usize * LEGACY_GROUP_INDEX_ENTRY_SIZE;
+    if index_len > 0 {
+        cursor.set_position(cursor.position() + index_len as u64);
+    }
+
+    let records_len = (header.payload_len as usize).saturating_sub(index_len);
+    let max_possible = records_len / RECORD_HEADER_SIZE;
     let capacity = (header.record_count as usize).min(max_possible);
     let mut records = Vec::with_capacity(capacity);
     for _ in 0..header.record_count {

--- a/influxdb3_catalog/src/format/reader/tests.rs
+++ b/influxdb3_catalog/src/format/reader/tests.rs
@@ -20,6 +20,7 @@ fn create_test_file(records: &[Record]) -> Bytes {
         catalog_uuid: 1337,
         sequence_number: 12345,
         record_count: records.len() as u32,
+        group_count: 0,
         payload_crc,
         payload_len: payload.len() as u64,
     };
@@ -160,6 +161,7 @@ fn truncated_record_header() {
         catalog_uuid: 1337,
         sequence_number: 12345,
         record_count: 2, // Claim 2 records
+        group_count: 0,
         payload_crc,
         payload_len: payload.len() as u64,
     };
@@ -185,6 +187,7 @@ fn build_raw_file(header_flags: u16, record_count: u32, payload: Vec<u8>) -> Byt
         catalog_uuid: 1337,
         sequence_number: 1,
         record_count,
+        group_count: 0,
         payload_crc,
         payload_len: payload.len() as u64,
     };
@@ -215,6 +218,47 @@ fn snapshot_payload_parses_like_log() {
     assert_eq!(parsed.len(), 2);
     assert_eq!(parsed[0].id(), 1);
     assert_eq!(parsed[1].id(), 2);
+}
+
+#[test]
+fn legacy_grouped_snapshot_skips_index_and_reads_records() {
+    // Regression for influxdb_pro#4026: snapshots written by the pre-#4026
+    // engine prefix the record payload with a group index of `group_count`
+    // 24-byte entries. The new flat reader must skip that index and return the
+    // records (already in application order) rather than rejecting the file.
+    let records = [
+        Record::new(1, RecordFlags::none(), 1, Bytes::from_static(b"alpha")),
+        Record::new(2, RecordFlags::none(), 2, Bytes::from_static(b"bravo")),
+    ];
+    let group_count = 2u32; // e.g. Global + one database
+    // Group-index bytes — opaque to the new reader, which only skips them.
+    let mut payload = vec![0u8; group_count as usize * 24];
+    for record in &records {
+        payload.extend_from_slice(&record.to_bytes());
+    }
+    let payload_crc = crc32fast::hash(&payload);
+    let header = Header {
+        format_version: FORMAT_VERSION,
+        flags: file_flags::SNAPSHOT,
+        catalog_uuid: 1337,
+        sequence_number: 7,
+        record_count: records.len() as u32,
+        group_count,
+        payload_crc,
+        payload_len: payload.len() as u64,
+    };
+    let mut file = Vec::new();
+    file.extend_from_slice(&header.to_bytes());
+    file.extend_from_slice(&payload);
+    let mut cursor = Cursor::new(Bytes::from(file));
+
+    let parsed = CatalogFile::read_from(&mut cursor).unwrap();
+    assert!(parsed.header.is_snapshot());
+    assert_eq!(parsed.records.len(), 2);
+    assert_eq!(parsed.records[0].id(), 1);
+    assert_eq!(parsed.records[1].id(), 2);
+    assert_eq!(&parsed.records[0].data[..], b"alpha");
+    assert_eq!(&parsed.records[1].data[..], b"bravo");
 }
 
 #[test]

--- a/influxdb3_catalog/src/object_store/versions/v3.rs
+++ b/influxdb3_catalog/src/object_store/versions/v3.rs
@@ -30,6 +30,19 @@ use crate::object_store::{
 
 const CATALOG_VERSION_PATH: &str = "catalog/v3";
 
+/// An [`InnerCatalog`] reconstructed from the object store, along with
+/// metadata about the snapshot file it was loaded from.
+#[derive(Debug)]
+pub(crate) struct CatalogLoad {
+    pub(crate) inner: InnerCatalog,
+    /// True when the snapshot file is not in the current single-entry form:
+    /// either the legacy multi-group layout (`group_count > 1`) or the
+    /// indexless flat layout (`group_count == 0`) that pre-flat readers
+    /// reject. Such a file should be rewritten in the current format at
+    /// startup.
+    pub(crate) snapshot_needs_rewrite: bool,
+}
+
 /// Maximum number of in-flight log file fetches during catalog load.
 ///
 /// `load_catalog` may need to replay every log file persisted since the last
@@ -118,7 +131,7 @@ impl ObjectStoreCatalog {
     ///
     /// Returns `Ok(None)` if no snapshot exists — i.e. no catalog has been
     /// initialized at this prefix.
-    pub(crate) async fn load_catalog(&self) -> Result<Option<InnerCatalog>> {
+    pub(crate) async fn load_catalog(&self) -> Result<Option<CatalogLoad>> {
         // `Ok(None)` (no snapshot exists at this prefix) is silent; a real
         // object-store / decode error during startup load fires the SLL
         // error variant so operators see the failure rather than a silent
@@ -131,6 +144,12 @@ impl ObjectStoreCatalog {
             return Ok(None);
         };
         let snapshot_sequence = snapshot.sequence_number();
+        // Exactly one group is the current writer's form, which every
+        // reader vintage accepts. Anything else gets rewritten at startup:
+        // the legacy multi-group layout (group_count > 1), and the indexless
+        // flat layout (group_count == 0) whose files pre-flat readers
+        // reject.
+        let snapshot_needs_rewrite = snapshot.header.group_count != 1;
         let catalog_uuid = Uuid::from_u128(snapshot.header.catalog_uuid);
         let mut inner = InnerCatalog::new(Arc::clone(&self.prefix), catalog_uuid);
         // Snapshots normally do not contain restore records, but pre-load
@@ -223,7 +242,10 @@ impl ObjectStoreCatalog {
             })?;
         }
 
-        Ok(Some(inner))
+        Ok(Some(CatalogLoad {
+            inner,
+            snapshot_needs_rewrite,
+        }))
     }
 
     /// Load an existing catalog, or initialize a fresh one by writing an
@@ -234,9 +256,9 @@ impl ObjectStoreCatalog {
     /// The initial snapshot carries a single [`SetStorageMode`] record so
     /// the storage mode configured on this `ObjectStoreCatalog` survives
     /// future reloads.
-    pub(crate) async fn load_or_create_catalog(&self) -> Result<InnerCatalog> {
-        if let Some(inner) = self.load_catalog().await? {
-            return Ok(inner);
+    pub(crate) async fn load_or_create_catalog(&self) -> Result<CatalogLoad> {
+        if let Some(load) = self.load_catalog().await? {
+            return Ok(load);
         }
 
         let catalog_uuid = Uuid::new_v4();
@@ -261,7 +283,10 @@ impl ObjectStoreCatalog {
         })?;
         let initial_snapshot = inner.create_snapshot();
         match self.initialize_snapshot(initial_snapshot).await? {
-            PersistCatalogResult::Success => Ok(inner),
+            PersistCatalogResult::Success => Ok(CatalogLoad {
+                inner,
+                snapshot_needs_rewrite: false,
+            }),
             PersistCatalogResult::AlreadyExists => self.load_catalog().await?.ok_or_else(|| {
                 ObjectStoreCatalogError::unexpected(
                     "initial snapshot existed but load_catalog returned None",

--- a/influxdb3_catalog/src/object_store/versions/v3/tests.rs
+++ b/influxdb3_catalog/src/object_store/versions/v3/tests.rs
@@ -140,7 +140,9 @@ async fn load_catalog_returns_none_for_empty_store() {
 async fn load_or_create_initializes_fresh_catalog() {
     let store =
         ObjectStoreCatalog::new("prefix", Arc::new(InMemory::new()), StorageMode::PachaTree);
-    let inner = store.load_or_create_catalog().await.unwrap();
+    let load = store.load_or_create_catalog().await.unwrap();
+    assert!(!load.snapshot_needs_rewrite);
+    let inner = load.inner;
 
     assert_eq!(inner.sequence_number(), CatalogSequenceNumber::new(0));
     assert_ne!(inner.catalog_uuid, Uuid::nil());
@@ -166,8 +168,8 @@ async fn load_or_create_initializes_fresh_catalog() {
 #[tokio::test]
 async fn load_or_create_is_idempotent() {
     let store = test_store();
-    let first = store.load_or_create_catalog().await.unwrap();
-    let second = store.load_or_create_catalog().await.unwrap();
+    let first = store.load_or_create_catalog().await.unwrap().inner;
+    let second = store.load_or_create_catalog().await.unwrap().inner;
     assert_eq!(first.catalog_uuid, second.catalog_uuid);
 }
 
@@ -184,8 +186,8 @@ async fn load_or_create_resolves_concurrent_init() {
         cat_a.load_or_create_catalog(),
         cat_b.load_or_create_catalog()
     );
-    let a = a.unwrap();
-    let b = b.unwrap();
+    let a = a.unwrap().inner;
+    let b = b.unwrap().inner;
     assert_eq!(a.catalog_uuid, b.catalog_uuid);
 }
 
@@ -224,7 +226,9 @@ async fn load_catalog_replays_snapshot_and_logs() {
         .await
         .unwrap();
 
-    let inner = store.load_catalog().await.unwrap().expect("load");
+    let load = store.load_catalog().await.unwrap().expect("load");
+    assert!(!load.snapshot_needs_rewrite);
+    let inner = load.inner;
     assert_eq!(inner.sequence_number(), CatalogSequenceNumber::new(2));
     assert_eq!(inner.ordered_records.len(), 3); // snapshot + 2 log records
 }


### PR DESCRIPTION
Source: 0af382e94c375a4ac3f7ad5fae56dda0ae5373a9

Backports changes from https://github.com/influxdata/influxdb/pull/27493 to 3.10