### PR TITLE
feat: Add DefaultPlanner stats to Engine stats

### DIFF
--- a/tsdb/engine/tsm1/engine.go
+++ b/tsdb/engine/tsm1/engine.go
@@ -149,6 +149,13 @@ const (
 	statTSMFullCompactionError    = "tsmFullCompactionErr"
 	statTSMFullCompactionDuration = "tsmFullCompactionDuration"
 	statTSMFullCompactionQueue    = "tsmFullCompactionQueue"
+
+	statCompactionPlannerFindGenerations = "compactionPlannerFindGenerations"
+	statCompactionPlannerPlanLevel1      = "compactionPlannerPlanLevel1"
+	statCompactionPlannerPlanLevel2      = "compactionPlannerPlanLevel2"
+	statCompactionPlannerPlanLevel3      = "compactionPlannerPlanLevel3"
+	statCompactionPlannerPlan            = "compactionPlannerPlan"
+	statCompactionPlannerPlanOptimize    = "compactionPlannerPlanOptimize"
 )
 
 // Engine represents a storage engine with compressed blocks.
@@ -709,6 +716,11 @@ type EngineStatistics struct {
 	TSMFullCompactionErrors   int64 // Counter of full compactions that have failed due to error.
 	TSMFullCompactionDuration int64 // Counter of number of wall nanoseconds spent in full compactions.
 	TSMFullCompactionsQueue   int64 // Gauge of full compactions queue.
+
+	CompactionPlannerFindGenerations int64                       // Counter of calls to CompactionPlanner.FindGenerations.
+	CompactionPlannerPlanLevel       [LevelCompactionCount]int64 // Counter of calls to CompactionPlanner.PlanLevel, by level (1..LevelCompactionCount).
+	CompactionPlannerPlan            int64                       // Counter of calls to CompactionPlanner.Plan.
+	CompactionPlannerPlanOptimize    int64                       // Counter of calls to CompactionPlanner.PlanOptimize.
 }
 
 // Statistics returns statistics for periodic monitoring.
@@ -752,6 +764,13 @@ func (e *Engine) Statistics(tags map[string]string) []models.Statistic {
 			statTSMFullCompactionError:    atomic.LoadInt64(&e.Stats.TSMFullCompactionErrors),
 			statTSMFullCompactionDuration: atomic.LoadInt64(&e.Stats.TSMFullCompactionDuration),
 			statTSMFullCompactionQueue:    atomic.LoadInt64(&e.Stats.TSMFullCompactionsQueue),
+
+			statCompactionPlannerFindGenerations: atomic.LoadInt64(&e.Stats.CompactionPlannerFindGenerations),
+			statCompactionPlannerPlanLevel1:      atomic.LoadInt64(&e.Stats.CompactionPlannerPlanLevel[0]),
+			statCompactionPlannerPlanLevel2:      atomic.LoadInt64(&e.Stats.CompactionPlannerPlanLevel[1]),
+			statCompactionPlannerPlanLevel3:      atomic.LoadInt64(&e.Stats.CompactionPlannerPlanLevel[2]),
+			statCompactionPlannerPlan:            atomic.LoadInt64(&e.Stats.CompactionPlannerPlan),
+			statCompactionPlannerPlanOptimize:    atomic.LoadInt64(&e.Stats.CompactionPlannerPlanOptimize),
 		},
 	})
 
