### PR TITLE
chore(sync): influxdb_pro 2026-07-07

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,7 +444,7 @@ dependencies = [
 
 [[package]]
 name = "arrow_util"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -541,7 +541,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "authz"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -655,7 +655,7 @@ dependencies = [
 
 [[package]]
 name = "backoff"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "rand 0.9.4",
  "snafu 0.9.0",
@@ -1078,7 +1078,7 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "catalog_cache"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "bytes",
  "criterion 0.8.2",
@@ -1222,14 +1222,14 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli_types"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "tokio",
 ]
 
 [[package]]
 name = "client_util"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "http 1.4.0",
  "iox_http_util",
@@ -1691,9 +1691,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1832,7 +1832,7 @@ dependencies = [
 
 [[package]]
 name = "data_types"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -2566,7 +2566,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion_util"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -2661,7 +2661,7 @@ dependencies = [
 
 [[package]]
 name = "dml"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "arrow_util",
  "data_types",
@@ -2773,7 +2773,7 @@ dependencies = [
 
 [[package]]
 name = "error_reporting"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "datafusion",
  "snafu 0.9.0",
@@ -2803,7 +2803,7 @@ dependencies = [
 
 [[package]]
 name = "executor"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "futures",
  "metric",
@@ -2884,7 +2884,7 @@ dependencies = [
 
 [[package]]
 name = "flightsql"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -3091,7 +3091,7 @@ dependencies = [
 
 [[package]]
 name = "futures_test_utils"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "clap",
  "futures",
@@ -3102,7 +3102,7 @@ dependencies = [
 
 [[package]]
 name = "generated_types"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "bytes",
  "pbjson",
@@ -3756,7 +3756,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb2_client"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "bytes",
  "futures",
@@ -3775,7 +3775,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3867,7 +3867,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_authz"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "async-trait",
  "authz",
@@ -3885,7 +3885,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_cache"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3920,7 +3920,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_catalog"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "ahash 0.8.12",
  "anyhow",
@@ -3977,7 +3977,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_clap_blocks"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4014,7 +4014,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_client"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "bytes",
  "flate2",
@@ -4035,7 +4035,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_commands"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4062,7 +4062,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_id"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "criterion 0.5.1",
  "indexmap 2.14.0",
@@ -4074,7 +4074,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_internal_api"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4095,7 +4095,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_load_generator"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4125,7 +4125,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_process"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "iox_time",
  "uuid",
@@ -4133,7 +4133,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_processing_engine"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4171,12 +4171,13 @@ dependencies = [
  "test-log",
  "thiserror 1.0.69",
  "tokio",
+ "tokio-util",
  "walkdir",
 ]
 
 [[package]]
 name = "influxdb3_py_api"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -4204,7 +4205,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_query_executor"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4255,7 +4256,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_server"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4342,7 +4343,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_shutdown"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "futures",
  "futures-util",
@@ -4357,14 +4358,14 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_startup"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "chrono",
 ]
 
 [[package]]
 name = "influxdb3_sys_events"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4383,7 +4384,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_system_tables"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4415,7 +4416,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_telemetry"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "futures",
  "futures-util",
@@ -4436,7 +4437,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_test_helpers"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4449,7 +4450,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_types"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4469,7 +4470,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_wal"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "async-trait",
  "bitcode",
@@ -4498,7 +4499,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_write"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4568,7 +4569,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb_influxql_parser"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "assert_matches",
  "chrono",
@@ -4585,7 +4586,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb_iox_client"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -4614,7 +4615,7 @@ dependencies = [
 
 [[package]]
 name = "ingester_query_grpc"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "base64 0.22.1",
  "data_types",
@@ -4680,7 +4681,7 @@ checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
 
 [[package]]
 name = "iox_http"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -4700,7 +4701,7 @@ dependencies = [
 
 [[package]]
 name = "iox_http_util"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "futures",
  "http 1.4.0",
@@ -4711,7 +4712,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "arrow",
  "arrow_util",
@@ -4760,7 +4761,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query_influxql"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "arrow",
  "assert_matches",
@@ -4787,7 +4788,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query_influxql_rewrite"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "influxdb_influxql_parser",
  "thiserror 2.0.18",
@@ -4795,7 +4796,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query_params"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "arrow",
  "assert_matches",
@@ -4809,7 +4810,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query_udf"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "datafusion-udf-wasm-host",
  "datafusion-udf-wasm-query",
@@ -4820,7 +4821,7 @@ dependencies = [
 
 [[package]]
 name = "iox_system_tables"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4830,7 +4831,7 @@ dependencies = [
 
 [[package]]
 name = "iox_time"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "chrono",
  "parking_lot",
@@ -4839,7 +4840,7 @@ dependencies = [
 
 [[package]]
 name = "iox_v1_query_api"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4953,7 +4954,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jemalloc_pprof_http"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "http-body-util",
  "hyper 1.9.0",
@@ -4966,7 +4967,7 @@ dependencies = [
 
 [[package]]
 name = "jemalloc_stats"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "futures",
  "snafu 0.9.0",
@@ -5159,7 +5160,7 @@ dependencies = [
 
 [[package]]
 name = "linear_buffer"
-version = "3.10.1"
+version = "3.10.3"
 
 [[package]]
 name = "linux-raw-sys"
@@ -5203,7 +5204,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "logfmt"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "humantime",
  "parking_lot",
@@ -5302,14 +5303,14 @@ dependencies = [
 
 [[package]]
 name = "metric"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "parking_lot",
 ]
 
 [[package]]
 name = "metric_exporters"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "metric",
  "mockito",
@@ -5434,7 +5435,7 @@ checksum = "9252111cf132ba0929b6f8e030cac2a24b507f3a4d6db6fb2896f27b354c714b"
 
 [[package]]
 name = "mutable_batch"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "arrow",
  "arrow_util",
@@ -5452,7 +5453,7 @@ dependencies = [
 
 [[package]]
 name = "mutable_batch_lp"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "arrow_util",
  "assert_matches",
@@ -5468,7 +5469,7 @@ dependencies = [
 
 [[package]]
 name = "mutable_batch_pb"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "arrow_util",
  "criterion 0.8.2",
@@ -5706,7 +5707,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_limit"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5718,7 +5719,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_mem_cache"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5746,7 +5747,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_metrics"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "async-trait",
  "bloom2",
@@ -5771,7 +5772,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_mock"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5785,7 +5786,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_size_hinting"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "chrono",
  "http 1.4.0",
@@ -5795,7 +5796,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_utils"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "async-trait",
  "backon",
@@ -5809,7 +5810,7 @@ dependencies = [
 
 [[package]]
 name = "observability_deps"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "tracing",
 ]
@@ -5874,7 +5875,7 @@ dependencies = [
 
 [[package]]
 name = "panic_logging"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "metric",
  "test_helpers",
@@ -5949,7 +5950,7 @@ dependencies = [
 
 [[package]]
 name = "parquet_file"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "arrow",
  "arrow_util",
@@ -5980,7 +5981,7 @@ dependencies = [
 
 [[package]]
 name = "partition"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "arrow",
  "assert_matches",
@@ -6277,7 +6278,7 @@ dependencies = [
 
 [[package]]
 name = "predicate"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6621,7 +6622,7 @@ dependencies = [
 
 [[package]]
 name = "query_functions"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "arrow",
  "chrono",
@@ -7331,7 +7332,7 @@ dependencies = [
 
 [[package]]
 name = "schema"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "arrow",
  "base64 0.22.1",
@@ -7514,7 +7515,7 @@ dependencies = [
 
 [[package]]
 name = "service_common"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -7528,7 +7529,7 @@ dependencies = [
 
 [[package]]
 name = "service_grpc_flight"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -7604,7 +7605,7 @@ dependencies = [
 
 [[package]]
 name = "sharder"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "criterion 0.8.2",
  "data_types",
@@ -8126,7 +8127,7 @@ dependencies = [
 
 [[package]]
 name = "table_batch"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "arrow_util",
  "bitvec",
@@ -8222,7 +8223,7 @@ dependencies = [
 
 [[package]]
 name = "test_helpers"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "async-trait",
  "dotenvy",
@@ -8241,7 +8242,7 @@ dependencies = [
 
 [[package]]
 name = "test_helpers_authz"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "futures",
  "generated_types",
@@ -8514,7 +8515,7 @@ dependencies = [
 
 [[package]]
 name = "tokio_metrics_bridge"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "metric",
  "parking_lot",
@@ -8523,7 +8524,7 @@ dependencies = [
 
 [[package]]
 name = "tokio_watchdog"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "metric",
  "test_helpers",
@@ -8746,7 +8747,7 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tower_trailer"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "futures",
  "http 1.4.0",
@@ -8758,7 +8759,7 @@ dependencies = [
 
 [[package]]
 name = "trace"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "chrono",
  "parking_lot",
@@ -8768,7 +8769,7 @@ dependencies = [
 
 [[package]]
 name = "trace_exporters"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8785,7 +8786,7 @@ dependencies = [
 
 [[package]]
 name = "trace_http"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "bytes",
  "futures",
@@ -8880,7 +8881,7 @@ dependencies = [
 
 [[package]]
 name = "tracker"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "futures",
  "hashbrown 0.14.5",
@@ -8900,7 +8901,7 @@ dependencies = [
 
 [[package]]
 name = "trogging"
-version = "3.10.1"
+version = "3.10.3"
 dependencies = [
  "clap",
  "logfmt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,7 +127,7 @@ exclude = [
 #
 # For porting to the actual OSS repo (influxdb), this would need to change to `-nightly`, i.e., by
 # stripping the `-oss`.
-version = "3.10.1"
+version = "3.10.3"
 authors = ["InfluxData OSS Developers"]
 edition = "2024"
 license = "MIT OR Apache-2.0"

--- a/deny.toml
+++ b/deny.toml
@@ -17,6 +17,14 @@ ignore = [
     # there are multiple replacements at this time but there isn't
     # yet a clear choice
     "RUSTSEC-2025-0141",
+    # quick-xml < 0.41.0 two DoS advisories: unbounded namespace-declaration
+    # allocation in NsReader (0195) and quadratic-time attribute duplicate check
+    # (0194). Pulled in transitively at two versions with no upgrade path yet:
+    # object_store (latest 0.14.0) pins quick-xml ^0.40.1 and inferno (latest
+    # 0.12.6, via pprof) pins ^0.39 — neither reaches the patched 0.41.0. Remove
+    # once object_store and pprof/inferno move to quick-xml >= 0.41.
+    "RUSTSEC-2026-0194",
+    "RUSTSEC-2026-0195",
     # rustls-webpki 0.102.8 CRL distribution point matching bug; low impact
     # (requires CA compromise). Stuck on 0.102.x via wasmtime's rustls 0.22.x
     # dep in datafusion-udf-wasm. Upstream also ignores this advisory.

--- a/influxdb3_internal_api/src/sll.rs
+++ b/influxdb3_internal_api/src/sll.rs
@@ -11,6 +11,7 @@
 //! types as OSS crates — emitters and sink agree on one identity.
 
 use std::fmt::Debug;
+use std::sync::Arc;
 
 /// Sink for system state-change events.
 pub trait SllSink: Send + Sync + Debug {
@@ -235,6 +236,30 @@ pub enum SystemEvent {
         phase: &'static str,
         error_code: &'static str,
         duration_ms: u64,
+    },
+
+    // ── replica_wal_skipped / replica_snapshot_skipped ────────────────
+    /// A replica node skipped a WAL file received from a peer ingester
+    /// because it could not be deserialized. `from_node_id` identifies
+    /// the peer whose file was skipped. Node-scoped.
+    ReplicaWalSkipped {
+        /// Peer ingester whose WAL file was skipped.
+        from_node_id: Arc<str>,
+        /// WAL file sequence number that was skipped.
+        wal_file_sequence_number: u64,
+        /// Error category code (never a full message).
+        error_code: &'static str,
+    },
+    /// A replica node skipped a snapshot received from a peer ingester
+    /// because it could not be deserialized. `from_node_id` identifies
+    /// the peer whose snapshot was skipped. Node-scoped.
+    ReplicaSnapshotSkipped {
+        /// Peer ingester whose snapshot was skipped.
+        from_node_id: Arc<str>,
+        /// Snapshot sequence number that was skipped.
+        snapshot_sequence_number: u64,
+        /// Error category code (never a full message).
+        error_code: &'static str,
     },
 }
 

--- a/influxdb3_processing_engine/Cargo.toml
+++ b/influxdb3_processing_engine/Cargo.toml
@@ -32,6 +32,7 @@ reqwest.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
+tokio-util.workspace = true
 walkdir.workspace = true
 
 [dev-dependencies]

--- a/influxdb3_processing_engine/src/lib.rs
+++ b/influxdb3_processing_engine/src/lib.rs
@@ -35,6 +35,7 @@ use std::time::{Duration, SystemTime};
 use tokio::fs as async_fs;
 use tokio::sync::oneshot::Receiver;
 use tokio::sync::{RwLock, mpsc, oneshot};
+use tokio_util::sync::CancellationToken;
 
 pub mod environment;
 pub mod manager;
@@ -181,6 +182,13 @@ struct PluginChannels {
     /// Secondary index: HTTP request triggers are routed by URL path, which
     /// is all the request handler knows. Maps path -> the trigger's ids.
     request_paths: HashMap<String, (DbId, TriggerId)>,
+    /// Per-scheduled-trigger cancellation tokens, kept in lock-step with the
+    /// scheduled triggers in `triggers`. Cancelling one makes the schedule loop
+    /// stop awaiting that trigger's in-flight run (the run itself keeps
+    /// executing, detached) so a `run_async=false` run can't block the trigger's
+    /// shutdown ACK and wedge all trigger management on the node (the
+    /// `disable`/`delete --force` hang).
+    schedule_cancels: HashMap<DbId, HashMap<TriggerId, CancellationToken>>,
 }
 
 const PLUGIN_EVENT_BUFFER_SIZE: usize = 60;
@@ -195,6 +203,11 @@ impl PluginChannels {
         let Some(sender) = self.triggers.get(&db_id).and_then(|m| m.get(&trigger_id)) else {
             return Ok(None);
         };
+        // Cancel the trigger's in-flight run first (scheduled triggers only), so a
+        // blocking run_async=false run is abandoned and the schedule loop can
+        // service the shutdown event sent below — otherwise the run blocks this
+        // shutdown's ACK and wedges all trigger management on the node.
+        self.cancel_schedule_trigger(db_id, trigger_id);
         let (tx, rx) = oneshot::channel();
         if sender.send_shutdown(tx).await.is_err() {
             return Err(ProcessingEngineError::TriggerShutdownError { db_id, trigger_id });
@@ -202,11 +215,25 @@ impl PluginChannels {
         Ok(Some(rx))
     }
 
+    /// Cancel a scheduled trigger's in-flight run, if one is registered.
+    fn cancel_schedule_trigger(&self, db_id: DbId, trigger_id: TriggerId) {
+        if let Some(token) = self
+            .schedule_cancels
+            .get(&db_id)
+            .and_then(|m| m.get(&trigger_id))
+        {
+            token.cancel();
+        }
+    }
+
     fn remove_trigger(&mut self, db_id: DbId, trigger_id: TriggerId) {
         if let Some(db_map) = self.triggers.get_mut(&db_id)
             && let Some(TriggerSender::Request { path, .. }) = db_map.remove(&trigger_id)
         {
             self.request_paths.remove(&path);
+        }
+        if let Some(db_map) = self.schedule_cancels.get_mut(&db_id) {
+            db_map.remove(&trigger_id);
         }
     }
 
@@ -216,6 +243,8 @@ impl PluginChannels {
             return receivers;
         };
         for (trigger_id, sender) in db_map {
+            // Cancel the in-flight run first (scheduled triggers only); see send_shutdown.
+            self.cancel_schedule_trigger(db_id, *trigger_id);
             let (tx, rx) = oneshot::channel();
             if sender.send_shutdown(tx).await.is_err() {
                 warn!(
@@ -238,6 +267,7 @@ impl PluginChannels {
                 }
             }
         }
+        self.schedule_cancels.remove(&db_id);
     }
 
     fn add_wal_trigger(&mut self, db_id: DbId, trigger_id: TriggerId) -> mpsc::Receiver<WalEvent> {
@@ -253,8 +283,13 @@ impl PluginChannels {
         &mut self,
         db_id: DbId,
         trigger_id: TriggerId,
+        cancel: CancellationToken,
     ) -> mpsc::Receiver<ScheduleEvent> {
         let (tx, rx) = mpsc::channel(PLUGIN_EVENT_BUFFER_SIZE);
+        self.schedule_cancels
+            .entry(db_id)
+            .or_default()
+            .insert(trigger_id, cancel);
         self.triggers
             .entry(db_id)
             .or_default()
@@ -646,12 +681,16 @@ impl ProcessingEngineManagerImpl {
                 return Ok(());
             }
 
+            // Per-trigger cancellation token (standalone). Scheduled triggers use
+            // it to interrupt an in-flight run_async=false run on stop.
+            let cancel = CancellationToken::new();
             let plugin_context = PluginContext {
                 write_endpoint: Arc::clone(&self.write_endpoint),
                 query_executor: Arc::clone(&self.query_executor),
                 sys_event_store: Arc::clone(&self.sys_event_store),
                 manager: Arc::clone(&self),
                 plugin_trigger_invocation_registry: self.plugin_trigger_invocation_registry.clone(),
+                cancel: cancel.clone(),
             };
             let plugin_code = Arc::new(self.read_plugin_code(&trigger.plugin_filename).await?);
             match trigger.trigger.plugin_type() {
@@ -672,11 +711,11 @@ impl ProcessingEngineManagerImpl {
                     )
                 }
                 PluginType::Schedule => {
-                    let rec = self
-                        .plugin_event_tx
-                        .write()
-                        .await
-                        .add_schedule_trigger(db_id, trigger_id);
+                    let rec = self.plugin_event_tx.write().await.add_schedule_trigger(
+                        db_id,
+                        trigger_id,
+                        cancel.clone(),
+                    );
 
                     plugins::run_schedule_plugin(
                         db_name.to_string(),

--- a/influxdb3_processing_engine/src/plugins.rs
+++ b/influxdb3_processing_engine/src/plugins.rs
@@ -32,13 +32,30 @@ use influxdb3_wal::{WalContents, WalOp};
 use influxdb3_write::{Precision, write_buffer};
 use iox_http_util::{ResponseBuilder, bytes_to_response_body};
 use iox_time::{Time, TimeProvider};
-use observability_deps::tracing::{error, info, warn};
+use observability_deps::tracing::{debug, error, info, warn};
 use std::{fmt::Debug, path::PathBuf, str::FromStr, sync::Arc, time::SystemTime};
 use tokio::sync::mpsc::{self, Receiver};
+use tokio_util::sync::CancellationToken;
 
 use anyhow::{Context, anyhow};
 use parking_lot::Mutex;
 use thiserror::Error;
+
+/// Await a spawned blocking plugin run, returning `None` if `cancel` fires
+/// first. On cancellation we stop awaiting the `JoinHandle` and drop it: the
+/// blocking task is *not* interrupted — it keeps running to completion and its
+/// result is discarded — but the caller no longer waits on it, so a stuck or
+/// slow run cannot delay trigger shutdown. (Core's plugin execution is not
+/// cancellation-aware, so detaching is the only lever available here.)
+async fn run_until_cancelled<T>(
+    join: tokio::task::JoinHandle<T>,
+    cancel: &CancellationToken,
+) -> Option<Result<T, tokio::task::JoinError>> {
+    tokio::select! {
+        joined = join => Some(joined),
+        _ = cancel.cancelled() => None,
+    }
+}
 
 #[derive(Debug, Error)]
 pub enum PluginError {
@@ -201,6 +218,9 @@ pub(crate) struct PluginContext {
     pub(crate) sys_event_store: Arc<SysEventStore>,
     // plugin invocation telemetry, when enabled by serve
     pub(crate) plugin_trigger_invocation_registry: Option<Arc<PluginTriggerInvocationRegistry>>,
+    // per-trigger cancellation token; cancelled when the trigger is stopped, to
+    // interrupt an in-flight scheduled run (see run_at_time).
+    pub(crate) cancel: CancellationToken,
 }
 
 #[derive(Debug, Clone)]
@@ -215,6 +235,9 @@ struct TriggerPlugin {
     logger: ProcessingEngineLogger,
     plugin_trigger_invocation_registry: Option<Arc<PluginTriggerInvocationRegistry>>,
     plugin_trigger_invocation_key: PluginTriggerInvocationKey,
+    /// Cancelled when this trigger is stopped (disable/force-delete), to
+    /// interrupt an in-flight scheduled run so shutdown isn't blocked.
+    cancel: CancellationToken,
 }
 
 impl TriggerPlugin {
@@ -246,6 +269,7 @@ impl TriggerPlugin {
             logger,
             plugin_trigger_invocation_registry: context.plugin_trigger_invocation_registry,
             plugin_trigger_invocation_key,
+            cancel: context.cancel,
         }
     }
 
@@ -927,7 +951,7 @@ impl ScheduleTriggerRunner {
             let plugin_code_str = plugin.plugin_code.code();
             let plugin_root = plugin.plugin_code.plugin_root().cloned();
             let write_endpoint = Arc::clone(&plugin.write_endpoint);
-            let result = tokio::task::spawn_blocking(move || {
+            let join = tokio::task::spawn_blocking(move || {
                 execute_schedule_trigger(
                     plugin_code_str.as_ref(),
                     trigger_time,
@@ -939,8 +963,23 @@ impl ScheduleTriggerRunner {
                     py_cache,
                     plugin_root.as_deref(),
                 )
-            })
-            .await?;
+            });
+            // Race the in-flight run against cancellation. If the trigger is
+            // disabled/force-deleted while a run_async=false run is in flight,
+            // return promptly so the schedule loop can service the shutdown event
+            // instead of blocking on the run — otherwise the run blocks the
+            // trigger's shutdown ACK and wedges all trigger management on the node
+            // (the disable/`delete --force` hang). This does not interrupt the
+            // run: the detached spawn_blocking task keeps executing to completion
+            // and its result is dropped; we simply stop awaiting it.
+            let Some(joined) = run_until_cancelled(join, &plugin.cancel).await else {
+                debug!(
+                    trigger_name = %plugin.trigger_definition.trigger_name,
+                    "scheduled plugin run cancelled before completion"
+                );
+                return Ok(PluginNextState::SuccessfulRun);
+            };
+            let result = joined?;
             match plugin
                 .handle_trigger_result(result, "schedule plugin")
                 .await

--- a/influxdb3_processing_engine/src/plugins/tests.rs
+++ b/influxdb3_processing_engine/src/plugins/tests.rs
@@ -11,6 +11,7 @@ use iox_time::{MockProvider, Time, TimeProvider};
 use object_store::memory::InMemory;
 use std::sync::Barrier;
 use std::time::Duration;
+use tokio_util::sync::CancellationToken;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_wal_plugin() {
@@ -789,5 +790,51 @@ async fn test_schedule_plugin_multi_file_syntax_error_surfaced() {
     assert!(
         msg.contains("SyntaxError"),
         "expected the real SyntaxError to be surfaced, got: {msg}"
+    );
+}
+
+/// When the token is not cancelled, `run_until_cancelled` yields the run's
+/// result unchanged.
+#[tokio::test(flavor = "multi_thread")]
+async fn run_until_cancelled_returns_result_when_not_cancelled() {
+    let cancel = CancellationToken::new();
+    let join = tokio::task::spawn_blocking(|| 42);
+    let result = run_until_cancelled(join, &cancel).await;
+    assert!(matches!(result, Some(Ok(42))));
+}
+
+/// The core of the disable/delete-hang fix: when the per-trigger token is
+/// cancelled while a blocking run is in flight, `run_until_cancelled` returns
+/// promptly (abandoning the run) instead of waiting for it to finish. If the
+/// race were removed this would block on the 30s task and the elapsed-time
+/// assertion would fail.
+#[tokio::test(flavor = "multi_thread")]
+async fn run_until_cancelled_abandons_blocking_run_on_cancel() {
+    let cancel = CancellationToken::new();
+    // A long-running task standing in for an in-flight plugin run. `run_at_time`
+    // uses spawn_blocking; `run_until_cancelled` is generic over the JoinHandle,
+    // so an async task exercises the same race while leaving nothing to join at
+    // teardown.
+    let join = tokio::spawn(async {
+        tokio::time::sleep(Duration::from_secs(30)).await;
+        42
+    });
+
+    // Cancel shortly after the run starts.
+    let canceller = cancel.clone();
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        canceller.cancel();
+    });
+
+    let start = std::time::Instant::now();
+    let result = run_until_cancelled(join, &cancel).await;
+    assert!(
+        result.is_none(),
+        "a cancelled run must be abandoned, not awaited to completion"
+    );
+    assert!(
+        start.elapsed() < Duration::from_secs(5),
+        "must return promptly on cancel, not wait out the blocking run"
     );
 }

--- a/influxdb3_processing_engine/src/tests.rs
+++ b/influxdb3_processing_engine/src/tests.rs
@@ -38,6 +38,7 @@ use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 use tempfile::NamedTempFile;
+use tokio_util::sync::CancellationToken;
 
 #[test_log::test(tokio::test)]
 async fn test_trigger_lifecycle() -> Result<(), Box<dyn std::error::Error>> {
@@ -1642,7 +1643,7 @@ async fn setup_db_with_trigger(
                 channels.add_wal_trigger(db_id, trigger_id);
             }
             "schedule" => {
-                channels.add_schedule_trigger(db_id, trigger_id);
+                channels.add_schedule_trigger(db_id, trigger_id, CancellationToken::new());
             }
             "request" => {
                 channels.add_request_trigger(
@@ -2011,6 +2012,7 @@ mod plugin_channels_tests {
     use influxdb3_id::{DbId, TriggerId};
     use iox_http_util::Response;
     use tokio::sync::oneshot;
+    use tokio_util::sync::CancellationToken;
 
     #[tokio::test]
     async fn add_wal_trigger_is_keyed_by_id() {
@@ -2136,6 +2138,48 @@ mod plugin_channels_tests {
         assert!(
             matches!(wal_rx.recv().await, Some(WalEvent::Shutdown(_))),
             "expected WalEvent::Shutdown"
+        );
+    }
+
+    /// Stopping a scheduled trigger must cancel its per-trigger token, so an
+    /// in-flight run_async=false run is interrupted (the schedule loop races this
+    /// token in run_at_time). Without it the disable/`delete --force` hang recurs.
+    #[tokio::test]
+    async fn send_shutdown_cancels_schedule_trigger_token() {
+        let mut channels = PluginChannels::default();
+        let (db_id, trigger_id) = (DbId::new(1), TriggerId::new(1));
+        let token = CancellationToken::new();
+        let _rx = channels.add_schedule_trigger(db_id, trigger_id, token.clone());
+        assert!(!token.is_cancelled());
+
+        let shutdown_rx = channels.send_shutdown(db_id, trigger_id).await.unwrap();
+        assert!(shutdown_rx.is_some(), "expected a shutdown receiver");
+        assert!(
+            token.is_cancelled(),
+            "stopping a scheduled trigger must cancel its per-trigger token"
+        );
+    }
+
+    /// Deleting a database must also cancel its scheduled triggers' tokens — a
+    /// blocking run_async=false run would otherwise hang the database deletion the
+    /// same way it hangs a single-trigger disable/delete.
+    #[tokio::test]
+    async fn shutdown_all_for_db_cancels_schedule_trigger_token() {
+        let mut channels = PluginChannels::default();
+        let (db_id, trigger_id) = (DbId::new(1), TriggerId::new(1));
+        let token = CancellationToken::new();
+        let _rx = channels.add_schedule_trigger(db_id, trigger_id, token.clone());
+        assert!(!token.is_cancelled());
+
+        let receivers = channels.shutdown_all_for_db(db_id).await;
+        assert_eq!(
+            receivers.len(),
+            1,
+            "expected one shutdown receiver for the schedule trigger"
+        );
+        assert!(
+            token.is_cancelled(),
+            "deleting a database must cancel its schedule triggers' tokens"
         );
     }
 }

--- a/influxdb3_wal/src/serialize.rs
+++ b/influxdb3_wal/src/serialize.rs
@@ -79,6 +79,27 @@ pub fn verify_file_type_and_deserialize(b: Bytes) -> Result<WalContents> {
     Ok(contents)
 }
 
+impl Error {
+    /// Returns `true` if this serialize error indicates a durably corrupt WAL file.
+    ///
+    /// "Durable" means the bytes themselves are wrong — a retry against the same
+    /// object will never succeed. Truncation (`WalFileTooSmall`), missing/incorrect
+    /// file magic (`InvalidWalFile`), and CRC mismatch (`Crc32Mismatch`) all qualify.
+    ///
+    /// `Bitcode(...)` is deliberately excluded: CRC validation runs before bitcode
+    /// decoding in `verify_file_type_and_deserialize`, so a `Bitcode` error means
+    /// the bytes are CRC-consistent but the reader can't decode them — almost always
+    /// a writer/reader version or schema skew, recoverable by upgrading the reader,
+    /// not by skipping the file. `Io(...)` and `TryFromSlice(...)` are transport-level
+    /// rather than content-level.
+    pub fn is_durable_wal_corruption(&self) -> bool {
+        matches!(
+            self,
+            Error::WalFileTooSmall { .. } | Error::InvalidWalFile | Error::Crc32Mismatch,
+        )
+    }
+}
+
 pub(crate) fn serialize_to_file_bytes(contents: &WalContents) -> Result<Vec<u8>> {
     let mut buf = Vec::new();
     buf.extend_from_slice(FILE_TYPE_IDENTIFIER);

--- a/influxdb3_wal/src/serialize/tests.rs
+++ b/influxdb3_wal/src/serialize/tests.rs
@@ -101,3 +101,52 @@ fn test_wal_file_with_header_but_no_checksum() {
         _ => panic!("Expected WalFileTooSmall error for file with only header"),
     }
 }
+
+#[test]
+fn is_durable_wal_corruption_matches_documented_variants() {
+    use super::Error;
+
+    assert!(Error::InvalidWalFile.is_durable_wal_corruption());
+    assert!(Error::Crc32Mismatch.is_durable_wal_corruption());
+    assert!(
+        Error::WalFileTooSmall {
+            expected: 12,
+            actual: 4,
+        }
+        .is_durable_wal_corruption()
+    );
+}
+
+#[test]
+fn is_durable_wal_corruption_rejects_transient_variants() {
+    use super::Error;
+    use std::io::Error as IoError;
+
+    assert!(!Error::Io(IoError::other("transient")).is_durable_wal_corruption());
+}
+
+// Pin the excluded variants explicitly. These are called out in the predicate's
+// doc comment as non-durable. A future contributor who wants to add one of them
+// to the durable-corruption set must fail this test on purpose — no accidental
+// widening of the predicate.
+#[test]
+fn is_durable_wal_corruption_rejects_bitcode_errors() {
+    use super::Error;
+
+    // bitcode::Error does not expose a public constructor in stable API, so
+    // roundtrip through a deliberately-truncated deserialize to obtain one.
+    let empty: &[u8] = &[];
+    let bitcode_err = bitcode::deserialize::<crate::WalContents>(empty).unwrap_err();
+    assert!(!Error::Bitcode(bitcode_err).is_durable_wal_corruption());
+}
+
+#[test]
+fn is_durable_wal_corruption_rejects_try_from_slice_errors() {
+    use super::Error;
+
+    // TryFromSliceError has no public constructor; produce one via a failing
+    // conversion.
+    let slice: &[u8] = &[0u8; 3];
+    let tfs_err = <[u8; 4]>::try_from(slice).unwrap_err();
+    assert!(!Error::TryFromSlice(tfs_err).is_durable_wal_corruption());
+}

--- a/influxdb3_write/src/write_buffer/validator.rs
+++ b/influxdb3_write/src/write_buffer/validator.rs
@@ -212,18 +212,30 @@ fn validate_and_qualify_v1_line(
 
     if let Some(tag_set) = &line.series.tag_set {
         for (tag_key, tag_val) in tag_set {
-            let col = txn
+            let col_id = txn
                 .column_or_create(table_name, tag_key.as_str(), InfluxColumnType::Tag)
                 .map_err(|error| WriteLineError {
                     original_line: line.to_string(),
                     line_number: line_number + 1,
                     error_message: error.to_string(),
-                })?;
-            fields.push(Field::new(
-                col.ord_id()
-                    .expect("parquet write paths require legacy column ids"),
-                FieldData::Tag(tag_val.to_string()),
-            ));
+                })?
+                .ord_id()
+                .expect("parquet write paths require legacy column ids");
+            // Reject a point that repeats a tag key. Without this a duplicate tag
+            // produces two columns with the same id, which desyncs the table buffer
+            // and later panics when building the record batch (all columns must have
+            // the same length). Mirrors the duplicate-field check below.
+            if !column_ids.insert(col_id) {
+                return Err(WriteLineError {
+                    original_line: line.to_string(),
+                    line_number: line_number + 1,
+                    error_message: format!(
+                        "invalid line protocol - multiple instances of '{}' tag found",
+                        tag_key.as_str()
+                    ),
+                });
+            }
+            fields.push(Field::new(col_id, FieldData::Tag(tag_val.to_string())));
             index_count += 1;
         }
     }

--- a/influxdb3_write/src/write_buffer/validator/tests.rs
+++ b/influxdb3_write/src/write_buffer/validator/tests.rs
@@ -97,3 +97,67 @@ async fn write_validator_v1() -> Result<(), Error> {
 
     Ok(())
 }
+
+/// A point that repeats a tag key must be rejected, the same way a repeated field key
+/// already is. Without this, the duplicate tag produces two columns with the same id,
+/// which desyncs the table buffer and later panics when building the record batch
+/// ("all columns in a record batch must have the same length"). See influxdb_pro#4375.
+#[tokio::test]
+async fn write_validator_rejects_duplicate_tag() -> Result<(), Error> {
+    let node_id = Arc::from("sample-host-id");
+    let obj_store = Arc::new(InMemory::new());
+    let time_provider = Arc::new(MockProvider::new(Time::from_timestamp_nanos(0)));
+    let database_name = DatabaseName::new("test").unwrap();
+    let catalog = Arc::new(
+        Catalog::new(node_id, obj_store, time_provider, Default::default())
+            .await
+            .unwrap(),
+    );
+
+    // accept_partial = true: the duplicate-tag line is collected into `errors` and
+    // dropped, so no row is buffered.
+    let result = WriteValidator::initialize(database_name.clone(), Arc::clone(&catalog))?
+        .v1_parse_lines_and_catalog_updates(
+            "cpu,tag1=foo,tag1=bar val1=\"bar\" 1234",
+            true,
+            Time::from_timestamp_nanos(0),
+            Precision::Auto,
+        )?
+        .commit_catalog_changes()
+        .await?
+        .unwrap_success()
+        .convert_lines_to_buffer(Gen1Duration::new_5m());
+
+    println!("result: {result:?}");
+    assert_eq!(
+        result.line_count, 0,
+        "the duplicate-tag line must not be buffered"
+    );
+    assert_eq!(result.errors.len(), 1, "expected exactly one line error");
+    assert!(
+        result.errors[0]
+            .error_message
+            .contains("multiple instances of 'tag1' tag found"),
+        "unexpected error message: {:?}",
+        result.errors
+    );
+
+    // accept_partial = false: the whole write is rejected with a ParseError.
+    let err = WriteValidator::initialize(database_name.clone(), Arc::clone(&catalog))?
+        .v1_parse_lines_and_catalog_updates(
+            "cpu,tag1=foo,tag1=bar val1=\"bar\" 1234",
+            false,
+            Time::from_timestamp_nanos(0),
+            Precision::Auto,
+        )
+        .err();
+    assert!(
+        matches!(
+            &err,
+            Some(Error::ParseError(e)) if e.error_message.contains("multiple instances of 'tag1' tag found")
+        ),
+        "expected a ParseError for the duplicate tag, got: {err:?}"
+    );
+
+    Ok(())
+}

--- a/object_store_utils/src/test_object_store.rs
+++ b/object_store_utils/src/test_object_store.rs
@@ -79,6 +79,10 @@ pub struct TestObjectStore {
     error_type: ErrorType,
     get_delay: Option<Duration>,
     put_delay: Option<Duration>,
+    /// Number of `get` requests currently executing against the inner store
+    in_flight_gets: AtomicUsize,
+    /// Peak value of `in_flight_gets`, for asserting concurrency bounds
+    max_in_flight_gets: AtomicUsize,
 }
 
 impl TestObjectStore {
@@ -95,6 +99,8 @@ impl TestObjectStore {
             error_type: ErrorType::default(),
             get_delay: None,
             put_delay: None,
+            in_flight_gets: AtomicUsize::new(0),
+            max_in_flight_gets: AtomicUsize::new(0),
         }
     }
 
@@ -222,6 +228,32 @@ impl TestObjectStore {
             sleep(delay).await;
         }
     }
+
+    /// Peak number of `get` requests that were executing concurrently
+    pub fn max_in_flight_gets(&self) -> usize {
+        self.max_in_flight_gets.load(Ordering::SeqCst)
+    }
+
+    /// Track an in-flight `get` for the returned guard's lifetime. A guard (rather
+    /// than a decrement after the await) keeps the count accurate when the request
+    /// future is cancelled mid-flight.
+    fn track_get(&self) -> InFlightGuard<'_> {
+        let current = self.in_flight_gets.fetch_add(1, Ordering::SeqCst) + 1;
+        self.max_in_flight_gets.fetch_max(current, Ordering::SeqCst);
+        InFlightGuard {
+            counter: &self.in_flight_gets,
+        }
+    }
+}
+
+struct InFlightGuard<'a> {
+    counter: &'a AtomicUsize,
+}
+
+impl Drop for InFlightGuard<'_> {
+    fn drop(&mut self) {
+        self.counter.fetch_sub(1, Ordering::SeqCst);
+    }
 }
 
 impl Display for TestObjectStore {
@@ -302,6 +334,7 @@ impl ObjectStore for TestObjectStore {
         }) {
             return Err(self.create_error());
         }
+        let _in_flight = self.track_get();
         self.maybe_delay_get().await;
         self.inner.get(location).await
     }


### PR DESCRIPTION
Sync of oss/ from influxdata/influxdb_pro branch `3.10` at v3.10.3, via `just oss-sync`.

Rolls up everything since the last sync: version bump to 3.10.3, duplicate tag key write rejection, per-trigger processing engine cancellation, WAL serialize corruption tolerance, crossbeam-epoch RUSTSEC-2026-0204 update and deny.toml entries, and an in-flight GET tracker on `TestObjectStore` used by the compacted-data load concurrency fix (influxdata/influxdb_pro#4415).