### PR TITLE
chore(sync): influxdb_pro 2026-06-15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,7 +444,7 @@ dependencies = [
 
 [[package]]
 name = "arrow_util"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -541,7 +541,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "authz"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -655,7 +655,7 @@ dependencies = [
 
 [[package]]
 name = "backoff"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "rand 0.9.4",
  "snafu 0.9.0",
@@ -1078,7 +1078,7 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "catalog_cache"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "bytes",
  "criterion 0.8.2",
@@ -1222,14 +1222,14 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli_types"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "tokio",
 ]
 
 [[package]]
 name = "client_util"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "http 1.4.0",
  "iox_http_util",
@@ -1832,7 +1832,7 @@ dependencies = [
 
 [[package]]
 name = "data_types"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -2566,7 +2566,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion_util"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -2661,7 +2661,7 @@ dependencies = [
 
 [[package]]
 name = "dml"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "arrow_util",
  "data_types",
@@ -2773,7 +2773,7 @@ dependencies = [
 
 [[package]]
 name = "error_reporting"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "datafusion",
  "snafu 0.9.0",
@@ -2803,7 +2803,7 @@ dependencies = [
 
 [[package]]
 name = "executor"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "futures",
  "metric",
@@ -2884,7 +2884,7 @@ dependencies = [
 
 [[package]]
 name = "flightsql"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -3091,7 +3091,7 @@ dependencies = [
 
 [[package]]
 name = "futures_test_utils"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "clap",
  "futures",
@@ -3102,7 +3102,7 @@ dependencies = [
 
 [[package]]
 name = "generated_types"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "bytes",
  "pbjson",
@@ -3756,7 +3756,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb2_client"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "bytes",
  "futures",
@@ -3775,7 +3775,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3867,7 +3867,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_authz"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "async-trait",
  "authz",
@@ -3885,7 +3885,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_cache"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3920,7 +3920,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_catalog"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "ahash 0.8.12",
  "anyhow",
@@ -3977,7 +3977,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_clap_blocks"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4014,7 +4014,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_client"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "bytes",
  "flate2",
@@ -4035,7 +4035,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_commands"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4062,7 +4062,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_id"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "criterion 0.5.1",
  "indexmap 2.14.0",
@@ -4074,7 +4074,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_internal_api"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4095,7 +4095,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_load_generator"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4125,7 +4125,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_process"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "iox_time",
  "uuid",
@@ -4133,7 +4133,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_processing_engine"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4176,7 +4176,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_py_api"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -4204,7 +4204,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_query_executor"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4255,7 +4255,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_server"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4342,7 +4342,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_shutdown"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "futures",
  "futures-util",
@@ -4357,14 +4357,14 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_startup"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "chrono",
 ]
 
 [[package]]
 name = "influxdb3_sys_events"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4383,7 +4383,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_system_tables"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4415,7 +4415,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_telemetry"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "futures",
  "futures-util",
@@ -4436,7 +4436,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_test_helpers"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4449,7 +4449,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_types"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4469,7 +4469,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_wal"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "async-trait",
  "bitcode",
@@ -4498,7 +4498,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_write"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4568,7 +4568,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb_influxql_parser"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "assert_matches",
  "chrono",
@@ -4585,7 +4585,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb_iox_client"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -4614,7 +4614,7 @@ dependencies = [
 
 [[package]]
 name = "ingester_query_grpc"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "base64 0.22.1",
  "data_types",
@@ -4680,7 +4680,7 @@ checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
 
 [[package]]
 name = "iox_http"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -4700,7 +4700,7 @@ dependencies = [
 
 [[package]]
 name = "iox_http_util"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "futures",
  "http 1.4.0",
@@ -4711,7 +4711,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "arrow",
  "arrow_util",
@@ -4760,7 +4760,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query_influxql"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "arrow",
  "assert_matches",
@@ -4787,7 +4787,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query_influxql_rewrite"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "influxdb_influxql_parser",
  "thiserror 2.0.18",
@@ -4795,7 +4795,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query_params"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "arrow",
  "assert_matches",
@@ -4809,7 +4809,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query_udf"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "datafusion-udf-wasm-host",
  "datafusion-udf-wasm-query",
@@ -4820,7 +4820,7 @@ dependencies = [
 
 [[package]]
 name = "iox_system_tables"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4830,7 +4830,7 @@ dependencies = [
 
 [[package]]
 name = "iox_time"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "chrono",
  "parking_lot",
@@ -4839,7 +4839,7 @@ dependencies = [
 
 [[package]]
 name = "iox_v1_query_api"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4953,7 +4953,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jemalloc_pprof_http"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "http-body-util",
  "hyper 1.9.0",
@@ -4966,7 +4966,7 @@ dependencies = [
 
 [[package]]
 name = "jemalloc_stats"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "futures",
  "snafu 0.9.0",
@@ -5159,7 +5159,7 @@ dependencies = [
 
 [[package]]
 name = "linear_buffer"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 
 [[package]]
 name = "linux-raw-sys"
@@ -5203,7 +5203,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "logfmt"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "humantime",
  "parking_lot",
@@ -5302,14 +5302,14 @@ dependencies = [
 
 [[package]]
 name = "metric"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "parking_lot",
 ]
 
 [[package]]
 name = "metric_exporters"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "metric",
  "mockito",
@@ -5434,7 +5434,7 @@ checksum = "9252111cf132ba0929b6f8e030cac2a24b507f3a4d6db6fb2896f27b354c714b"
 
 [[package]]
 name = "mutable_batch"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "arrow",
  "arrow_util",
@@ -5452,7 +5452,7 @@ dependencies = [
 
 [[package]]
 name = "mutable_batch_lp"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "arrow_util",
  "assert_matches",
@@ -5468,7 +5468,7 @@ dependencies = [
 
 [[package]]
 name = "mutable_batch_pb"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "arrow_util",
  "criterion 0.8.2",
@@ -5706,7 +5706,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_limit"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5718,7 +5718,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_mem_cache"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5746,7 +5746,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_metrics"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "async-trait",
  "bloom2",
@@ -5771,7 +5771,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_mock"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5785,7 +5785,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_size_hinting"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "chrono",
  "http 1.4.0",
@@ -5795,7 +5795,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_utils"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "async-trait",
  "backon",
@@ -5809,7 +5809,7 @@ dependencies = [
 
 [[package]]
 name = "observability_deps"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "tracing",
 ]
@@ -5874,7 +5874,7 @@ dependencies = [
 
 [[package]]
 name = "panic_logging"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "metric",
  "test_helpers",
@@ -5949,7 +5949,7 @@ dependencies = [
 
 [[package]]
 name = "parquet_file"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "arrow",
  "arrow_util",
@@ -5980,7 +5980,7 @@ dependencies = [
 
 [[package]]
 name = "partition"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "arrow",
  "assert_matches",
@@ -6277,7 +6277,7 @@ dependencies = [
 
 [[package]]
 name = "predicate"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6621,7 +6621,7 @@ dependencies = [
 
 [[package]]
 name = "query_functions"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "arrow",
  "chrono",
@@ -7331,7 +7331,7 @@ dependencies = [
 
 [[package]]
 name = "schema"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "arrow",
  "base64 0.22.1",
@@ -7514,7 +7514,7 @@ dependencies = [
 
 [[package]]
 name = "service_common"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -7528,7 +7528,7 @@ dependencies = [
 
 [[package]]
 name = "service_grpc_flight"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -7604,7 +7604,7 @@ dependencies = [
 
 [[package]]
 name = "sharder"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "criterion 0.8.2",
  "data_types",
@@ -8126,7 +8126,7 @@ dependencies = [
 
 [[package]]
 name = "table_batch"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "arrow_util",
  "bitvec",
@@ -8222,7 +8222,7 @@ dependencies = [
 
 [[package]]
 name = "test_helpers"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "async-trait",
  "dotenvy",
@@ -8241,7 +8241,7 @@ dependencies = [
 
 [[package]]
 name = "test_helpers_authz"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "futures",
  "generated_types",
@@ -8514,7 +8514,7 @@ dependencies = [
 
 [[package]]
 name = "tokio_metrics_bridge"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "metric",
  "parking_lot",
@@ -8523,7 +8523,7 @@ dependencies = [
 
 [[package]]
 name = "tokio_watchdog"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "metric",
  "test_helpers",
@@ -8746,7 +8746,7 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tower_trailer"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "futures",
  "http 1.4.0",
@@ -8758,7 +8758,7 @@ dependencies = [
 
 [[package]]
 name = "trace"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "chrono",
  "parking_lot",
@@ -8768,7 +8768,7 @@ dependencies = [
 
 [[package]]
 name = "trace_exporters"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8785,7 +8785,7 @@ dependencies = [
 
 [[package]]
 name = "trace_http"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "bytes",
  "futures",
@@ -8880,7 +8880,7 @@ dependencies = [
 
 [[package]]
 name = "tracker"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "futures",
  "hashbrown 0.14.5",
@@ -8900,7 +8900,7 @@ dependencies = [
 
 [[package]]
 name = "trogging"
-version = "3.10.0-oss-nightly"
+version = "3.10.0-0.rc.1"
 dependencies = [
  "clap",
  "logfmt",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,7 +444,7 @@ dependencies = [
 
 [[package]]
 name = "arrow_util"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -541,7 +541,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "authz"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -655,7 +655,7 @@ dependencies = [
 
 [[package]]
 name = "backoff"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "rand 0.9.4",
  "snafu 0.9.0",
@@ -1078,7 +1078,7 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "catalog_cache"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "bytes",
  "criterion 0.8.2",
@@ -1222,14 +1222,14 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli_types"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "tokio",
 ]
 
 [[package]]
 name = "client_util"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "http 1.4.0",
  "iox_http_util",
@@ -1832,7 +1832,7 @@ dependencies = [
 
 [[package]]
 name = "data_types"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -2566,7 +2566,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion_util"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -2661,7 +2661,7 @@ dependencies = [
 
 [[package]]
 name = "dml"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "arrow_util",
  "data_types",
@@ -2773,7 +2773,7 @@ dependencies = [
 
 [[package]]
 name = "error_reporting"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "datafusion",
  "snafu 0.9.0",
@@ -2803,7 +2803,7 @@ dependencies = [
 
 [[package]]
 name = "executor"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "futures",
  "metric",
@@ -2884,7 +2884,7 @@ dependencies = [
 
 [[package]]
 name = "flightsql"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -3091,7 +3091,7 @@ dependencies = [
 
 [[package]]
 name = "futures_test_utils"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "clap",
  "futures",
@@ -3102,7 +3102,7 @@ dependencies = [
 
 [[package]]
 name = "generated_types"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "bytes",
  "pbjson",
@@ -3756,7 +3756,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb2_client"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "bytes",
  "futures",
@@ -3775,7 +3775,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3867,7 +3867,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_authz"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "async-trait",
  "authz",
@@ -3885,7 +3885,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_cache"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3920,7 +3920,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_catalog"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "ahash 0.8.12",
  "anyhow",
@@ -3977,7 +3977,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_clap_blocks"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4014,7 +4014,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_client"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "bytes",
  "flate2",
@@ -4035,7 +4035,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_commands"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4062,7 +4062,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_id"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "criterion 0.5.1",
  "indexmap 2.14.0",
@@ -4074,7 +4074,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_internal_api"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4095,7 +4095,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_load_generator"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4125,7 +4125,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_process"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "iox_time",
  "uuid",
@@ -4133,7 +4133,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_processing_engine"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4176,7 +4176,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_py_api"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -4204,7 +4204,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_query_executor"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4255,7 +4255,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_server"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4342,7 +4342,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_shutdown"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "futures",
  "futures-util",
@@ -4357,14 +4357,14 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_startup"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "chrono",
 ]
 
 [[package]]
 name = "influxdb3_sys_events"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4383,7 +4383,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_system_tables"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4415,7 +4415,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_telemetry"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "futures",
  "futures-util",
@@ -4436,7 +4436,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_test_helpers"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4449,7 +4449,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_types"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4469,7 +4469,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_wal"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "async-trait",
  "bitcode",
@@ -4498,7 +4498,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_write"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4568,7 +4568,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb_influxql_parser"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "assert_matches",
  "chrono",
@@ -4585,7 +4585,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb_iox_client"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -4614,7 +4614,7 @@ dependencies = [
 
 [[package]]
 name = "ingester_query_grpc"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "base64 0.22.1",
  "data_types",
@@ -4680,7 +4680,7 @@ checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
 
 [[package]]
 name = "iox_http"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -4700,7 +4700,7 @@ dependencies = [
 
 [[package]]
 name = "iox_http_util"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "futures",
  "http 1.4.0",
@@ -4711,7 +4711,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "arrow",
  "arrow_util",
@@ -4760,7 +4760,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query_influxql"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "arrow",
  "assert_matches",
@@ -4787,7 +4787,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query_influxql_rewrite"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "influxdb_influxql_parser",
  "thiserror 2.0.18",
@@ -4795,7 +4795,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query_params"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "arrow",
  "assert_matches",
@@ -4809,7 +4809,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query_udf"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "datafusion-udf-wasm-host",
  "datafusion-udf-wasm-query",
@@ -4820,7 +4820,7 @@ dependencies = [
 
 [[package]]
 name = "iox_system_tables"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4830,7 +4830,7 @@ dependencies = [
 
 [[package]]
 name = "iox_time"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "chrono",
  "parking_lot",
@@ -4839,7 +4839,7 @@ dependencies = [
 
 [[package]]
 name = "iox_v1_query_api"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4953,7 +4953,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jemalloc_pprof_http"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "http-body-util",
  "hyper 1.9.0",
@@ -4966,7 +4966,7 @@ dependencies = [
 
 [[package]]
 name = "jemalloc_stats"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "futures",
  "snafu 0.9.0",
@@ -5159,7 +5159,7 @@ dependencies = [
 
 [[package]]
 name = "linear_buffer"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 
 [[package]]
 name = "linux-raw-sys"
@@ -5203,7 +5203,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "logfmt"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "humantime",
  "parking_lot",
@@ -5302,14 +5302,14 @@ dependencies = [
 
 [[package]]
 name = "metric"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "parking_lot",
 ]
 
 [[package]]
 name = "metric_exporters"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "metric",
  "mockito",
@@ -5434,7 +5434,7 @@ checksum = "9252111cf132ba0929b6f8e030cac2a24b507f3a4d6db6fb2896f27b354c714b"
 
 [[package]]
 name = "mutable_batch"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "arrow",
  "arrow_util",
@@ -5452,7 +5452,7 @@ dependencies = [
 
 [[package]]
 name = "mutable_batch_lp"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "arrow_util",
  "assert_matches",
@@ -5468,7 +5468,7 @@ dependencies = [
 
 [[package]]
 name = "mutable_batch_pb"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "arrow_util",
  "criterion 0.8.2",
@@ -5706,7 +5706,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_limit"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5718,7 +5718,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_mem_cache"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5746,7 +5746,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_metrics"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "async-trait",
  "bloom2",
@@ -5771,7 +5771,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_mock"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5785,7 +5785,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_size_hinting"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "chrono",
  "http 1.4.0",
@@ -5795,7 +5795,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_utils"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "async-trait",
  "backon",
@@ -5809,7 +5809,7 @@ dependencies = [
 
 [[package]]
 name = "observability_deps"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "tracing",
 ]
@@ -5874,7 +5874,7 @@ dependencies = [
 
 [[package]]
 name = "panic_logging"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "metric",
  "test_helpers",
@@ -5949,7 +5949,7 @@ dependencies = [
 
 [[package]]
 name = "parquet_file"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "arrow",
  "arrow_util",
@@ -5980,7 +5980,7 @@ dependencies = [
 
 [[package]]
 name = "partition"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "arrow",
  "assert_matches",
@@ -6277,7 +6277,7 @@ dependencies = [
 
 [[package]]
 name = "predicate"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6621,7 +6621,7 @@ dependencies = [
 
 [[package]]
 name = "query_functions"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "arrow",
  "chrono",
@@ -7331,7 +7331,7 @@ dependencies = [
 
 [[package]]
 name = "schema"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "arrow",
  "base64 0.22.1",
@@ -7514,7 +7514,7 @@ dependencies = [
 
 [[package]]
 name = "service_common"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -7528,7 +7528,7 @@ dependencies = [
 
 [[package]]
 name = "service_grpc_flight"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -7604,7 +7604,7 @@ dependencies = [
 
 [[package]]
 name = "sharder"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "criterion 0.8.2",
  "data_types",
@@ -8126,7 +8126,7 @@ dependencies = [
 
 [[package]]
 name = "table_batch"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "arrow_util",
  "bitvec",
@@ -8222,7 +8222,7 @@ dependencies = [
 
 [[package]]
 name = "test_helpers"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "async-trait",
  "dotenvy",
@@ -8241,7 +8241,7 @@ dependencies = [
 
 [[package]]
 name = "test_helpers_authz"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "futures",
  "generated_types",
@@ -8514,7 +8514,7 @@ dependencies = [
 
 [[package]]
 name = "tokio_metrics_bridge"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "metric",
  "parking_lot",
@@ -8523,7 +8523,7 @@ dependencies = [
 
 [[package]]
 name = "tokio_watchdog"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "metric",
  "test_helpers",
@@ -8746,7 +8746,7 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tower_trailer"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "futures",
  "http 1.4.0",
@@ -8758,7 +8758,7 @@ dependencies = [
 
 [[package]]
 name = "trace"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "chrono",
  "parking_lot",
@@ -8768,7 +8768,7 @@ dependencies = [
 
 [[package]]
 name = "trace_exporters"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8785,7 +8785,7 @@ dependencies = [
 
 [[package]]
 name = "trace_http"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "bytes",
  "futures",
@@ -8880,7 +8880,7 @@ dependencies = [
 
 [[package]]
 name = "tracker"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "futures",
  "hashbrown 0.14.5",
@@ -8900,7 +8900,7 @@ dependencies = [
 
 [[package]]
 name = "trogging"
-version = "3.10.0-0.rc.1"
+version = "3.10.0-oss-nightly"
 dependencies = [
  "clap",
  "logfmt",

--- a/core/iox_query/src/query_log.rs
+++ b/core/iox_query/src/query_log.rs
@@ -576,15 +576,30 @@ impl QueryLogEntry {
             } = ingester_metrics
         );
 
-        // Emit query text exactly once at the start of lifecycle logging.
-        // Later phase logs can be correlated by `id`, so repeating query text is unnecessary.
-        // This also prevents log pollution from long-text queries.
+        // Emit `query_text` on the initial `received` phase and on terminal phases
+        // (`success`, `fail`, `cancel`). Intermediate phases (`logically_planned`,
+        // `physically_planned`, `execution_permit`) omit it to keep noise down.
         //
-        // Using two `info!` calls instead of using inline conditional check
-        // `query_type=(*phase == QueryPhase::Received).then(|| ...)` because
-        // it includes query_text=None, which isn't true and just adds extra
-        // noise to the logs.
-        if *phase == QueryPhase::Received {
+        // Terminal-phase `query_text` is required for incident and EAR log analysis:
+        // it lets us tie a specific query to its `parquet_file` counts and latency
+        // stats from a single log line without joining on `id` across the full
+        // lifecycle, which is often impractical when logs are sampled, sharded, or
+        // truncated.
+        //
+        // Using two `info!` calls instead of an inline conditional like
+        // `query_text=(needs_text).then(|| ...)` because the latter emits
+        // `query_text=None` for intermediate phases, which is noisy and misleading.
+        // Exhaustive `match` so a new `QueryPhase` variant is a compile error
+        // here until its query_text emit/omit behavior is chosen.
+        let emit_query_text = match phase {
+            QueryPhase::Received | QueryPhase::Success | QueryPhase::Fail | QueryPhase::Cancel => {
+                true
+            }
+            QueryPhase::LogicallyPlanned
+            | QueryPhase::PhysicallyPlanned
+            | QueryPhase::ExecutionPermit => false,
+        };
+        if emit_query_text {
             info!(
                 when=phase.name(),
                 id=%id,
@@ -626,8 +641,8 @@ impl QueryLogEntry {
                 namespace_id=namespace_id.get(),
                 namespace_name=namespace_name.as_ref(),
                 query_type=query_type,
-                // Reduce repeated log payload for non-received phases by omitting query text.
-                // query_text=%query_text,
+                // Intermediate phases omit `query_text` to reduce per-line noise;
+                // it is still emitted on `received` and on terminal phases.
                 query_params=%query_params,
                 auth_id,
                 trace_id=trace_id.map(|id| format!("{:x}", id.get())),
@@ -3163,7 +3178,7 @@ mod test_super {
         level = INFO; message = query; when = "logically_planned"; id = 00000000-0000-0000-0000-000000000001; namespace_id = 1; namespace_name = "ns"; query_type = "sql"; query_params = Params { }; issue_time = 1970-01-01T00:00:00.100+00:00; logical_plan_duration_secs = 0.001; success = false; running = true; cancelled = false;
         level = INFO; message = query; when = "physically_planned"; id = 00000000-0000-0000-0000-000000000001; namespace_id = 1; namespace_name = "ns"; query_type = "sql"; query_params = Params { }; issue_time = 1970-01-01T00:00:00.100+00:00; partitions = 0; parquet_files = 0; deduplicated_partitions = 0; deduplicated_parquet_files = 0; logical_plan_duration_secs = 0.001; physical_plan_duration_secs = 0.002; plan_duration_secs = 0.003; success = false; running = true; cancelled = false;
         level = INFO; message = query; when = "execution_permit"; id = 00000000-0000-0000-0000-000000000001; namespace_id = 1; namespace_name = "ns"; query_type = "sql"; query_params = Params { }; issue_time = 1970-01-01T00:00:00.100+00:00; partitions = 0; parquet_files = 0; deduplicated_partitions = 0; deduplicated_parquet_files = 0; logical_plan_duration_secs = 0.001; physical_plan_duration_secs = 0.002; plan_duration_secs = 0.003; permit_duration_secs = 0.01; success = false; running = true; cancelled = false;
-        level = INFO; message = query; when = "success"; id = 00000000-0000-0000-0000-000000000001; namespace_id = 1; namespace_name = "ns"; query_type = "sql"; query_params = Params { }; issue_time = 1970-01-01T00:00:00.100+00:00; partitions = 0; num_rows = 10; parquet_files = 0; deduplicated_partitions = 0; deduplicated_parquet_files = 0; logical_plan_duration_secs = 0.001; physical_plan_duration_secs = 0.002; plan_duration_secs = 0.003; permit_duration_secs = 0.01; execute_duration_secs = 0.1; end2end_duration_secs = 0.113; compute_duration_secs = 1.337; max_memory = 0; ingester_metrics.latency_to_plan_secs = 0.0; ingester_metrics.latency_to_full_data_secs = 0.0; ingester_metrics.response_rows = 0; ingester_metrics.partition_count = 0; ingester_metrics.response_size = 0; success = true; running = false; cancelled = false;
+        level = INFO; message = query; when = "success"; id = 00000000-0000-0000-0000-000000000001; namespace_id = 1; namespace_name = "ns"; query_type = "sql"; query_text = SELECT 1; query_params = Params { }; issue_time = 1970-01-01T00:00:00.100+00:00; partitions = 0; num_rows = 10; parquet_files = 0; deduplicated_partitions = 0; deduplicated_parquet_files = 0; logical_plan_duration_secs = 0.001; physical_plan_duration_secs = 0.002; plan_duration_secs = 0.003; permit_duration_secs = 0.01; execute_duration_secs = 0.1; end2end_duration_secs = 0.113; compute_duration_secs = 1.337; max_memory = 0; ingester_metrics.latency_to_plan_secs = 0.0; ingester_metrics.latency_to_full_data_secs = 0.0; ingester_metrics.response_rows = 0; ingester_metrics.partition_count = 0; ingester_metrics.response_size = 0; success = true; running = false; cancelled = false;
         "#);
     }
 
@@ -4467,7 +4482,7 @@ mod test_super {
         level = INFO; message = query; when = "logically_planned"; id = 00000000-0000-0000-0000-000000000001; namespace_id = 1; namespace_name = "ns"; query_type = "sql"; query_params = Params { "a" => TRUE, }; issue_time = 1970-01-01T00:00:00.100+00:00; logical_plan_duration_secs = 0.001; success = false; running = true; cancelled = false;
         level = INFO; message = query; when = "physically_planned"; id = 00000000-0000-0000-0000-000000000001; namespace_id = 1; namespace_name = "ns"; query_type = "sql"; query_params = Params { "a" => TRUE, }; issue_time = 1970-01-01T00:00:00.100+00:00; partitions = 0; parquet_files = 0; deduplicated_partitions = 0; deduplicated_parquet_files = 0; logical_plan_duration_secs = 0.001; physical_plan_duration_secs = 0.002; plan_duration_secs = 0.003; success = false; running = true; cancelled = false;
         level = INFO; message = query; when = "execution_permit"; id = 00000000-0000-0000-0000-000000000001; namespace_id = 1; namespace_name = "ns"; query_type = "sql"; query_params = Params { "a" => TRUE, }; issue_time = 1970-01-01T00:00:00.100+00:00; partitions = 0; parquet_files = 0; deduplicated_partitions = 0; deduplicated_parquet_files = 0; logical_plan_duration_secs = 0.001; physical_plan_duration_secs = 0.002; plan_duration_secs = 0.003; permit_duration_secs = 0.01; success = false; running = true; cancelled = false;
-        level = INFO; message = query; when = "success"; id = 00000000-0000-0000-0000-000000000001; namespace_id = 1; namespace_name = "ns"; query_type = "sql"; query_params = Params { "a" => TRUE, }; issue_time = 1970-01-01T00:00:00.100+00:00; partitions = 0; num_rows = 10; parquet_files = 0; deduplicated_partitions = 0; deduplicated_parquet_files = 0; logical_plan_duration_secs = 0.001; physical_plan_duration_secs = 0.002; plan_duration_secs = 0.003; permit_duration_secs = 0.01; execute_duration_secs = 0.1; end2end_duration_secs = 0.113; compute_duration_secs = 1.337; max_memory = 0; ingester_metrics.latency_to_plan_secs = 0.0; ingester_metrics.latency_to_full_data_secs = 0.0; ingester_metrics.response_rows = 0; ingester_metrics.partition_count = 0; ingester_metrics.response_size = 0; success = true; running = false; cancelled = false;
+        level = INFO; message = query; when = "success"; id = 00000000-0000-0000-0000-000000000001; namespace_id = 1; namespace_name = "ns"; query_type = "sql"; query_text = SELECT $a;; query_params = Params { "a" => TRUE, }; issue_time = 1970-01-01T00:00:00.100+00:00; partitions = 0; num_rows = 10; parquet_files = 0; deduplicated_partitions = 0; deduplicated_parquet_files = 0; logical_plan_duration_secs = 0.001; physical_plan_duration_secs = 0.002; plan_duration_secs = 0.003; permit_duration_secs = 0.01; execute_duration_secs = 0.1; end2end_duration_secs = 0.113; compute_duration_secs = 1.337; max_memory = 0; ingester_metrics.latency_to_plan_secs = 0.0; ingester_metrics.latency_to_full_data_secs = 0.0; ingester_metrics.response_rows = 0; ingester_metrics.partition_count = 0; ingester_metrics.response_size = 0; success = true; running = false; cancelled = false;
         "#);
     }
 
@@ -5768,7 +5783,7 @@ mod test_super {
         level = INFO; message = query; when = "logically_planned"; id = 00000000-0000-0000-0000-000000000001; namespace_id = 1; namespace_name = "ns"; query_type = "sql"; query_params = Params { }; auth_id = "auth-token"; issue_time = 1970-01-01T00:00:00.100+00:00; logical_plan_duration_secs = 0.001; success = false; running = true; cancelled = false;
         level = INFO; message = query; when = "physically_planned"; id = 00000000-0000-0000-0000-000000000001; namespace_id = 1; namespace_name = "ns"; query_type = "sql"; query_params = Params { }; auth_id = "auth-token"; issue_time = 1970-01-01T00:00:00.100+00:00; partitions = 0; parquet_files = 0; deduplicated_partitions = 0; deduplicated_parquet_files = 0; logical_plan_duration_secs = 0.001; physical_plan_duration_secs = 0.002; plan_duration_secs = 0.003; success = false; running = true; cancelled = false;
         level = INFO; message = query; when = "execution_permit"; id = 00000000-0000-0000-0000-000000000001; namespace_id = 1; namespace_name = "ns"; query_type = "sql"; query_params = Params { }; auth_id = "auth-token"; issue_time = 1970-01-01T00:00:00.100+00:00; partitions = 0; parquet_files = 0; deduplicated_partitions = 0; deduplicated_parquet_files = 0; logical_plan_duration_secs = 0.001; physical_plan_duration_secs = 0.002; plan_duration_secs = 0.003; permit_duration_secs = 0.01; success = false; running = true; cancelled = false;
-        level = INFO; message = query; when = "success"; id = 00000000-0000-0000-0000-000000000001; namespace_id = 1; namespace_name = "ns"; query_type = "sql"; query_params = Params { }; auth_id = "auth-token"; issue_time = 1970-01-01T00:00:00.100+00:00; partitions = 0; num_rows = 10; parquet_files = 0; deduplicated_partitions = 0; deduplicated_parquet_files = 0; logical_plan_duration_secs = 0.001; physical_plan_duration_secs = 0.002; plan_duration_secs = 0.003; permit_duration_secs = 0.01; execute_duration_secs = 0.1; end2end_duration_secs = 0.113; compute_duration_secs = 1.337; max_memory = 0; ingester_metrics.latency_to_plan_secs = 0.0; ingester_metrics.latency_to_full_data_secs = 0.0; ingester_metrics.response_rows = 0; ingester_metrics.partition_count = 0; ingester_metrics.response_size = 0; success = true; running = false; cancelled = false;
+        level = INFO; message = query; when = "success"; id = 00000000-0000-0000-0000-000000000001; namespace_id = 1; namespace_name = "ns"; query_type = "sql"; query_text = SELECT 1; query_params = Params { }; auth_id = "auth-token"; issue_time = 1970-01-01T00:00:00.100+00:00; partitions = 0; num_rows = 10; parquet_files = 0; deduplicated_partitions = 0; deduplicated_parquet_files = 0; logical_plan_duration_secs = 0.001; physical_plan_duration_secs = 0.002; plan_duration_secs = 0.003; permit_duration_secs = 0.01; execute_duration_secs = 0.1; end2end_duration_secs = 0.113; compute_duration_secs = 1.337; max_memory = 0; ingester_metrics.latency_to_plan_secs = 0.0; ingester_metrics.latency_to_full_data_secs = 0.0; ingester_metrics.response_rows = 0; ingester_metrics.partition_count = 0; ingester_metrics.response_size = 0; success = true; running = false; cancelled = false;
         "#);
     }
 
@@ -6105,7 +6120,7 @@ mod test_super {
             format_logs(capture),
             @r#"
         level = INFO; message = query; when = "received"; id = 00000000-0000-0000-0000-000000000001; namespace_id = 1; namespace_name = "ns"; query_type = "sql"; query_text = SELECT 1; query_params = Params { }; issue_time = 1970-01-01T00:00:00.100+00:00; success = false; running = true; cancelled = false;
-        level = INFO; message = query; when = "fail"; id = 00000000-0000-0000-0000-000000000001; namespace_id = 1; namespace_name = "ns"; query_type = "sql"; query_params = Params { }; issue_time = 1970-01-01T00:00:00.100+00:00; logical_plan_duration_secs = 0.001; end2end_duration_secs = 0.001; success = false; running = false; cancelled = false;
+        level = INFO; message = query; when = "fail"; id = 00000000-0000-0000-0000-000000000001; namespace_id = 1; namespace_name = "ns"; query_type = "sql"; query_text = SELECT 1; query_params = Params { }; issue_time = 1970-01-01T00:00:00.100+00:00; logical_plan_duration_secs = 0.001; end2end_duration_secs = 0.001; success = false; running = false; cancelled = false;
         "#);
     }
 
@@ -6464,7 +6479,7 @@ mod test_super {
         level = INFO; message = query; when = "logically_planned"; id = 00000000-0000-0000-0000-000000000001; namespace_id = 1; namespace_name = "ns"; query_type = "sql"; query_params = Params { }; issue_time = 1970-01-01T00:00:00.100+00:00; logical_plan_duration_secs = 0.001; success = false; running = true; cancelled = false;
         level = INFO; message = query; when = "physically_planned"; id = 00000000-0000-0000-0000-000000000001; namespace_id = 1; namespace_name = "ns"; query_type = "sql"; query_params = Params { }; issue_time = 1970-01-01T00:00:00.100+00:00; partitions = 0; parquet_files = 0; deduplicated_partitions = 0; deduplicated_parquet_files = 0; logical_plan_duration_secs = 0.001; physical_plan_duration_secs = 0.002; plan_duration_secs = 0.003; success = false; running = true; cancelled = false;
         level = INFO; message = query; when = "execution_permit"; id = 00000000-0000-0000-0000-000000000001; namespace_id = 1; namespace_name = "ns"; query_type = "sql"; query_params = Params { }; issue_time = 1970-01-01T00:00:00.100+00:00; partitions = 0; parquet_files = 0; deduplicated_partitions = 0; deduplicated_parquet_files = 0; logical_plan_duration_secs = 0.001; physical_plan_duration_secs = 0.002; plan_duration_secs = 0.003; permit_duration_secs = 0.01; success = false; running = true; cancelled = false;
-        level = INFO; message = query; when = "fail"; id = 00000000-0000-0000-0000-000000000001; namespace_id = 1; namespace_name = "ns"; query_type = "sql"; query_params = Params { }; issue_time = 1970-01-01T00:00:00.100+00:00; partitions = 0; num_rows = 10; parquet_files = 0; deduplicated_partitions = 0; deduplicated_parquet_files = 0; logical_plan_duration_secs = 0.001; physical_plan_duration_secs = 0.002; plan_duration_secs = 0.003; permit_duration_secs = 0.01; execute_duration_secs = 0.1; end2end_duration_secs = 0.113; compute_duration_secs = 1.337; max_memory = 0; ingester_metrics.latency_to_plan_secs = 0.0; ingester_metrics.latency_to_full_data_secs = 0.0; ingester_metrics.response_rows = 0; ingester_metrics.partition_count = 0; ingester_metrics.response_size = 0; success = false; running = false; cancelled = false;
+        level = INFO; message = query; when = "fail"; id = 00000000-0000-0000-0000-000000000001; namespace_id = 1; namespace_name = "ns"; query_type = "sql"; query_text = SELECT 1; query_params = Params { }; issue_time = 1970-01-01T00:00:00.100+00:00; partitions = 0; num_rows = 10; parquet_files = 0; deduplicated_partitions = 0; deduplicated_parquet_files = 0; logical_plan_duration_secs = 0.001; physical_plan_duration_secs = 0.002; plan_duration_secs = 0.003; permit_duration_secs = 0.01; execute_duration_secs = 0.1; end2end_duration_secs = 0.113; compute_duration_secs = 1.337; max_memory = 0; ingester_metrics.latency_to_plan_secs = 0.0; ingester_metrics.latency_to_full_data_secs = 0.0; ingester_metrics.response_rows = 0; ingester_metrics.partition_count = 0; ingester_metrics.response_size = 0; success = false; running = false; cancelled = false;
         "#);
     }
 
@@ -6800,7 +6815,7 @@ mod test_super {
             format_logs(capture),
             @r#"
         level = INFO; message = query; when = "received"; id = 00000000-0000-0000-0000-000000000001; namespace_id = 1; namespace_name = "ns"; query_type = "sql"; query_text = SELECT 1; query_params = Params { }; issue_time = 1970-01-01T00:00:00.100+00:00; success = false; running = true; cancelled = false;
-        level = INFO; message = query; when = "cancel"; id = 00000000-0000-0000-0000-000000000001; namespace_id = 1; namespace_name = "ns"; query_type = "sql"; query_params = Params { }; issue_time = 1970-01-01T00:00:00.100+00:00; end2end_duration_secs = 0.001; success = false; running = false; cancelled = true;
+        level = INFO; message = query; when = "cancel"; id = 00000000-0000-0000-0000-000000000001; namespace_id = 1; namespace_name = "ns"; query_type = "sql"; query_text = SELECT 1; query_params = Params { }; issue_time = 1970-01-01T00:00:00.100+00:00; end2end_duration_secs = 0.001; success = false; running = false; cancelled = true;
         "#);
     }
 
@@ -7150,7 +7165,7 @@ mod test_super {
         level = INFO; message = query; when = "received"; id = 00000000-0000-0000-0000-000000000001; namespace_id = 1; namespace_name = "ns"; query_type = "sql"; query_text = SELECT 1; query_params = Params { }; issue_time = 1970-01-01T00:00:00.100+00:00; success = false; running = true; cancelled = false;
         level = INFO; message = query; when = "logically_planned"; id = 00000000-0000-0000-0000-000000000001; namespace_id = 1; namespace_name = "ns"; query_type = "sql"; query_params = Params { }; issue_time = 1970-01-01T00:00:00.100+00:00; logical_plan_duration_secs = 0.001; success = false; running = true; cancelled = false;
         level = INFO; message = query; when = "physically_planned"; id = 00000000-0000-0000-0000-000000000001; namespace_id = 1; namespace_name = "ns"; query_type = "sql"; query_params = Params { }; issue_time = 1970-01-01T00:00:00.100+00:00; partitions = 0; parquet_files = 0; deduplicated_partitions = 0; deduplicated_parquet_files = 0; logical_plan_duration_secs = 0.001; physical_plan_duration_secs = 0.002; plan_duration_secs = 0.003; success = false; running = true; cancelled = false;
-        level = INFO; message = query; when = "cancel"; id = 00000000-0000-0000-0000-000000000001; namespace_id = 1; namespace_name = "ns"; query_type = "sql"; query_params = Params { }; issue_time = 1970-01-01T00:00:00.100+00:00; partitions = 0; parquet_files = 0; deduplicated_partitions = 0; deduplicated_parquet_files = 0; logical_plan_duration_secs = 0.001; physical_plan_duration_secs = 0.002; plan_duration_secs = 0.003; end2end_duration_secs = 0.013; success = false; running = false; cancelled = true;
+        level = INFO; message = query; when = "cancel"; id = 00000000-0000-0000-0000-000000000001; namespace_id = 1; namespace_name = "ns"; query_type = "sql"; query_text = SELECT 1; query_params = Params { }; issue_time = 1970-01-01T00:00:00.100+00:00; partitions = 0; parquet_files = 0; deduplicated_partitions = 0; deduplicated_parquet_files = 0; logical_plan_duration_secs = 0.001; physical_plan_duration_secs = 0.002; plan_duration_secs = 0.003; end2end_duration_secs = 0.013; success = false; running = false; cancelled = true;
         "#);
     }
 
@@ -7509,7 +7524,7 @@ mod test_super {
         level = INFO; message = query; when = "logically_planned"; id = 00000000-0000-0000-0000-000000000001; namespace_id = 1; namespace_name = "ns"; query_type = "sql"; query_params = Params { }; issue_time = 1970-01-01T00:00:00.100+00:00; logical_plan_duration_secs = 0.001; success = false; running = true; cancelled = false;
         level = INFO; message = query; when = "physically_planned"; id = 00000000-0000-0000-0000-000000000001; namespace_id = 1; namespace_name = "ns"; query_type = "sql"; query_params = Params { }; issue_time = 1970-01-01T00:00:00.100+00:00; partitions = 0; parquet_files = 0; deduplicated_partitions = 0; deduplicated_parquet_files = 0; logical_plan_duration_secs = 0.001; physical_plan_duration_secs = 0.002; plan_duration_secs = 0.003; success = false; running = true; cancelled = false;
         level = INFO; message = query; when = "execution_permit"; id = 00000000-0000-0000-0000-000000000001; namespace_id = 1; namespace_name = "ns"; query_type = "sql"; query_params = Params { }; issue_time = 1970-01-01T00:00:00.100+00:00; partitions = 0; parquet_files = 0; deduplicated_partitions = 0; deduplicated_parquet_files = 0; logical_plan_duration_secs = 0.001; physical_plan_duration_secs = 0.002; plan_duration_secs = 0.003; permit_duration_secs = 0.01; success = false; running = true; cancelled = false;
-        level = INFO; message = query; when = "cancel"; id = 00000000-0000-0000-0000-000000000001; namespace_id = 1; namespace_name = "ns"; query_type = "sql"; query_params = Params { }; issue_time = 1970-01-01T00:00:00.100+00:00; partitions = 0; num_rows = 10; parquet_files = 0; deduplicated_partitions = 0; deduplicated_parquet_files = 0; logical_plan_duration_secs = 0.001; physical_plan_duration_secs = 0.002; plan_duration_secs = 0.003; permit_duration_secs = 0.01; end2end_duration_secs = 0.113; compute_duration_secs = 1.337; max_memory = 0; ingester_metrics.latency_to_plan_secs = 0.0; ingester_metrics.latency_to_full_data_secs = 0.0; ingester_metrics.response_rows = 0; ingester_metrics.partition_count = 0; ingester_metrics.response_size = 0; success = false; running = false; cancelled = true;
+        level = INFO; message = query; when = "cancel"; id = 00000000-0000-0000-0000-000000000001; namespace_id = 1; namespace_name = "ns"; query_type = "sql"; query_text = SELECT 1; query_params = Params { }; issue_time = 1970-01-01T00:00:00.100+00:00; partitions = 0; num_rows = 10; parquet_files = 0; deduplicated_partitions = 0; deduplicated_parquet_files = 0; logical_plan_duration_secs = 0.001; physical_plan_duration_secs = 0.002; plan_duration_secs = 0.003; permit_duration_secs = 0.01; end2end_duration_secs = 0.113; compute_duration_secs = 1.337; max_memory = 0; ingester_metrics.latency_to_plan_secs = 0.0; ingester_metrics.latency_to_full_data_secs = 0.0; ingester_metrics.response_rows = 0; ingester_metrics.partition_count = 0; ingester_metrics.response_size = 0; success = false; running = false; cancelled = true;
         "#);
     }
 

--- a/deny.toml
+++ b/deny.toml
@@ -74,6 +74,18 @@ ignore = [
     "RUSTSEC-2026-0149",
     #
     # TODO: update wasmtime via datafusion-udf-wasm to a patched version (>=43.0.2 <44.0.0 or >=44.0.1)
+    #
+    # pyo3 0.24-0.28 out-of-bounds read in Iterator::nth/nth_back on
+    # PyList/PyTuple iterators; fix is only in pyo3 0.29 (API-breaking bump,
+    # tracked in influxdb_pro#4072). Not reachable here: no nth/nth_back calls
+    # in our pyo3-consuming crates, and the overflow needs a Rust-side n near
+    # usize::MAX, which our embedding never produces.
+    "RUSTSEC-2026-0176",
+    #
+    # pyo3 0.15-0.29 unsoundness bug. Possible data race in functions supplied
+    # to PyCFunction::new_closure, or PyCFunction::new_closure_bound.
+    # Neither of these methods are used in this code.
+    "RUSTSEC-2026-0177",
 ]
 git-fetch-with-cli = true
 

--- a/influxdb3/src/commands/create.rs
+++ b/influxdb3/src/commands/create.rs
@@ -150,7 +150,7 @@ pub struct DatabaseConfig {
     /// The retention period for the database as a human-readable duration, e.g., "30d", "24h"
     pub retention_period: Option<Duration>,
 
-    /// An optional arg to use a custom ca for useful for testing with self signed certs
+    /// An optional arg to use a custom CA, useful for testing with self-signed certs
     #[clap(long = "tls-ca", env = "INFLUXDB3_TLS_CA")]
     ca_cert: Option<PathBuf>,
 
@@ -197,7 +197,7 @@ pub struct LastCacheConfig {
     #[clap(required = false)]
     cache_name: Option<String>,
 
-    /// An optional arg to use a custom ca for useful for testing with self signed certs
+    /// An optional arg to use a custom CA, useful for testing with self-signed certs
     #[clap(long = "tls-ca", env = "INFLUXDB3_TLS_CA")]
     ca_cert: Option<PathBuf>,
 
@@ -238,7 +238,7 @@ pub struct DistinctCacheConfig {
     #[clap(required = false)]
     cache_name: Option<String>,
 
-    /// An optional arg to use a custom ca for useful for testing with self signed certs
+    /// An optional arg to use a custom CA, useful for testing with self-signed certs
     #[clap(long = "tls-ca", env = "INFLUXDB3_TLS_CA")]
     ca_cert: Option<PathBuf>,
 
@@ -265,7 +265,7 @@ pub struct TableConfig {
     /// The name of the table to be created
     table_name: String,
 
-    /// An optional arg to use a custom ca for useful for testing with self signed certs
+    /// An optional arg to use a custom CA, useful for testing with self-signed certs
     #[clap(long = "tls-ca", env = "INFLUXDB3_TLS_CA")]
     ca_cert: Option<PathBuf>,
 
@@ -310,7 +310,7 @@ pub struct TriggerConfig {
     /// Name for the new trigger
     trigger_name: String,
 
-    /// An optional arg to use a custom ca for useful for testing with self signed certs
+    /// An optional arg to use a custom CA, useful for testing with self-signed certs
     #[clap(long = "tls-ca", env = "INFLUXDB3_TLS_CA")]
     ca_cert: Option<PathBuf>,
 

--- a/influxdb3/src/commands/create/token.rs
+++ b/influxdb3/src/commands/create/token.rs
@@ -198,8 +198,8 @@ pub struct InfluxDb3ServerConfig {
     )]
     pub auth_token: Option<Secret<String>>,
 
-    /// An optional arg to use a custom ca for useful for testing with self signed certs
-    #[clap(name = "tls-ca", long = "tls-ca")]
+    /// An optional arg to use a custom CA, useful for testing with self-signed certs
+    #[clap(name = "tls-ca", long = "tls-ca", env = "INFLUXDB3_TLS_CA")]
     pub ca_cert: Option<PathBuf>,
 
     /// Disable TLS certificate verification

--- a/influxdb3/src/commands/delete.rs
+++ b/influxdb3/src/commands/delete.rs
@@ -126,7 +126,7 @@ pub struct DatabaseConfig {
     #[clap(long = "hard-delete", value_name = "WHEN")]
     pub hard_delete: Option<String>,
 
-    /// An optional arg to use a custom ca for useful for testing with self signed certs
+    /// An optional arg to use a custom CA, useful for testing with self-signed certs
     #[clap(long = "tls-ca", env = "INFLUXDB3_TLS_CA")]
     ca_cert: Option<PathBuf>,
 
@@ -152,7 +152,7 @@ pub struct LastCacheConfig {
     #[clap(required = true)]
     cache_name: String,
 
-    /// An optional arg to use a custom ca for useful for testing with self signed certs
+    /// An optional arg to use a custom CA, useful for testing with self-signed certs
     #[clap(long = "tls-ca", env = "INFLUXDB3_TLS_CA")]
     ca_cert: Option<PathBuf>,
 
@@ -174,7 +174,7 @@ pub struct DistinctCacheConfig {
     #[clap(required = true)]
     cache_name: String,
 
-    /// An optional arg to use a custom ca for useful for testing with self signed certs
+    /// An optional arg to use a custom CA, useful for testing with self-signed certs
     #[clap(long = "tls-ca", env = "INFLUXDB3_TLS_CA")]
     ca_cert: Option<PathBuf>,
 
@@ -196,7 +196,7 @@ pub struct TableConfig {
     #[clap(long = "hard-delete", value_name = "WHEN")]
     hard_delete: Option<String>,
 
-    /// An optional arg to use a custom ca for useful for testing with self signed certs
+    /// An optional arg to use a custom CA, useful for testing with self-signed certs
     #[clap(long = "tls-ca", env = "INFLUXDB3_TLS_CA")]
     ca_cert: Option<PathBuf>,
 
@@ -222,7 +222,7 @@ pub struct TriggerConfig {
     #[clap(required = true)]
     trigger_name: String,
 
-    /// An optional arg to use a custom ca for useful for testing with self signed certs
+    /// An optional arg to use a custom CA, useful for testing with self-signed certs
     #[clap(long = "tls-ca", env = "INFLUXDB3_TLS_CA")]
     ca_cert: Option<PathBuf>,
 
@@ -250,7 +250,7 @@ pub struct TokenConfig {
     #[clap(long = "token-name")]
     pub token_name: String,
 
-    /// An optional arg to use a custom ca for useful for testing with self signed certs
+    /// An optional arg to use a custom CA, useful for testing with self-signed certs
     #[clap(long = "tls-ca", env = "INFLUXDB3_TLS_CA")]
     ca_cert: Option<PathBuf>,
 

--- a/influxdb3/src/commands/plugin_test/wal.rs
+++ b/influxdb3/src/commands/plugin_test/wal.rs
@@ -13,7 +13,7 @@ pub struct Config {
     #[clap(flatten)]
     wal_plugin_test: WalPluginTest,
 
-    /// An optional arg to use a custom ca for useful for testing with self signed certs
+    /// An optional arg to use a custom CA, useful for testing with self-signed certs
     #[clap(long = "tls-ca", env = "INFLUXDB3_TLS_CA")]
     ca_cert: Option<PathBuf>,
 

--- a/influxdb3/src/commands/show.rs
+++ b/influxdb3/src/commands/show.rs
@@ -51,7 +51,7 @@ pub struct ShowTokensConfig {
     #[clap(value_enum, long = "format", default_value = "pretty")]
     output_format: Format,
 
-    /// An optional arg to use a custom ca for useful for testing with self signed certs
+    /// An optional arg to use a custom CA, useful for testing with self-signed certs
     #[clap(long = "tls-ca", env = "INFLUXDB3_TLS_CA")]
     ca_cert: Option<PathBuf>,
 
@@ -79,7 +79,7 @@ pub struct PluginsConfig {
     #[clap(value_enum, long = "format", default_value = "pretty")]
     output_format: Format,
 
-    /// An optional arg to use a custom ca for useful for testing with self signed certs
+    /// An optional arg to use a custom CA, useful for testing with self-signed certs
     #[clap(long = "tls-ca", env = "INFLUXDB3_TLS_CA")]
     ca_cert: Option<PathBuf>,
 
@@ -111,7 +111,7 @@ pub struct RetentionConfig {
     #[clap(value_enum, long = "format", default_value = "pretty")]
     output_format: Format,
 
-    /// An optional arg to use a custom ca for useful for testing with self signed certs
+    /// An optional arg to use a custom CA, useful for testing with self-signed certs
     #[clap(long = "tls-ca", env = "INFLUXDB3_TLS_CA")]
     ca_cert: Option<PathBuf>,
 
@@ -143,7 +143,7 @@ pub struct DatabaseConfig {
     #[clap(value_enum, long = "format", default_value = "pretty")]
     output_format: Format,
 
-    /// An optional arg to use a custom ca for useful for testing with self signed certs
+    /// An optional arg to use a custom CA, useful for testing with self-signed certs
     #[clap(long = "tls-ca", env = "INFLUXDB3_TLS_CA")]
     ca_cert: Option<PathBuf>,
 

--- a/influxdb3/src/commands/show/system.rs
+++ b/influxdb3/src/commands/show/system.rs
@@ -97,7 +97,7 @@ pub(super) struct TableListConfig {
     #[clap(value_enum, long = "format", default_value = "pretty")]
     output_format: Format,
 
-    /// An optional arg to use a custom ca for useful for testing with self signed certs
+    /// An optional arg to use a custom CA, useful for testing with self-signed certs
     #[clap(long = "tls-ca", env = "INFLUXDB3_TLS_CA")]
     ca_cert: Option<PathBuf>,
 
@@ -162,7 +162,7 @@ pub(super) struct TableConfig {
     #[clap(value_enum, long = "format", default_value = "pretty")]
     output_format: Format,
 
-    /// An optional arg to use a custom ca for useful for testing with self signed certs
+    /// An optional arg to use a custom CA, useful for testing with self-signed certs
     #[clap(long = "tls-ca", env = "INFLUXDB3_TLS_CA")]
     ca_cert: Option<PathBuf>,
 
@@ -258,7 +258,7 @@ pub(super) struct SummaryConfig {
     #[clap(value_enum, long = "format", default_value = "pretty")]
     output_format: Format,
 
-    /// An optional arg to use a custom ca for useful for testing with self signed certs
+    /// An optional arg to use a custom CA, useful for testing with self-signed certs
     #[clap(long = "tls-ca", env = "INFLUXDB3_TLS_CA")]
     ca_cert: Option<PathBuf>,
 

--- a/influxdb3/src/commands/update.rs
+++ b/influxdb3/src/commands/update.rs
@@ -30,7 +30,7 @@ pub struct UpdateDatabase {
     #[clap(long, short = 'r')]
     retention_period: Option<String>,
 
-    /// An optional arg to use a custom ca for useful for testing with self signed certs
+    /// An optional arg to use a custom CA, useful for testing with self-signed certs
     #[clap(long = "tls-ca", env = "INFLUXDB3_TLS_CA")]
     ca_cert: Option<PathBuf>,
 
@@ -52,7 +52,7 @@ pub struct UpdateTrigger {
     #[clap(long, short = 'p')]
     path: PathBuf,
 
-    /// An optional arg to use a custom ca for useful for testing with self signed certs
+    /// An optional arg to use a custom CA, useful for testing with self-signed certs
     #[clap(long = "tls-ca", env = "INFLUXDB3_TLS_CA")]
     ca_cert: Option<PathBuf>,
 

--- a/influxdb3/src/lib.rs
+++ b/influxdb3/src/lib.rs
@@ -800,16 +800,36 @@ fn init_logs_and_tracing(
 
     let layers = log_layer;
 
-    // Optionally enable the tokio console exporter layer, if enabled.
-    //
-    // This spawns a background tokio task to serve the instrumentation data,
-    // and hooks the instrumentation into the tracing pipeline.
+    // Attach the tokio-console exporter layer only when requested via
+    // `--tokio-console-enabled` / `TOKIO_CONSOLE_ENABLED`. It spawns a
+    // background task serving instrumentation data and retains per-task span
+    // stats whose memory scales with task-spawn rate × retention, so it must
+    // be opt-in, and the upstream 1 h retention default is lowered to 60 s
+    // (`TOKIO_CONSOLE_RETENTION` still overrides). See influxdb_pro#4040.
     #[cfg(feature = "tokio_console")]
     let layers = {
         use console_subscriber::ConsoleLayer;
-        let console_layer = ConsoleLayer::builder().with_default_env().spawn();
+        let console_layer = if config.tokio_console.enabled {
+            let mut builder = ConsoleLayer::builder()
+                .retention(std::time::Duration::from_secs(60))
+                .with_default_env();
+            if let Some(capacity) = config.tokio_console.event_buffer_capacity {
+                builder = builder.event_buffer_capacity(capacity);
+            }
+            if let Some(capacity) = config.tokio_console.client_buffer_capacity {
+                builder = builder.client_buffer_capacity(capacity);
+            }
+            Some(builder.spawn())
+        } else {
+            None
+        };
         layers.and_then(console_layer)
     };
+
+    #[cfg(not(feature = "tokio_console"))]
+    if config.tokio_console.enabled {
+        return Err(trogging::Error::TokioConsoleMissing);
+    }
 
     let subscriber = Registry::default().with(layers);
     let guard = trogging::install_global(subscriber)?;

--- a/influxdb3_commands/src/disable.rs
+++ b/influxdb3_commands/src/disable.rs
@@ -45,7 +45,7 @@ struct TriggerConfig {
     #[clap(required = true)]
     trigger_name: String,
 
-    /// An optional arg to use a custom ca for useful for testing with self signed certs
+    /// An optional arg to use a custom CA, useful for testing with self-signed certs
     #[clap(long = "tls-ca", env = "INFLUXDB3_TLS_CA")]
     pub ca_cert: Option<PathBuf>,
 

--- a/influxdb3_commands/src/enable.rs
+++ b/influxdb3_commands/src/enable.rs
@@ -45,7 +45,7 @@ struct TriggerConfig {
     #[clap(required = true)]
     trigger_name: String,
 
-    /// An optional arg to use a custom ca for useful for testing with self signed certs
+    /// An optional arg to use a custom CA, useful for testing with self-signed certs
     #[clap(long = "tls-ca", env = "INFLUXDB3_TLS_CA")]
     pub ca_cert: Option<PathBuf>,
 

--- a/influxdb3_commands/src/install.rs
+++ b/influxdb3_commands/src/install.rs
@@ -52,7 +52,7 @@ pub struct PackageConfig {
     #[arg(required_unless_present = "requirements")]
     packages: Vec<String>,
 
-    /// An optional arg to use a custom ca for useful for testing with self signed certs
+    /// An optional arg to use a custom CA, useful for testing with self-signed certs
     #[clap(long = "tls-ca", env = "INFLUXDB3_TLS_CA")]
     ca_cert: Option<PathBuf>,
 

--- a/influxdb3_commands/src/query.rs
+++ b/influxdb3_commands/src/query.rs
@@ -74,7 +74,7 @@ pub struct Config {
     /// The query string to execute
     query: Option<String>,
 
-    /// An optional arg to use a custom ca for useful for testing with self signed certs
+    /// An optional arg to use a custom CA, useful for testing with self-signed certs
     #[clap(long = "tls-ca", env = "INFLUXDB3_TLS_CA")]
     ca_cert: Option<PathBuf>,
 

--- a/influxdb3_commands/src/test.rs
+++ b/influxdb3_commands/src/test.rs
@@ -73,7 +73,7 @@ pub struct WalPluginConfig {
     pub filename: String,
     #[clap(long = "cache-name")]
     pub cache_name: Option<String>,
-    /// An optional arg to use a custom ca for useful for testing with self signed certs
+    /// An optional arg to use a custom CA, useful for testing with self-signed certs
     #[clap(long = "tls-ca", env = "INFLUXDB3_TLS_CA")]
     pub ca_cert: Option<PathBuf>,
 
@@ -98,7 +98,7 @@ pub struct SchedulePluginConfig {
     pub schedule: Option<String>,
     #[clap(long = "cache-name")]
     pub cache_name: Option<String>,
-    /// An optional arg to use a custom ca for useful for testing with self signed certs
+    /// An optional arg to use a custom CA, useful for testing with self-signed certs
     #[clap(long = "tls-ca", env = "INFLUXDB3_TLS_CA")]
     pub ca_cert: Option<PathBuf>,
 

--- a/influxdb3_commands/src/write.rs
+++ b/influxdb3_commands/src/write.rs
@@ -82,7 +82,7 @@ pub struct Config {
     #[clap(short = 'p', long = "precision")]
     precision: Option<Precision>,
 
-    /// An optional arg to use a custom ca for useful for testing with self signed certs
+    /// An optional arg to use a custom CA, useful for testing with self-signed certs
     #[clap(long = "tls-ca", env = "INFLUXDB3_TLS_CA")]
     ca_cert: Option<PathBuf>,
 


### PR DESCRIPTION
## Summary

Sync `oss/` from influxdata/influxdb_pro to the `3.10` release branch ahead of cutting `v3.10.0-0.rc.2`. Brings over the oss-touching commits landed on the monolith `3.10` branch since the 2026-06-10 sync:

- `influxdata/influxdb_pro#4130` — remove dead `serve --tls-ca`; make cancel row-delete TLS-capable; add missing `INFLUXDB3_TLS_CA` env bindings
- `influxdata/influxdb_pro#4107` — honor `--tokio-console-enabled` and bound console retention (backport of #4053)
- `influxdata/influxdb_pro#4071` — emit `query_text` on terminal query-log phases (backport of #4016)
- `influxdata/influxdb_pro#4089` — `deny.toml`: ignore RUSTSEC-2026-0177
- `influxdata/influxdb_pro#4074` — `deny.toml`: ignore RUSTSEC-2026-0176 (pyo3 nth/nth_back OOB read)
- `influxdata/influxdb_pro#4042` — version bump to 3.10.0-0.rc.1

Generated by `just oss-sync`. `cargo check --workspace`, `cargo fmt --all --check`, and `cargo check --locked` all pass.