@@ -2358,11 +2377,20 @@ func makePlannedCompactionGroup(groups []CompactionGroup, pointsPerBlock int) []
 }
 
 func (e *Engine) planCompactionsLevel(generations TsmGenerations, level int) []PlannedCompactionGroup {
+	// The stat array is sized to LevelCompactionCount, so the number of exported
+	// stat keys is fixed at compile time. Only valid levels are counted; an
+	// out-of-range level (a programming error here, since this method is only
+	// ever called with levels 1..LevelCompactionCount) is ignored rather than
+	// allowed to grow the exported stat set without bound.
+	if level >= 1 && level <= LevelCompactionCount {
+		atomic.AddInt64(&e.Stats.CompactionPlannerPlanLevel[level-1], 1)
+	}
 	groups, _ := e.CompactionPlan.PlanLevel(generations, level)
 	return makePlannedCompactionGroup(groups, tsdb.DefaultMaxPointsPerBlock)
 }
 
 func (e *Engine) planCompactionsInner() ([]PlannedCompactionGroup, []PlannedCompactionGroup, []PlannedCompactionGroup, []PlannedCompactionGroup, []PlannedCompactionGroup) {
+	atomic.AddInt64(&e.Stats.CompactionPlannerFindGenerations, 1)
 	generations := e.CompactionPlan.FindGenerations()
 
 	// Find our compaction plans
@@ -2370,7 +2398,9 @@ func (e *Engine) planCompactionsInner() ([]PlannedCompactionGroup, []PlannedComp
 	level2Groups := e.planCompactionsLevel(generations, 2)
 	level3Groups := e.planCompactionsLevel(generations, 3)
 	lastModified := e.LastModified()
+	atomic.AddInt64(&e.Stats.CompactionPlannerPlan, 1)
 	l4Groups, _ := e.CompactionPlan.Plan(generations, lastModified)
+	atomic.AddInt64(&e.Stats.CompactionPlannerPlanOptimize, 1)
 	l5Groups, _, l5GenCount := e.CompactionPlan.PlanOptimize(generations, lastModified)
 
 	// Some groups in level 4 may contain already optimized files. In these cases, it is

--- a/tsdb/engine/tsm1/engine_test.go
+++ b/tsdb/engine/tsm1/engine_test.go
@@ -2403,17 +2403,19 @@ func TestEngine_Statistics_TSI1Cache(t *testing.T) {
 // PlanLevel three times (levels 1-3), Plan once, and PlanOptimize once, so after
 // N cycles the counters are deterministic regardless of the installed planner.
 func TestEngine_Statistics_CompactionPlanner(t *testing.T) {
-	e := MustOpenEngine(tsdb.TSI1IndexName)
+	e, err := NewEngine(tsdb.TSI1IndexName)
+	require.NoError(t, err)
+	// Disable background compactions so PlanCompactions is only invoked by this test.
+	e.SetEnabled(false)
+	require.NoError(t, e.Open())
 	defer e.Close()
 
 	// Install a no-op planner so PlanCompactions exercises every planner method
-	// without doing real compaction work. MustOpenEngine does not enable
-	// background compactions, so PlanCompactions is only called from this test
-	// and the counts stay deterministic.
+	// without doing real compaction work.
 	e.CompactionPlan = &mockPlanner{}
 
 	const cycles = 3
-	for range cycles {
+	for i := 0; i < cycles; i++ {
 		e.PlanCompactions()
 	}
 

--- a/tsdb/engine/tsm1/engine_test.go
+++ b/tsdb/engine/tsm1/engine_test.go
@@ -2397,6 +2397,50 @@ func TestEngine_Statistics_TSI1Cache(t *testing.T) {
 	}
 }
 
+// TestEngine_Statistics_CompactionPlanner verifies that calls to the
+// CompactionPlanner methods are counted and surfaced through the engine's
+// Statistics aggregator. Each PlanCompactions cycle calls FindGenerations once,
+// PlanLevel three times (levels 1-3), Plan once, and PlanOptimize once, so after
+// N cycles the counters are deterministic regardless of the installed planner.
+func TestEngine_Statistics_CompactionPlanner(t *testing.T) {
+	e := MustOpenEngine(tsdb.TSI1IndexName)
+	defer e.Close()
+
+	// Install a no-op planner so PlanCompactions exercises every planner method
+	// without doing real compaction work. MustOpenEngine does not enable
+	// background compactions, so PlanCompactions is only called from this test
+	// and the counts stay deterministic.
+	e.CompactionPlan = &mockPlanner{}
+
+	const cycles = 3
+	for range cycles {
+		e.PlanCompactions()
+	}
+
+	stats := e.Statistics(map[string]string{"database": "db0", "id": "1"})
+
+	var found *models.Statistic
+	for i := range stats {
+		if stats[i].Name == "tsm1_engine" {
+			found = &stats[i]
+			break
+		}
+	}
+	require.NotNil(t, found, "expected a tsm1_engine statistic in engine output")
+	require.Equal(t, int64(cycles), found.Values["compactionPlannerFindGenerations"].(int64),
+		"FindGenerations is called once per cycle")
+	require.Equal(t, int64(cycles), found.Values["compactionPlannerPlanLevel1"].(int64),
+		"PlanLevel is called once per cycle at level 1")
+	require.Equal(t, int64(cycles), found.Values["compactionPlannerPlanLevel2"].(int64),
+		"PlanLevel is called once per cycle at level 2")
+	require.Equal(t, int64(cycles), found.Values["compactionPlannerPlanLevel3"].(int64),
+		"PlanLevel is called once per cycle at level 3")
+	require.Equal(t, int64(cycles), found.Values["compactionPlannerPlan"].(int64),
+		"Plan is called once per cycle")
+	require.Equal(t, int64(cycles), found.Values["compactionPlannerPlanOptimize"].(int64),
+		"PlanOptimize is called once per cycle")
+}
+
 func TestEngine_WritePoints_TypeConflict(t *testing.T) {
 	os.Setenv("INFLUXDB_SERIES_TYPE_CHECK_ENABLED", "1")
 	defer os.Unsetenv("INFLUXDB_SERIES_TYPE_CHECK_ENABLED")


### PR DESCRIPTION
Add compaction planning statistics to the tsm1 engine. New counters in EngineStatistics track how often each CompactionPlanner method runs during a planning cycle: FindGenerations, Plan, PlanOptimize, and PlanLevel (counted per level, 1 through LevelCompactionCount). The counters are incremented atomically as plans are built in planCompactionsInner and planCompactionsLevel, and are surfaced through the engine's Statistics aggregator under the tsm1_engine measurement, giving operators visibility into how frequently the planner is invoked and at which levels. Out-of-range levels are ignored so the exported stat set stays bounded at compile time. A test installs a no-op planner and runs several planning cycles to confirm the counts are deterministic and reported correctly regardless of the installed planner.

Closes https://github.com/influxdata/influxdb/issues/27307