### PR TITLE
feat: add remote address (host) to query logging

### DIFF
--- a/query/executor.go
+++ b/query/executor.go
@@ -204,6 +204,9 @@ type ExecutionOptions struct {
 
 	// UserID is the ID of the user executing the query.
 	UserID string
+
+	// Remote requesting address
+	Host string
 }
 
 type (
@@ -479,6 +482,7 @@ type Task struct {
 	closing   chan struct{}
 	monitorCh chan error
 	err       error
+	host      string
 	mu        sync.Mutex
 }
 

--- a/query/executor_test.go
+++ b/query/executor_test.go
@@ -321,7 +321,8 @@ func TestQueryExecutor_Abort(t *testing.T) {
 
 func TestQueryExecutor_ShowQueries(t *testing.T) {
 	const testUser = "Fred"
-	const userColumn = 5
+	// Column layout is queryFieldNames: host, qid, query, database, duration, status, user.
+	const userColumn = 6
 	e := NewQueryExecutor()
 	e.StatementExecutor = &StatementExecutor{
 		ExecuteStatementFn: func(stmt influxql.Statement, ctx *query.ExecutionContext) error {
@@ -347,9 +348,9 @@ func TestQueryExecutor_ShowQueries(t *testing.T) {
 	} else if len(result.Series[0].Values) != 1 {
 		t.Errorf("expected %d row, got %d", 1, len(result.Series[0].Values))
 	} else if result.Series[0].Values[0][userColumn] != testUser {
-		t.Errorf("unexpected user: %s", result.Series[0].Values[0][0])
+		t.Errorf("unexpected user: %s", result.Series[0].Values[0][userColumn])
 	} else if result.Series[0].Columns[userColumn] != "user" {
-		t.Errorf("unexpected column: %s", result.Series[0].Columns[5])
+		t.Errorf("unexpected column: %s", result.Series[0].Columns[userColumn])
 	}
 	if result.Err != nil {
 		t.Errorf("unexpected error: %s", result.Err)
@@ -362,7 +363,8 @@ func TestQueryExecutor_ShowQueries(t *testing.T) {
 // databases they have read access to, while an admin should see all queries.
 func TestQueryExecutor_ShowQueries_NonAdminFiltering(t *testing.T) {
 	const (
-		dbColumn     = 2
+		// Column layout is queryFieldNames: host, qid, query, database, duration, status, user.
+		dbColumn     = 3
 		allowedDB    = "mydb"
 		forbiddenDB  = "secretdb"
 		nonAdminUser = "bar"

--- a/query/task_manager.go
+++ b/query/task_manager.go
@@ -31,7 +31,7 @@ const (
 )
 
 var (
-	queryFieldNames []string = []string{"qid", "query", "database", "duration", "status", "user"}
+	queryFieldNames []string = []string{"host", "qid", "query", "database", "duration", "status", "user"}
 )
 
 func (t TaskStatus) String() string {
@@ -149,7 +149,7 @@ func (t *TaskManager) executeShowQueriesStatement(q *influxql.ShowQueriesStateme
 
 		d = prettyTime(d)
 
-		values = append(values, []interface{}{id, qi.query, qi.database, d.String(), qi.status.String(), qi.userID})
+		values = append(values, []interface{}{qi.host, id, qi.query, qi.database, d.String(), qi.status.String(), qi.userID})
 	}
 
 	return []*models.Row{{
@@ -172,12 +172,14 @@ func prettyTime(d time.Duration) time.Duration {
 
 func (t *TaskManager) LogCurrentQueries(logFunc func(string, ...zap.Field)) {
 	for _, queryInfo := range t.Queries() {
-		logFunc("Current Queries", zap.Uint64(queryFieldNames[0], queryInfo.ID),
-			zap.String(queryFieldNames[1], queryInfo.Query),
-			zap.String(queryFieldNames[2], queryInfo.Database),
-			zap.String(queryFieldNames[3], prettyTime(queryInfo.Duration).String()),
-			zap.String(queryFieldNames[4], queryInfo.Status.String()),
-			zap.String(queryFieldNames[5], queryInfo.User))
+		logFunc("Current Queries",
+			zap.String(queryFieldNames[0], queryInfo.Host),
+			zap.Uint64(queryFieldNames[1], queryInfo.ID),
+			zap.String(queryFieldNames[2], queryInfo.Query),
+			zap.String(queryFieldNames[3], queryInfo.Database),
+			zap.String(queryFieldNames[4], prettyTime(queryInfo.Duration).String()),
+			zap.String(queryFieldNames[5], queryInfo.Status.String()),
+			zap.String(queryFieldNames[6], queryInfo.User))
 	}
 }
 
@@ -218,6 +220,7 @@ func (t *TaskManager) AttachQuery(q *influxql.Query, opt ExecutionOptions, inter
 		startTime: time.Now(),
 		closing:   make(chan struct{}),
 		monitorCh: make(chan error),
+		host:      opt.Host,
 	}
 	t.queries[qid] = query
 
@@ -229,8 +232,8 @@ func (t *TaskManager) AttachQuery(q *influxql.Query, opt ExecutionOptions, inter
 
 			select {
 			case <-timer.C:
-				t.Logger.Warn(fmt.Sprintf("Detected slow query: %s (qid: %d, database: %s, user: %s, threshold: %s)",
-					query.query, qid, query.database, query.userID, t.LogQueriesAfter))
+				t.Logger.Warn(fmt.Sprintf("Detected slow query from %s: %s (qid: %d, database: %s, user: %s, threshold: %s)",
+					query.host, query.query, qid, query.database, query.userID, t.LogQueriesAfter))
 			case <-closing:
 			}
 			return nil
@@ -288,6 +291,7 @@ func (t *TaskManager) DetachQuery(qid uint64) error {
 
 // QueryInfo represents the information for a query.
 type QueryInfo struct {
+	Host     string        `json:"host"`
 	ID       uint64        `json:"id"`
 	Query    string        `json:"query"`
 	Database string        `json:"database"`
@@ -305,6 +309,7 @@ func (t *TaskManager) Queries() []QueryInfo {
 	queries := make([]QueryInfo, 0, len(t.queries))
 	for id, qi := range t.queries {
 		queries = append(queries, QueryInfo{
+			Host:     qi.host,
 			ID:       id,
 			Query:    qi.query,
 			Database: qi.database,

--- a/query/task_manager_test.go
+++ b/query/task_manager_test.go
@@ -1,0 +1,163 @@
+package query_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/influxdata/influxdb/query"
+	"github.com/influxdata/influxdb/services/meta"
+	"github.com/influxdata/influxql"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+// TestTaskManager_Queries_Host verifies that the requesting client host passed
+// in ExecutionOptions is threaded through onto the tracked Task and surfaced in
+// the QueryInfo returned by Queries().
+func TestTaskManager_Queries_Host(t *testing.T) {
+	tm := query.NewTaskManager()
+
+	q, err := influxql.ParseQuery("SELECT * FROM cpu")
+	require.NoError(t, err)
+
+	const clientHost = "10.0.0.5:12345"
+	_, detach, err := tm.AttachQuery(q, query.ExecutionOptions{
+		Database: "mydb",
+		UserID:   "alice",
+		Host:     clientHost,
+	}, nil)
+	require.NoError(t, err)
+	defer detach()
+
+	queries := tm.Queries()
+	require.Len(t, queries, 1)
+	require.Equal(t, clientHost, queries[0].Host)
+	// Sanity check that the pre-existing fields are still populated correctly.
+	require.Equal(t, "mydb", queries[0].Database)
+	require.Equal(t, "alice", queries[0].User)
+}
+
+// TestTaskManager_LogCurrentQueries_Host verifies that LogCurrentQueries emits
+// the host as the first structured field, matching queryFieldNames ordering.
+func TestTaskManager_LogCurrentQueries_Host(t *testing.T) {
+	tm := query.NewTaskManager()
+
+	q, err := influxql.ParseQuery("SELECT * FROM cpu")
+	require.NoError(t, err)
+
+	const clientHost = "192.0.2.10:5000"
+	_, detach, err := tm.AttachQuery(q, query.ExecutionOptions{Host: clientHost}, nil)
+	require.NoError(t, err)
+	defer detach()
+
+	fieldsByMsg := make(map[string][]zap.Field)
+	tm.LogCurrentQueries(func(msg string, fields ...zap.Field) {
+		fieldsByMsg[msg] = fields
+	})
+
+	fields, ok := fieldsByMsg["Current Queries"]
+	require.True(t, ok, "expected a \"Current Queries\" log entry")
+	require.NotEmpty(t, fields)
+
+	require.Equal(t, "host", fields[0].Key)
+	require.Equal(t, clientHost, fields[0].String)
+}
+
+// TestTaskManager_SlowQueryLog_Host verifies that the slow-query warning names
+// the client the query originated from.
+func TestTaskManager_SlowQueryLog_Host(t *testing.T) {
+	core, logs := observer.New(zapcore.WarnLevel)
+
+	tm := query.NewTaskManager()
+	tm.Logger = zap.New(core)
+	tm.LogQueriesAfter = time.Millisecond
+
+	q, err := influxql.ParseQuery("SELECT * FROM cpu")
+	require.NoError(t, err)
+
+	const clientHost = "203.0.113.9:4444"
+	_, detach, err := tm.AttachQuery(q, query.ExecutionOptions{
+		Database: "mydb",
+		UserID:   "alice",
+		Host:     clientHost,
+	}, nil)
+	require.NoError(t, err)
+	defer detach()
+
+	require.Eventually(t, func() bool {
+		return logs.FilterMessageSnippet("Detected slow query from " + clientHost).Len() > 0
+	}, time.Second, 5*time.Millisecond, "expected a slow-query warning naming the client host")
+}
+
+// TestTaskManager_ShowQueries_HostColumn verifies that SHOW QUERIES reports the
+// client host and that its column headers stay aligned with the row values.
+func TestTaskManager_ShowQueries_HostColumn(t *testing.T) {
+	e := NewQueryExecutor()
+
+	// blockCh keeps the SELECT alive so it stays visible in SHOW QUERIES.
+	blockCh := make(chan struct{})
+	defer close(blockCh)
+
+	e.StatementExecutor = &StatementExecutor{
+		ExecuteStatementFn: func(stmt influxql.Statement, ctx *query.ExecutionContext) error {
+			switch stmt.(type) {
+			case *influxql.ShowQueriesStatement:
+				return e.TaskManager.ExecuteStatement(ctx, stmt)
+			case *influxql.SelectStatement:
+				<-blockCh
+				return nil
+			}
+			t.Errorf("unexpected statement: %s", stmt)
+			return errUnexpected
+		},
+	}
+
+	const clientHost = "198.51.100.23:5555"
+	sel, err := influxql.ParseQuery("SELECT * FROM cpu")
+	require.NoError(t, err)
+	go func() {
+		discardOutput(e.ExecuteQuery(sel, query.ExecutionOptions{
+			Database: "mydb",
+			UserID:   "alice",
+			Host:     clientHost,
+		}, nil))
+	}()
+
+	// Wait for the background SELECT to register with the TaskManager.
+	require.Eventually(t, func() bool {
+		return len(e.TaskManager.Queries()) >= 1
+	}, time.Second, 5*time.Millisecond)
+
+	showQ, err := influxql.ParseQuery("SHOW QUERIES")
+	require.NoError(t, err)
+
+	results := e.ExecuteQuery(showQ, query.ExecutionOptions{
+		UserID:           "alice",
+		CoarseAuthorizer: &meta.UserInfo{Name: "alice", Admin: true},
+	}, nil)
+	result := <-results
+	require.NoError(t, result.Err)
+	require.Len(t, result.Series, 1)
+
+	series := result.Series[0]
+	require.Equal(t, "host", series.Columns[0])
+
+	// Every row must have exactly one value per column, otherwise the reported
+	// values are shifted relative to their headers.
+	for _, row := range series.Values {
+		require.Lenf(t, row, len(series.Columns),
+			"SHOW QUERIES row has %d values but %d columns: %v", len(row), len(series.Columns), row)
+	}
+
+	// The SELECT we launched must be reported under the host column.
+	var found bool
+	for _, row := range series.Values {
+		if host, ok := row[0].(string); ok && host == clientHost {
+			found = true
+			break
+		}
+	}
+	require.Truef(t, found, "expected SHOW QUERIES to report host %q; rows=%v", clientHost, series.Values)
+}

--- a/services/continuous_querier/service.go
+++ b/services/continuous_querier/service.go
@@ -13,6 +13,7 @@ import (
 	"github.com/influxdata/influxdb/models"
 	"github.com/influxdata/influxdb/monitor/diagnostics"
 	"github.com/influxdata/influxdb/query"
+	"github.com/influxdata/influxdb/services/httpd"
 	"github.com/influxdata/influxdb/services/meta"
 	"github.com/influxdata/influxql"
 	"go.uber.org/zap"
@@ -443,6 +444,7 @@ func (s *Service) runContinuousQueryAndWriteResult(cq *ContinuousQuery) *query.R
 	// Execute the SELECT.
 	ch := s.QueryExecutor.ExecuteQuery(q, query.ExecutionOptions{
 		Database: cq.Database,
+		Host:     httpd.PrintableRemoteAddr(nil),
 	}, closing)
 
 	// There is only one statement, so we will only ever receive one result

--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -734,6 +734,7 @@ func (h *Handler) serveQuery(w http.ResponseWriter, r *http.Request, user meta.U
 		NodeID:          nodeID,
 		Authorizer:      fineAuthorizer,
 		UserID:          userName,
+		Host:            PrintableRemoteAddr(r),
 	}
 
 	if h.Config.AuthEnabled {

--- a/services/httpd/response_logger.go
+++ b/services/httpd/response_logger.go
@@ -86,15 +86,7 @@ func buildLogLine(l *responseLogger, r *http.Request, start time.Time) string {
 
 	username := parseUsername(r)
 
-	host, _, err := net.SplitHostPort(r.RemoteAddr)
-	if err != nil {
-		host = r.RemoteAddr
-	}
-
-	if xff := r.Header["X-Forwarded-For"]; xff != nil {
-		addrs := append(xff, host)
-		host = strings.Join(addrs, ",")
-	}
+	host := PrintableRemoteAddr(r)
 
 	uri := r.URL.RequestURI()
 
@@ -152,6 +144,19 @@ func buildLogLine(l *responseLogger, r *http.Request, start time.Time) string {
 			// with apache's %D parameter in mod_log_config
 			int64(time.Since(start)/time.Microsecond))
 	}
+}
+
+func PrintableRemoteAddr(r *http.Request) string {
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		host = r.RemoteAddr
+	}
+
+	if xff := r.Header["X-Forwarded-For"]; xff != nil {
+		addrs := append(xff, host)
+		host = strings.Join(addrs, ",")
+	}
+	return host
 }
 
 // detect detects the first presence of a non blank string and returns it

--- a/services/httpd/response_logger.go
+++ b/services/httpd/response_logger.go
@@ -155,7 +155,9 @@ func PrintableRemoteAddr(r *http.Request) string {
 	}
 
 	if xff := r.Header["X-Forwarded-For"]; xff != nil {
-		addrs := append(xff, host)
+		addrs := make([]string, 0, len(xff)+1)
+		addrs = append(addrs, xff...)
+		addrs = append(addrs, host)
 		host = strings.Join(addrs, ",")
 	}
 	return host

--- a/services/httpd/response_logger.go
+++ b/services/httpd/response_logger.go
@@ -146,6 +146,8 @@ func buildLogLine(l *responseLogger, r *http.Request, start time.Time) string {
 	}
 }
 
+// PrintableRemoteAddr returns a printable representation of the request's remote address.
+// If X-Forwarded-For is present, its values are prepended (in order) before the RemoteAddr host.
 func PrintableRemoteAddr(r *http.Request) string {
 	host, _, err := net.SplitHostPort(r.RemoteAddr)
 	if err != nil {

--- a/services/httpd/response_logger.go
+++ b/services/httpd/response_logger.go
@@ -11,6 +11,8 @@ import (
 	"github.com/influxdata/influxql"
 )
 
+const NoHostSentinel = "internal"
+
 // responseLogger is wrapper of http.ResponseWriter that keeps track of its HTTP status
 // code and body size
 type responseLogger struct {
@@ -168,10 +170,10 @@ func PrintableRemoteAddr(r *http.Request) string {
 			host = strings.Join(addrs, ",")
 		}
 	}
-	return detect(host, "internal")
+	return detect(host, NoHostSentinel)
 }
 
-// detect detects the first presence of a non blank string and returns it
+// detect detects the first presence of a non-empty string and returns it
 func detect(values ...string) string {
 	for _, v := range values {
 		if v != "" {

--- a/services/httpd/response_logger.go
+++ b/services/httpd/response_logger.go
@@ -160,7 +160,7 @@ func PrintableRemoteAddr(r *http.Request) string {
 		addrs = append(addrs, host)
 		host = strings.Join(addrs, ",")
 	}
-	return host
+	return detect(host, "internal")
 }
 
 // detect detects the first presence of a non blank string and returns it

--- a/services/httpd/response_logger.go
+++ b/services/httpd/response_logger.go
@@ -148,17 +148,23 @@ func buildLogLine(l *responseLogger, r *http.Request, start time.Time) string {
 
 // PrintableRemoteAddr returns a printable representation of the request's remote address.
 // If X-Forwarded-For is present, its values are prepended (in order) before the RemoteAddr host.
+// Fall back to "internal" if no remote address is present.
 func PrintableRemoteAddr(r *http.Request) string {
-	host, _, err := net.SplitHostPort(r.RemoteAddr)
-	if err != nil {
-		host = r.RemoteAddr
-	}
+	var host string
+	var err error
 
-	if xff := r.Header["X-Forwarded-For"]; xff != nil {
-		addrs := make([]string, 0, len(xff)+1)
-		addrs = append(addrs, xff...)
-		addrs = append(addrs, host)
-		host = strings.Join(addrs, ",")
+	if r != nil {
+		host, _, err = net.SplitHostPort(r.RemoteAddr)
+		if err != nil {
+			host = r.RemoteAddr
+		}
+
+		if xff := r.Header["X-Forwarded-For"]; xff != nil {
+			addrs := make([]string, 0, len(xff)+1)
+			addrs = append(addrs, xff...)
+			addrs = append(addrs, host)
+			host = strings.Join(addrs, ",")
+		}
 	}
 	return detect(host, "internal")
 }

--- a/services/httpd/response_logger.go
+++ b/services/httpd/response_logger.go
@@ -159,10 +159,12 @@ func PrintableRemoteAddr(r *http.Request) string {
 			host = r.RemoteAddr
 		}
 
-		if xff := r.Header["X-Forwarded-For"]; xff != nil {
+		if xff := r.Header["X-Forwarded-For"]; len(xff) > 0 {
 			addrs := make([]string, 0, len(xff)+1)
 			addrs = append(addrs, xff...)
-			addrs = append(addrs, host)
+			if host != "" {
+				addrs = append(addrs, host)
+			}
 			host = strings.Join(addrs, ",")
 		}
 	}

--- a/services/httpd/response_logger_test.go
+++ b/services/httpd/response_logger_test.go
@@ -1,0 +1,67 @@
+package httpd_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/influxdata/influxdb/services/httpd"
+	"github.com/stretchr/testify/require"
+)
+
+// TestPrintableRemoteAddr verifies the host string derived from a request's
+// RemoteAddr and any X-Forwarded-For headers. This is the logic that was
+// extracted out of buildLogLine so it can be reused by the query Host field.
+func TestPrintableRemoteAddr(t *testing.T) {
+	tests := []struct {
+		name       string
+		remoteAddr string
+		forwarded  []string // one entry per X-Forwarded-For header line
+		want       string
+	}{
+		{
+			name:       "host and port strips the port",
+			remoteAddr: "10.1.2.3:4567",
+			want:       "10.1.2.3",
+		},
+		{
+			name:       "ipv6 host and port strips the port",
+			remoteAddr: "[::1]:8086",
+			want:       "::1",
+		},
+		{
+			name:       "unparseable remote addr is returned verbatim",
+			remoteAddr: "not-an-addr",
+			want:       "not-an-addr",
+		},
+		{
+			name:       "single forwarded-for is prepended",
+			remoteAddr: "10.1.2.3:4567",
+			forwarded:  []string{"192.168.0.1"},
+			want:       "192.168.0.1,10.1.2.3",
+		},
+		{
+			name:       "multiple forwarded-for values keep order then remote host",
+			remoteAddr: "10.1.2.3:4567",
+			forwarded:  []string{"192.168.0.1", "203.0.113.7"},
+			want:       "192.168.0.1,203.0.113.7,10.1.2.3",
+		},
+		{
+			name:       "forwarded-for with unparseable remote addr",
+			remoteAddr: "unixsocket",
+			forwarded:  []string{"192.168.0.1"},
+			want:       "192.168.0.1,unixsocket",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r, err := http.NewRequest("GET", "/query", nil)
+			require.NoError(t, err)
+			r.RemoteAddr = tt.remoteAddr
+			for _, f := range tt.forwarded {
+				r.Header.Add("X-Forwarded-For", f)
+			}
+			require.Equal(t, tt.want, httpd.PrintableRemoteAddr(r))
+		})
+	}
+}

--- a/services/httpd/response_logger_test.go
+++ b/services/httpd/response_logger_test.go
@@ -51,6 +51,11 @@ func TestPrintableRemoteAddr(t *testing.T) {
 			forwarded:  []string{"192.168.0.1"},
 			want:       "192.168.0.1,unixsocket",
 		},
+		{
+			name:       "empty remote addr falls back to internal",
+			remoteAddr: "",
+			want:       httpd.NoHostSentinel,
+		},
 	}
 
 	for _, tt := range tests {
@@ -64,4 +69,5 @@ func TestPrintableRemoteAddr(t *testing.T) {
 			require.Equal(t, tt.want, httpd.PrintableRemoteAddr(r))
 		})
 	}
+	require.Equal(t, httpd.NoHostSentinel, httpd.PrintableRemoteAddr(nil))
 }


### PR DESCRIPTION
Add the remote address from the http request to
slow query logging and active queries at shutdown
logging
