### PR TITLE
chore(sync): influxdb_pro 2026-07-07

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,7 +444,7 @@ dependencies = [
 
 [[package]]
 name = "arrow_util"
-version = "3.9.6"
+version = "3.9.8"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -541,7 +541,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "authz"
-version = "3.9.6"
+version = "3.9.8"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -655,7 +655,7 @@ dependencies = [
 
 [[package]]
 name = "backoff"
-version = "3.9.6"
+version = "3.9.8"
 dependencies = [
  "rand 0.9.2",
  "snafu 0.9.0",
@@ -1069,7 +1069,7 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "catalog_cache"
-version = "3.9.6"
+version = "3.9.8"
 dependencies = [
  "bytes",
  "criterion 0.8.2",
@@ -1207,7 +1207,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "client_util"
-version = "3.9.6"
+version = "3.9.8"
 dependencies = [
  "http 1.4.0",
  "iox_http_util",
@@ -1653,9 +1653,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1785,7 +1785,7 @@ dependencies = [
 
 [[package]]
 name = "data_types"
-version = "3.9.6"
+version = "3.9.8"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -2518,7 +2518,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion_util"
-version = "3.9.6"
+version = "3.9.8"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -2602,7 +2602,7 @@ dependencies = [
 
 [[package]]
 name = "dml"
-version = "3.9.6"
+version = "3.9.8"
 dependencies = [
  "arrow_util",
  "data_types",
@@ -2714,7 +2714,7 @@ dependencies = [
 
 [[package]]
 name = "error_reporting"
-version = "3.9.6"
+version = "3.9.8"
 dependencies = [
  "datafusion",
  "snafu 0.9.0",
@@ -2744,7 +2744,7 @@ dependencies = [
 
 [[package]]
 name = "executor"
-version = "3.9.6"
+version = "3.9.8"
 dependencies = [
  "futures",
  "metric",
@@ -2825,7 +2825,7 @@ dependencies = [
 
 [[package]]
 name = "flightsql"
-version = "3.9.6"
+version = "3.9.8"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -3032,7 +3032,7 @@ dependencies = [
 
 [[package]]
 name = "futures_test_utils"
-version = "3.9.6"
+version = "3.9.8"
 dependencies = [
  "clap",
  "futures",
@@ -3043,7 +3043,7 @@ dependencies = [
 
 [[package]]
 name = "generated_types"
-version = "3.9.6"
+version = "3.9.8"
 dependencies = [
  "bytes",
  "pbjson",
@@ -3692,7 +3692,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb2_client"
-version = "3.9.6"
+version = "3.9.8"
 dependencies = [
  "bytes",
  "futures",
@@ -3711,7 +3711,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3"
-version = "3.9.6"
+version = "3.9.8"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3801,7 +3801,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_authz"
-version = "3.9.6"
+version = "3.9.8"
 dependencies = [
  "async-trait",
  "authz",
@@ -3818,7 +3818,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_cache"
-version = "3.9.6"
+version = "3.9.8"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3853,7 +3853,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_catalog"
-version = "3.9.6"
+version = "3.9.8"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3905,7 +3905,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_clap_blocks"
-version = "3.9.6"
+version = "3.9.8"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3942,7 +3942,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_client"
-version = "3.9.6"
+version = "3.9.8"
 dependencies = [
  "bytes",
  "hashbrown 0.14.5",
@@ -3962,7 +3962,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_commands"
-version = "3.9.6"
+version = "3.9.8"
 dependencies = [
  "anyhow",
  "clap",
@@ -3981,7 +3981,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_id"
-version = "3.9.6"
+version = "3.9.8"
 dependencies = [
  "indexmap 2.13.0",
  "serde",
@@ -3991,7 +3991,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_internal_api"
-version = "3.9.6"
+version = "3.9.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4012,7 +4012,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_load_generator"
-version = "3.9.6"
+version = "3.9.8"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4041,7 +4041,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_process"
-version = "3.9.6"
+version = "3.9.8"
 dependencies = [
  "iox_time",
  "uuid",
@@ -4049,7 +4049,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_processing_engine"
-version = "3.9.6"
+version = "3.9.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4088,12 +4088,13 @@ dependencies = [
  "test-log",
  "thiserror 1.0.69",
  "tokio",
+ "tokio-util",
  "walkdir",
 ]
 
 [[package]]
 name = "influxdb3_py_api"
-version = "3.9.6"
+version = "3.9.8"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -4121,7 +4122,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_query_executor"
-version = "3.9.6"
+version = "3.9.8"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4171,7 +4172,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_server"
-version = "3.9.6"
+version = "3.9.8"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4254,7 +4255,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_shutdown"
-version = "3.9.6"
+version = "3.9.8"
 dependencies = [
  "futures",
  "futures-util",
@@ -4269,14 +4270,14 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_startup"
-version = "3.9.6"
+version = "3.9.8"
 dependencies = [
  "chrono",
 ]
 
 [[package]]
 name = "influxdb3_sys_events"
-version = "3.9.6"
+version = "3.9.8"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4295,7 +4296,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_system_tables"
-version = "3.9.6"
+version = "3.9.8"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4327,7 +4328,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_telemetry"
-version = "3.9.6"
+version = "3.9.8"
 dependencies = [
  "futures",
  "futures-util",
@@ -4348,7 +4349,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_test_helpers"
-version = "3.9.6"
+version = "3.9.8"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4361,7 +4362,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_types"
-version = "3.9.6"
+version = "3.9.8"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4381,7 +4382,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_wal"
-version = "3.9.6"
+version = "3.9.8"
 dependencies = [
  "async-trait",
  "bitcode",
@@ -4409,7 +4410,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_write"
-version = "3.9.6"
+version = "3.9.8"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4478,7 +4479,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb_influxql_parser"
-version = "3.9.6"
+version = "3.9.8"
 dependencies = [
  "assert_matches",
  "chrono",
@@ -4495,7 +4496,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb_iox_client"
-version = "3.9.6"
+version = "3.9.8"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -4524,7 +4525,7 @@ dependencies = [
 
 [[package]]
 name = "ingester_query_grpc"
-version = "3.9.6"
+version = "3.9.8"
 dependencies = [
  "base64 0.22.1",
  "data_types",
@@ -4581,7 +4582,7 @@ checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
 
 [[package]]
 name = "iox_http"
-version = "3.9.6"
+version = "3.9.8"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -4601,7 +4602,7 @@ dependencies = [
 
 [[package]]
 name = "iox_http_util"
-version = "3.9.6"
+version = "3.9.8"
 dependencies = [
  "futures",
  "http 1.4.0",
@@ -4612,7 +4613,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query"
-version = "3.9.6"
+version = "3.9.8"
 dependencies = [
  "arrow",
  "arrow_util",
@@ -4661,7 +4662,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query_influxql"
-version = "3.9.6"
+version = "3.9.8"
 dependencies = [
  "arrow",
  "assert_matches",
@@ -4688,7 +4689,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query_influxql_rewrite"
-version = "3.9.6"
+version = "3.9.8"
 dependencies = [
  "influxdb_influxql_parser",
  "thiserror 2.0.18",
@@ -4696,7 +4697,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query_params"
-version = "3.9.6"
+version = "3.9.8"
 dependencies = [
  "arrow",
  "assert_matches",
@@ -4710,7 +4711,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query_udf"
-version = "3.9.6"
+version = "3.9.8"
 dependencies = [
  "datafusion-udf-wasm-host",
  "datafusion-udf-wasm-query",
@@ -4721,7 +4722,7 @@ dependencies = [
 
 [[package]]
 name = "iox_system_tables"
-version = "3.9.6"
+version = "3.9.8"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4731,7 +4732,7 @@ dependencies = [
 
 [[package]]
 name = "iox_time"
-version = "3.9.6"
+version = "3.9.8"
 dependencies = [
  "chrono",
  "parking_lot",
@@ -4740,7 +4741,7 @@ dependencies = [
 
 [[package]]
 name = "iox_v1_query_api"
-version = "3.9.6"
+version = "3.9.8"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4854,7 +4855,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jemalloc_stats"
-version = "3.9.6"
+version = "3.9.8"
 dependencies = [
  "snafu 0.9.0",
  "tikv-jemalloc-ctl",
@@ -4999,7 +5000,7 @@ dependencies = [
 
 [[package]]
 name = "linear_buffer"
-version = "3.9.6"
+version = "3.9.8"
 
 [[package]]
 name = "linux-raw-sys"
@@ -5043,7 +5044,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "logfmt"
-version = "3.9.6"
+version = "3.9.8"
 dependencies = [
  "humantime",
  "parking_lot",
@@ -5151,14 +5152,14 @@ dependencies = [
 
 [[package]]
 name = "metric"
-version = "3.9.6"
+version = "3.9.8"
 dependencies = [
  "parking_lot",
 ]
 
 [[package]]
 name = "metric_exporters"
-version = "3.9.6"
+version = "3.9.8"
 dependencies = [
  "metric",
  "mockito",
@@ -5283,7 +5284,7 @@ checksum = "9252111cf132ba0929b6f8e030cac2a24b507f3a4d6db6fb2896f27b354c714b"
 
 [[package]]
 name = "mutable_batch"
-version = "3.9.6"
+version = "3.9.8"
 dependencies = [
  "arrow",
  "arrow_util",
@@ -5301,7 +5302,7 @@ dependencies = [
 
 [[package]]
 name = "mutable_batch_lp"
-version = "3.9.6"
+version = "3.9.8"
 dependencies = [
  "arrow_util",
  "assert_matches",
@@ -5317,7 +5318,7 @@ dependencies = [
 
 [[package]]
 name = "mutable_batch_pb"
-version = "3.9.6"
+version = "3.9.8"
 dependencies = [
  "arrow_util",
  "criterion 0.8.2",
@@ -5555,7 +5556,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_limit"
-version = "3.9.6"
+version = "3.9.8"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5567,7 +5568,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_mem_cache"
-version = "3.9.6"
+version = "3.9.8"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5594,7 +5595,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_metrics"
-version = "3.9.6"
+version = "3.9.8"
 dependencies = [
  "async-trait",
  "bloom2",
@@ -5619,7 +5620,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_mock"
-version = "3.9.6"
+version = "3.9.8"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5633,7 +5634,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_size_hinting"
-version = "3.9.6"
+version = "3.9.8"
 dependencies = [
  "chrono",
  "http 1.4.0",
@@ -5643,7 +5644,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_utils"
-version = "3.9.6"
+version = "3.9.8"
 dependencies = [
  "async-trait",
  "backon",
@@ -5656,7 +5657,7 @@ dependencies = [
 
 [[package]]
 name = "observability_deps"
-version = "3.9.6"
+version = "3.9.8"
 dependencies = [
  "tracing",
 ]
@@ -5721,7 +5722,7 @@ dependencies = [
 
 [[package]]
 name = "panic_logging"
-version = "3.9.6"
+version = "3.9.8"
 dependencies = [
  "metric",
  "test_helpers",
@@ -5796,7 +5797,7 @@ dependencies = [
 
 [[package]]
 name = "parquet_file"
-version = "3.9.6"
+version = "3.9.8"
 dependencies = [
  "arrow",
  "arrow_util",
@@ -5825,7 +5826,7 @@ dependencies = [
 
 [[package]]
 name = "partition"
-version = "3.9.6"
+version = "3.9.8"
 dependencies = [
  "arrow",
  "assert_matches",
@@ -6122,7 +6123,7 @@ dependencies = [
 
 [[package]]
 name = "predicate"
-version = "3.9.6"
+version = "3.9.8"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6468,7 +6469,7 @@ dependencies = [
 
 [[package]]
 name = "query_functions"
-version = "3.9.6"
+version = "3.9.8"
 dependencies = [
  "arrow",
  "chrono",
@@ -7151,7 +7152,7 @@ dependencies = [
 
 [[package]]
 name = "schema"
-version = "3.9.6"
+version = "3.9.8"
 dependencies = [
  "arrow",
  "base64 0.22.1",
@@ -7334,7 +7335,7 @@ dependencies = [
 
 [[package]]
 name = "service_common"
-version = "3.9.6"
+version = "3.9.8"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -7348,7 +7349,7 @@ dependencies = [
 
 [[package]]
 name = "service_grpc_flight"
-version = "3.9.6"
+version = "3.9.8"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -7415,7 +7416,7 @@ dependencies = [
 
 [[package]]
 name = "sharder"
-version = "3.9.6"
+version = "3.9.8"
 dependencies = [
  "criterion 0.8.2",
  "data_types",
@@ -7937,7 +7938,7 @@ dependencies = [
 
 [[package]]
 name = "table_batch"
-version = "3.9.6"
+version = "3.9.8"
 dependencies = [
  "arrow_util",
  "bitvec",
@@ -8023,7 +8024,7 @@ dependencies = [
 
 [[package]]
 name = "test_helpers"
-version = "3.9.6"
+version = "3.9.8"
 dependencies = [
  "async-trait",
  "dotenvy",
@@ -8042,7 +8043,7 @@ dependencies = [
 
 [[package]]
 name = "test_helpers_authz"
-version = "3.9.6"
+version = "3.9.8"
 dependencies = [
  "futures",
  "generated_types",
@@ -8315,7 +8316,7 @@ dependencies = [
 
 [[package]]
 name = "tokio_metrics_bridge"
-version = "3.9.6"
+version = "3.9.8"
 dependencies = [
  "metric",
  "parking_lot",
@@ -8324,7 +8325,7 @@ dependencies = [
 
 [[package]]
 name = "tokio_watchdog"
-version = "3.9.6"
+version = "3.9.8"
 dependencies = [
  "metric",
  "test_helpers",
@@ -8547,7 +8548,7 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tower_trailer"
-version = "3.9.6"
+version = "3.9.8"
 dependencies = [
  "futures",
  "http 1.4.0",
@@ -8559,7 +8560,7 @@ dependencies = [
 
 [[package]]
 name = "trace"
-version = "3.9.6"
+version = "3.9.8"
 dependencies = [
  "chrono",
  "parking_lot",
@@ -8569,7 +8570,7 @@ dependencies = [
 
 [[package]]
 name = "trace_exporters"
-version = "3.9.6"
+version = "3.9.8"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8586,7 +8587,7 @@ dependencies = [
 
 [[package]]
 name = "trace_http"
-version = "3.9.6"
+version = "3.9.8"
 dependencies = [
  "bytes",
  "futures",
@@ -8681,7 +8682,7 @@ dependencies = [
 
 [[package]]
 name = "tracker"
-version = "3.9.6"
+version = "3.9.8"
 dependencies = [
  "futures",
  "hashbrown 0.14.5",
@@ -8701,7 +8702,7 @@ dependencies = [
 
 [[package]]
 name = "trogging"
-version = "3.9.6"
+version = "3.9.8"
 dependencies = [
  "clap",
  "logfmt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,7 +125,7 @@ exclude = [
 #
 # For porting to the actual OSS repo (influxdb), this would need to change to `-nightly`, i.e., by
 # stripping the `-oss`.
-version = "3.9.6"
+version = "3.9.8"
 authors = ["InfluxData OSS Developers"]
 edition = "2024"
 license = "MIT OR Apache-2.0"

--- a/deny.toml
+++ b/deny.toml
@@ -17,6 +17,14 @@ ignore = [
     # there are multiple replacements at this time but there isn't
     # yet a clear choice
     "RUSTSEC-2025-0141",
+    # quick-xml < 0.41.0 two DoS advisories: unbounded namespace-declaration
+    # allocation in NsReader (0195) and quadratic-time attribute duplicate check
+    # (0194). Pulled in transitively at two versions with no upgrade path yet:
+    # object_store (latest 0.14.0) pins quick-xml ^0.40.1 and inferno (latest
+    # 0.12.6, via pprof) pins ^0.39 — neither reaches the patched 0.41.0. Remove
+    # once object_store and pprof/inferno move to quick-xml >= 0.41.
+    "RUSTSEC-2026-0194",
+    "RUSTSEC-2026-0195",
     # rustls-webpki 0.102.8 CRL distribution point matching bug; low impact
     # (requires CA compromise). Stuck on 0.102.x via wasmtime's rustls 0.22.x
     # dep in datafusion-udf-wasm. Upstream also ignores this advisory.

--- a/influxdb3_processing_engine/Cargo.toml
+++ b/influxdb3_processing_engine/Cargo.toml
@@ -36,6 +36,7 @@ reqwest.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
+tokio-util.workspace = true
 walkdir = "2"
 
 [dev-dependencies]

--- a/influxdb3_processing_engine/src/lib.rs
+++ b/influxdb3_processing_engine/src/lib.rs
@@ -36,6 +36,7 @@ use std::time::{Duration, SystemTime};
 use tokio::fs as async_fs;
 use tokio::sync::oneshot::Receiver;
 use tokio::sync::{RwLock, mpsc, oneshot};
+use tokio_util::sync::CancellationToken;
 
 pub mod environment;
 pub mod manager;
@@ -129,6 +130,11 @@ struct PluginChannels {
     wal_triggers: HashMap<String, HashMap<String, mpsc::Sender<WalEvent>>>,
     /// Map of database to schedule trigger name to handler
     schedule_triggers: HashMap<String, HashMap<String, mpsc::Sender<ScheduleEvent>>>,
+    /// Map of database to schedule trigger name to the cancellation token used,
+    /// when the trigger is stopped, to make the schedule loop stop awaiting an
+    /// in-flight run (the run itself keeps executing, detached) so it can't block
+    /// shutdown.
+    schedule_cancels: HashMap<String, HashMap<String, CancellationToken>>,
     /// Map of request path to the request trigger handler
     request_triggers: HashMap<String, mpsc::Sender<RequestEvent>>,
 }
@@ -165,6 +171,13 @@ impl PluginChannels {
                 if let Some(trigger_map) = self.schedule_triggers.get(&db)
                     && let Some(sender) = trigger_map.get(&trigger)
                 {
+                    // cancel any in-flight scheduled plugin run so the trigger task can
+                    // observe the shutdown promptly instead of blocking on the run.
+                    if let Some(token) =
+                        self.schedule_cancels.get(&db).and_then(|m| m.get(&trigger))
+                    {
+                        token.cancel();
+                    }
                     // create a one shot to wait for the shutdown to complete
                     let (tx, rx) = oneshot::channel();
                     if sender.send(ScheduleEvent::Shutdown(tx)).await.is_err() {
@@ -212,6 +225,9 @@ impl PluginChannels {
                 if let Some(trigger_map) = self.schedule_triggers.get_mut(&db) {
                     trigger_map.remove(&trigger);
                 }
+                if let Some(cancel_map) = self.schedule_cancels.get_mut(&db) {
+                    cancel_map.remove(&trigger);
+                }
             }
             TriggerSpecificationDefinition::RequestPath { .. } => {
                 self.request_triggers.remove(&trigger);
@@ -239,6 +255,15 @@ impl PluginChannels {
 
         if let Some(trigger_map) = self.schedule_triggers.get(db) {
             for (trigger_name, sender) in trigger_map {
+                // cancel any in-flight scheduled plugin run so the trigger task can
+                // observe the shutdown promptly instead of blocking on the run.
+                if let Some(token) = self
+                    .schedule_cancels
+                    .get(db)
+                    .and_then(|m| m.get(trigger_name))
+                {
+                    token.cancel();
+                }
                 let (tx, rx) = oneshot::channel();
                 if sender.send(ScheduleEvent::Shutdown(tx)).await.is_err() {
                     warn!(
@@ -272,6 +297,7 @@ impl PluginChannels {
     fn remove_all_for_db(&mut self, db: &str, request_paths: &[String]) {
         self.wal_triggers.remove(db);
         self.schedule_triggers.remove(db);
+        self.schedule_cancels.remove(db);
         for path in request_paths {
             self.request_triggers.remove(path.as_str());
         }
@@ -287,12 +313,17 @@ impl PluginChannels {
         &mut self,
         db: String,
         trigger: String,
+        cancel: CancellationToken,
     ) -> mpsc::Receiver<ScheduleEvent> {
         let (tx, rx) = mpsc::channel(PLUGIN_EVENT_BUFFER_SIZE);
         self.schedule_triggers
+            .entry(db.clone())
+            .or_default()
+            .insert(trigger.clone(), tx);
+        self.schedule_cancels
             .entry(db)
             .or_default()
-            .insert(trigger, tx);
+            .insert(trigger, cancel);
         rx
     }
 
@@ -645,11 +676,16 @@ impl ProcessingEngineManagerImpl {
                 return Ok(());
             }
 
+            // Cancellation token used to abandon an in-flight scheduled plugin run
+            // when the trigger is stopped. Only scheduled triggers register it with
+            // the plugin channels; other plugin types ignore it.
+            let cancel = CancellationToken::new();
             let plugin_context = PluginContext {
                 write_buffer: Arc::clone(&self.write_buffer),
                 query_executor: Arc::clone(&self.query_executor),
                 sys_event_store: Arc::clone(&self.sys_event_store),
                 manager: Arc::clone(&self),
+                cancel: cancel.clone(),
             };
             let plugin_code = Arc::new(self.read_plugin_code(&trigger.plugin_filename).await?);
             match trigger.trigger.plugin_type() {
@@ -669,11 +705,11 @@ impl ProcessingEngineManagerImpl {
                     )
                 }
                 PluginType::Schedule => {
-                    let rec = self
-                        .plugin_event_tx
-                        .write()
-                        .await
-                        .add_schedule_trigger(db_name.to_string(), trigger_name.to_string());
+                    let rec = self.plugin_event_tx.write().await.add_schedule_trigger(
+                        db_name.to_string(),
+                        trigger_name.to_string(),
+                        cancel.clone(),
+                    );
 
                     plugins::run_schedule_plugin(
                         db_name.to_string(),

--- a/influxdb3_processing_engine/src/plugins.rs
+++ b/influxdb3_processing_engine/src/plugins.rs
@@ -18,7 +18,7 @@ use futures_util::future::BoxFuture;
 use influxdb3_write::{BufferedWriteRequest, Bufferer, Precision, write_buffer};
 use iox_time::Time;
 use iox_time::TimeProvider;
-use observability_deps::tracing::error;
+use observability_deps::tracing::{debug, error};
 use std::fmt::Debug;
 use std::path::PathBuf;
 
@@ -29,6 +29,7 @@ use std::sync::Arc;
 use thiserror::Error;
 
 use tokio::sync::mpsc;
+use tokio_util::sync::CancellationToken;
 
 /// A buffering implementation of Bufferer for dry-run testing.
 /// Collects writes without persisting them.
@@ -241,6 +242,25 @@ pub(crate) struct PluginContext {
     pub(crate) manager: Arc<ProcessingEngineManagerImpl>,
     // sys events for writing logs to ring buffers
     pub(crate) sys_event_store: Arc<SysEventStore>,
+    // cancellation token used to abandon an in-flight scheduled plugin run when
+    // the trigger is stopped.
+    pub(crate) cancel: CancellationToken,
+}
+
+/// Await a spawned blocking plugin run, returning `Some(result)` when it
+/// finishes or `None` if `cancel` fires first. On cancellation we stop awaiting
+/// the `JoinHandle` and drop it: the blocking task is *not* interrupted — it
+/// keeps running to completion and its result is discarded — but the caller no
+/// longer waits on it. (Core's plugin execution is not cancellation-aware, so
+/// detaching is the only lever available here.)
+async fn run_until_cancelled<T>(
+    join: tokio::task::JoinHandle<T>,
+    cancel: &CancellationToken,
+) -> Option<Result<T, tokio::task::JoinError>> {
+    tokio::select! {
+        joined = join => Some(joined),
+        _ = cancel.cancelled() => None,
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -252,6 +272,7 @@ struct TriggerPlugin {
     query_executor: Arc<dyn QueryExecutor>,
     manager: Arc<ProcessingEngineManagerImpl>,
     logger: ProcessingEngineLogger,
+    cancel: CancellationToken,
 }
 
 mod python_plugin {
@@ -299,6 +320,7 @@ mod python_plugin {
                 query_executor: Arc::clone(&context.query_executor),
                 manager: Arc::clone(&context.manager),
                 logger,
+                cancel: context.cancel,
             }
         }
 
@@ -995,7 +1017,7 @@ mod python_plugin {
                 let plugin_code_str = plugin.plugin_code.code();
                 let plugin_root = plugin.plugin_code.plugin_root().cloned();
                 let write_buffer = Arc::clone(&plugin.write_buffer);
-                let result = tokio::task::spawn_blocking(move || {
+                let join = tokio::task::spawn_blocking(move || {
                     execute_schedule_trigger(
                         plugin_code_str.as_ref(),
                         trigger_time,
@@ -1007,8 +1029,20 @@ mod python_plugin {
                         py_cache,
                         plugin_root.as_deref(),
                     )
-                })
-                .await?;
+                });
+                // Race the blocking plugin run against the trigger's cancellation
+                // token so a stop/delete stops awaiting a long-running run instead
+                // of blocking shutdown on it. This does not interrupt the run: the
+                // detached task keeps executing to completion and its result is
+                // dropped.
+                let Some(joined) = run_until_cancelled(join, &plugin.cancel).await else {
+                    debug!(
+                        trigger_name = %plugin.trigger_definition.trigger_name,
+                        "scheduled plugin run cancelled before completion"
+                    );
+                    return Ok(PluginNextState::SuccessfulRun);
+                };
+                let result = joined?;
                 match plugin
                     .handle_trigger_result(result, "schedule plugin")
                     .await

--- a/influxdb3_processing_engine/src/plugins/tests.rs
+++ b/influxdb3_processing_engine/src/plugins/tests.rs
@@ -384,3 +384,32 @@ def process_writes(influxdb3_local, table_batches, args=None):
         "Plugin B's helper should still be callable from its own namespace"
     );
 }
+
+/// When the blocking run finishes before cancellation, the joined result is
+/// returned unchanged.
+#[tokio::test]
+async fn run_until_cancelled_returns_result_when_not_cancelled() {
+    let cancel = CancellationToken::new();
+    let join = tokio::task::spawn_blocking(|| 42);
+    let result = run_until_cancelled(join, &cancel).await;
+    assert_eq!(
+        result.expect("should not be cancelled").expect("join ok"),
+        42
+    );
+}
+
+/// When the cancellation token fires, the in-flight run is abandoned and
+/// `run_until_cancelled` resolves to `None` without waiting for the task.
+#[tokio::test]
+async fn run_until_cancelled_abandons_blocking_run_on_cancel() {
+    let cancel = CancellationToken::new();
+    // A task that won't complete promptly. Use an async sleep so the abandoned
+    // task doesn't tie up a blocking thread during test teardown.
+    let join = tokio::spawn(async {
+        tokio::time::sleep(Duration::from_secs(30)).await;
+        0
+    });
+    cancel.cancel();
+    let result = run_until_cancelled(join, &cancel).await;
+    assert!(result.is_none(), "cancellation should win the race");
+}

--- a/influxdb3_processing_engine/src/tests.rs
+++ b/influxdb3_processing_engine/src/tests.rs
@@ -33,6 +33,7 @@ use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 use tempfile::NamedTempFile;
+use tokio_util::sync::CancellationToken;
 
 #[test_log::test(tokio::test)]
 async fn test_trigger_lifecycle() -> Result<(), Box<dyn std::error::Error>> {
@@ -1714,7 +1715,11 @@ async fn setup_db_with_trigger(
                 channels.add_wal_trigger("test_db".to_string(), trigger_name.to_string());
             }
             "schedule" => {
-                channels.add_schedule_trigger("test_db".to_string(), trigger_name.to_string());
+                channels.add_schedule_trigger(
+                    "test_db".to_string(),
+                    trigger_name.to_string(),
+                    CancellationToken::new(),
+                );
             }
             "request" => {
                 channels.add_request_trigger("/api/v3/engine/test_db/test_endpoint".to_string());
@@ -1922,4 +1927,64 @@ async fn test_hard_delete_removes_request_triggers() -> Result<(), Box<dyn std::
         );
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod plugin_channels_tests {
+    use super::*;
+    use crate::PluginChannels;
+
+    fn schedule_spec() -> TriggerSpecificationDefinition {
+        TriggerSpecificationDefinition::Schedule {
+            schedule: "0 * * * * *".to_string(),
+        }
+    }
+
+    /// Stopping a single schedule trigger must fire its cancellation token so an
+    /// in-flight plugin run is abandoned instead of blocking the shutdown.
+    #[tokio::test]
+    async fn send_shutdown_cancels_schedule_trigger_token() {
+        let mut channels = PluginChannels::default();
+        let cancel = CancellationToken::new();
+        // keep the receiver alive so the shutdown send succeeds
+        let _rx = channels.add_schedule_trigger(
+            "test_db".to_string(),
+            "sched".to_string(),
+            cancel.clone(),
+        );
+
+        assert!(!cancel.is_cancelled());
+
+        let result = channels
+            .send_shutdown("test_db".to_string(), "sched".to_string(), &schedule_spec())
+            .await
+            .expect("send_shutdown should succeed");
+        assert!(result.is_some(), "expected a shutdown receiver");
+        assert!(
+            cancel.is_cancelled(),
+            "stopping the schedule trigger should cancel its in-flight run token"
+        );
+    }
+
+    /// Deleting a database must fire the cancellation tokens of all its schedule
+    /// triggers so their in-flight runs are abandoned during cleanup.
+    #[tokio::test]
+    async fn shutdown_all_for_db_cancels_schedule_trigger_token() {
+        let mut channels = PluginChannels::default();
+        let cancel = CancellationToken::new();
+        let _rx = channels.add_schedule_trigger(
+            "test_db".to_string(),
+            "sched".to_string(),
+            cancel.clone(),
+        );
+
+        assert!(!cancel.is_cancelled());
+
+        let receivers = channels.shutdown_all_for_db("test_db", &[]).await;
+        assert_eq!(receivers.len(), 1, "expected one shutdown receiver");
+        assert!(
+            cancel.is_cancelled(),
+            "deleting the db should cancel the schedule trigger's in-flight run token"
+        );
+    }
 }

--- a/influxdb3_write/src/write_buffer/validator.rs
+++ b/influxdb3_write/src/write_buffer/validator.rs
@@ -209,17 +209,29 @@ fn validate_and_qualify_v1_line(
 
     if let Some(tag_set) = &line.series.tag_set {
         for (tag_key, tag_val) in tag_set {
-            let col = txn
+            let col_id = txn
                 .column_or_create(table_name, tag_key.as_str(), InfluxColumnType::Tag)
                 .map_err(|error| WriteLineError {
                     original_line: line.to_string(),
                     line_number: line_number + 1,
                     error_message: error.to_string(),
-                })?;
-            fields.push(Field::new(
-                col.ord_id(),
-                FieldData::Tag(tag_val.to_string()),
-            ));
+                })?
+                .ord_id();
+            // Reject a point that repeats a tag key. Without this a duplicate tag
+            // produces two columns with the same id, which desyncs the table buffer
+            // and later panics when building the record batch (all columns must have
+            // the same length). Mirrors the duplicate-field check below.
+            if !column_ids.insert(col_id) {
+                return Err(WriteLineError {
+                    original_line: line.to_string(),
+                    line_number: line_number + 1,
+                    error_message: format!(
+                        "invalid line protocol - multiple instances of '{}' tag found",
+                        tag_key.as_str()
+                    ),
+                });
+            }
+            fields.push(Field::new(col_id, FieldData::Tag(tag_val.to_string())));
             index_count += 1;
         }
     }

--- a/influxdb3_write/src/write_buffer/validator/tests.rs
+++ b/influxdb3_write/src/write_buffer/validator/tests.rs
@@ -94,3 +94,67 @@ async fn write_validator_v1() -> Result<(), Error> {
 
     Ok(())
 }
+
+/// A point that repeats a tag key must be rejected, the same way a repeated field key
+/// already is. Without this, the duplicate tag produces two columns with the same id,
+/// which desyncs the table buffer and later panics when building the record batch
+/// ("all columns in a record batch must have the same length"). See influxdb_pro#4375.
+#[tokio::test]
+async fn write_validator_rejects_duplicate_tag() -> Result<(), Error> {
+    let node_id = Arc::from("sample-host-id");
+    let obj_store = Arc::new(InMemory::new());
+    let time_provider = Arc::new(MockProvider::new(Time::from_timestamp_nanos(0)));
+    let database_name = NamespaceName::new("test").unwrap();
+    let catalog = Arc::new(
+        Catalog::new(node_id, obj_store, time_provider, Default::default())
+            .await
+            .unwrap(),
+    );
+
+    // accept_partial = true: the duplicate-tag line is collected into `errors` and
+    // dropped, so no row is buffered.
+    let result = WriteValidator::initialize(database_name.clone(), Arc::clone(&catalog))?
+        .v1_parse_lines_and_catalog_updates(
+            "cpu,tag1=foo,tag1=bar val1=\"bar\" 1234",
+            true,
+            Time::from_timestamp_nanos(0),
+            Precision::Auto,
+        )?
+        .commit_catalog_changes()
+        .await?
+        .unwrap_success()
+        .convert_lines_to_buffer(Gen1Duration::new_5m());
+
+    println!("result: {result:?}");
+    assert_eq!(
+        result.line_count, 0,
+        "the duplicate-tag line must not be buffered"
+    );
+    assert_eq!(result.errors.len(), 1, "expected exactly one line error");
+    assert!(
+        result.errors[0]
+            .error_message
+            .contains("multiple instances of 'tag1' tag found"),
+        "unexpected error message: {:?}",
+        result.errors
+    );
+
+    // accept_partial = false: the whole write is rejected with a ParseError.
+    let err = WriteValidator::initialize(database_name.clone(), Arc::clone(&catalog))?
+        .v1_parse_lines_and_catalog_updates(
+            "cpu,tag1=foo,tag1=bar val1=\"bar\" 1234",
+            false,
+            Time::from_timestamp_nanos(0),
+            Precision::Auto,
+        )
+        .err();
+    assert!(
+        matches!(
+            &err,
+            Some(Error::ParseError(e)) if e.error_message.contains("multiple instances of 'tag1' tag found")
+        ),
+        "expected a ParseError for the duplicate tag, got: {err:?}"
+    );
+
+    Ok(())
+}

--- a/object_store_utils/src/test_object_store.rs
+++ b/object_store_utils/src/test_object_store.rs
@@ -79,6 +79,10 @@ pub struct TestObjectStore {
     error_type: ErrorType,
     get_delay: Option<Duration>,
     put_delay: Option<Duration>,
+    /// Number of `get` requests currently executing against the inner store
+    in_flight_gets: AtomicUsize,
+    /// Peak value of `in_flight_gets`, for asserting concurrency bounds
+    max_in_flight_gets: AtomicUsize,
 }
 
 impl TestObjectStore {
@@ -95,6 +99,8 @@ impl TestObjectStore {
             error_type: ErrorType::default(),
             get_delay: None,
             put_delay: None,
+            in_flight_gets: AtomicUsize::new(0),
+            max_in_flight_gets: AtomicUsize::new(0),
         }
     }
 
@@ -222,6 +228,32 @@ impl TestObjectStore {
             sleep(delay).await;
         }
     }
+
+    /// Peak number of `get` requests that were executing concurrently
+    pub fn max_in_flight_gets(&self) -> usize {
+        self.max_in_flight_gets.load(Ordering::SeqCst)
+    }
+
+    /// Track an in-flight `get` for the returned guard's lifetime. A guard (rather
+    /// than a decrement after the await) keeps the count accurate when the request
+    /// future is cancelled mid-flight.
+    fn track_get(&self) -> InFlightGuard<'_> {
+        let current = self.in_flight_gets.fetch_add(1, Ordering::SeqCst) + 1;
+        self.max_in_flight_gets.fetch_max(current, Ordering::SeqCst);
+        InFlightGuard {
+            counter: &self.in_flight_gets,
+        }
+    }
+}
+
+struct InFlightGuard<'a> {
+    counter: &'a AtomicUsize,
+}
+
+impl Drop for InFlightGuard<'_> {
+    fn drop(&mut self) {
+        self.counter.fetch_sub(1, Ordering::SeqCst);
+    }
 }
 
 impl Display for TestObjectStore {
@@ -302,6 +334,7 @@ impl ObjectStore for TestObjectStore {
         }) {
             return Err(self.create_error());
         }
+        let _in_flight = self.track_get();
         self.maybe_delay_get().await;
         self.inner.get(location).await
     }


### PR DESCRIPTION
Sync of oss/ from influxdata/influxdb_pro branch `3.9` at v3.9.8, via `just oss-sync`.

Rolls up everything since the last sync: version bump to 3.9.8, duplicate tag key write rejection, processing engine scheduled-run fixes, crossbeam-epoch RUSTSEC-2026-0204 update and deny.toml entries, and an in-flight GET tracker on `TestObjectStore` used by the compacted-data load concurrency fix (influxdata/influxdb_pro#4417).