### PR TITLE
fix: clean up prober on DB migration

### DIFF
--- a/bolt/kv.go
+++ b/bolt/kv.go
@@ -458,6 +458,7 @@ func (s *KVStore) migrateRestored(ctx context.Context) error {
 
 	restoredKV := NewKVStore(s.log.With(zap.String("service", "restored kvstore-bolt")), s.tempPath())
 	restoredKV.WithDB(restoredClient.DB())
+	defer restoredKV.StopProber()
 
 	migrator, err := migration.NewMigrator(
 		s.log.With(zap.String("service", "bolt restore migrations")),


### PR DESCRIPTION
Avoid leaking a prober routine on database migration.