### PR TITLE
chore: unify health check response labels

### DIFF
--- a/http/check_handler.go
+++ b/http/check_handler.go
@@ -24,6 +24,11 @@ const (
 	statusReady    = "ready"
 	messageHealthy = "healthy"
 
+	// healthName is the top-level Name reported on the /health response.
+	// QueryHealthCheck reuses it so the check identity it returns is the
+	// same whether the remote /health succeeds or fails.
+	healthName = "influxdb"
+
 	// startingBody is the response body for non-/health-or-/ready requests
 	// received before SetHandler installs a delegate.
 	startingBody = `{"status":"` + statusStarting + `"}` + "\n"
@@ -163,7 +168,7 @@ func (h *HealthReadyHandler) writeHealth(w http.ResponseWriter, r *http.Request)
 		message = firstFailureMessage(resp.Checks())
 	}
 	body := healthBody{
-		Name:    "influxdb",
+		Name:    healthName,
 		Status:  string(resp.Status()),
 		Message: message,
 		Checks:  resp.Checks(),

--- a/http/query_handler.go
+++ b/http/query_handler.go
@@ -612,30 +612,28 @@ func SimpleQuery(addr *url.URL, flux, org, token string, headers ...string) ([]b
 	return GetQueryResponseBody(res)
 }
 
-const queryHealthName = "query health"
-
 func QueryHealthCheck(url string, insecureSkipVerify bool) check.Response {
 	u, err := NewURL(url, "/health")
 	if err != nil {
-		return check.NamedFail(queryHealthName, errors.Wrap(err, "could not form URL").Error())
+		return check.NamedFail(healthName, errors.Wrap(err, "could not form URL").Error())
 	}
 
 	hc := NewClient(u.Scheme, insecureSkipVerify)
 	resp, err := hc.Get(u.String())
 	if err != nil {
-		return check.NamedFail(queryHealthName, errors.Wrap(err, "error getting response").Error())
+		return check.NamedFail(healthName, errors.Wrap(err, "error getting response").Error())
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode/100 != 2 {
-		return check.NamedFail(queryHealthName, fmt.Sprintf("http error %v", resp.StatusCode))
+		return check.NamedFail(healthName, fmt.Sprintf("http error %v", resp.StatusCode))
 	}
 
 	// check.Response is an interface; decode into the concrete
 	// BasicResponse and return it.
 	var healthResponse check.BasicResponse
 	if err = json.NewDecoder(resp.Body).Decode(&healthResponse); err != nil {
-		return check.NamedFail(queryHealthName, errors.Wrap(err, "error decoding JSON response").Error())
+		return check.NamedFail(healthName, errors.Wrap(err, "error decoding JSON response").Error())
 	}
 
 	return healthResponse


### PR DESCRIPTION
Unify health check labels to be the same on success and failure

(cherry picked from commit cf7ae180b41730c0a0d801d3f60e14b883de8d27)

