### PR TITLE
chore(sync): influxdb_pro 2026-06-25

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,7 +444,7 @@ dependencies = [
 
 [[package]]
 name = "arrow_util"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -541,7 +541,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "authz"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -655,7 +655,7 @@ dependencies = [
 
 [[package]]
 name = "backoff"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "rand 0.9.4",
  "snafu 0.9.0",
@@ -1078,7 +1078,7 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "catalog_cache"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "bytes",
  "criterion 0.8.2",
@@ -1222,14 +1222,14 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli_types"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "tokio",
 ]
 
 [[package]]
 name = "client_util"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "http 1.4.0",
  "iox_http_util",
@@ -1832,7 +1832,7 @@ dependencies = [
 
 [[package]]
 name = "data_types"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -2566,7 +2566,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion_util"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -2661,7 +2661,7 @@ dependencies = [
 
 [[package]]
 name = "dml"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "arrow_util",
  "data_types",
@@ -2773,7 +2773,7 @@ dependencies = [
 
 [[package]]
 name = "error_reporting"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "datafusion",
  "snafu 0.9.0",
@@ -2803,7 +2803,7 @@ dependencies = [
 
 [[package]]
 name = "executor"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "futures",
  "metric",
@@ -2884,7 +2884,7 @@ dependencies = [
 
 [[package]]
 name = "flightsql"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -3091,7 +3091,7 @@ dependencies = [
 
 [[package]]
 name = "futures_test_utils"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "clap",
  "futures",
@@ -3102,7 +3102,7 @@ dependencies = [
 
 [[package]]
 name = "generated_types"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "bytes",
  "pbjson",
@@ -3756,7 +3756,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb2_client"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "bytes",
  "futures",
@@ -3775,7 +3775,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3867,7 +3867,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_authz"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "async-trait",
  "authz",
@@ -3885,7 +3885,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_cache"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3920,7 +3920,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_catalog"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "ahash 0.8.12",
  "anyhow",
@@ -3977,7 +3977,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_clap_blocks"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4014,7 +4014,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_client"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "bytes",
  "flate2",
@@ -4035,7 +4035,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_commands"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4062,7 +4062,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_id"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "criterion 0.5.1",
  "indexmap 2.14.0",
@@ -4074,7 +4074,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_internal_api"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4095,7 +4095,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_load_generator"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4125,7 +4125,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_process"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "iox_time",
  "uuid",
@@ -4133,7 +4133,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_processing_engine"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4176,7 +4176,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_py_api"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -4204,7 +4204,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_query_executor"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4255,7 +4255,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_server"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4342,7 +4342,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_shutdown"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "futures",
  "futures-util",
@@ -4357,14 +4357,14 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_startup"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "chrono",
 ]
 
 [[package]]
 name = "influxdb3_sys_events"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4383,7 +4383,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_system_tables"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4415,7 +4415,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_telemetry"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "futures",
  "futures-util",
@@ -4436,7 +4436,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_test_helpers"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4449,7 +4449,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_types"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4469,7 +4469,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_wal"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "async-trait",
  "bitcode",
@@ -4498,7 +4498,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_write"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4568,7 +4568,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb_influxql_parser"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "assert_matches",
  "chrono",
@@ -4585,7 +4585,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb_iox_client"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -4614,7 +4614,7 @@ dependencies = [
 
 [[package]]
 name = "ingester_query_grpc"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "base64 0.22.1",
  "data_types",
@@ -4680,7 +4680,7 @@ checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
 
 [[package]]
 name = "iox_http"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -4700,7 +4700,7 @@ dependencies = [
 
 [[package]]
 name = "iox_http_util"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "futures",
  "http 1.4.0",
@@ -4711,7 +4711,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "arrow",
  "arrow_util",
@@ -4760,7 +4760,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query_influxql"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "arrow",
  "assert_matches",
@@ -4787,7 +4787,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query_influxql_rewrite"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "influxdb_influxql_parser",
  "thiserror 2.0.18",
@@ -4795,7 +4795,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query_params"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "arrow",
  "assert_matches",
@@ -4809,7 +4809,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query_udf"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "datafusion-udf-wasm-host",
  "datafusion-udf-wasm-query",
@@ -4820,7 +4820,7 @@ dependencies = [
 
 [[package]]
 name = "iox_system_tables"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4830,7 +4830,7 @@ dependencies = [
 
 [[package]]
 name = "iox_time"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "chrono",
  "parking_lot",
@@ -4839,7 +4839,7 @@ dependencies = [
 
 [[package]]
 name = "iox_v1_query_api"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4953,7 +4953,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jemalloc_pprof_http"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "http-body-util",
  "hyper 1.9.0",
@@ -4966,7 +4966,7 @@ dependencies = [
 
 [[package]]
 name = "jemalloc_stats"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "futures",
  "snafu 0.9.0",
@@ -5159,7 +5159,7 @@ dependencies = [
 
 [[package]]
 name = "linear_buffer"
-version = "3.10.0"
+version = "3.10.1"
 
 [[package]]
 name = "linux-raw-sys"
@@ -5203,7 +5203,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "logfmt"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "humantime",
  "parking_lot",
@@ -5302,14 +5302,14 @@ dependencies = [
 
 [[package]]
 name = "metric"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "parking_lot",
 ]
 
 [[package]]
 name = "metric_exporters"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "metric",
  "mockito",
@@ -5434,7 +5434,7 @@ checksum = "9252111cf132ba0929b6f8e030cac2a24b507f3a4d6db6fb2896f27b354c714b"
 
 [[package]]
 name = "mutable_batch"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "arrow",
  "arrow_util",
@@ -5452,7 +5452,7 @@ dependencies = [
 
 [[package]]
 name = "mutable_batch_lp"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "arrow_util",
  "assert_matches",
@@ -5468,7 +5468,7 @@ dependencies = [
 
 [[package]]
 name = "mutable_batch_pb"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "arrow_util",
  "criterion 0.8.2",
@@ -5706,7 +5706,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_limit"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5718,7 +5718,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_mem_cache"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5746,7 +5746,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_metrics"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "async-trait",
  "bloom2",
@@ -5771,7 +5771,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_mock"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5785,7 +5785,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_size_hinting"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "chrono",
  "http 1.4.0",
@@ -5795,7 +5795,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_utils"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "async-trait",
  "backon",
@@ -5809,7 +5809,7 @@ dependencies = [
 
 [[package]]
 name = "observability_deps"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "tracing",
 ]
@@ -5874,7 +5874,7 @@ dependencies = [
 
 [[package]]
 name = "panic_logging"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "metric",
  "test_helpers",
@@ -5949,7 +5949,7 @@ dependencies = [
 
 [[package]]
 name = "parquet_file"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "arrow",
  "arrow_util",
@@ -5980,7 +5980,7 @@ dependencies = [
 
 [[package]]
 name = "partition"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "arrow",
  "assert_matches",
@@ -6277,7 +6277,7 @@ dependencies = [
 
 [[package]]
 name = "predicate"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6621,7 +6621,7 @@ dependencies = [
 
 [[package]]
 name = "query_functions"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "arrow",
  "chrono",
@@ -7331,7 +7331,7 @@ dependencies = [
 
 [[package]]
 name = "schema"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "arrow",
  "base64 0.22.1",
@@ -7514,7 +7514,7 @@ dependencies = [
 
 [[package]]
 name = "service_common"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -7528,7 +7528,7 @@ dependencies = [
 
 [[package]]
 name = "service_grpc_flight"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -7604,7 +7604,7 @@ dependencies = [
 
 [[package]]
 name = "sharder"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "criterion 0.8.2",
  "data_types",
@@ -8126,7 +8126,7 @@ dependencies = [
 
 [[package]]
 name = "table_batch"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "arrow_util",
  "bitvec",
@@ -8222,7 +8222,7 @@ dependencies = [
 
 [[package]]
 name = "test_helpers"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "async-trait",
  "dotenvy",
@@ -8241,7 +8241,7 @@ dependencies = [
 
 [[package]]
 name = "test_helpers_authz"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "futures",
  "generated_types",
@@ -8514,7 +8514,7 @@ dependencies = [
 
 [[package]]
 name = "tokio_metrics_bridge"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "metric",
  "parking_lot",
@@ -8523,7 +8523,7 @@ dependencies = [
 
 [[package]]
 name = "tokio_watchdog"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "metric",
  "test_helpers",
@@ -8746,7 +8746,7 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tower_trailer"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "futures",
  "http 1.4.0",
@@ -8758,7 +8758,7 @@ dependencies = [
 
 [[package]]
 name = "trace"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "chrono",
  "parking_lot",
@@ -8768,7 +8768,7 @@ dependencies = [
 
 [[package]]
 name = "trace_exporters"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8785,7 +8785,7 @@ dependencies = [
 
 [[package]]
 name = "trace_http"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "bytes",
  "futures",
@@ -8880,7 +8880,7 @@ dependencies = [
 
 [[package]]
 name = "tracker"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "futures",
  "hashbrown 0.14.5",
@@ -8900,7 +8900,7 @@ dependencies = [
 
 [[package]]
 name = "trogging"
-version = "3.10.0"
+version = "3.10.1"
 dependencies = [
  "clap",
  "logfmt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,7 +127,7 @@ exclude = [
 #
 # For porting to the actual OSS repo (influxdb), this would need to change to `-nightly`, i.e., by
 # stripping the `-oss`.
-version = "3.10.0"
+version = "3.10.1"
 authors = ["InfluxData OSS Developers"]
 edition = "2024"
 license = "MIT OR Apache-2.0"

--- a/influxdb3_write/src/lib.rs
+++ b/influxdb3_write/src/lib.rs
@@ -256,6 +256,56 @@ impl PersistedSnapshot {
         (db_count, table_count, file_count)
     }
 
+    /// Count `(databases, tables, files)` in the `removed_files` collection.
+    pub fn removed_db_table_and_file_count(&self) -> (u64, u64, u64) {
+        let mut db_count = 0;
+        let mut table_count = 0;
+        let mut file_count = 0;
+        for (_, db_tables) in &self.removed_files {
+            db_count += 1;
+            table_count += db_tables.tables.len() as u64;
+            file_count += db_tables.tables.values().fold(0, |mut acc, files| {
+                acc += files.len() as u64;
+                acc
+            });
+        }
+        (db_count, table_count, file_count)
+    }
+
+    /// The `(database, table)` holding the most parquet files across both the
+    /// persisted and removed collections, with that file count. Used to point
+    /// at the source of an unusually large snapshot manifest.
+    pub fn largest_table_by_file_count(&self) -> Option<(DbId, TableId, u64)> {
+        let mut worst: Option<(DbId, TableId, u64)> = None;
+        for map in [&self.databases, &self.removed_files] {
+            for (db_id, db_tables) in map {
+                for (table_id, files) in &db_tables.tables {
+                    let count = files.len() as u64;
+                    if worst.is_none_or(|(_, _, wc)| count > wc) {
+                        worst = Some((*db_id, *table_id, count));
+                    }
+                }
+            }
+        }
+        worst
+    }
+
+    /// The number of distinct gen1 time buckets (parquet `chunk_time` values)
+    /// spanned by the persisted files. A large value alongside many tables
+    /// indicates a wide time range (e.g. a historical backfill) fanned out
+    /// across tables, which multiplies the file count in a single snapshot.
+    pub fn distinct_chunk_time_count(&self) -> usize {
+        let mut times = std::collections::HashSet::new();
+        for (_, db_tables) in &self.databases {
+            for (_, files) in &db_tables.tables {
+                for file in files {
+                    times.insert(file.chunk_time);
+                }
+            }
+        }
+        times.len()
+    }
+
     pub fn overall_db_table_file_counts(host_snapshots: &[PersistedSnapshot]) -> (u64, u64, u64) {
         host_snapshots.iter().fold((0, 0, 0), |mut acc, item| {
             let (db_count, table_count, file_count) = item.db_table_and_file_count();

--- a/influxdb3_write/src/persister.rs
+++ b/influxdb3_write/src/persister.rs
@@ -315,12 +315,48 @@ impl Persister {
         let snapshot_file_path =
             SnapshotInfoFilePath::new(self.node_identifier_prefix.as_str(), seq);
         let json = serde_json::to_vec_pretty(persisted_snapshot)?;
+        let manifest_bytes = json.len();
+
+        // A healthy snapshot manifest is small (KB to a few MB). A large one
+        // indicates a pathological number of files and risks exceeding object
+        // store limits, so warn with a breakdown (added vs removed files and
+        // the worst offending table) to identify the cause. The breakdown is
+        // only computed above the threshold to keep the common path cheap.
+        const LARGE_SNAPSHOT_MANIFEST_BYTES: usize = 1024 * 1024 * 1024; // 1 GiB
+        if manifest_bytes >= LARGE_SNAPSHOT_MANIFEST_BYTES {
+            let (added_dbs, added_tables, added_files) = snapshot.db_table_and_file_count();
+            let (removed_dbs, removed_tables, removed_files) =
+                snapshot.removed_db_table_and_file_count();
+            warn!(
+                snapshot_sequence_number = seq.as_u64(),
+                manifest_bytes,
+                added_dbs,
+                added_tables,
+                added_files,
+                removed_dbs,
+                removed_tables,
+                removed_files,
+                parquet_size_bytes = snapshot.parquet_size_bytes,
+                row_count = snapshot.row_count,
+                time_span_ns = snapshot.max_time.saturating_sub(snapshot.min_time),
+                gen1_buckets = snapshot.distinct_chunk_time_count(),
+                worst_table = ?snapshot.largest_table_by_file_count(),
+                "persisting unusually large snapshot manifest"
+            );
+        }
+
+        // Use an adaptive put: snapshot manifests are usually small, but with
+        // very large numbers of files they can exceed the object store's
+        // single-PUT limit (e.g. Azure's 5 GiB cap), which fails the snapshot
+        // and stalls the WAL. put_adaptive routes oversized payloads through a
+        // multipart upload instead of a single PUT.
         self.object_store
-            .put(snapshot_file_path.as_ref(), json.into())
+            .put_adaptive(snapshot_file_path.as_ref(), json.into())
             .await?;
 
         debug!(
             snapshot_sequence_number = seq.as_u64(),
+            manifest_bytes,
             path = %snapshot_file_path.as_ref(),
             "persist_snapshot: completed"
         );


### PR DESCRIPTION
Source: 03019b127ccd9c0c6fbfb236826a1b18ecee9090

Commits:
- `03019b127c` chore: update versions to 3.10.1 (influxdata/influxdb_pro#4294)
- `68a1256bc1` fix(write/snapshot): persist snapshot manifests via multipart upload (influxdata/influxdb_pro#4292)

Routine oss/ sync from influxdb_pro for the 3.10.1 Core release. Advances Core from 3.10.0 to 3.10.1 with the snapshot multipart-upload fix (#4292)

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
