### PR TITLE
fix: move default startup choice match to end of case

### DIFF
--- a/install_influxdb.sh
+++ b/install_influxdb.sh
@@ -1437,6 +1437,14 @@ else
     STARTUP_CHOICE=${STARTUP_CHOICE:-1}
 
     case "$STARTUP_CHOICE" in
+        3)
+            # Skip startup
+            START_SERVICE="n"
+            ;;
+        2)
+            # Custom Configuration - existing detailed flow
+            START_SERVICE="y"
+            ;;
         1|*)
             # Quick Start - use defaults and check for existing license
             if [ "$STARTUP_CHOICE" != "1" ]; then
@@ -1445,14 +1453,6 @@ else
             setup_quick_start_defaults enterprise
             setup_license_for_quick_start
             START_SERVICE="y"
-            ;;
-        2)
-            # Custom Configuration - existing detailed flow
-            START_SERVICE="y"
-            ;;
-        3)
-            # Skip startup
-            START_SERVICE="n"
             ;;
     esac
 


### PR DESCRIPTION
This moves the default startup choice match (`1|*)`) to the end of the case statement to fix a bug in the install script.

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
