### PR TITLE
feat: split tsm1 FileStore lock into fast and slow RWMutexes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/influxdata/flux v0.200.0
 	github.com/influxdata/httprouter v1.3.1-0.20191122104820-ee83e2772f69
 	github.com/influxdata/influx-cli/v2 v2.7.1-0.20250130214939-76d1c4d9b777
-	github.com/influxdata/influxql v1.3.0
+	github.com/influxdata/influxql v1.4.1
 	github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839
 	github.com/influxdata/pkg-config v0.3.0
 	github.com/jmoiron/sqlx v1.3.4

--- a/go.sum
+++ b/go.sum
@@ -526,8 +526,8 @@ github.com/influxdata/influx-cli/v2 v2.7.1-0.20250130214939-76d1c4d9b777 h1:T5fM
 github.com/influxdata/influx-cli/v2 v2.7.1-0.20250130214939-76d1c4d9b777/go.mod h1:0R6klN42p+Vr8M7WQpkNYeOubSQ57M3hx/LxsapGXV8=
 github.com/influxdata/influxdb-client-go/v2 v2.3.1-0.20210518120617-5d1fff431040 h1:MBLCfcSsUyFPDJp6T7EoHp/Ph3Jkrm4EuUKLD2rUWHg=
 github.com/influxdata/influxdb-client-go/v2 v2.3.1-0.20210518120617-5d1fff431040/go.mod h1:vLNHdxTJkIf2mSLvGrpj8TCcISApPoXkaxP8g9uRlW8=
-github.com/influxdata/influxql v1.3.0 h1:z2VZEK1LGItlUW8LLiKzX8duC5t6/SDM7Doj2rKs8Kw=
-github.com/influxdata/influxql v1.3.0/go.mod h1:VqxAKyQz5p8GzgGsxWalCWYGxEqw6kvJo2IickMQiQk=
+github.com/influxdata/influxql v1.4.1 h1:UB+TMc9cB6mDdkPmH/5sBU8FQ+ZCWRX2JPcPDIFrLcs=
+github.com/influxdata/influxql v1.4.1/go.mod h1:VqxAKyQz5p8GzgGsxWalCWYGxEqw6kvJo2IickMQiQk=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 h1:W9WBk7wlPfJLvMCdtV4zPulc4uCPrlywQOmbFOhgQNU=
 github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839/go.mod h1:xaLFMmpvUxqXtVkUJfg9QmT88cDaCJ3ZKgdZ78oO8Qo=
 github.com/influxdata/line-protocol-corpus v0.0.0-20210519164801-ca6fa5da0184/go.mod h1:03nmhxzZ7Xk2pdG+lmMd7mHDfeVOYFyhOgwO61qWU98=

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -820,7 +820,7 @@ func (e *Engine) Open(ctx context.Context) error {
 		}
 	}
 
-	if err := e.FileStore.Open(ctx); err != nil {
+	if err := e.FileStore.Open(); err != nil {
 		return err
 	}
 

--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -820,7 +820,7 @@ func (e *Engine) Open(ctx context.Context) error {
 		}
 	}
 
