### PR TITLE
fix: correct TestPartition_Compact_Write_Fail (#27516)

### DIFF
--- a/tsdb/index/tsi1/export_test.go
+++ b/tsdb/index/tsi1/export_test.go
@@ -1,0 +1,46 @@
+package tsi1
+
+import (
+	"time"
+
+	"github.com/influxdata/influxdb/models"
+	"github.com/influxdata/influxdb/tsdb"
+)
+
+// This file holds exported methods that exist only to support tests. Because it
+// is a _test.go file it is compiled only by `go test`, so these helpers do not
+// become part of the production build or the public package API, yet they remain
+// callable from the external tsi1_test package.
+
+// SetMaxLogFileSize provides a setter for the partition setting of maxLogFileSize
+// that is otherwise only available at creation time. Returns the previous value.
+// Only for tests!
+func (p *Partition) SetMaxLogFileSize(new int64) (old int64) {
+	p.mu.Lock()
+	old, p.maxLogFileSize = p.maxLogFileSize, new
+	p.mu.Unlock()
+	return old
+}
+
+// SetMaxLogFileAge provides a setter for the partition setting of maxLogFileAge
+// that is otherwise only available at creation time. Returns the previous value.
+// Only for tests!
+func (p *Partition) SetMaxLogFileAge(new time.Duration) (old time.Duration) {
+	p.mu.Lock()
+	old, p.maxLogFileAge = p.maxLogFileAge, new
+	p.mu.Unlock()
+	return old
+}
+
+// SetManifestPathForTest is only to force a bad path in testing.
+func (p *Partition) SetManifestPathForTest(path string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.manifestPathFn = func() string { return path }
+}
+
+// CreateSeriesListIfNotExists is an exported wrapper around
+// createSeriesListIfNotExists for use in tests only. Only for tests!
+func (p *Partition) CreateSeriesListIfNotExists(names [][]byte, tagsSlice []models.Tags, tracker tsdb.StatsTracker) ([]uint64, error) {
+	return p.createSeriesListIfNotExists(names, tagsSlice, tracker)
+}

--- a/tsdb/index/tsi1/partition.go
+++ b/tsdb/index/tsi1/partition.go
@@ -111,16 +111,6 @@ func NewPartition(sfile *tsdb.SeriesFile, path string) *Partition {
 	return p
 }
 
-// SetMaxLogFileSize provides a setter for the partition setting of maxLogFileSize
-// that is otherwise only available at creation time. Returns the previous value.
-// Only for tests!
-func (p *Partition) SetMaxLogFileSize(new int64) (old int64) {
-	p.mu.Lock()
-	old, p.maxLogFileSize = p.maxLogFileSize, new
-	p.mu.Unlock()
-	return old
-}
-
 // bytes estimates the memory footprint of this Partition, in bytes.
 func (p *Partition) bytes() int {
 	var b int
@@ -470,13 +460,6 @@ func (p *Partition) manifest(newFileSet *FileSet) *Manifest {
 	}
 
 	return m
-}
-
-// SetManifestPathForTest is only to force a bad path in testing
-func (p *Partition) SetManifestPathForTest(path string) {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	p.manifestPathFn = func() string { return path }
 }
 
 // WithLogger sets the logger for the index.

--- a/tsdb/index/tsi1/partition_test.go
+++ b/tsdb/index/tsi1/partition_test.go
@@ -7,9 +7,12 @@ import (
 	"path/filepath"
 	"syscall"
 	"testing"
+	"time"
 
+	"github.com/influxdata/influxdb/models"
 	"github.com/influxdata/influxdb/tsdb"
 	"github.com/influxdata/influxdb/tsdb/index/tsi1"
+	"github.com/stretchr/testify/require"
 )
 
 func TestPartition_Open(t *testing.T) {
@@ -144,23 +147,46 @@ func TestPartition_Compact_Write_Fail(t *testing.T) {
 		})
 
 		p := MustOpenPartition(sfile.SeriesFile)
-		t.Cleanup(func() {
-			if err := p.Close(); err != nil {
-				t.Fatalf("error closing partition: %v", err)
-			}
-		})
-		p.Partition.SetMaxLogFileSize(-1)
+		t.Cleanup(func() { require.NoError(t, p.Close(), "error closing partition") })
+
+		// Long age so writing a series does not auto-roll the active log file
+		// (a bare Partition has maxLogFileAge == 0, which compacts any non-empty log).
+		p.Partition.SetMaxLogFileAge(time.Hour)
+
+		// Seed one series so the active log file is non-empty.
+		_, err := p.CreateSeriesListIfNotExists(
+			[][]byte{[]byte("cpu")},
+			[]models.Tags{models.NewTags(map[string]string{"region": "east"})},
+			notrack)
+		require.NoError(t, err, "creating series")
+
+		// Size threshold 1: the populated log needs compaction, but a freshly
+		// rolled EMPTY log (size 0 < 1) does not, so the async re-trigger chain
+		// settles and the count cannot grow past fileN+1 under any interleaving.
+		p.Partition.SetMaxLogFileSize(1)
 		fileN := p.FileN()
 		p.Compact()
-		if (1 + fileN) != p.FileN() {
-			t.Fatalf("manifest write in compaction should have succeeded, but number of files did not change correctly: expected %d files, got %d files", fileN+1, p.FileN())
-		}
+		p.Wait() // settles; cannot re-trigger because the rolled log is empty
+		require.Equal(t, fileN+1, p.FileN(),
+			"manifest write in compaction should have succeeded and changed the file count")
+
+		// Part 2: a failing MANIFEST write during the roll must roll back, leaving
+		// the count unchanged. Raise the threshold so the next write doesn't roll,
+		// then shrink it again so the populated log needs compaction.
+		p.Partition.SetMaxLogFileSize(tsdb.DefaultMaxIndexLogFileSize)
+		_, err = p.CreateSeriesListIfNotExists(
+			[][]byte{[]byte("mem")},
+			[]models.Tags{models.NewTags(map[string]string{"region": "west"})},
+			notrack)
+		require.NoError(t, err, "creating second series")
+		p.Partition.SetMaxLogFileSize(1)
+
 		p.SetManifestPathForTest(badManifestPath)
 		fileN = p.FileN()
 		p.Compact()
-		if fileN != p.FileN() {
-			t.Fatalf("manifest write should have failed the compaction, but number of files changed: expected %d files, got %d files", fileN, p.FileN())
-		}
+		p.Wait()
+		require.Equal(t, fileN, p.FileN(),
+			"failed manifest write must not change the file count")
 	})
 }
 


### PR DESCRIPTION
The test forced compaction with maxLogFileSize=-1, which makes even an empty log file always need compaction, so the async compactor kept re-triggering and prepending log files; a background re-trigger could inflate the file count before the assertion ran, failing intermittently under scheduler load. Seed the log with a series and use a positive size threshold so a freshly rolled, empty log no longer needs compaction; the compactor now settles after one pass and the file count is deterministic.

Failed only on the Darwin build of V2.

Closes https://github.com/influxdata/influxdb/issues/27515

(cherry picked from commit 1f2c054eaba320d4062c0d22114b0b27ce5f0609)

Closes https://github.com/influxdata/influxdb/issues/27517