### PR TITLE
feat: start/stop influxd on package install/uninstall

### DIFF
--- a/.circleci/packages/influxdb2/control/post-install
+++ b/.circleci/packages/influxdb2/control/post-install
@@ -16,6 +16,7 @@ function install_systemd {
     # Service file is now installed directly by RPM - just enable it
     systemctl daemon-reload
     systemctl enable influxdb
+    systemctl restart influxdb
 }
 
 function install_update_rcd {

--- a/.circleci/packages/influxdb2/control/post-uninstall
+++ b/.circleci/packages/influxdb2/control/post-uninstall
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 function disable_systemd {
+    systemctl stop influxdb
     systemctl disable influxdb
 }
 


### PR DESCRIPTION
Closes #24926.

Targeting `main-2.x` as this is the version I'm using. I can rebase to `main` if required.

- Restart influxd on package install/upgrade/downgrade.
- Stop influxd on package uninstall.

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
