### PR TITLE
chore(sync): influxdb_pro 2026-06-25

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,7 +444,7 @@ dependencies = [
 
 [[package]]
 name = "arrow_util"
-version = "3.9.4"
+version = "3.9.6"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -541,7 +541,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "authz"
-version = "3.9.4"
+version = "3.9.6"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -655,7 +655,7 @@ dependencies = [
 
 [[package]]
 name = "backoff"
-version = "3.9.4"
+version = "3.9.6"
 dependencies = [
  "rand 0.9.2",
  "snafu 0.9.0",
@@ -1069,7 +1069,7 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "catalog_cache"
-version = "3.9.4"
+version = "3.9.6"
 dependencies = [
  "bytes",
  "criterion 0.8.2",
@@ -1207,7 +1207,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "client_util"
-version = "3.9.4"
+version = "3.9.6"
 dependencies = [
  "http 1.4.0",
  "iox_http_util",
@@ -1785,7 +1785,7 @@ dependencies = [
 
 [[package]]
 name = "data_types"
-version = "3.9.4"
+version = "3.9.6"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -2518,7 +2518,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion_util"
-version = "3.9.4"
+version = "3.9.6"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -2602,7 +2602,7 @@ dependencies = [
 
 [[package]]
 name = "dml"
-version = "3.9.4"
+version = "3.9.6"
 dependencies = [
  "arrow_util",
  "data_types",
@@ -2714,7 +2714,7 @@ dependencies = [
 
 [[package]]
 name = "error_reporting"
-version = "3.9.4"
+version = "3.9.6"
 dependencies = [
  "datafusion",
  "snafu 0.9.0",
@@ -2744,7 +2744,7 @@ dependencies = [
 
 [[package]]
 name = "executor"
-version = "3.9.4"
+version = "3.9.6"
 dependencies = [
  "futures",
  "metric",
@@ -2825,7 +2825,7 @@ dependencies = [
 
 [[package]]
 name = "flightsql"
-version = "3.9.4"
+version = "3.9.6"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -3032,7 +3032,7 @@ dependencies = [
 
 [[package]]
 name = "futures_test_utils"
-version = "3.9.4"
+version = "3.9.6"
 dependencies = [
  "clap",
  "futures",
@@ -3043,7 +3043,7 @@ dependencies = [
 
 [[package]]
 name = "generated_types"
-version = "3.9.4"
+version = "3.9.6"
 dependencies = [
  "bytes",
  "pbjson",
@@ -3692,7 +3692,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb2_client"
-version = "3.9.4"
+version = "3.9.6"
 dependencies = [
  "bytes",
  "futures",
@@ -3711,7 +3711,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3"
-version = "3.9.4"
+version = "3.9.6"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3801,7 +3801,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_authz"
-version = "3.9.4"
+version = "3.9.6"
 dependencies = [
  "async-trait",
  "authz",
@@ -3818,7 +3818,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_cache"
-version = "3.9.4"
+version = "3.9.6"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3853,7 +3853,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_catalog"
-version = "3.9.4"
+version = "3.9.6"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3905,7 +3905,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_clap_blocks"
-version = "3.9.4"
+version = "3.9.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3942,7 +3942,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_client"
-version = "3.9.4"
+version = "3.9.6"
 dependencies = [
  "bytes",
  "hashbrown 0.14.5",
@@ -3962,7 +3962,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_commands"
-version = "3.9.4"
+version = "3.9.6"
 dependencies = [
  "anyhow",
  "clap",
@@ -3981,7 +3981,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_id"
-version = "3.9.4"
+version = "3.9.6"
 dependencies = [
  "indexmap 2.13.0",
  "serde",
@@ -3991,7 +3991,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_internal_api"
-version = "3.9.4"
+version = "3.9.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4012,7 +4012,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_load_generator"
-version = "3.9.4"
+version = "3.9.6"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4041,7 +4041,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_process"
-version = "3.9.4"
+version = "3.9.6"
 dependencies = [
  "iox_time",
  "uuid",
@@ -4049,7 +4049,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_processing_engine"
-version = "3.9.4"
+version = "3.9.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4093,7 +4093,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_py_api"
-version = "3.9.4"
+version = "3.9.6"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -4121,7 +4121,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_query_executor"
-version = "3.9.4"
+version = "3.9.6"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4171,7 +4171,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_server"
-version = "3.9.4"
+version = "3.9.6"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4254,7 +4254,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_shutdown"
-version = "3.9.4"
+version = "3.9.6"
 dependencies = [
  "futures",
  "futures-util",
@@ -4269,14 +4269,14 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_startup"
-version = "3.9.4"
+version = "3.9.6"
 dependencies = [
  "chrono",
 ]
 
 [[package]]
 name = "influxdb3_sys_events"
-version = "3.9.4"
+version = "3.9.6"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4295,7 +4295,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_system_tables"
-version = "3.9.4"
+version = "3.9.6"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4327,7 +4327,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_telemetry"
-version = "3.9.4"
+version = "3.9.6"
 dependencies = [
  "futures",
  "futures-util",
@@ -4348,7 +4348,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_test_helpers"
-version = "3.9.4"
+version = "3.9.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4361,7 +4361,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_types"
-version = "3.9.4"
+version = "3.9.6"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4381,7 +4381,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_wal"
-version = "3.9.4"
+version = "3.9.6"
 dependencies = [
  "async-trait",
  "bitcode",
@@ -4409,7 +4409,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_write"
-version = "3.9.4"
+version = "3.9.6"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4478,7 +4478,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb_influxql_parser"
-version = "3.9.4"
+version = "3.9.6"
 dependencies = [
  "assert_matches",
  "chrono",
@@ -4495,7 +4495,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb_iox_client"
-version = "3.9.4"
+version = "3.9.6"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -4524,7 +4524,7 @@ dependencies = [
 
 [[package]]
 name = "ingester_query_grpc"
-version = "3.9.4"
+version = "3.9.6"
 dependencies = [
  "base64 0.22.1",
  "data_types",
@@ -4581,7 +4581,7 @@ checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
 
 [[package]]
 name = "iox_http"
-version = "3.9.4"
+version = "3.9.6"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -4601,7 +4601,7 @@ dependencies = [
 
 [[package]]
 name = "iox_http_util"
-version = "3.9.4"
+version = "3.9.6"
 dependencies = [
  "futures",
  "http 1.4.0",
@@ -4612,7 +4612,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query"
-version = "3.9.4"
+version = "3.9.6"
 dependencies = [
  "arrow",
  "arrow_util",
@@ -4661,7 +4661,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query_influxql"
-version = "3.9.4"
+version = "3.9.6"
 dependencies = [
  "arrow",
  "assert_matches",
@@ -4688,7 +4688,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query_influxql_rewrite"
-version = "3.9.4"
+version = "3.9.6"
 dependencies = [
  "influxdb_influxql_parser",
  "thiserror 2.0.18",
@@ -4696,7 +4696,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query_params"
-version = "3.9.4"
+version = "3.9.6"
 dependencies = [
  "arrow",
  "assert_matches",
@@ -4710,7 +4710,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query_udf"
-version = "3.9.4"
+version = "3.9.6"
 dependencies = [
  "datafusion-udf-wasm-host",
  "datafusion-udf-wasm-query",
@@ -4721,7 +4721,7 @@ dependencies = [
 
 [[package]]
 name = "iox_system_tables"
-version = "3.9.4"
+version = "3.9.6"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4731,7 +4731,7 @@ dependencies = [
 
 [[package]]
 name = "iox_time"
-version = "3.9.4"
+version = "3.9.6"
 dependencies = [
  "chrono",
  "parking_lot",
@@ -4740,7 +4740,7 @@ dependencies = [
 
 [[package]]
 name = "iox_v1_query_api"
-version = "3.9.4"
+version = "3.9.6"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4854,7 +4854,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jemalloc_stats"
-version = "3.9.4"
+version = "3.9.6"
 dependencies = [
  "snafu 0.9.0",
  "tikv-jemalloc-ctl",
@@ -4999,7 +4999,7 @@ dependencies = [
 
 [[package]]
 name = "linear_buffer"
-version = "3.9.4"
+version = "3.9.6"
 
 [[package]]
 name = "linux-raw-sys"
@@ -5043,7 +5043,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "logfmt"
-version = "3.9.4"
+version = "3.9.6"
 dependencies = [
  "humantime",
  "parking_lot",
@@ -5151,14 +5151,14 @@ dependencies = [
 
 [[package]]
 name = "metric"
-version = "3.9.4"
+version = "3.9.6"
 dependencies = [
  "parking_lot",
 ]
 
 [[package]]
 name = "metric_exporters"
-version = "3.9.4"
+version = "3.9.6"
 dependencies = [
  "metric",
  "mockito",
@@ -5283,7 +5283,7 @@ checksum = "9252111cf132ba0929b6f8e030cac2a24b507f3a4d6db6fb2896f27b354c714b"
 
 [[package]]
 name = "mutable_batch"
-version = "3.9.4"
+version = "3.9.6"
 dependencies = [
  "arrow",
  "arrow_util",
@@ -5301,7 +5301,7 @@ dependencies = [
 
 [[package]]
 name = "mutable_batch_lp"
-version = "3.9.4"
+version = "3.9.6"
 dependencies = [
  "arrow_util",
  "assert_matches",
@@ -5317,7 +5317,7 @@ dependencies = [
 
 [[package]]
 name = "mutable_batch_pb"
-version = "3.9.4"
+version = "3.9.6"
 dependencies = [
  "arrow_util",
  "criterion 0.8.2",
@@ -5555,7 +5555,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_limit"
-version = "3.9.4"
+version = "3.9.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5567,7 +5567,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_mem_cache"
-version = "3.9.4"
+version = "3.9.6"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5594,7 +5594,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_metrics"
-version = "3.9.4"
+version = "3.9.6"
 dependencies = [
  "async-trait",
  "bloom2",
@@ -5619,7 +5619,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_mock"
-version = "3.9.4"
+version = "3.9.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5633,7 +5633,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_size_hinting"
-version = "3.9.4"
+version = "3.9.6"
 dependencies = [
  "chrono",
  "http 1.4.0",
@@ -5643,7 +5643,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_utils"
-version = "3.9.4"
+version = "3.9.6"
 dependencies = [
  "async-trait",
  "backon",
@@ -5656,7 +5656,7 @@ dependencies = [
 
 [[package]]
 name = "observability_deps"
-version = "3.9.4"
+version = "3.9.6"
 dependencies = [
  "tracing",
 ]
@@ -5721,7 +5721,7 @@ dependencies = [
 
 [[package]]
 name = "panic_logging"
-version = "3.9.4"
+version = "3.9.6"
 dependencies = [
  "metric",
  "test_helpers",
@@ -5796,7 +5796,7 @@ dependencies = [
 
 [[package]]
 name = "parquet_file"
-version = "3.9.4"
+version = "3.9.6"
 dependencies = [
  "arrow",
  "arrow_util",
@@ -5825,7 +5825,7 @@ dependencies = [
 
 [[package]]
 name = "partition"
-version = "3.9.4"
+version = "3.9.6"
 dependencies = [
  "arrow",
  "assert_matches",
@@ -6122,7 +6122,7 @@ dependencies = [
 
 [[package]]
 name = "predicate"
-version = "3.9.4"
+version = "3.9.6"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6468,7 +6468,7 @@ dependencies = [
 
 [[package]]
 name = "query_functions"
-version = "3.9.4"
+version = "3.9.6"
 dependencies = [
  "arrow",
  "chrono",
@@ -7151,7 +7151,7 @@ dependencies = [
 
 [[package]]
 name = "schema"
-version = "3.9.4"
+version = "3.9.6"
 dependencies = [
  "arrow",
  "base64 0.22.1",
@@ -7334,7 +7334,7 @@ dependencies = [
 
 [[package]]
 name = "service_common"
-version = "3.9.4"
+version = "3.9.6"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -7348,7 +7348,7 @@ dependencies = [
 
 [[package]]
 name = "service_grpc_flight"
-version = "3.9.4"
+version = "3.9.6"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -7415,7 +7415,7 @@ dependencies = [
 
 [[package]]
 name = "sharder"
-version = "3.9.4"
+version = "3.9.6"
 dependencies = [
  "criterion 0.8.2",
  "data_types",
@@ -7937,7 +7937,7 @@ dependencies = [
 
 [[package]]
 name = "table_batch"
-version = "3.9.4"
+version = "3.9.6"
 dependencies = [
  "arrow_util",
  "bitvec",
@@ -8023,7 +8023,7 @@ dependencies = [
 
 [[package]]
 name = "test_helpers"
-version = "3.9.4"
+version = "3.9.6"
 dependencies = [
  "async-trait",
  "dotenvy",
@@ -8042,7 +8042,7 @@ dependencies = [
 
 [[package]]
 name = "test_helpers_authz"
-version = "3.9.4"
+version = "3.9.6"
 dependencies = [
  "futures",
  "generated_types",
@@ -8315,7 +8315,7 @@ dependencies = [
 
 [[package]]
 name = "tokio_metrics_bridge"
-version = "3.9.4"
+version = "3.9.6"
 dependencies = [
  "metric",
  "parking_lot",
@@ -8324,7 +8324,7 @@ dependencies = [
 
 [[package]]
 name = "tokio_watchdog"
-version = "3.9.4"
+version = "3.9.6"
 dependencies = [
  "metric",
  "test_helpers",
@@ -8547,7 +8547,7 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tower_trailer"
-version = "3.9.4"
+version = "3.9.6"
 dependencies = [
  "futures",
  "http 1.4.0",
@@ -8559,7 +8559,7 @@ dependencies = [
 
 [[package]]
 name = "trace"
-version = "3.9.4"
+version = "3.9.6"
 dependencies = [
  "chrono",
  "parking_lot",
@@ -8569,7 +8569,7 @@ dependencies = [
 
 [[package]]
 name = "trace_exporters"
-version = "3.9.4"
+version = "3.9.6"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8586,7 +8586,7 @@ dependencies = [
 
 [[package]]
 name = "trace_http"
-version = "3.9.4"
+version = "3.9.6"
 dependencies = [
  "bytes",
  "futures",
@@ -8681,7 +8681,7 @@ dependencies = [
 
 [[package]]
 name = "tracker"
-version = "3.9.4"
+version = "3.9.6"
 dependencies = [
  "futures",
  "hashbrown 0.14.5",
@@ -8701,7 +8701,7 @@ dependencies = [
 
 [[package]]
 name = "trogging"
-version = "3.9.4"
+version = "3.9.6"
 dependencies = [
  "clap",
  "logfmt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,7 +125,7 @@ exclude = [
 #
 # For porting to the actual OSS repo (influxdb), this would need to change to `-nightly`, i.e., by
 # stripping the `-oss`.
-version = "3.9.4"
+version = "3.9.6"
 authors = ["InfluxData OSS Developers"]
 edition = "2024"
 license = "MIT OR Apache-2.0"

--- a/influxdb3_write/src/lib.rs
+++ b/influxdb3_write/src/lib.rs
@@ -279,6 +279,56 @@ impl PersistedSnapshot {
         (db_count, table_count, file_count)
     }
 
+    /// Count `(databases, tables, files)` in the `removed_files` collection.
+    pub fn removed_db_table_and_file_count(&self) -> (u64, u64, u64) {
+        let mut db_count = 0;
+        let mut table_count = 0;
+        let mut file_count = 0;
+        for (_, db_tables) in &self.removed_files {
+            db_count += 1;
+            table_count += db_tables.tables.len() as u64;
+            file_count += db_tables.tables.values().fold(0, |mut acc, files| {
+                acc += files.len() as u64;
+                acc
+            });
+        }
+        (db_count, table_count, file_count)
+    }
+
+    /// The `(database, table)` holding the most parquet files across both the
+    /// persisted and removed collections, with that file count. Used to point
+    /// at the source of an unusually large snapshot manifest.
+    pub fn largest_table_by_file_count(&self) -> Option<(DbId, TableId, u64)> {
+        let mut worst: Option<(DbId, TableId, u64)> = None;
+        for map in [&self.databases, &self.removed_files] {
+            for (db_id, db_tables) in map {
+                for (table_id, files) in &db_tables.tables {
+                    let count = files.len() as u64;
+                    if worst.is_none_or(|(_, _, wc)| count > wc) {
+                        worst = Some((*db_id, *table_id, count));
+                    }
+                }
+            }
+        }
+        worst
+    }
+
+    /// The number of distinct gen1 time buckets (parquet `chunk_time` values)
+    /// spanned by the persisted files. A large value alongside many tables
+    /// indicates a wide time range (e.g. a historical backfill) fanned out
+    /// across tables, which multiplies the file count in a single snapshot.
+    pub fn distinct_chunk_time_count(&self) -> usize {
+        let mut times = std::collections::HashSet::new();
+        for (_, db_tables) in &self.databases {
+            for (_, files) in &db_tables.tables {
+                for file in files {
+                    times.insert(file.chunk_time);
+                }
+            }
+        }
+        times.len()
+    }
+
     pub fn overall_db_table_file_counts(host_snapshots: &[PersistedSnapshot]) -> (u64, u64, u64) {
         host_snapshots.iter().fold((0, 0, 0), |mut acc, item| {
             let (db_count, table_count, file_count) = item.db_table_and_file_count();

--- a/influxdb3_write/src/persister.rs
+++ b/influxdb3_write/src/persister.rs
@@ -315,12 +315,48 @@ impl Persister {
         let snapshot_file_path =
             SnapshotInfoFilePath::new(self.node_identifier_prefix.as_str(), seq);
         let json = serde_json::to_vec_pretty(persisted_snapshot)?;
+        let manifest_bytes = json.len();
+
+        // A healthy snapshot manifest is small (KB to a few MB). A large one
+        // indicates a pathological number of files and risks exceeding object
+        // store limits, so warn with a breakdown (added vs removed files and
+        // the worst offending table) to identify the cause. The breakdown is
+        // only computed above the threshold to keep the common path cheap.
+        const LARGE_SNAPSHOT_MANIFEST_BYTES: usize = 1024 * 1024 * 1024; // 1 GiB
+        if manifest_bytes >= LARGE_SNAPSHOT_MANIFEST_BYTES {
+            let (added_dbs, added_tables, added_files) = snapshot.db_table_and_file_count();
+            let (removed_dbs, removed_tables, removed_files) =
+                snapshot.removed_db_table_and_file_count();
+            warn!(
+                snapshot_sequence_number = seq.as_u64(),
+                manifest_bytes,
+                added_dbs,
+                added_tables,
+                added_files,
+                removed_dbs,
+                removed_tables,
+                removed_files,
+                parquet_size_bytes = snapshot.parquet_size_bytes,
+                row_count = snapshot.row_count,
+                time_span_ns = snapshot.max_time.saturating_sub(snapshot.min_time),
+                gen1_buckets = snapshot.distinct_chunk_time_count(),
+                worst_table = ?snapshot.largest_table_by_file_count(),
+                "persisting unusually large snapshot manifest"
+            );
+        }
+
+        // Use an adaptive put: snapshot manifests are usually small, but with
+        // very large numbers of files they can exceed the object store's
+        // single-PUT limit (e.g. Azure's 5 GiB cap), which fails the snapshot
+        // and stalls the WAL. put_adaptive routes oversized payloads through a
+        // multipart upload instead of a single PUT.
         self.object_store
-            .put(snapshot_file_path.as_ref(), json.into())
+            .put_adaptive(snapshot_file_path.as_ref(), json.into())
             .await?;
 
         debug!(
             snapshot_sequence_number = seq.as_u64(),
+            manifest_bytes,
             path = %snapshot_file_path.as_ref(),
             "persist_snapshot: completed"
         );


### PR DESCRIPTION
Source: 5bd310935afee7fca398a27bdf01837d9c29f2d6

Commits:
- `5bd310935a` chore: update versions to 3.9.6 (influxdata/influxdb_pro#4295)
- `df34b5c0bc` chore(3.9): bump version to 3.9.5 (influxdata/influxdb_pro#4267)
- `39ccebcc11` fix(write/snapshot): persist snapshot manifests via multipart upload (influxdata/influxdb_pro#4266)

Routine oss/ sync from influxdb_pro for the 3.9.6 Core release. Core skipped 3.9.5, so this advances it from 3.9.4 to 3.9.6 and includes the snapshot multipart-upload fix (#4266) that shipped in Enterprise 3.9.5.

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
