### PR TITLE
chore(sync): influxdb_pro 2026-06-30

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -76,7 +76,15 @@ ignore = [
     # Another wasmtime advisory:
     "RUSTSEC-2026-0182",
     #
-    # TODO: update wasmtime via datafusion-udf-wasm to a patched version (>=43.0.2 <44.0.0 or >=44.0.1)
+    # wasmtime-wasi 41.0.4 WASI hard links and renames bypass FilePerms for the
+    # destination (https://rustsec.org/advisories/RUSTSEC-2026-0188). Same transitive
+    # path via datafusion-udf-wasm; only reachable if a Wasm UDF is loaded with WASI
+    # filesystem preopens granted, and UDFs are disabled by default
+    # (udfs_enabled = false). Fix requires wasmtime-wasi >=45.0.3, which needs an
+    # upstream datafusion-udf-wasm bump.
+    "RUSTSEC-2026-0188",
+    #
+    # TODO: update wasmtime-wasi via datafusion-udf-wasm to a patched version (>=45.0.3; >=46.0.1 is also fixed)
     #
     # pyo3 0.24-0.28 out-of-bounds read in Iterator::nth/nth_back on
     # PyList/PyTuple iterators; fix is only in pyo3 0.29 (API-breaking bump,


### PR DESCRIPTION
Source: 51c8ba7ad6d02decb2e99d77ff8b61f0106bd3c8

Commits:
- `343be1040a` chore: fix cargo deny check `wasmtime-wasi` (influxdata/influxdb_pro#4317) (influxdata/influxdb_pro#4325)
