### PR TITLE
chore: sync influxdb_pro and bump version to 3.9.4

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -146,10 +146,10 @@ parameters:
   # Consistent environment setup for Python Build Standalone
   PBS_DATE:
     type: string
-    default: "20260211"
+    default: "20260610"
   PBS_VERSION:
     type: string
-    default: "3.13.12"
+    default: "3.13.14"
 
 # Consistent Cargo environment configuration
 cargo_env: &cargo_env
@@ -271,7 +271,13 @@ jobs:
           command: cargo install cargo-deny --locked
       - run:
           name: cargo-deny Checks
-          command: cargo deny check -s
+          # `--warn unsound` downgrades RustSec `informational = "unsound"`
+          # advisories to warnings. They flag API soundness concerns, not
+          # exploitable vulnerabilities, so we don't fail CI on them. The
+          # advisory-db maintainers themselves recommend ignoring
+          # informational=unsound reports for security checks:
+          # https://github.com/rustsec/advisory-db/issues/2572#issuecomment-3740573839
+          command: cargo deny check -s --warn unsound
 
   doc:
     docker:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,7 +444,7 @@ dependencies = [
 
 [[package]]
 name = "arrow_util"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -541,7 +541,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "authz"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -655,7 +655,7 @@ dependencies = [
 
 [[package]]
 name = "backoff"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "rand 0.9.2",
  "snafu 0.9.0",
@@ -1069,7 +1069,7 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "catalog_cache"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "bytes",
  "criterion 0.8.2",
@@ -1207,7 +1207,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "client_util"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "http 1.4.0",
  "iox_http_util",
@@ -1785,7 +1785,7 @@ dependencies = [
 
 [[package]]
 name = "data_types"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -2518,7 +2518,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion_util"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -2602,7 +2602,7 @@ dependencies = [
 
 [[package]]
 name = "dml"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "arrow_util",
  "data_types",
@@ -2714,7 +2714,7 @@ dependencies = [
 
 [[package]]
 name = "error_reporting"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "datafusion",
  "snafu 0.9.0",
@@ -2744,7 +2744,7 @@ dependencies = [
 
 [[package]]
 name = "executor"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "futures",
  "metric",
@@ -2825,7 +2825,7 @@ dependencies = [
 
 [[package]]
 name = "flightsql"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -3032,7 +3032,7 @@ dependencies = [
 
 [[package]]
 name = "futures_test_utils"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "clap",
  "futures",
@@ -3043,7 +3043,7 @@ dependencies = [
 
 [[package]]
 name = "generated_types"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "bytes",
  "pbjson",
@@ -3692,7 +3692,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb2_client"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "bytes",
  "futures",
@@ -3711,7 +3711,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3801,7 +3801,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_authz"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "async-trait",
  "authz",
@@ -3818,7 +3818,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_cache"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3853,7 +3853,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_catalog"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3905,7 +3905,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_clap_blocks"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3942,7 +3942,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_client"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "bytes",
  "hashbrown 0.14.5",
@@ -3962,7 +3962,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_commands"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -3981,7 +3981,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_id"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "indexmap 2.13.0",
  "serde",
@@ -3991,7 +3991,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_internal_api"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4012,7 +4012,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_load_generator"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4041,7 +4041,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_process"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "iox_time",
  "uuid",
@@ -4049,7 +4049,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_processing_engine"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4093,7 +4093,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_py_api"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -4121,7 +4121,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_query_executor"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4171,7 +4171,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_server"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4254,7 +4254,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_shutdown"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "futures",
  "futures-util",
@@ -4269,14 +4269,14 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_startup"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "chrono",
 ]
 
 [[package]]
 name = "influxdb3_sys_events"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4295,7 +4295,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_system_tables"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4327,7 +4327,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_telemetry"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "futures",
  "futures-util",
@@ -4348,7 +4348,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_test_helpers"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4361,7 +4361,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_types"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4381,7 +4381,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_wal"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "async-trait",
  "bitcode",
@@ -4409,7 +4409,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_write"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4478,7 +4478,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb_influxql_parser"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "assert_matches",
  "chrono",
@@ -4495,7 +4495,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb_iox_client"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -4524,7 +4524,7 @@ dependencies = [
 
 [[package]]
 name = "ingester_query_grpc"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "base64 0.22.1",
  "data_types",
@@ -4581,7 +4581,7 @@ checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
 
 [[package]]
 name = "iox_http"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -4601,7 +4601,7 @@ dependencies = [
 
 [[package]]
 name = "iox_http_util"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "futures",
  "http 1.4.0",
@@ -4612,7 +4612,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "arrow",
  "arrow_util",
@@ -4661,7 +4661,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query_influxql"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "arrow",
  "assert_matches",
@@ -4688,7 +4688,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query_influxql_rewrite"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "influxdb_influxql_parser",
  "thiserror 2.0.18",
@@ -4696,7 +4696,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query_params"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "arrow",
  "assert_matches",
@@ -4710,7 +4710,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query_udf"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "datafusion-udf-wasm-host",
  "datafusion-udf-wasm-query",
@@ -4721,7 +4721,7 @@ dependencies = [
 
 [[package]]
 name = "iox_system_tables"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4731,7 +4731,7 @@ dependencies = [
 
 [[package]]
 name = "iox_time"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "chrono",
  "parking_lot",
@@ -4740,7 +4740,7 @@ dependencies = [
 
 [[package]]
 name = "iox_v1_query_api"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4854,7 +4854,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jemalloc_stats"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "snafu 0.9.0",
  "tikv-jemalloc-ctl",
@@ -4999,7 +4999,7 @@ dependencies = [
 
 [[package]]
 name = "linear_buffer"
-version = "3.9.3"
+version = "3.9.4"
 
 [[package]]
 name = "linux-raw-sys"
@@ -5043,7 +5043,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "logfmt"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "humantime",
  "parking_lot",
@@ -5151,14 +5151,14 @@ dependencies = [
 
 [[package]]
 name = "metric"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "parking_lot",
 ]
 
 [[package]]
 name = "metric_exporters"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "metric",
  "mockito",
@@ -5283,7 +5283,7 @@ checksum = "9252111cf132ba0929b6f8e030cac2a24b507f3a4d6db6fb2896f27b354c714b"
 
 [[package]]
 name = "mutable_batch"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "arrow",
  "arrow_util",
@@ -5301,7 +5301,7 @@ dependencies = [
 
 [[package]]
 name = "mutable_batch_lp"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "arrow_util",
  "assert_matches",
@@ -5317,7 +5317,7 @@ dependencies = [
 
 [[package]]
 name = "mutable_batch_pb"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "arrow_util",
  "criterion 0.8.2",
@@ -5555,7 +5555,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_limit"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5567,7 +5567,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_mem_cache"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5594,7 +5594,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_metrics"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "async-trait",
  "bloom2",
@@ -5619,7 +5619,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_mock"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5633,7 +5633,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_size_hinting"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "chrono",
  "http 1.4.0",
@@ -5643,7 +5643,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_utils"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "async-trait",
  "backon",
@@ -5656,7 +5656,7 @@ dependencies = [
 
 [[package]]
 name = "observability_deps"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "tracing",
 ]
@@ -5721,7 +5721,7 @@ dependencies = [
 
 [[package]]
 name = "panic_logging"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "metric",
  "test_helpers",
@@ -5796,7 +5796,7 @@ dependencies = [
 
 [[package]]
 name = "parquet_file"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "arrow",
  "arrow_util",
@@ -5825,7 +5825,7 @@ dependencies = [
 
 [[package]]
 name = "partition"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "arrow",
  "assert_matches",
@@ -6122,7 +6122,7 @@ dependencies = [
 
 [[package]]
 name = "predicate"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6468,7 +6468,7 @@ dependencies = [
 
 [[package]]
 name = "query_functions"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "arrow",
  "chrono",
@@ -7151,7 +7151,7 @@ dependencies = [
 
 [[package]]
 name = "schema"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "arrow",
  "base64 0.22.1",
@@ -7334,7 +7334,7 @@ dependencies = [
 
 [[package]]
 name = "service_common"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -7348,7 +7348,7 @@ dependencies = [
 
 [[package]]
 name = "service_grpc_flight"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -7415,7 +7415,7 @@ dependencies = [
 
 [[package]]
 name = "sharder"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "criterion 0.8.2",
  "data_types",
@@ -7937,7 +7937,7 @@ dependencies = [
 
 [[package]]
 name = "table_batch"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "arrow_util",
  "bitvec",
@@ -8023,7 +8023,7 @@ dependencies = [
 
 [[package]]
 name = "test_helpers"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "async-trait",
  "dotenvy",
@@ -8042,7 +8042,7 @@ dependencies = [
 
 [[package]]
 name = "test_helpers_authz"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "futures",
  "generated_types",
@@ -8315,7 +8315,7 @@ dependencies = [
 
 [[package]]
 name = "tokio_metrics_bridge"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "metric",
  "parking_lot",
@@ -8324,7 +8324,7 @@ dependencies = [
 
 [[package]]
 name = "tokio_watchdog"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "metric",
  "test_helpers",
@@ -8547,7 +8547,7 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tower_trailer"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "futures",
  "http 1.4.0",
@@ -8559,7 +8559,7 @@ dependencies = [
 
 [[package]]
 name = "trace"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "chrono",
  "parking_lot",
@@ -8569,7 +8569,7 @@ dependencies = [
 
 [[package]]
 name = "trace_exporters"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8586,7 +8586,7 @@ dependencies = [
 
 [[package]]
 name = "trace_http"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "bytes",
  "futures",
@@ -8681,7 +8681,7 @@ dependencies = [
 
 [[package]]
 name = "tracker"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "futures",
  "hashbrown 0.14.5",
@@ -8701,7 +8701,7 @@ dependencies = [
 
 [[package]]
 name = "trogging"
-version = "3.9.3"
+version = "3.9.4"
 dependencies = [
  "clap",
  "logfmt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,7 +125,7 @@ exclude = [
 #
 # For porting to the actual OSS repo (influxdb), this would need to change to `-nightly`, i.e., by
 # stripping the `-oss`.
-version = "3.9.3"
+version = "3.9.4"
 authors = ["InfluxData OSS Developers"]
 edition = "2024"
 license = "MIT OR Apache-2.0"

--- a/core/influxdb_influxql_parser/src/time_range.rs
+++ b/core/influxdb_influxql_parser/src/time_range.rs
@@ -294,8 +294,22 @@ pub fn split_cond(
                 }
                 node @ CE::Binary(ConditionalBinary {
                     op: Eq | NotEq | Gt | GtEq | Lt | LtEq | EqRegex | NotEqRegex,
-                    ..
+                    lhs,
+                    rhs,
                 }) => {
+                    // The comparison `node` already contains its operands. A
+                    // bare boolean literal operand (e.g. the `false` in
+                    // `"b0" = false`) was independently pushed by the
+                    // boolean-literal arm below; drop those stray pushes so the
+                    // And/Or combiner does not mistake them for separate
+                    // top-level conditions (#14340).
+                    for operand in [lhs, rhs] {
+                        if matches!(operand.as_ref(), CE::Expr(e)
+                            if matches!(e.as_ref(), Expr::Literal(Literal::Boolean(_))))
+                        {
+                            stack.pop();
+                        }
+                    }
                     stack.push(Some(node.clone()));
                 }
                 node @ CE::Expr(expr)
@@ -903,6 +917,23 @@ mod test {
         let (cond, tr) = split_exprs("true OR time > 0").unwrap();
         assert_eq!(cond.unwrap().to_string(), "true");
         assert_eq!(tr, range!(lower = 1));
+
+        // boolean field filter must be preserved regardless of operand order
+        // relative to a time predicate.
+        // see https://github.com/influxdata/influxdb_iox/issues/14340
+        let (cond, tr) = split_exprs("time < now() AND \"b0\" = false").unwrap();
+        assert_eq!(cond.unwrap().to_string(), "b0 = false");
+        assert_eq!(tr, range!(upper ex = 1672531200000000000));
+
+        // regression lock: the reverse operand order must yield identical results
+        let (cond, tr) = split_exprs("\"b0\" = false AND time < now()").unwrap();
+        assert_eq!(cond.unwrap().to_string(), "b0 = false");
+        assert_eq!(tr, range!(upper ex = 1672531200000000000));
+
+        // multiple boolean field filters are all preserved
+        let (cond, tr) = split_exprs("time < now() AND \"b0\" = false AND \"b1\" = false").unwrap();
+        assert_eq!(cond.unwrap().to_string(), "b0 = false AND b1 = false");
+        assert_eq!(tr, range!(upper ex = 1672531200000000000));
 
         // fallible
         assert_error!(split_exprs("time > '2004-04-09T'"), ExprError::Expression(ref s) if s == "invalid expression \"'2004-04-09T'\": '2004-04-09T' is not a valid timestamp");

--- a/core/iox_query/src/physical_optimizer/sort/order_union_sorted_inputs.rs
+++ b/core/iox_query/src/physical_optimizer/sort/order_union_sorted_inputs.rs
@@ -2033,6 +2033,253 @@ mod test {
         );
     }
 
+    // Parameterized matrix over chunk-schema heterogeneity. Cases
+    // named `*_with_overlapping_ingester` are the pre-fix failures;
+    // the matrix asserts planning success for all.
+    // See <https://github.com/influxdata/EAR/issues/6894>.
+
+    // Column names; SQL is built from these.
+    const TAG1: &str = "tag1";
+    const VAR_TAG: &str = "tag2";
+    const FLD: &str = "fld";
+    const VAR_FLD: &str = "extra_fld";
+
+    const EAR_6894_ERROR: &str = "Endpoints of an Interval should have the same type";
+
+    fn reproducer_sql() -> String {
+        format!(
+            "SELECT *, \
+             ROW_NUMBER() OVER (PARTITION BY {TAG1} ORDER BY time DESC) AS row_num \
+             FROM data \
+             WHERE time >= TIMESTAMP '1970-01-01T00:00:00Z' AND {FLD} > 0"
+        )
+    }
+
+    #[derive(Debug, Clone, Copy)]
+    enum InconsistentKind {
+        Tag,
+        Field,
+    }
+
+    #[derive(Debug, Clone, Copy)]
+    struct Case {
+        name: &'static str,
+        kind: InconsistentKind,
+        // chunk_a: parquet time [1000,2000]; chunk_b: parquet time
+        // [3000,4000]; ingester (if Some): time [1500,2500] —
+        // overlaps chunk_a.
+        chunk_a_has: bool,
+        chunk_b_has: bool,
+        overlapping_ingester_has: Option<bool>,
+    }
+
+    const CASES: &[Case] = &[
+        Case {
+            name: "tag_parquet_only_inconsistent",
+            kind: InconsistentKind::Tag,
+            chunk_a_has: true,
+            chunk_b_has: false,
+            overlapping_ingester_has: None,
+        },
+        Case {
+            name: "field_parquet_only_inconsistent",
+            kind: InconsistentKind::Field,
+            chunk_a_has: true,
+            chunk_b_has: false,
+            overlapping_ingester_has: None,
+        },
+        Case {
+            name: "tag_on_parquet_a_only_with_overlapping_ingester",
+            kind: InconsistentKind::Tag,
+            chunk_a_has: true,
+            chunk_b_has: false,
+            overlapping_ingester_has: Some(false),
+        },
+        Case {
+            name: "tag_on_parquet_a_and_ingester",
+            kind: InconsistentKind::Tag,
+            chunk_a_has: true,
+            chunk_b_has: false,
+            overlapping_ingester_has: Some(true),
+        },
+        Case {
+            name: "tag_on_ingester_only",
+            kind: InconsistentKind::Tag,
+            chunk_a_has: false,
+            chunk_b_has: false,
+            overlapping_ingester_has: Some(true),
+        },
+        Case {
+            name: "field_on_parquet_a_only_with_overlapping_ingester",
+            kind: InconsistentKind::Field,
+            chunk_a_has: true,
+            chunk_b_has: false,
+            overlapping_ingester_has: Some(false),
+        },
+        Case {
+            name: "field_on_parquet_a_and_ingester",
+            kind: InconsistentKind::Field,
+            chunk_a_has: true,
+            chunk_b_has: false,
+            overlapping_ingester_has: Some(true),
+        },
+        Case {
+            name: "field_on_ingester_only",
+            kind: InconsistentKind::Field,
+            chunk_a_has: false,
+            chunk_b_has: false,
+            overlapping_ingester_has: Some(true),
+        },
+    ];
+
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    enum ChunkRole {
+        Parquet,
+        Ingester,
+    }
+
+    /// Builds a chunk with always-present (`tag1`, `fld`, time)
+    /// columns; adds the variable column when `has_variable`. Parquet
+    /// chunks get `with_dummy_parquet_file` + dedupe-clean; ingester
+    /// chunks use `i64::MAX - id` ordering (IOx "newest").
+    fn build_chunk(
+        chunk_id: u128,
+        role: ChunkRole,
+        time_min: i64,
+        time_max: i64,
+        kind: InconsistentKind,
+        has_variable: bool,
+    ) -> TestChunk {
+        let mut c = TestChunk::new("data").with_id(chunk_id);
+        c = match role {
+            ChunkRole::Ingester => c.with_order(i64::MAX - (chunk_id as i64)),
+            ChunkRole::Parquet => c.with_order(chunk_id as i64),
+        };
+        c = c
+            .with_time_column_with_stats(Some(time_min), Some(time_max))
+            .with_tag_column_with_stats(TAG1, Some("a"), Some("a"));
+
+        if let (InconsistentKind::Tag, true) = (kind, has_variable) {
+            c = c.with_tag_column_with_stats(VAR_TAG, Some("x"), Some("x"));
+        }
+
+        // Ingester field columns omit stats; parquet sets them.
+        c = if role == ChunkRole::Ingester {
+            c.with_i64_field_column(FLD)
+        } else {
+            c.with_i64_field_column_with_stats(FLD, Some(10), Some(40))
+        };
+
+        if let (InconsistentKind::Field, true) = (kind, has_variable) {
+            c = if role == ChunkRole::Ingester {
+                c.with_i64_field_column(VAR_FLD)
+            } else {
+                c.with_i64_field_column_with_stats(VAR_FLD, Some(100), Some(200))
+            };
+        }
+
+        match role {
+            ChunkRole::Parquet => c
+                .with_may_contain_pk_duplicates(false)
+                .with_dummy_parquet_file(),
+            ChunkRole::Ingester => c,
+        }
+    }
+
+    fn build_provider_for_case(case: &Case) -> Arc<crate::provider::ChunkTableProvider> {
+        let mut sb = IOxSchemaBuilder::new();
+        sb.tag(TAG1);
+        match case.kind {
+            InconsistentKind::Tag => {
+                sb.tag(VAR_TAG).influx_field(FLD, InfluxFieldType::Integer);
+            }
+            InconsistentKind::Field => {
+                sb.influx_field(FLD, InfluxFieldType::Integer)
+                    .influx_field(VAR_FLD, InfluxFieldType::Integer);
+            }
+        }
+        sb.timestamp();
+        let canonical_schema: schema::Schema = sb.build().unwrap();
+
+        let chunk_a = build_chunk(
+            1,
+            ChunkRole::Parquet,
+            1_000,
+            2_000,
+            case.kind,
+            case.chunk_a_has,
+        );
+        let chunk_b = build_chunk(
+            2,
+            ChunkRole::Parquet,
+            3_000,
+            4_000,
+            case.kind,
+            case.chunk_b_has,
+        );
+        let mut builder = ProviderBuilder::new(Arc::from("data"), canonical_schema)
+            .add_chunk(Arc::new(chunk_a) as Arc<dyn QueryChunk>)
+            .add_chunk(Arc::new(chunk_b) as Arc<dyn QueryChunk>);
+        if let Some(has) = case.overlapping_ingester_has {
+            let ingester = build_chunk(3, ChunkRole::Ingester, 1_500, 2_500, case.kind, has);
+            builder = builder.add_chunk(Arc::new(ingester) as Arc<dyn QueryChunk>);
+        }
+        Arc::new(builder.build().unwrap())
+    }
+
+    async fn plan_for_case(case: &Case) -> Result<Arc<dyn ExecutionPlan>, String> {
+        let exec = Executor::new_with_config_and_executor(
+            ExecutorConfig::testing(),
+            DedicatedExecutor::new_testing(),
+        );
+        let ctx = exec.new_context();
+        ctx.inner()
+            .register_table("data", build_provider_for_case(case))
+            .map_err(|e| e.to_string())?;
+        ctx.sql_to_physical_plan(&reproducer_sql())
+            .await
+            .map_err(|e| e.to_string())
+    }
+
+    /// Runs all `CASES`: asserts no `EAR_6894_ERROR`, and that
+    /// `RecordBatchesExec` is present whenever an ingester chunk
+    /// was configured (so the overlap is real, not pruned away).
+    #[tokio::test]
+    async fn ear6894_matrix() {
+        test_helpers::maybe_start_logging();
+
+        let mut failures = Vec::new();
+        for case in CASES {
+            match plan_for_case(case).await {
+                Err(e) => {
+                    let hint = if e.contains(EAR_6894_ERROR) {
+                        " (matches known EAR #6894 signature)"
+                    } else {
+                        ""
+                    };
+                    failures.push(format!("[{}] planning failed{hint}: {e}", case.name));
+                }
+                Ok(plan) => {
+                    let formatted = format_execution_plan(&plan).join("\n");
+                    if case.overlapping_ingester_has.is_some()
+                        && !formatted.contains("RecordBatchesExec")
+                    {
+                        failures.push(format!(
+                            "[{}] expected RecordBatchesExec in plan; got:\n{formatted}",
+                            case.name
+                        ));
+                    }
+                }
+            }
+        }
+
+        assert!(
+            failures.is_empty(),
+            "EAR #6894 matrix had failures:\n{}",
+            failures.join("\n")
+        );
+    }
+
     // ------------------------------------------------------------------
     // Helper functions
     // ------------------------------------------------------------------

--- a/core/iox_query/src/statistics/partition_statistics/project_schema.rs
+++ b/core/iox_query/src/statistics/partition_statistics/project_schema.rs
@@ -10,7 +10,10 @@ use datafusion::{
 use itertools::Itertools;
 
 use crate::{
-    CHUNK_ORDER_FIELD, chunk_order_field, statistics::partition_statistics::util::pretty_fmt_fields,
+    CHUNK_ORDER_FIELD, chunk_order_field,
+    statistics::{
+        partition_statistics::util::pretty_fmt_fields, stats_utils::synthesize_absent_column_stats,
+    },
 };
 
 /// Takes in a datasource schema and statistics, and projects the scan schema on top.
@@ -34,14 +37,14 @@ pub(crate) fn project_schema_onto_datasrc_statistics(
                 if *field == *CHUNK_ORDER_FIELD {
                     return Ok(ColumnStatistics::new_unknown());
                 } else {
-                    // (c) adding an empty column (e.g. different parquet files could have slightly different schema).
-                    return Ok(ColumnStatistics {
-                        null_count: src_statistics.num_rows,
-                        max_value: Precision::Exact(ScalarValue::Null),
-                        min_value: Precision::Exact(ScalarValue::Null),
-                        distinct_count: Precision::Absent,
-                        sum_value: Precision::Absent,
-                    });
+                    // (c) column present in project_schema but absent
+                    // from this src — synthesize a typed-null stats
+                    // entry. See
+                    // <https://github.com/influxdata/EAR/issues/6894>.
+                    return Ok(synthesize_absent_column_stats(
+                        field,
+                        src_statistics.num_rows,
+                    ));
                 }
             };
 
@@ -513,14 +516,17 @@ mod tests {
         ));
 
         /* Test: works for datasource projection */
-        // ** SPECIAL FOR DATASRC = fills in nulls for aliases missing in filegroup schema **
+        // ** SPECIAL FOR DATASRC = fills in typed nulls for aliases missing in filegroup schema **
         let actual =
             project_schema_onto_datasrc_statistics(&src_stats, &src_schema, &project_schema)
                 .expect("ok");
+        // Synthesized columns get a typed null based on the project
+        // schema's field type. `build_schema` declares all columns as
+        // Int64, so the synthesized null is `Int64(None)`.
         let datasrc_null_columns = ColumnStatistics {
             null_count: expected_stats.num_rows,
-            max_value: Precision::Exact(ScalarValue::Null),
-            min_value: Precision::Exact(ScalarValue::Null),
+            max_value: Precision::Exact(ScalarValue::Int64(None)),
+            min_value: Precision::Exact(ScalarValue::Int64(None)),
             distinct_count: Precision::Absent,
             sum_value: Precision::Absent,
         };
@@ -539,7 +545,7 @@ mod tests {
         );
         assert_eq!(
             actual.column_statistics[1], datasrc_null_columns,
-            "aliased column should have NULL min/max"
+            "aliased column should have typed NULL min/max"
         );
 
         /* Test: errors for chunk order projection */

--- a/core/iox_query/src/statistics/schema_bound.rs
+++ b/core/iox_query/src/statistics/schema_bound.rs
@@ -2,11 +2,10 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use arrow::datatypes::SchemaRef;
-use datafusion::common::stats::Precision;
-use datafusion::common::{ColumnStatistics, Statistics};
-use datafusion::scalar::ScalarValue;
+use datafusion::common::Statistics;
 
 use crate::QueryChunk;
+use crate::statistics::stats_utils::synthesize_absent_column_stats;
 
 pub(crate) struct SchemaBoundStatistics {
     schema: SchemaRef,
@@ -39,23 +38,13 @@ impl SchemaBoundStatistics {
         let chunk_stats = chunk.stats();
         let chunk_schema = chunk.schema();
 
-        // A vector of absent stats for all columns in the schema
+        // A vector of typed-null stats for all columns in the schema;
+        // entries for columns the chunk has are overwritten below.
         let mut schema_col_stats_for_chunk = self
             .schema
             .fields()
             .iter()
-            .map(|f| {
-                let null_val =
-                    ScalarValue::try_from(f.data_type()).expect("works for all IOx types");
-
-                ColumnStatistics {
-                    null_count: chunk_stats.num_rows,
-                    max_value: Precision::Exact(null_val.clone()),
-                    min_value: Precision::Exact(null_val),
-                    distinct_count: Precision::Absent,
-                    sum_value: Precision::Absent,
-                }
-            })
+            .map(|f| synthesize_absent_column_stats(f, chunk_stats.num_rows))
             .collect::<Vec<_>>();
 
         // Fill stats of columns in the chunk, or fallback values

--- a/core/iox_query/src/statistics/stats_utils.rs
+++ b/core/iox_query/src/statistics/stats_utils.rs
@@ -1,10 +1,32 @@
 use arrow::compute::rank;
+use arrow::datatypes::Field;
 use datafusion::common::ColumnStatistics;
 use datafusion::common::stats::Precision;
 use datafusion::error::DataFusionError;
 use datafusion::physical_plan::expressions::Column;
 use datafusion::physical_plan::projection::ProjectionExec;
 use datafusion::scalar::ScalarValue;
+
+/// `ColumnStatistics` for a column absent from a chunk but present in the
+/// outer schema. Min/max use a typed null derived from `field.data_type()`
+/// so synthesized bounds match those produced for the same column on
+/// chunks that have it. Falls back to untyped `ScalarValue::Null` for
+/// Arrow types that `ScalarValue::try_from` does not handle.
+///
+/// See <https://github.com/influxdata/EAR/issues/6894>.
+pub(crate) fn synthesize_absent_column_stats(
+    field: &Field,
+    null_count: Precision<usize>,
+) -> ColumnStatistics {
+    let typed_null = ScalarValue::try_from(field.data_type()).unwrap_or(ScalarValue::Null);
+    ColumnStatistics {
+        null_count,
+        max_value: Precision::Exact(typed_null.clone()),
+        min_value: Precision::Exact(typed_null),
+        distinct_count: Precision::Absent,
+        sum_value: Precision::Absent,
+    }
+}
 
 /// Return min max of a ColumnStatistics with precise values
 pub fn column_statistics_min_max(

--- a/core/iox_query_influxql/src/plan/planner.rs
+++ b/core/iox_query_influxql/src/plan/planner.rs
@@ -6127,6 +6127,24 @@ mod tests {
             assert_snapshot!(plan("SELECT f64_field FROM data WHERE foo !~ /^host/"));
         }
 
+        /// A WHERE clause mixing a time predicate with a boolean-field
+        /// comparison must preserve the boolean filter regardless of operand
+        /// order. Previously, when the time predicate appeared first the plan
+        /// collapsed to an empty result.
+        /// see https://github.com/influxdata/influxdb_iox/issues/14340
+        #[test]
+        fn test_where_clause_time_and_bool_field() {
+            // time predicate first (previously collapsed to an empty plan)
+            assert_snapshot!(plan(
+                "SELECT f64_field FROM data WHERE time < 1500000000000000000 AND bool_field = false"
+            ));
+            // boolean field first; must produce the same filter as the
+            // time-first form above
+            assert_snapshot!(plan(
+                "SELECT f64_field FROM data WHERE bool_field = false AND time < 1500000000000000000"
+            ));
+        }
+
         /// Tests for mathematical expressions in the WHERE clause
         #[test]
         fn test_where_clause_mathematical_expressions() {

--- a/core/iox_query_influxql/src/plan/snapshots/iox_query_influxql__plan__planner__tests__select_raw__where_clause_time_and_bool_field-2.snap
+++ b/core/iox_query_influxql/src/plan/snapshots/iox_query_influxql__plan__planner__tests__select_raw__where_clause_time_and_bool_field-2.snap
@@ -1,0 +1,9 @@
+---
+source: core/iox_query_influxql/src/plan/planner.rs
+expression: "plan(\"SELECT f64_field FROM data WHERE bool_field = false AND time < 1500000000000000000\")"
+---
+Sort: time ASC NULLS LAST [iox::measurement:Dictionary(Int32, Utf8), time:Timestamp(Nanosecond, None), f64_field:Float64;N]
+  Projection: Dictionary(Int32, Utf8("data")) AS iox::measurement, data.time AS time, data.f64_field AS f64_field [iox::measurement:Dictionary(Int32, Utf8), time:Timestamp(Nanosecond, None), f64_field:Float64;N]
+    Filter: data.time <= TimestampNanosecond(1499999999999999999, None) AND NOT bool_field [TIME:Boolean;N, bar:Dictionary(Int32, Utf8);N, bool_field:Boolean;N, f64_field:Float64;N, foo:Dictionary(Int32, Utf8);N, i64_field:Int64;N, mixedCase:Float64;N, str_field:Utf8;N, time:Timestamp(Nanosecond, None), with space:Float64;N]
+      Filter: data.f64_field IS NOT NULL [TIME:Boolean;N, bar:Dictionary(Int32, Utf8);N, bool_field:Boolean;N, f64_field:Float64;N, foo:Dictionary(Int32, Utf8);N, i64_field:Int64;N, mixedCase:Float64;N, str_field:Utf8;N, time:Timestamp(Nanosecond, None), with space:Float64;N]
+        TableScan: data [TIME:Boolean;N, bar:Dictionary(Int32, Utf8);N, bool_field:Boolean;N, f64_field:Float64;N, foo:Dictionary(Int32, Utf8);N, i64_field:Int64;N, mixedCase:Float64;N, str_field:Utf8;N, time:Timestamp(Nanosecond, None), with space:Float64;N]

--- a/core/iox_query_influxql/src/plan/snapshots/iox_query_influxql__plan__planner__tests__select_raw__where_clause_time_and_bool_field.snap
+++ b/core/iox_query_influxql/src/plan/snapshots/iox_query_influxql__plan__planner__tests__select_raw__where_clause_time_and_bool_field.snap
@@ -1,0 +1,9 @@
+---
+source: core/iox_query_influxql/src/plan/planner.rs
+expression: "plan(\"SELECT f64_field FROM data WHERE time < 1500000000000000000 AND bool_field = false\")"
+---
+Sort: time ASC NULLS LAST [iox::measurement:Dictionary(Int32, Utf8), time:Timestamp(Nanosecond, None), f64_field:Float64;N]
+  Projection: Dictionary(Int32, Utf8("data")) AS iox::measurement, data.time AS time, data.f64_field AS f64_field [iox::measurement:Dictionary(Int32, Utf8), time:Timestamp(Nanosecond, None), f64_field:Float64;N]
+    Filter: data.time <= TimestampNanosecond(1499999999999999999, None) AND NOT bool_field [TIME:Boolean;N, bar:Dictionary(Int32, Utf8);N, bool_field:Boolean;N, f64_field:Float64;N, foo:Dictionary(Int32, Utf8);N, i64_field:Int64;N, mixedCase:Float64;N, str_field:Utf8;N, time:Timestamp(Nanosecond, None), with space:Float64;N]
+      Filter: data.f64_field IS NOT NULL [TIME:Boolean;N, bar:Dictionary(Int32, Utf8);N, bool_field:Boolean;N, f64_field:Float64;N, foo:Dictionary(Int32, Utf8);N, i64_field:Int64;N, mixedCase:Float64;N, str_field:Utf8;N, time:Timestamp(Nanosecond, None), with space:Float64;N]
+        TableScan: data [TIME:Boolean;N, bar:Dictionary(Int32, Utf8);N, bool_field:Boolean;N, f64_field:Float64;N, foo:Dictionary(Int32, Utf8);N, i64_field:Int64;N, mixedCase:Float64;N, str_field:Utf8;N, time:Timestamp(Nanosecond, None), with space:Float64;N]

--- a/deny.toml
+++ b/deny.toml
@@ -66,6 +66,9 @@ ignore = [
     # WASI filesystem access required (we don't grant any preopened dirs to UDFs):
     "RUSTSEC-2026-0149", # GHSA-2r75-cxrj-cmph: WASI path_open(TRUNCATE) bypasses FilePerms::WRITE host restriction
     #
+    # Another wasmtime advisory:
+    "RUSTSEC-2026-0182",
+    #
     # TODO: update wasmtime via datafusion-udf-wasm to a patched version (>=42.0.2)
 
     # rand unsoundness: only reachable with rand's `log` feature plus a custom logger
@@ -74,6 +77,18 @@ ignore = [
     # unreachable. Patched in rand >=0.9.3 / >=0.8.6; the 0.8.x copy is pinned
     # transitively via cap-rand/wasmtime. Tracked for a version bump on main.
     "RUSTSEC-2026-0097", # rand unsound with custom logger calling thread_rng (log feature not enabled here)
+    #
+    # pyo3 0.24-0.28 out-of-bounds read in Iterator::nth/nth_back on
+    # PyList/PyTuple iterators; fix is only in pyo3 0.29 (API-breaking bump,
+    # tracked in influxdb_pro#4072). Not reachable here: no nth/nth_back calls
+    # in our pyo3-consuming crates, and the overflow needs a Rust-side n near
+    # usize::MAX, which our embedding never produces.
+    "RUSTSEC-2026-0176",
+    #
+    # pyo3 0.15-0.29 unsoundness bug. Possible data race in functions supplied
+    # to PyCFunction::new_closure, or PyCFunction::new_closure_bound.
+    # Neither of these methods are used in this code.
+    "RUSTSEC-2026-0177",
 ]
 git-fetch-with-cli = true
 

--- a/influxdb3/src/commands/serve.rs
+++ b/influxdb3/src/commands/serve.rs
@@ -1146,10 +1146,7 @@ pub async fn command(config: Config, user_params: HashMap<String, String>) -> Re
     let key_file = config.key_file;
 
     // Start processing engine triggers
-    Arc::clone(&processing_engine)
-        .start_triggers()
-        .await
-        .expect("failed to start processing engine triggers");
+    Arc::clone(&processing_engine).start_triggers().await;
 
     write_buffer
         .wal()

--- a/influxdb3/src/lib.rs
+++ b/influxdb3/src/lib.rs
@@ -671,16 +671,36 @@ fn init_logs_and_tracing(
 
     let layers = log_layer;
 
-    // Optionally enable the tokio console exporter layer, if enabled.
-    //
-    // This spawns a background tokio task to serve the instrumentation data,
-    // and hooks the instrumentation into the tracing pipeline.
+    // Attach the tokio-console exporter layer only when requested via
+    // `--tokio-console-enabled` / `TOKIO_CONSOLE_ENABLED`. It spawns a
+    // background task serving instrumentation data and retains per-task span
+    // stats whose memory scales with task-spawn rate × retention, so it must
+    // be opt-in, and the upstream 1 h retention default is lowered to 60 s
+    // (`TOKIO_CONSOLE_RETENTION` still overrides). See influxdb_pro#4040.
     #[cfg(feature = "tokio_console")]
     let layers = {
         use console_subscriber::ConsoleLayer;
-        let console_layer = ConsoleLayer::builder().with_default_env().spawn();
+        let console_layer = if config.tokio_console.enabled {
+            let mut builder = ConsoleLayer::builder()
+                .retention(std::time::Duration::from_secs(60))
+                .with_default_env();
+            if let Some(capacity) = config.tokio_console.event_buffer_capacity {
+                builder = builder.event_buffer_capacity(capacity);
+            }
+            if let Some(capacity) = config.tokio_console.client_buffer_capacity {
+                builder = builder.client_buffer_capacity(capacity);
+            }
+            Some(builder.spawn())
+        } else {
+            None
+        };
         layers.and_then(console_layer)
     };
+
+    #[cfg(not(feature = "tokio_console"))]
+    if config.tokio_console.enabled {
+        return Err(trogging::Error::TokioConsoleMissing);
+    }
 
     let subscriber = Registry::default().with(layers);
     trogging::install_global(subscriber)

--- a/influxdb3_processing_engine/src/lib.rs
+++ b/influxdb3_processing_engine/src/lib.rs
@@ -759,14 +759,18 @@ impl ProcessingEngineManagerImpl {
         Ok(())
     }
 
-    pub async fn start_triggers(self: Arc<Self>) -> Result<(), ProcessingEngineError> {
+    pub async fn start_triggers(self: Arc<Self>) {
         let triggers = self.catalog.active_triggers();
         for (db_name, trigger_name) in triggers {
-            Arc::clone(&self)
-                .run_trigger(&db_name, &trigger_name)
-                .await?;
+            if let Err(error) = Arc::clone(&self).run_trigger(&db_name, &trigger_name).await {
+                error!(
+                    ?error,
+                    db_name = %db_name,
+                    trigger_name = %trigger_name,
+                    "failed to start trigger at boot; continuing in degraded state"
+                );
+            }
         }
-        Ok(())
     }
 
     /// dry_run_wal_plugin doesn't write data to the DB but it does perform

--- a/influxdb3_server/src/tests.rs
+++ b/influxdb3_server/src/tests.rs
@@ -1429,10 +1429,7 @@ async fn setup_server(start_time: i64) -> (String, CancellationToken, Arc<dyn Wr
         &[&tokio_rustls::rustls::version::TLS13];
 
     // Start processing engine triggers
-    Arc::clone(&processing_engine)
-        .start_triggers()
-        .await
-        .expect("failed to start processing engine triggers");
+    Arc::clone(&processing_engine).start_triggers().await;
 
     write_buffer
         .wal()

--- a/influxdb3_write/src/lib.rs
+++ b/influxdb3_write/src/lib.rs
@@ -146,11 +146,8 @@ impl Serialize for WriteLineError {
         use serde::ser::SerializeStruct;
         let mut state = serializer.serialize_struct("WriteLineError", 3)?;
         const TRUNCATE_LIMIT: usize = 20;
-        let truncated_line = if self.original_line.len() > TRUNCATE_LIMIT {
-            &self.original_line[..TRUNCATE_LIMIT]
-        } else {
-            &self.original_line
-        };
+        let truncated_line =
+            &self.original_line[..self.original_line.floor_char_boundary(TRUNCATE_LIMIT)];
         state.serialize_field("error_message", &self.error_message)?;
         state.serialize_field("line_number", &self.line_number)?;
         state.serialize_field("original_line", truncated_line)?;

--- a/influxdb3_write/src/tests.rs
+++ b/influxdb3_write/src/tests.rs
@@ -252,3 +252,44 @@ async fn test_filter_on_time_with_date_trunc() {
         })
         .expect("create ChunkFilter");
 }
+
+#[test]
+fn test_write_line_error_serialize_truncates_at_utf8_boundary() {
+    use crate::WriteLineError;
+
+    // Serialize caps `original_line` at this many bytes (mirrors the constant in the impl).
+    const TRUNCATE_LIMIT: usize = 20;
+
+    // 19 ASCII bytes followed by a 2-byte 'é' starting at byte 19. A naive `[..TRUNCATE_LIMIT]`
+    // slice lands in the middle of 'é' and would panic; floor_char_boundary backs up to byte 19.
+    let long_line = format!("{}érest of the line", "a".repeat(19));
+    assert!(
+        !long_line.is_char_boundary(TRUNCATE_LIMIT),
+        "test premise: byte {TRUNCATE_LIMIT} must fall inside a multi-byte char",
+    );
+
+    let err = WriteLineError {
+        original_line: long_line,
+        line_number: 1,
+        error_message: "bad line".to_string(),
+    };
+    let json = serde_json::to_string(&err).expect("serialize must not panic");
+    let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+    let emitted = parsed["original_line"]
+        .as_str()
+        .expect("original_line must serialize as a JSON string");
+
+    assert_eq!(emitted, "a".repeat(19));
+
+    // Short input passes through unchanged.
+    let short = "short line";
+    assert!(short.len() < TRUNCATE_LIMIT);
+    let err = WriteLineError {
+        original_line: short.to_string(),
+        line_number: 2,
+        error_message: "bad".to_string(),
+    };
+    let json = serde_json::to_string(&err).unwrap();
+    let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+    assert_eq!(parsed["original_line"].as_str().unwrap(), short);
+}


### PR DESCRIPTION
## Summary

Syncs `oss/` from influxdata/influxdb_pro and bumps the version to `3.9.4` for the 3.9.4 patch release.

Includes:
- influxdata/influxdb_pro#3804
- influxdata/influxdb_pro#3292
- influxdata/influxdb_pro#4134
- influxdata/influxdb_pro#3586
- influxdata/influxdb_pro#4053
- influxdata/influxdb_pro#4139
- influxdata/influxdb_pro#3603
- influxdata/influxdb_pro#4090
- influxdata/influxdb_pro#3861.