### PR TITLE
chore(sync): influxdb_pro 2026-06-15 (Python 3.13.14 + wasmtime RUSTSEC ignore)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,10 +146,10 @@ parameters:
   # Consistent environment setup for Python Build Standalone
   PBS_DATE:
     type: string
-    default: "20260602"
+    default: "20260610"
   PBS_VERSION:
     type: string
-    default: "3.13.13"
+    default: "3.13.14"
 
 # Consistent Cargo environment configuration
 cargo_env: &cargo_env

--- a/deny.toml
+++ b/deny.toml
@@ -73,6 +73,9 @@ ignore = [
     # upstream datafusion-udf-wasm bump.
     "RUSTSEC-2026-0149",
     #
+    # Another wasmtime advisory:
+    "RUSTSEC-2026-0182",
+    #
     # TODO: update wasmtime via datafusion-udf-wasm to a patched version (>=43.0.2 <44.0.0 or >=44.0.1)
     #
     # pyo3 0.24-0.28 out-of-bounds read in Iterator::nth/nth_back on


### PR DESCRIPTION
## Summary

`oss/` sync to the `3.10` release branch, on top of the prior sync (#27499, merged). Brings over the two oss-touching changes since:

- `influxdata/influxdb_pro#4137` (3.10 backport of influxdata/influxdb_pro#4134) — bump Python Build Standalone to `3.13.14-20260610` for the upstream 3.13.14 security fixes (`.circleci/config.yml`).
- `influxdata/influxdb_pro#4140` — ignore RUSTSEC-2026-0182 (wasmtime advisory) in `deny.toml`.