-	if err := e.FileStore.Open(); err != nil {
+	if err := e.FileStore.Open(ctx); err != nil {
 		return err
 	}
 

--- a/tsdb/engine/tsm1/file_store.go
+++ b/tsdb/engine/tsm1/file_store.go
@@ -622,7 +622,7 @@ func (f *FileStore) DeleteRange(keys [][]byte, min, max int64) error {
 }
 
 // Open loads all the TSM files in the configured directory.
-func (f *FileStore) Open() error {
+func (f *FileStore) Open(ctx context.Context) error {
 	f.wlock()
 	defer f.wunlock()
 

--- a/tsdb/engine/tsm1/file_store.go
+++ b/tsdb/engine/tsm1/file_store.go
@@ -169,12 +169,34 @@ var (
 
 // FileStore is an abstraction around multiple TSM files.
 type FileStore struct {
-	mu           sync.RWMutex
+	// fastMu and slowMu together protect the files field (and the mutable scalar
+	// fields below: lastModified, lastFileStats, currentGeneration,
+	// currentTempDirID, newReaderBlockCount). A single mutex would be adequate for
+	// correctness, but the separation isolates lock contention so that a writer
+	// waiting on a slow reader cannot stall hot, performance-sensitive readers.
+	//
+	// When a write lock is required, BOTH must be acquired, slowMu first then
+	// fastMu (use wlock/wunlock so the order is always correct). When only a read
+	// lock is required, acquiring EITHER fastMu.RLock or slowMu.RLock is adequate.
+	// Very quick and performance-sensitive operations may use fastMu; slow or
+	// non-sensitive operations must use slowMu. When in doubt, use slowMu.
+	//
+	// No reader ever takes both locks, and writers always take them in the same
+	// order (slowMu then fastMu), so there is no deadlock. The long drain wait for
+	// a slow reader happens on slowMu, which the fast lane never touches, so fastMu
+	// is held only for the actual mutation.
+	fastMu sync.RWMutex
+	slowMu sync.RWMutex
+
+	// lastModified is written only under the full write lock (wlock), so it is
+	// safe to read on either lane, including the fast lane (see LastModified).
 	lastModified time.Time
 	// Most recently known file stats. If nil then stats will need to be
 	// recalculated
 	lastFileStats []ExtFileStat
 
+	// currentGeneration is written only under the full write lock (wlock), so it is
+	// safe to read on either lane, including the fast lane (see CurrentGeneration).
 	currentGeneration int
 	dir               string
 
@@ -201,6 +223,19 @@ type FileStore struct {
 	// newReaderBlockCount keeps track of the current new reader block requests.
 	// If non-zero, no new TSMReader objects may be created.
 	newReaderBlockCount int
+}
+
+// wlock takes the full write lock on the FileStore: slowMu then fastMu. This is
+// the only correct acquisition order; always pair it with wunlock.
+func (f *FileStore) wlock() {
+	f.slowMu.Lock()
+	f.fastMu.Lock()
+}
+
+// wunlock releases the full write lock in the reverse order of wlock.
+func (f *FileStore) wunlock() {
+	f.fastMu.Unlock()
+	f.slowMu.Unlock()
 }
 
 // FileStat holds information about a TSM file on disk.
@@ -402,24 +437,24 @@ func (f *fileStoreMetrics) remove() {
 
 // Count returns the number of TSM files currently loaded.
 func (f *FileStore) Count() int {
-	f.mu.RLock()
-	defer f.mu.RUnlock()
+	f.fastMu.RLock()
+	defer f.fastMu.RUnlock()
 	return len(f.files)
 }
 
 // Files returns the slice of TSM files currently loaded. This is only used for
 // tests, and the files aren't guaranteed to stay valid in the presence of compactions.
 func (f *FileStore) Files() []TSMFile {
-	f.mu.RLock()
-	defer f.mu.RUnlock()
+	f.fastMu.RLock()
+	defer f.fastMu.RUnlock()
 	return f.files
 }
 
 // Free releases any resources held by the FileStore.  The resources will be re-acquired
 // if necessary if they are needed after freeing them.
 func (f *FileStore) Free() error {
-	f.mu.RLock()
-	defer f.mu.RUnlock()
+	f.slowMu.RLock()
+	defer f.slowMu.RUnlock()
 	for _, f := range f.files {
 		if err := f.Free(); err != nil {
 			return err
@@ -430,15 +465,15 @@ func (f *FileStore) Free() error {
 
 // CurrentGeneration returns the current generation of the TSM files.
 func (f *FileStore) CurrentGeneration() int {
-	f.mu.RLock()
-	defer f.mu.RUnlock()
+	f.fastMu.RLock()
+	defer f.fastMu.RUnlock()
 	return f.currentGeneration
 }
 
 // NextGeneration increments the max file ID and returns the new value.
 func (f *FileStore) NextGeneration() int {
-	f.mu.Lock()
-	defer f.mu.Unlock()
+	f.wlock()
+	defer f.wunlock()
 	f.currentGeneration++
 	return f.currentGeneration
 }
@@ -446,13 +481,13 @@ func (f *FileStore) NextGeneration() int {
 // WalkKeys calls fn for every key in every TSM file known to the FileStore.  If the key
 // exists in multiple files, it will be invoked for each file.
 func (f *FileStore) WalkKeys(seek []byte, fn func(key []byte, typ byte) error) error {
-	f.mu.RLock()
+	f.slowMu.RLock()
 	if len(f.files) == 0 {
-		f.mu.RUnlock()
+		f.slowMu.RUnlock()
 		return nil
 	}
 	if f.newReadersBlocked() {
-		f.mu.RUnlock()
+		f.slowMu.RUnlock()
 		return fmt.Errorf("WalkKeys: %q: %w", f.dir, ErrNewReadersBlocked)
 	}
 
@@ -463,7 +498,7 @@ func (f *FileStore) WalkKeys(seek []byte, fn func(key []byte, typ byte) error) e
 	}
 
 	ki := newMergeKeyIterator(f.files, seek)
-	f.mu.RUnlock()
+	f.slowMu.RUnlock()
 	for ki.Next() {
 		key, typ := ki.Read()
 		if err := fn(key, typ); err != nil {
@@ -476,9 +511,11 @@ func (f *FileStore) WalkKeys(seek []byte, fn func(key []byte, typ byte) error) e
 
 // Keys returns all keys and types for all files in the file store.
 func (f *FileStore) Keys() map[string]byte {
-	f.mu.RLock()
-	defer f.mu.RUnlock()
-
+	// Do not take a read lock here: WalkKeys acquires the read lock itself, and
+	// holding it across that call would be a recursive read lock. Go's RWMutex is
+	// writer-preferring, so a writer that begins waiting between these two RLock
+	// calls would block the inner RLock while the outer one is still held,
+	// deadlocking. WalkKeys provides all the locking this method needs.
 	uniqueKeys := map[string]byte{}
 	if err := f.WalkKeys(nil, func(key []byte, typ byte) error {
 		uniqueKeys[string(key)] = typ
@@ -492,8 +529,8 @@ func (f *FileStore) Keys() map[string]byte {
 
 // Type returns the type of values store at the block for key.
 func (f *FileStore) Type(key []byte) (byte, error) {
-	f.mu.RLock()
-	defer f.mu.RUnlock()
+	f.slowMu.RLock()
+	defer f.slowMu.RUnlock()
 
 	for _, f := range f.files {
 		if f.Contains(key) {
@@ -512,9 +549,9 @@ func (f *FileStore) Apply(ctx context.Context, fn func(r TSMFile) error) error {
 	// Limit apply fn to number of cores
 	limiter := limiter.NewFixed(runtime.GOMAXPROCS(0))
 
-	f.mu.RLock()
+	f.slowMu.RLock()
 	if f.newReadersBlocked() {
-		f.mu.RUnlock()
+		f.slowMu.RUnlock()
 		return fmt.Errorf("Apply: %q: %w", f.dir, ErrNewReadersBlocked)
 	}
 	errC := make(chan error, len(f.files))
@@ -539,12 +576,12 @@ func (f *FileStore) Apply(ctx context.Context, fn func(r TSMFile) error) error {
 			applyErr = err
 		}
 	}
-	f.mu.RUnlock()
+	f.slowMu.RUnlock()
 
-	f.mu.Lock()
+	f.wlock()
 	f.lastModified = time.Now().UTC()
 	f.lastFileStats = nil
-	f.mu.Unlock()
+	f.wunlock()
 
 	return applyErr
 }
@@ -553,13 +590,13 @@ func (f *FileStore) Apply(ctx context.Context, fn func(r TSMFile) error) error {
 // be used with smaller batches of series keys.
 func (f *FileStore) DeleteRange(keys [][]byte, min, max int64) error {
 	var batches BatchDeleters
-	f.mu.RLock()
+	f.slowMu.RLock()
 	for _, f := range f.files {
 		if f.OverlapsTimeRange(min, max) {
 			batches = append(batches, f.BatchDelete())
 		}
 	}
-	f.mu.RUnlock()
+	f.slowMu.RUnlock()
 
 	if len(batches) == 0 {
 		return nil
@@ -577,17 +614,17 @@ func (f *FileStore) DeleteRange(keys [][]byte, min, max int64) error {
 		return err
 	}
 
-	f.mu.Lock()
+	f.wlock()
 	f.lastModified = time.Now().UTC()
 	f.lastFileStats = nil
-	f.mu.Unlock()
+	f.wunlock()
 	return nil
 }
 
 // Open loads all the TSM files in the configured directory.
-func (f *FileStore) Open(ctx context.Context) error {
-	f.mu.Lock()
-	defer f.mu.Unlock()
+func (f *FileStore) Open() error {
+	f.wlock()
+	defer f.wunlock()
 
 	// Not loading files from disk so nothing to do
 	if f.dir == "" {
@@ -748,7 +785,7 @@ func (f *FileStore) Open(ctx context.Context) error {
 // Close closes the file store.
 func (f *FileStore) Close() error {
 	// Make the object appear closed to other method calls.
-	f.mu.Lock()
+	f.wlock()
 
 	files := f.files
 
@@ -758,7 +795,7 @@ func (f *FileStore) Close() error {
 	f.stats.SetFiles(0)
 
 	// Let other methods access this closed object while we do the actual closing.
-	f.mu.Unlock()
+	f.wunlock()
 
 	var errSlice []error
 	for _, tsmFile := range files {
@@ -775,8 +812,8 @@ func (f *FileStore) DiskSizeBytes() int64 {
 // Read returns the slice of values for the given key and the given timestamp,
 // if any file matches those constraints.
 func (f *FileStore) Read(key []byte, t int64) ([]Value, error) {
-	f.mu.RLock()
-	defer f.mu.RUnlock()
+	f.slowMu.RLock()
+	defer f.slowMu.RUnlock()
 
 	for _, f := range f.files {
 		// Can this file possibly contain this key and timestamp?
@@ -798,8 +835,8 @@ func (f *FileStore) Read(key []byte, t int64) ([]Value, error) {
 }
 
 func (f *FileStore) Cost(key []byte, min, max int64) query.IteratorCost {
-	f.mu.RLock()
-	defer f.mu.RUnlock()
+	f.slowMu.RLock()
+	defer f.slowMu.RUnlock()
 	return f.cost(key, min, max)
 }
 
@@ -807,8 +844,8 @@ func (f *FileStore) Cost(key []byte, min, max int64) query.IteratorCost {
 // Otherwise it returns nil. If it returns a file, you must call Unref on it when
 // you are done, and never use it after that.
 func (f *FileStore) TSMReader(path string) (*TSMReader, error) {
-	f.mu.RLock()
-	defer f.mu.RUnlock()
+	f.slowMu.RLock()
+	defer f.slowMu.RUnlock()
 	if f.newReadersBlocked() {
 		return nil, fmt.Errorf("TSMReader: %q (%q): %w", f.dir, path, ErrNewReadersBlocked)
 	}
@@ -827,8 +864,8 @@ func (f *FileStore) TSMReader(path string) (*TSMReader, error) {
 // of reader blocks is decremented. If the reader blocks drops to 0, then
 // new readers will be granted access to the files.
 func (f *FileStore) SetNewReadersBlocked(block bool) error {
-	f.mu.Lock()
-	defer f.mu.Unlock()
+	f.wlock()
+	defer f.wunlock()
 	if block {
 		if f.newReaderBlockCount < 0 {
 			return fmt.Errorf("newReaderBlockCount for %q was %d before block operation, block failed", f.dir, f.newReaderBlockCount)
@@ -844,7 +881,7 @@ func (f *FileStore) SetNewReadersBlocked(block bool) error {
 }
 
 // newReadersBlocked returns true if new references to TSMReader objects are not allowed.
-// Must be called with f.mu lock held (reader or writer).
+// Must be called while holding either read lock (fastMu or slowMu) or both write locks.
 // See SetNewReadersBlocked for interface to allow and block access to TSMReader objects.
 func (f *FileStore) newReadersBlocked() bool {
 	return f.newReaderBlockCount > 0
@@ -856,8 +893,8 @@ func (f *FileStore) newReadersBlocked() bool {
 // that requires no active readers. Calling InUse without a new readers block results
 // in an error.
 func (f *FileStore) InUse() (bool, error) {
-	f.mu.RLock()
-	defer f.mu.RUnlock()
+	f.slowMu.RLock()
+	defer f.slowMu.RUnlock()
 	if !f.newReadersBlocked() {
 		return false, fmt.Errorf("InUse called without a new reader block for %q", f.dir)
 	}
@@ -871,8 +908,8 @@ func (f *FileStore) InUse() (bool, error) {
 
 // KeyCursor returns a KeyCursor for key and t across the files in the FileStore.
 func (f *FileStore) KeyCursor(ctx context.Context, key []byte, t int64, ascending bool) *KeyCursor {
-	f.mu.RLock()
-	defer f.mu.RUnlock()
+	f.fastMu.RLock()
+	defer f.fastMu.RUnlock()
 	if f.newReadersBlocked() {
 		// New readers are blocked for this FileStore because there is a delete attempt in progress.
 		// Return an empty cursor to appease the callers since they generally don't handle
@@ -890,17 +927,17 @@ func (f *FileStore) KeyCursor(ctx context.Context, key []byte, t int64, ascendin
 
 // Stats returns the stats of the underlying files, preferring the cached version if it is still valid.
 func (f *FileStore) Stats() []ExtFileStat {
-	f.mu.RLock()
+	f.slowMu.RLock()
 	if len(f.lastFileStats) > 0 {
-		defer f.mu.RUnlock()
+		defer f.slowMu.RUnlock()
 		return f.lastFileStats
 	}
-	f.mu.RUnlock()
+	f.slowMu.RUnlock()
 
 	// The file stats cache is invalid due to changes to files. Need to
 	// recalculate.
-	f.mu.Lock()
-	defer f.mu.Unlock()
+	f.wlock()
+	defer f.wunlock()
 
 	if len(f.lastFileStats) > 0 {
 		return f.lastFileStats
@@ -932,9 +969,7 @@ func (f *FileStore) replace(oldFiles, newFiles []string, updatedFn func(r []TSMF
 		return nil
 	}
 
-	f.mu.RLock()
-	maxTime := f.lastModified
-	f.mu.RUnlock()
+	maxTime := f.LastModified()
 
 	updated := make([]TSMFile, 0, len(newFiles))
 	tsmTmpExt := fmt.Sprintf("%s.%s", TSMFileExtension, TmpTSMFileExtension)
@@ -1001,8 +1036,8 @@ func (f *FileStore) replace(oldFiles, newFiles []string, updatedFn func(r []TSMF
 		updatedFn(updated)
 	}
 
-	f.mu.Lock()
-	defer f.mu.Unlock()
+	f.wlock()
+	defer f.wunlock()
 
 	// Copy the current set of active files while we rename
 	// and load the new files.  We copy the pointers here to minimize
@@ -1038,8 +1073,9 @@ func (f *FileStore) replace(oldFiles, newFiles []string, updatedFn func(r []TSMF
 				// In order to ensure that there are no races with this (file held externally calls Ref
 				// after we check InUse), we need to maintain the invariant that every handle to a file
 				// is handed out in use (Ref'd), and handlers only ever relinquish the file once (call Unref
-				// exactly once, and never use it again). InUse is only valid during a write lock, since
-				// we allow calls to Ref and Unref under the read lock and no lock at all respectively.
+				// exactly once, and never use it again). InUse is only valid while holding both write locks
+				// (we are here, via wlock), since we allow calls to Ref and Unref under either read lock and
+				// no lock at all respectively.
 				if file.InUse() {
 					// Copy all the tombstones related to this TSM file
 					var deletes []string
@@ -1118,8 +1154,8 @@ func (f *FileStore) replace(oldFiles, newFiles []string, updatedFn func(r []TSMF
 // LastModified returns the last time the file store was updated with new
 // TSM files or a delete.
 func (f *FileStore) LastModified() time.Time {
-	f.mu.RLock()
-	defer f.mu.RUnlock()
+	f.fastMu.RLock()
+	defer f.fastMu.RUnlock()
 
 	return f.lastModified
 }
@@ -1167,7 +1203,7 @@ func (f *FileStore) cost(key []byte, min, max int64) query.IteratorCost {
 
 // locations returns the files and index blocks for a key and time.  ascending indicates
 // whether the key will be scan in ascending time order or descenging time order.
-// This function assumes the read-lock has been taken.
+// This function assumes a read lock (fastMu or slowMu) or both write locks have been taken.
 func (f *FileStore) locations(key []byte, t int64, ascending bool) []*location {
 	var cache []IndexEntry
 	locations := make([]*location, 0, len(f.files))
@@ -1332,9 +1368,9 @@ func (f *FileStore) linkNotCopy(oldPath, newPath string) error {
 func (f *FileStore) CreateSnapshot() (string, error) {
 	f.traceLogger.Info("Creating snapshot", zap.String("dir", f.dir))
 
-	f.mu.Lock()
+	f.wlock()
 	if f.newReadersBlocked() {
-		f.mu.Unlock()
+		f.wunlock()
 		return "", fmt.Errorf("CreateSnapshot: %q: %w", f.dir, ErrNewReadersBlocked)
 	}
 	// create a copy of the files slice and ensure they aren't closed out from
@@ -1350,9 +1386,8 @@ func (f *FileStore) CreateSnapshot() (string, error) {
 	// increment and keep track of the current temp dir for when we drop the lock.
 	// this ensures we are the only writer to the directory.
 	f.currentTempDirID += 1
-	tmpPath := fmt.Sprintf("%d.%s", f.currentTempDirID, TmpTSMFileExtension)
-	tmpPath = filepath.Join(f.dir, tmpPath)
-	f.mu.Unlock()
+	tmpPath := filepath.Join(f.dir, fmt.Sprintf("%d.%s", f.currentTempDirID, TmpTSMFileExtension))
+	f.wunlock()
 
 	// create the tmp directory and add the hard links. there is no longer any shared
 	// mutable state.
@@ -1477,7 +1512,7 @@ func (a ascLocations) Less(i, j int) bool {
 }
 
 // newKeyCursor returns a new instance of KeyCursor.
-// This function assumes the read-lock has been taken.
+// This function assumes a read lock (fastMu or slowMu) or both write locks have been taken.
 func newKeyCursor(ctx context.Context, fs *FileStore, key []byte, t int64, ascending bool) *KeyCursor {
 	c := &KeyCursor{
 		key:       key,

--- a/tsdb/engine/tsm1/file_store.go
+++ b/tsdb/engine/tsm1/file_store.go
@@ -697,7 +697,7 @@ func (f *FileStore) Open() error {
 			// Ensure a limited number of TSM files are loaded at once.
 			// Systems which have very large datasets (1TB+) can have thousands
 			// of TSM files which can cause extremely long load times.
-			if err := f.openLimiter.Take(ctx); err != nil {
+			if err := f.openLimiter.Take(context.Background()); err != nil {
 				f.logger.Error("Failed to open tsm file", zap.String("path", file.Name()), zap.Error(err))
 				readerC <- &res{err: fmt.Errorf("failed to open tsm file %q: %w", file.Name(), err)}
 				return

--- a/tsdb/engine/tsm1/file_store_test.go
+++ b/tsdb/engine/tsm1/file_store_test.go
@@ -2402,7 +2402,7 @@ func TestFileStore_Open(t *testing.T) {
 	}
 
 	fs := newTestFileStore(t, dir)
-	if err := fs.Open(); err != nil {
+	if err := fs.Open(t.Context()); err != nil {
 		fatal(t, "opening file store", err)
 	}
 
@@ -2444,7 +2444,7 @@ func TestFileStore_OpenFail(t *testing.T) {
 
 func openFail(t *testing.T, dir string, fullErrMsg string, initErr error) {
 	fs := tsm1.NewFileStore(dir, tsdb.EngineTags{}, tsm1.TestMmapInitFailOption(initErr))
-	err := fs.Open()
+	err := fs.Open(t.Context())
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), fullErrMsg)
 	defer func() { assert.NoError(t, fs.Close(), "unexpected error on FileStore.Close") }()
@@ -2467,7 +2467,7 @@ func TestFileStore_Remove(t *testing.T) {
 	}
 
 	fs := newTestFileStore(t, dir)
-	if err := fs.Open(); err != nil {
+	if err := fs.Open(t.Context()); err != nil {
 		fatal(t, "opening file store", err)
 	}
 
@@ -2510,7 +2510,7 @@ func TestFileStore_Replace(t *testing.T) {
 	os.Rename(files[2], replacement)
 
 	fs := newTestFileStore(t, dir)
-	if err := fs.Open(); err != nil {
+	if err := fs.Open(t.Context()); err != nil {
 		fatal(t, "opening file store", err)
 	}
 
@@ -2595,7 +2595,7 @@ func TestFileStore_Open_Deleted(t *testing.T) {
 	}
 
 	fs := newTestFileStore(t, dir)
-	if err := fs.Open(); err != nil {
+	if err := fs.Open(t.Context()); err != nil {
 		fatal(t, "opening file store", err)
 	}
 
@@ -2608,7 +2608,7 @@ func TestFileStore_Open_Deleted(t *testing.T) {
 	}
 
 	fs2 := newTestFileStore(t, dir)
-	if err := fs2.Open(); err != nil {
+	if err := fs2.Open(t.Context()); err != nil {
 		fatal(t, "opening file store", err)
 	}
 
@@ -2702,7 +2702,7 @@ func TestFileStore_Stats(t *testing.T) {
 	}
 
 	fs := newTestFileStore(t, dir)
-	if err := fs.Open(); err != nil {
+	if err := fs.Open(t.Context()); err != nil {
 		fatal(t, "opening file store", err)
 	}
 
@@ -2838,7 +2838,7 @@ func TestFileStore_ReaderBlocking(t *testing.T) {
 	require.NoError(t, err)
 
 	fs := newTestFileStore(t, dir)
-	require.NoError(t, fs.Open())
+	require.NoError(t, fs.Open(t.Context()))
 
 	fsInUse := func() bool {
 		t.Helper()
@@ -3195,7 +3195,7 @@ func BenchmarkFileStore_Stats(b *testing.B) {
 	fs := newTestFileStore(b, dir)
 	fs.WithLogger(zaptest.NewLogger(b))
 
-	if err := fs.Open(); err != nil {
+	if err := fs.Open(b.Context()); err != nil {
 		b.Fatalf("opening file store %v", err)
 	}
 
@@ -3249,7 +3249,7 @@ func BenchmarkFileStore_FastLaneContention(b *testing.B) {
 			if testing.Verbose() {
 				fs.WithLogger(zaptest.NewLogger(b))
 			}
-			require.NoError(b, fs.Open())
+			require.NoError(b, fs.Open(b.Context()))
 
 			// Throwaway files for the Replace writer to churn. Register cleanup
 			// immediately so the dir is removed even if the sub-benchmark exits

--- a/tsdb/engine/tsm1/file_store_test.go
+++ b/tsdb/engine/tsm1/file_store_test.go
@@ -3356,7 +3356,11 @@ func TestFileStore_ConcurrentLocking(t *testing.T) {
 	if testing.Verbose() {
 		fs.WithLogger(zaptest.NewLogger(t))
 	}
-	require.NoError(t, fs.Open())
+	// Load the permanent cpu file via Replace, matching the convention used by the
+	// rest of this file. Do NOT also call fs.Open(): Open globs dir/*.tsm and would
+	// load the same cpu file a second time, so f.files would start as {cpu, cpu} and
+	// the Count()/Files() bounds below (cpu + at most one churned mem file) would be
+	// violated from the first churn onward.
 	require.NoError(t, fs.Replace(nil, files))
 	// Use assert (not require) in this cleanup: require's FailNow during teardown
 	// could short-circuit the temp-dir RemoveAll defers above and obscure the

--- a/tsdb/engine/tsm1/file_store_test.go
+++ b/tsdb/engine/tsm1/file_store_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -2401,7 +2402,7 @@ func TestFileStore_Open(t *testing.T) {
 	}
 
 	fs := newTestFileStore(t, dir)
-	if err := fs.Open(context.Background()); err != nil {
+	if err := fs.Open(); err != nil {
 		fatal(t, "opening file store", err)
 	}
 
@@ -2443,7 +2444,7 @@ func TestFileStore_OpenFail(t *testing.T) {
 
 func openFail(t *testing.T, dir string, fullErrMsg string, initErr error) {
 	fs := tsm1.NewFileStore(dir, tsdb.EngineTags{}, tsm1.TestMmapInitFailOption(initErr))
-	err := fs.Open(context.Background())
+	err := fs.Open()
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), fullErrMsg)
 	defer func() { assert.NoError(t, fs.Close(), "unexpected error on FileStore.Close") }()
@@ -2466,7 +2467,7 @@ func TestFileStore_Remove(t *testing.T) {
 	}
 
 	fs := newTestFileStore(t, dir)
-	if err := fs.Open(context.Background()); err != nil {
+	if err := fs.Open(); err != nil {
 		fatal(t, "opening file store", err)
 	}
 
@@ -2509,7 +2510,7 @@ func TestFileStore_Replace(t *testing.T) {
 	os.Rename(files[2], replacement)
 
 	fs := newTestFileStore(t, dir)
-	if err := fs.Open(context.Background()); err != nil {
+	if err := fs.Open(); err != nil {
 		fatal(t, "opening file store", err)
 	}
 
@@ -2594,7 +2595,7 @@ func TestFileStore_Open_Deleted(t *testing.T) {
 	}
 
 	fs := newTestFileStore(t, dir)
-	if err := fs.Open(context.Background()); err != nil {
+	if err := fs.Open(); err != nil {
 		fatal(t, "opening file store", err)
 	}
 
@@ -2607,7 +2608,7 @@ func TestFileStore_Open_Deleted(t *testing.T) {
 	}
 
 	fs2 := newTestFileStore(t, dir)
-	if err := fs2.Open(context.Background()); err != nil {
+	if err := fs2.Open(); err != nil {
 		fatal(t, "opening file store", err)
 	}
 
@@ -2701,7 +2702,7 @@ func TestFileStore_Stats(t *testing.T) {
 	}
 
 	fs := newTestFileStore(t, dir)
-	if err := fs.Open(context.Background()); err != nil {
+	if err := fs.Open(); err != nil {
 		fatal(t, "opening file store", err)
 	}
 
@@ -2837,7 +2838,7 @@ func TestFileStore_ReaderBlocking(t *testing.T) {
 	require.NoError(t, err)
 
 	fs := newTestFileStore(t, dir)
-	require.NoError(t, fs.Open(context.Background()))
+	require.NoError(t, fs.Open())
 
 	fsInUse := func() bool {
 		t.Helper()
@@ -3108,9 +3109,14 @@ func newFileDir(tb testing.TB, dir string, values ...keyValues) ([]string, error
 }
 
 func newFiles(tb testing.TB, dir string, values ...keyValues) ([]string, error) {
+	return newFilesId(tb, dir, 1, values...)
+}
+
+// newFilesId allows specifying a starting file id so that multiple calls into the
+// same directory do not collide on file names.
+func newFilesId(tb testing.TB, dir string, id int, values ...keyValues) ([]string, error) {
 	var files []string
 
-	id := 1
 	for _, v := range values {
 		f := MustTempFile(tb, dir)
 		w, err := tsm1.NewTSMWriter(f)
@@ -3144,6 +3150,14 @@ func newFiles(tb testing.TB, dir string, values ...keyValues) ([]string, error) 
 type keyValues struct {
 	key    string
 	values []tsm1.Value
+}
+
+func MustTempDir() string {
+	dir, err := os.MkdirTemp("", "tsm1-test")
+	if err != nil {
+		panic(fmt.Sprintf("failed to create temp dir: %v", err))
+	}
+	return dir
 }
 
 func MustTempFile(tb testing.TB, dir string) *os.File {
@@ -3181,7 +3195,7 @@ func BenchmarkFileStore_Stats(b *testing.B) {
 	fs := newTestFileStore(b, dir)
 	fs.WithLogger(zaptest.NewLogger(b))
 
-	if err := fs.Open(context.Background()); err != nil {
+	if err := fs.Open(); err != nil {
 		b.Fatalf("opening file store %v", err)
 	}
 
@@ -3190,4 +3204,298 @@ func BenchmarkFileStore_Stats(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		fsResult = fs.Stats()
 	}
+}
+
+// applyHoldTime is how long the Apply callback holds the read lock, to stall
+// write-lock acquisition and create the contended environment.
+const applyHoldTime = 100 * time.Microsecond
+
+// BenchmarkFileStore_FastLaneContention measures each fast-lane reader's exposure
+// to FileStore lock contention. Background goroutines create the contention for the
+// whole sub-benchmark: one holds the read lock for a while via Apply, another stalls
+// on the write lock via Replace. The Replace writer churns a separate "mem" key (it
+// never removes the "cpu" file the victim reads) and threads oldFiles so the live
+// file set stays bounded. The victim fast-lane reader is then measured across b.N
+// operations. Splitting mu into fastMu/slowMu keeps these readers off the slow drain
+// path, so their latency should drop substantially compared to a single shared mutex.
+func BenchmarkFileStore_FastLaneContention(b *testing.B) {
+	// fn takes the FileStore explicitly because a fresh one is built per sub-benchmark.
+	victims := []struct {
+		name string
+		fn   func(fs *tsm1.FileStore)
+	}{
+		{"KeyCursor", func(fs *tsm1.FileStore) { fs.KeyCursor(context.Background(), []byte("cpu"), 0, true).Close() }},
+		{"Count", func(fs *tsm1.FileStore) { _ = fs.Count() }},
+		{"Files", func(fs *tsm1.FileStore) { _ = fs.Files() }},
+		{"CurrentGeneration", func(fs *tsm1.FileStore) { _ = fs.CurrentGeneration() }},
+		{"LastModified", func(fs *tsm1.FileStore) { _ = fs.LastModified() }},
+	}
+
+	for _, v := range victims {
+		b.Run(v.name, func(b *testing.B) {
+			// Fresh FileStore per sub-benchmark so churned files do not accumulate
+			// across runs. Register cleanup right after creation so the dir is
+			// removed even if a require below aborts the sub-benchmark early.
+			// b.Cleanup runs after the benchmark, so it does not affect timing, and
+			// it runs after the explicit fs.Close() below, preserving owner-before-
+			// storage teardown ordering.
+			dir := MustTempDir()
+			b.Cleanup(func() { assert.NoError(b, os.RemoveAll(dir)) })
+			data := []keyValues{{"cpu", []tsm1.Value{tsm1.NewValue(0, 1.0)}}}
+			_, err := newFileDir(b, dir, data...)
+			require.NoError(b, err)
+
+			fs := newTestFileStore(b, dir)
+			if testing.Verbose() {
+				fs.WithLogger(zaptest.NewLogger(b))
+			}
+			require.NoError(b, fs.Open())
+
+			// Throwaway files for the Replace writer to churn. Register cleanup
+			// immediately so the dir is removed even if the sub-benchmark exits
+			// early. Registered after dir's cleanup, so under LIFO it runs first
+			// (churn before dir), matching the original teardown order.
+			churn := MustTempDir()
+			b.Cleanup(func() { assert.NoError(b, os.RemoveAll(churn)) })
+
+			// Start the contended environment once and run it for the whole
+			// sub-benchmark; only the victim loop below is timed.
+			var wg sync.WaitGroup
+			done := make(chan struct{})
+
+			// Apply - hold the read lock for a while to slow down write-lock
+			// acquisition. Not measured; it just creates the contended environment.
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for {
+					select {
+					case <-done:
+						return
+					default:
+						assert.NoError(b, fs.Apply(b.Context(), func(r tsm1.TSMFile) error {
+							// Hold the read lock a while.
+							time.Sleep(applyHoldTime)
+							return nil
+						}))
+					}
+				}
+			}()
+
+			// Replace - request the write lock but be stalled by Apply. Churns a
+			// "mem" key (never "cpu") and threads oldFiles so the file set stays
+			// bounded. Not measured; it just creates the contended environment.
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				id := 1
+				var oldFiles []string
+				for {
+					select {
+					case <-done:
+						return
+					default:
+						churnData := []keyValues{
+							{"mem", []tsm1.Value{tsm1.NewValue(0, 1.0), tsm1.NewValue(1, 2.0)}},
+						}
+						id++
+						files, err := newFilesId(b, churn, id, churnData...)
+						assert.NoError(b, err)
+						assert.NoError(b, fs.Replace(oldFiles, files))
+						oldFiles = files
+					}
+				}
+			}()
+
+			// Measure the victim across b.N operations under contention.
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				v.fn(fs)
+			}
+			b.StopTimer()
+
+			// Stop and join the contention goroutines, then close the FileStore.
+			// The temp-dir removals are registered as b.Cleanup above, so they run
+			// after this explicit Close (owner before storage).
+			close(done)
+			wg.Wait()
+			assert.NoError(b, fs.Close())
+		})
+	}
+}
+
+// TestFileStore_ConcurrentLocking exercises the fastMu/slowMu split under a heavy
+// concurrent mix of fast-lane readers (KeyCursor/Count/Files/CurrentGeneration/
+// LastModified), slow-lane readers (Read/Keys/WalkKeys/Apply), and writers
+// (NextGeneration via wlock, plus a file-mutating Replace loop). Run with -race to
+// catch data races and any lock-ordering deadlock. The "cpu" file is never removed,
+// so reads of it must always observe the original value.
+func TestFileStore_ConcurrentLocking(t *testing.T) {
+	const (
+		numReaders = 16
+		iters      = 200
+	)
+
+	// Register both temp-dir cleanups BEFORE creating the FileStore so that the
+	// deferred fs.Close() (registered last) runs FIRST under LIFO ordering: the
+	// store is closed before its backing directories are removed. The Replace
+	// churn can hand still-in-use files to the async purger, so closing the owner
+	// before deleting its storage keeps teardown ordered.
+	dir := MustTempDir()
+	defer func() { assert.NoError(t, os.RemoveAll(dir)) }()
+
+	// Throwaway files for the Replace writer to churn.
+	churnDir := MustTempDir()
+	defer func() { assert.NoError(t, os.RemoveAll(churnDir)) }()
+
+	// Permanent data file the readers depend on; never passed as oldFiles to Replace.
+	files, err := newFiles(t, dir, keyValues{"cpu", []tsm1.Value{tsm1.NewValue(0, 1.0)}})
+	require.NoError(t, err)
+
+	fs := newTestFileStore(t, dir)
+	if testing.Verbose() {
+		fs.WithLogger(zaptest.NewLogger(t))
+	}
+	require.NoError(t, fs.Open())
+	require.NoError(t, fs.Replace(nil, files))
+	// Use assert (not require) in this cleanup: require's FailNow during teardown
+	// could short-circuit the temp-dir RemoveAll defers above and obscure the
+	// original failure. assert lets teardown finish deterministically.
+	defer func() { assert.NoError(t, fs.Close()) }()
+
+	var concurrency, maxConcurrency atomic.Int64
+	bump := func() {
+		c := concurrency.Add(1)
+		for {
+			old := maxConcurrency.Load()
+			if c <= old || maxConcurrency.CompareAndSwap(old, c) {
+				break
+			}
+		}
+	}
+
+	// Each op exercises one lock path AND asserts its result, so the test catches
+	// not just races/deadlocks but also wrong values handed back under contention
+	// (e.g. a torn read of the files slice). The "cpu" key is stable, so reads of it
+	// are exact; the Replace writer churns a single "mem" file, so the file set is
+	// always {cpu} or {cpu, mem} and the generation counter is bounded by iters.
+	// Use assert (not require) since these run in spawned goroutines, where require's
+	// FailNow is unsafe.
+	ops := []func(){
+		func() {
+			c := fs.KeyCursor(context.Background(), []byte("cpu"), 0, true)
+			defer c.Close()
+			var buf []tsm1.FloatValue
+			values, err := c.ReadFloatBlock(&buf)
+			if assert.NoError(t, err) && assert.Len(t, values, 1) {
+				assert.Equal(t, int64(0), values[0].UnixNano())
+				assert.Equal(t, 1.0, values[0].Value())
+			}
+		},
+		func() {
+			c := fs.Count()
+			assert.GreaterOrEqual(t, c, 1) // cpu is always present
+			assert.LessOrEqual(t, c, 2)    // cpu + at most one churned mem file
+		},
+		func() {
+			fl := fs.Files()
+			assert.GreaterOrEqual(t, len(fl), 1)
+			assert.LessOrEqual(t, len(fl), 2)
+			for _, f := range fl {
+				assert.NotNil(t, f)
+			}
+		},
+		func() {
+			g := fs.CurrentGeneration()
+			assert.GreaterOrEqual(t, g, 0)  // never set via Open; bumped by NextGeneration
+			assert.LessOrEqual(t, g, iters) // at most one increment per NextGeneration op call
+		},
+		func() { assert.False(t, fs.LastModified().IsZero()) }, // set when cpu was loaded
+		func() {
+			v, err := fs.Read([]byte("cpu"), 0)
+			if assert.NoError(t, err) && assert.Len(t, v, 1) {
+				assert.Equal(t, 1.0, v[0].Value())
+			}
+		},
+		func() {
+			keys := fs.Keys()
+			if typ, ok := keys["cpu"]; assert.True(t, ok) {
+				assert.Equal(t, byte(tsm1.BlockFloat64), typ)
+			}
+		},
+		func() {
+			var sawCPU bool
+			err := fs.WalkKeys(nil, func(key []byte, typ byte) error {
+				if string(key) == "cpu" {
+					sawCPU = true
+					assert.Equal(t, byte(tsm1.BlockFloat64), typ)
+				}
+				return nil
+			})
+			if assert.NoError(t, err) {
+				assert.True(t, sawCPU)
+			}
+		},
+		func() {
+			// Apply runs fn in parallel goroutines, so count invocations atomically.
+			var applied atomic.Int64
+			err := fs.Apply(context.Background(), func(r tsm1.TSMFile) error {
+				applied.Add(1)
+				return nil
+			})
+			if assert.NoError(t, err) {
+				assert.GreaterOrEqual(t, applied.Load(), int64(1)) // cpu at least
+			}
+		},
+		func() {
+			g := fs.NextGeneration() // scalar writer through wlock
+			assert.GreaterOrEqual(t, g, 1)
+			assert.LessOrEqual(t, g, iters)
+		},
+	}
+
+	// Gate all goroutines so they start as simultaneously as possible.
+	var startGate sync.RWMutex
+	startGate.Lock()
+
+	var wg sync.WaitGroup
+	for i := 0; i < numReaders; i++ {
+		wg.Add(1)
+		op := ops[i%len(ops)]
+		go func() {
+			startGate.RLock()
+			defer startGate.RUnlock()
+			defer wg.Done()
+			for j := 0; j < iters; j++ {
+				bump()
+				op()
+				concurrency.Add(-1)
+			}
+		}()
+	}
+
+	// A single dedicated file-mutating writer. Kept to one goroutine so the file
+	// lifecycle (create, then hand the previous set to Replace as oldFiles) stays
+	// well-defined; writer-vs-writer ordering is still exercised against the
+	// NextGeneration op above.
+	wg.Add(1)
+	go func() {
+		startGate.RLock()
+		defer startGate.RUnlock()
+		defer wg.Done()
+		var oldFiles []string
+		for j := 0; j < iters; j++ {
+			bump()
+			nf, err := newFilesId(t, churnDir, j+2, keyValues{"mem", []tsm1.Value{tsm1.NewValue(int64(j), 2.0)}})
+			if assert.NoError(t, err) {
+				assert.NoError(t, fs.Replace(oldFiles, nf))
+				oldFiles = nf
+			}
+			concurrency.Add(-1)
+		}
+	}()
+
+	startGate.Unlock() // release everyone at once
+	wg.Wait()
+	t.Logf("max concurrency: %d", maxConcurrency.Load())
 }

--- a/tsdb/engine/tsm1/mmap_unix.go
+++ b/tsdb/engine/tsm1/mmap_unix.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"syscall"
 
-	"github.com/influxdata/influxdb/pkg/file"
+	"github.com/influxdata/influxdb/v2/pkg/file"
 	"golang.org/x/sys/unix"
 )
 

--- a/tsdb/engine/tsm1/mmap_unix.go
+++ b/tsdb/engine/tsm1/mmap_unix.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"syscall"
 
+	"github.com/influxdata/influxdb/pkg/file"
 	"golang.org/x/sys/unix"
 )
 
@@ -40,4 +41,36 @@ func madviseDontNeed(b []byte) error {
 // From: github.com/boltdb/bolt/bolt_unix.go
 func madvise(b []byte, advice int) (err error) {
 	return unix.Madvise(b, advice)
+}
+
+// rename moves the backing file to path while leaving the existing memory
+// mapping intact. On Unix a mapping is backed by the inode, so it survives both
+// the rename of the file and the closing of any descriptor to it. This matters
+// because in-flight readers hold raw slices into m.b (for example the index keys
+// returned by KeyAt) without holding the FileStore lock; FileStore.replace only
+// reaches this path when the file is still referenced (InUse). Keeping the
+// mapping alive lets those readers finish safely, and the mapping is released
+// later by close() once all references drain and the purger closes the reader.
+//
+// Only the descriptor is reopened at the new path so that path() and the
+// eventual file removal operate on the renamed file. The mapping (m.b) and the
+// index that aliases it are intentionally left untouched.
+func (m *mmapAccessor) rename(path string) error {
+	m.incAccess()
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if err := file.RenameFile(m.f.Name(), path); err != nil {
+		return err
+	}
+
+	newf, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+
+	oldf := m.f
+	m.f = newf
+	return oldf.Close()
 }

--- a/tsdb/engine/tsm1/mmap_windows.go
+++ b/tsdb/engine/tsm1/mmap_windows.go
@@ -9,7 +9,7 @@ import (
 	"syscall"
 	"unsafe"
 
-	"github.com/influxdata/influxdb/pkg/file"
+	"github.com/influxdata/influxdb/v2/pkg/file"
 )
 
 // mmap implementation for Windows

--- a/tsdb/engine/tsm1/mmap_windows.go
+++ b/tsdb/engine/tsm1/mmap_windows.go
@@ -2,11 +2,14 @@ package tsm1
 
 import (
 	"errors"
+	"io"
 	"os"
 	"reflect"
 	"sync"
 	"syscall"
 	"unsafe"
+
+	"github.com/influxdata/influxdb/pkg/file"
 )
 
 // mmap implementation for Windows
@@ -129,5 +132,64 @@ func madviseDontNeed(b []byte) error { return nil }
 
 func madvise(b []byte, advice int) error {
 	// Not implemented
+	return nil
+}
+
+// rename moves the backing file to path, used by FileStore.replace when the
+// file is still referenced (InUse) by in-flight readers.
+//
+// LIMITATION: Windows cannot rename or delete a file that has an open handle or
+// an active mapping, so the mapping must be unmapped and the descriptor closed
+// before the rename, then remapped afterward. Unlike the Unix implementation
+// (see mmap_unix.go), this cannot preserve the original mapping. In-flight
+// readers that hold raw slices into the old mapping (for example the index keys
+// returned by KeyAt, which alias m.b) without holding the FileStore lock will
+// read freed memory and may fault. This is a pre-existing limitation of the
+// Windows mmap path and was not introduced by the fast/slow lock split; it is
+// documented here so the divergence from Unix is explicit. A correct Windows
+// fix would have to drain references before unmapping, which would block the
+// writer (holding both FileStore mutexes) for the lifetime of the slowest
+// reader and defeat the purger design.
+func (m *mmapAccessor) rename(path string) error {
+	m.incAccess()
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	err := munmap(m.b)
+	if err != nil {
+		return err
+	}
+
+	if err := m.f.Close(); err != nil {
+		return err
+	}
+
+	if err := file.RenameFile(m.f.Name(), path); err != nil {
+		return err
+	}
+
+	m.f, err = os.Open(path)
+	if err != nil {
+		return err
+	}
+
+	if _, err := m.f.Seek(0, io.SeekStart); err != nil {
+		return err
+	}
+
+	stat, err := m.f.Stat()
+	if err != nil {
+		return err
+	}
+
+	m.b, err = mmap(m.f, 0, int(stat.Size()))
+	if err != nil {
+		return err
+	}
+
+	if m.mmapWillNeed {
+		return madviseWillNeed(m.b)
+	}
 	return nil
 }

--- a/tsdb/engine/tsm1/reader.go
+++ b/tsdb/engine/tsm1/reader.go
@@ -14,7 +14,6 @@ import (
 	"sync/atomic"
 
 	"github.com/influxdata/influxdb/v2/pkg/bytesutil"
-	"github.com/influxdata/influxdb/v2/pkg/file"
 	"github.com/influxdata/influxdb/v2/tsdb"
 )
 
@@ -1541,50 +1540,6 @@ func (m *mmapAccessor) free() error {
 
 func (m *mmapAccessor) incAccess() {
 	atomic.AddUint64(&m.accessCount, 1)
-}
-
-func (m *mmapAccessor) rename(path string) error {
-	m.incAccess()
-
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	err := munmap(m.b)
-	if err != nil {
-		return err
-	}
-
-	if err := m.f.Close(); err != nil {
-		return err
-	}
-
-	if err := file.RenameFile(m.f.Name(), path); err != nil {
-		return err
-	}
-
-	m.f, err = os.Open(path)
-	if err != nil {
-		return err
-	}
-
-	if _, err := m.f.Seek(0, 0); err != nil {
-		return err
-	}
-
-	stat, err := m.f.Stat()
-	if err != nil {
-		return err
-	}
-
-	m.b, err = mmap(m.f, 0, int(stat.Size()))
-	if err != nil {
-		return err
-	}
-
-	if m.mmapWillNeed {
-		return madviseWillNeed(m.b)
-	}
-	return nil
 }
 
 func (m *mmapAccessor) read(key []byte, timestamp int64) ([]Value, error) {

--- a/tsdb/index/tsi1/export_test.go
+++ b/tsdb/index/tsi1/export_test.go
@@ -1,0 +1,45 @@
+package tsi1
+
+import (
+	"time"
+
+	"github.com/influxdata/influxdb/v2/models"
+)
+
+// This file holds exported methods that exist only to support tests. Because it
+// is a _test.go file it is compiled only by `go test`, so these helpers do not
+// become part of the production build or the public package API, yet they remain
+// callable from the external tsi1_test package.
+
+// SetMaxLogFileSize provides a setter for the partition setting of maxLogFileSize
+// that is otherwise only available at creation time. Returns the previous value.
+// Only for tests!
+func (p *Partition) SetMaxLogFileSize(new int64) (old int64) {
+	p.mu.Lock()
+	old, p.maxLogFileSize = p.maxLogFileSize, new
+	p.mu.Unlock()
+	return old
+}
+
+// SetMaxLogFileAge provides a setter for the partition setting of maxLogFileAge
+// that is otherwise only available at creation time. Returns the previous value.
+// Only for tests!
+func (p *Partition) SetMaxLogFileAge(new time.Duration) (old time.Duration) {
+	p.mu.Lock()
+	old, p.maxLogFileAge = p.maxLogFileAge, new
+	p.mu.Unlock()
+	return old
+}
+
+// SetManifestPathForTest is only to force a bad path in testing.
+func (p *Partition) SetManifestPathForTest(path string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.manifestPathFn = func() string { return path }
+}
+
+// CreateSeriesListIfNotExists is an exported wrapper around
+// createSeriesListIfNotExists for use in tests only. Only for tests!
+func (p *Partition) CreateSeriesListIfNotExists(names [][]byte, tagsSlice []models.Tags) ([]uint64, error) {
+	return p.createSeriesListIfNotExists(names, tagsSlice)
+}

--- a/tsdb/index/tsi1/partition.go
+++ b/tsdb/index/tsi1/partition.go
@@ -112,16 +112,6 @@ func NewPartition(sfile *tsdb.SeriesFile, path string) *Partition {
 	return p
 }
 
-// SetMaxLogFileSize provides a setter for the partition setting of maxLogFileSize
-// that is otherwise only available at creation time. Returns the previous value.
-// Only for tests!
-func (p *Partition) SetMaxLogFileSize(new int64) (old int64) {
-	p.mu.Lock()
-	old, p.maxLogFileSize = p.maxLogFileSize, new
-	p.mu.Unlock()
-	return old
-}
-
 // bytes estimates the memory footprint of this Partition, in bytes.
 func (p *Partition) bytes() int {
 	var b int
@@ -470,13 +460,6 @@ func (p *Partition) manifest(newFileSet *FileSet) *Manifest {
 	}
 
 	return m
-}
-
-// SetManifestPathForTest is only to force a bad path in testing
-func (p *Partition) SetManifestPathForTest(path string) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	p.manifestPathFn = func() string { return path }
 }
 
 // WithLogger sets the logger for the index.

--- a/tsdb/index/tsi1/partition_test.go
+++ b/tsdb/index/tsi1/partition_test.go
@@ -7,9 +7,12 @@ import (
 	"path/filepath"
 	"syscall"
 	"testing"
+	"time"
 
+	"github.com/influxdata/influxdb/v2/models"
 	"github.com/influxdata/influxdb/v2/tsdb"
 	"github.com/influxdata/influxdb/v2/tsdb/index/tsi1"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPartition_Open(t *testing.T) {
@@ -129,23 +132,45 @@ func TestPartition_Compact_Write_Fail(t *testing.T) {
 		t.Cleanup(func() { sfile.Close() })
 
 		p := MustOpenPartition(t, sfile.SeriesFile)
-		t.Cleanup(func() {
-			if err := p.Close(); err != nil {
-				t.Fatalf("error closing partition: %v", err)
-			}
-		})
-		p.Partition.SetMaxLogFileSize(-1)
+		t.Cleanup(func() { require.NoError(t, p.Close(), "error closing partition") })
+
+		// Long age so writing a series does not auto-roll the active log file
+		// (a bare Partition has maxLogFileAge == 0, which compacts any non-empty log).
+		p.Partition.SetMaxLogFileAge(time.Hour)
+
+		// Seed one series so the active log file is non-empty.
+		_, err := p.CreateSeriesListIfNotExists(
+			[][]byte{[]byte("cpu")},
+			[]models.Tags{models.NewTags(map[string]string{"region": "east"})})
+		require.NoError(t, err, "creating series")
+
+		// Size threshold 1: the populated log needs compaction, but a freshly
+		// rolled EMPTY log (size 0 < 1) does not, so the async re-trigger chain
+		// settles and the count cannot grow past fileN+1 under any interleaving.
+		p.Partition.SetMaxLogFileSize(1)
+
 		fileN := p.FileN()
 		p.Compact()
-		if (1 + fileN) != p.FileN() {
-			t.Fatalf("manifest write in compaction should have succeeded, but number of files did not change correctly: expected %d files, got %d files", fileN+1, p.FileN())
-		}
+		p.Wait() // settles; cannot re-trigger because the rolled log is empty
+		require.Equal(t, fileN+1, p.FileN(),
+			"manifest write in compaction should have succeeded and changed the file count")
+
+		// Part 2: a failing MANIFEST write during the roll must roll back, leaving
+		// the count unchanged. Raise the threshold so the next write doesn't roll,
+		// then shrink it again so the populated log needs compaction.
+		p.Partition.SetMaxLogFileSize(tsdb.DefaultMaxIndexLogFileSize)
+		_, err = p.CreateSeriesListIfNotExists(
+			[][]byte{[]byte("mem")},
+			[]models.Tags{models.NewTags(map[string]string{"region": "west"})})
+		require.NoError(t, err, "creating second series")
+		p.Partition.SetMaxLogFileSize(1)
+
 		p.SetManifestPathForTest(badManifestPath)
 		fileN = p.FileN()
 		p.Compact()
-		if fileN != p.FileN() {
-			t.Fatalf("manifest write should have failed the compaction, but number of files changed: expected %d files, got %d files", fileN, p.FileN())
-		}
+		p.Wait()
+		require.Equal(t, fileN, p.FileN(),
+			"failed manifest write must not change the file count")
 	})
 }
 


### PR DESCRIPTION
The tsm1 FileStore previously guarded its file list and scalar fields with a
single sync.RWMutex. Because Go's RWMutex is writer-preferring, a waiting
writer blocks all new readers, so a slow maintenance reader (Apply, a delete,
or a stats recompute) holding the read lock could stall a compaction's
write-lock acquisition, which in turn stalled hot, latency-sensitive query
reads such as KeyCursor. This commit splits the single mutex into a fast lane
and a slow lane: readers take either lock, while writers take both (slow then
fast) through new wlock/wunlock helpers. Genuinely O(1) hot operations
(KeyCursor, Count, Files, CurrentGeneration, LastModified) use the fast lane
and the long or maintenance operations use the slow lane, so the drain wait
falls on the slow lane and the fast lane is held only for the brief in-memory
mutation. The Ref/InUse/purger deletion-safety invariant is preserved because
every writer still holds both locks during the InUse check.
    
The change also fixes a latent deadlock in Keys, which held a read lock and
then called WalkKeys, which re-acquired the same lock: a recursive read lock
that deadlocks whenever a writer is waiting between the two acquisitions, so
Keys now relies on WalkKeys for its locking. Two new tests cover the work.
TestFileStore_ConcurrentLocking drives a heavy concurrent mix of fast readers,
slow readers, and writers under the race detector, asserting both the absence
of deadlocks and the correctness of every value returned, and
BenchmarkFileStore_FastLaneContention measures each fast-lane reader's latency
while Apply holds the read lock and Replace stalls on the write lock.
    
This also fixes a race condition in FileStore.replace, which
moves a still-referenced TSM file out of the way by renaming it,
but the mmap accessor's rename unmapped and remapped the file's memory.
Readers such as WalkKeys hold only a reference (not the FileStore lock) while
iterating, and the keys they return alias the mapping, so unmapping it under
them caused a use-after-free fault. The rename now leaves the mapping intact on
Unix, where a mapping survives both the rename and closing its descriptor, so
referenced readers keep working until the purger closes the file once all
references drain; Windows cannot rename a mapped file and therefore retains its
prior behavior, now documented as a limitation. This was a pre-existing bug
surfaced by the new concurrent FileStore locking test.
    
(cherry picked from commit 66b0dd767660fab185f034b1a871fde04dfd0874)
    
Closes https://github.com/influxdata/influxdb/issues/27504
