### PR TITLE
chore(sync): influxdb_pro 2026-06-30

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -70,6 +70,16 @@ ignore = [
     "RUSTSEC-2026-0182",
     #
     # TODO: update wasmtime via datafusion-udf-wasm to a patched version (>=42.0.2)
+    #
+    # wasmtime-wasi 41.0.4 WASI hard links and renames bypass FilePerms for the
+    # destination (https://rustsec.org/advisories/RUSTSEC-2026-0188). Same transitive
+    # path via datafusion-udf-wasm; only reachable if a Wasm UDF is loaded with WASI
+    # filesystem preopens granted, and UDFs are disabled by default
+    # (udfs_enabled = false). Fix requires wasmtime-wasi >=45.0.3, which needs an
+    # upstream datafusion-udf-wasm bump.
+    "RUSTSEC-2026-0188",
+    #
+    # TODO: update wasmtime-wasi via datafusion-udf-wasm to a patched version (>=45.0.3; >=46.0.1 is also fixed)
 
     # rand unsoundness: only reachable with rand's `log` feature plus a custom logger
     # that calls rand::rng() and triggers a reseed. We don't enable rand's `log`


### PR DESCRIPTION
Source: 3fd16efc7b61cec99bf2940425928b6e8d5651dd

Commits:
- `2ba0f7b4d9` chore: fix cargo deny check `wasmtime-wasi` (influxdata/influxdb_pro#4317) (influxdata/influxdb_pro#4326)
