### PR TITLE
feat: mTLS support

### DIFF
--- a/client/v2/client.go
+++ b/client/v2/client.go
@@ -44,7 +44,8 @@ type HTTPConfig struct {
 	InsecureSkipVerify bool
 
 	// TLSConfig allows the user to set their own TLS config for the HTTP
-	// Client. If set, this option overrides InsecureSkipVerify.
+	// Client. If set, it is used as-is and its own InsecureSkipVerify applies;
+	// the InsecureSkipVerify field above is ignored.
 	TLSConfig *tls.Config
 
 	// Proxy configures the Proxy function on the HTTP client.
@@ -128,9 +129,10 @@ func NewHTTPClient(conf HTTPConfig) (HTTPClient, error) {
 		DialContext: conf.DialContext,
 	}
 	if conf.TLSConfig != nil {
+		// A supplied TLSConfig is used as-is, including its own
+		// InsecureSkipVerify; the HTTPConfig.InsecureSkipVerify field only
+		// applies when no TLSConfig is given.
 		tr.TLSClientConfig = conf.TLSConfig
-		// Make sure to preserve the InsecureSkipVerify setting from the config.
-		tr.TLSClientConfig.InsecureSkipVerify = conf.InsecureSkipVerify
 	}
 	return &client{
 		url:       *u,

--- a/cmd/influxd/run/server.go
+++ b/cmd/influxd/run/server.go
@@ -613,6 +613,17 @@ func (s *Server) ApplyReloadedConfig(config *Config, log *zap.Logger) error {
 		}
 	}
 
+	// Reload the subscriber's client TLS certificate at its currently
+	// configured path so rotated certificates are picked up.
+	if s.Subscriber != nil {
+		if af, err := s.Subscriber.PrepareReloadTLSCertificates(); err == nil {
+			applyFuncs = append(applyFuncs, af)
+		} else {
+			log.Error("error reloading subscriber service TLS certificate, no new configuration applied", zap.Error(err))
+			return err
+		}
+	}
+
 	// We've verified that the configuration should load, now apply it. Keep going even if something fails to apply.
 	var applyErrs []error
 	for _, af := range applyFuncs {

--- a/etc/config.sample.toml
+++ b/etc/config.sample.toml
@@ -389,6 +389,15 @@
   # Allows insecure file permissions for https-certificate and https-private-key when enabled.
   # https-insecure-certificate = false
 
+  # The type of client certificate authentication (mutual TLS) to require. One of
+  # NoClientCert, RequestClientCert, RequireAnyClientCert, VerifyClientCertIfGiven, or
+  # RequireAndVerifyClientCert. Unset leaves client authentication disabled (NoClientCert).
+  # https-client-auth-type = "RequireAndVerifyClientCert"
+
+  # CA certificates used to verify client certificates during client authentication.
+  # "paths" lists PEM files to trust; "include-system" also trusts the host's system CA pool.
+  # https-client-ca = { paths = ["/etc/ssl/client-ca.pem"], include-system = false }
+
   # The JWT auth shared secret to validate requests using JSON web tokens.
   # shared-secret = ""
 
@@ -469,6 +478,19 @@
 
   # The path to the PEM encoded CA certs file. If the empty string, the default system certs will be used
   # ca-certs = ""
+
+  # Additional CA certificates used to verify subscription endpoint server certificates,
+  # combined with ca-certs above. "paths" lists PEM files to trust; "include-system" also
+  # trusts the host's system CA pool.
+  # root-ca = { paths = ["/etc/ssl/subscriber-ca.pem"], include-system = false }
+
+  # Client certificate (and its private key) the subscriber presents to HTTPS endpoints
+  # for mutual TLS. Empty means no client certificate is presented.
+  # certificate = ""
+  # private-key = ""
+
+  # Allows insecure file permissions on certificate and private-key when enabled.
+  # insecure-certificate = false
 
   # The number of writer goroutines processing the write channel.
   # write-concurrency = 40
@@ -589,6 +611,15 @@
 
   # Allows insecure file permissions on certificate and private-key when enabled.
   # insecure-certificate = false
+
+  # The type of client certificate authentication (mutual TLS) to require. One of
+  # NoClientCert, RequestClientCert, RequireAnyClientCert, VerifyClientCertIfGiven, or
+  # RequireAndVerifyClientCert. Unset leaves client authentication disabled (NoClientCert).
+  # client-auth-type = "RequireAndVerifyClientCert"
+
+  # CA certificates used to verify client certificates during client authentication.
+  # "paths" lists PEM files to trust; "include-system" also trusts the host's system CA pool.
+  # client-ca = { paths = ["/etc/ssl/client-ca.pem"], include-system = false }
 
   # Log an error for every malformed point.
   # log-point-errors = true

--- a/pkg/tlsconfig/configmanager.go
+++ b/pkg/tlsconfig/configmanager.go
@@ -26,35 +26,57 @@ type TLSConfigManager struct {
 	certLoader *TLSCertLoader
 }
 
-// caConfig contains configuration to configure a TLS CA config.
+// CAConfig configures a CA certificate pool: the PEM files to trust and whether
+// to also include the host's system CA pool. It is used for both root CAs
+// (verifying peer server certificates) and client CAs (verifying client
+// certificates during client authentication).
+//
+// It is designed to be embedded in configuration structs as a *CAConfig so that
+// "not configured" is distinguishable from "configured": a nil pointer leaves
+// the base TLS config's pool in place (for root CAs, that means Go's implicit
+// system roots), while a non-nil value is used exactly as given. In particular,
+// a non-nil config with Paths but without IncludeSystem trusts only those
+// paths, because IncludeSystem's zero value is the correct default once the
+// user has configured a pool.
+type CAConfig struct {
+	// Paths are the PEM files whose certificates are added to the pool.
+	Paths []string `toml:"paths"`
+
+	// IncludeSystem includes the host's system CA pool in addition to Paths.
+	IncludeSystem bool `toml:"include-system"`
+}
+
+// hasTrustAnchors reports whether the config would verify against any
+// certificates. A config with no paths and no system pool trusts nothing and
+// cannot verify a peer.
+func (cc *CAConfig) hasTrustAnchors() bool {
+	return len(cc.Paths) > 0 || cc.IncludeSystem
+}
+
+// customCAConfig returns an internal caConfig that builds a pool from cc.
+func (cc *CAConfig) customCAConfig() caConfig {
+	return caConfig{custom: true, includeSystem: cc.IncludeSystem, files: cc.Paths}
+}
+
+// caConfig is the internal, resolved CA configuration used to build a pool.
 type caConfig struct {
-	// custom indicates if caConfig specifies a custom CA config. If false,
-	// the rest of the configuration is ignored.
+	// custom indicates a certificate pool should be built. When false,
+	// newCertPool returns nil so the base *tls.Config is left as-is.
 	custom bool
 
-	// includeSystem indicates if system root CA should be included.
+	// includeSystem indicates if the system CA pool should be included.
 	includeSystem bool
 
-	// files lists paths to PEM files to include in CA.
+	// files lists paths to PEM files to include in the pool.
 	files []string
-}
-
-// setIncludeSystem sets includeSystem and marks the config as custom.
-func (c *caConfig) setIncludeSystem(include bool) {
-	c.custom = true
-	c.includeSystem = include
-}
-
-// addFiles adds a list of files to be included in CA configuration and marks config as custom.
-func (c *caConfig) addFiles(files ...string) {
-	c.custom = true
-	c.files = append(c.files, files...)
 }
 
 // newCertPool returns a x509.CertPool for the configuration in c. If c is not a custom config, then
 // nil is returned.
 func (c *caConfig) newCertPool() (*x509.CertPool, error) {
-	// Only create a CertPool for a custom CA config.
+	// Only create a CertPool for a custom CA config that has either a CA certificate list or
+	// explicitly includes the system CA. A "custom CA" without any certificates
+	// is almost certainly from default config values.
 	if !c.custom {
 		return nil, nil
 	}
@@ -102,14 +124,19 @@ type tlsConfigManagerConfig struct {
 	// allowInsecure indicates if certificate checks should be ignored.
 	allowInsecure bool
 
-	// rootCAConfig is the root CA config.
-	rootCAConfig caConfig
+	// rootCA configures the CA pool used to verify peer certificates. A nil
+	// value leaves the base config's roots (and Go's implicit system pool).
+	rootCA *CAConfig
 
-	// clientCAConfig is the CA config for servers to use for verifying client certificates.
-	clientCAConfig caConfig
+	// clientCA configures the CA pool used to verify client certificates during
+	// client authentication. A nil value under client auth uses the system pool.
+	clientCA *CAConfig
 
-	// clientAuth indicates the type of ClientAuth required by a server.
-	clientAuth tls.ClientAuthType
+	// clientAuth indicates the type of ClientAuth required by a server. A nil
+	// value means it was not configured and the base config's ClientAuth is
+	// left in place; a non-nil value overrides it, even with the zero value
+	// (tls.NoClientCert).
+	clientAuth *tls.ClientAuthType
 
 	// certLoaderOpts are options for the underlying TLSCertLoader.
 	certLoaderOpts []TLSCertLoaderOpt
@@ -152,38 +179,48 @@ func WithAllowInsecure(allowInsecure bool) TLSConfigManagerOpt {
 	}
 }
 
-// WithRootCAIncludeSystem specifies if the system CA should be included in the root CA.
-func WithRootCAIncludeSystem(includeSystem bool) TLSConfigManagerOpt {
+// WithRootCA configures the CA pool used to verify peer (server) certificates.
+// A nil config leaves the base config's roots in place (Go's implicit system
+// pool). A non-nil config is used as-is; one that trusts no certificates is an
+// error at construction unless insecure connections are allowed.
+func WithRootCA(cc *CAConfig) TLSConfigManagerOpt {
 	return func(cp *tlsConfigManagerConfig) {
-		cp.rootCAConfig.setIncludeSystem(includeSystem)
+		cp.rootCA = cc
 	}
 }
 
-// WithRootCAFiles specifies a list of paths to PEM files that contain root CAs.
-func WithRootCAFiles(pemFiles ...string) TLSConfigManagerOpt {
+// WithClientCA configures the CA pool used to verify client certificates during
+// client authentication. A nil config leaves the base config's client pool in
+// place; a non-nil config is validated and built into a pool whether or not
+// client authentication is enabled via WithClientAuth, and one that trusts no
+// certificates is an error at construction. The pool is only actually used to
+// verify clients when client authentication is enabled.
+func WithClientCA(cc *CAConfig) TLSConfigManagerOpt {
 	return func(cp *tlsConfigManagerConfig) {
-		cp.rootCAConfig.addFiles(pemFiles...)
+		cp.clientCA = cc
 	}
 }
 
-// WithClientCAIncludeSystem specifies if the system CA should be included in the client CA for client authentication.
-func WithClientCAIncludeSystem(includeSystem bool) TLSConfigManagerOpt {
-	return func(cp *tlsConfigManagerConfig) {
-		cp.clientCAConfig.setIncludeSystem(includeSystem)
-	}
-}
-
-// WithClientCAFiles specifies a list of paths to PEM files that contain root CA for client authentication.
-func WithClientCAFiles(pemFiles ...string) TLSConfigManagerOpt {
-	return func(cp *tlsConfigManagerConfig) {
-		cp.clientCAConfig.addFiles(pemFiles...)
-	}
-}
-
-// WithClientAuth specifies the type TLS client authentication a server should perform.
+// WithClientAuth specifies the type of TLS client authentication a server
+// should perform. When used, it overrides the base config's ClientAuth with
+// auth, even if auth is the zero value (tls.NoClientCert).
 func WithClientAuth(auth tls.ClientAuthType) TLSConfigManagerOpt {
 	return func(cp *tlsConfigManagerConfig) {
-		cp.clientAuth = auth
+		cp.clientAuth = &auth
+	}
+}
+
+// WithClientAuthPtr specifies the type of TLS client authentication a server
+// should perform, allowing "not configured" to be distinguished from an
+// explicit value. When clientAuthPtr is nil the base config's ClientAuth is left
+// in place; when it is non-nil the base config's ClientAuth is overridden with
+// *clientAuthPtr, even if that is the zero value (tls.NoClientCert).
+func WithClientAuthPtr(clientAuthPtr *tls.ClientAuthType) TLSConfigManagerOpt {
+	return func(cp *tlsConfigManagerConfig) {
+		if clientAuthPtr != nil {
+			auth := *clientAuthPtr
+			cp.clientAuth = &auth
+		}
 	}
 }
 
@@ -216,6 +253,27 @@ func WithIgnoreFilePermissions(ignore bool) TLSConfigManagerOpt {
 	}
 }
 
+// errCATrustsNothing is returned by resolveCA when a configured CA pool would
+// trust no certificates. Callers wrap it with root/client context.
+var errCATrustsNothing = errors.New("trusts no certificates: set paths or enable include-system")
+
+// resolveCA resolves a user-facing *CAConfig into an internal pool config,
+// shared by root and client CAs. A nil config leaves the base config's pool in
+// place (for root CAs, that means Go's implicit system roots). A non-nil config
+// is always validated and built into a pool, regardless of how (or whether) the
+// pool will be used, so a misconfigured CA is reported at construction; one that
+// trusts no certificates returns errCATrustsNothing for the caller to wrap with
+// the appropriate root/client context.
+func resolveCA(cc *CAConfig) (caConfig, error) {
+	if cc == nil {
+		return caConfig{}, nil // leave the base config's pool
+	}
+	if !cc.hasTrustAnchors() {
+		return caConfig{}, errCATrustsNothing
+	}
+	return cc.customCAConfig(), nil
+}
+
 // newTLSConfigManager returns a TLSConfigManager configured by opts.
 func newTLSConfigManager(opts ...TLSConfigManagerOpt) (*TLSConfigManager, error) {
 	c := tlsConfigManagerConfig{}
@@ -236,9 +294,22 @@ func newTLSConfigManager(opts ...TLSConfigManagerOpt) (*TLSConfigManager, error)
 		// Modify configuration.
 		tlsConfig.InsecureSkipVerify = c.allowInsecure
 
-		// Only overwrite default value of ClientAuth.
-		if tlsConfig.ClientAuth == tls.NoClientCert {
-			tlsConfig.ClientAuth = c.clientAuth
+		// Override ClientAuth only when it was explicitly configured; otherwise
+		// leave the base config's value in place.
+		if c.clientAuth != nil {
+			tlsConfig.ClientAuth = *c.clientAuth
+		}
+
+		// Resolve the user-facing *CAConfig values into internal pool configs,
+		// applying the not-configured defaults and rejecting configurations
+		// that trust no certificates. See CAConfig for the nil/non-nil semantics.
+		rootCAConfig, err := resolveCA(c.rootCA)
+		if err != nil {
+			return nil, fmt.Errorf("root CA configuration %w", err)
+		}
+		clientCAConfig, err := resolveCA(c.clientCA)
+		if err != nil {
+			return nil, fmt.Errorf("client CA configuration %w", err)
 		}
 
 		// Setup CA pools.
@@ -252,10 +323,10 @@ func newTLSConfigManager(opts ...TLSConfigManagerOpt) (*TLSConfigManager, error)
 			return nil
 		}
 
-		if err := setupPool(&tlsConfig.RootCAs, c.rootCAConfig); err != nil {
+		if err := setupPool(&tlsConfig.RootCAs, rootCAConfig); err != nil {
 			return nil, fmt.Errorf("error creating root CA pool: %w", err)
 		}
-		if err := setupPool(&tlsConfig.ClientCAs, c.clientCAConfig); err != nil {
+		if err := setupPool(&tlsConfig.ClientCAs, clientCAConfig); err != nil {
 			return nil, fmt.Errorf("error creating client CA pool: %w", err)
 		}
 

--- a/pkg/tlsconfig/configmanager_test.go
+++ b/pkg/tlsconfig/configmanager_test.go
@@ -854,7 +854,7 @@ func TestTLSConfigManager_WithRootCAFiles(t *testing.T) {
 		require.True(t, expectedPool.AppendCertsFromPEM(caCert))
 
 		manager, err := NewTLSConfigManager(true, nil, ss.CertPath, ss.KeyPath, false,
-			WithRootCAFiles(ss.CACertPath))
+			WithRootCA(&CAConfig{Paths: []string{ss.CACertPath}}))
 		require.NoError(t, err)
 		defer func() {
 			require.NoError(t, manager.Close())
@@ -878,7 +878,7 @@ func TestTLSConfigManager_WithRootCAFiles(t *testing.T) {
 
 		// Client manager trusting the CA that signed the server certificate
 		clientManager, err := NewClientTLSConfigManager(true, nil, false,
-			WithRootCAFiles(ss.CACertPath))
+			WithRootCA(&CAConfig{Paths: []string{ss.CACertPath}}))
 		require.NoError(t, err)
 		defer func() {
 			require.NoError(t, clientManager.Close())
@@ -918,6 +918,9 @@ func TestTLSConfigManager_WithRootCAFiles(t *testing.T) {
 
 	t.Run("client rejects server without CA", func(t *testing.T) {
 		ss := selfsigned.NewSelfSignedCert(t)
+		// A different, unrelated self-signed CA. It makes for a valid (non-empty)
+		// root CA config that nonetheless does not trust the server's certificate.
+		otherSS := selfsigned.NewSelfSignedCert(t, selfsigned.WithCASubject("other", "Other CA"))
 
 		// Server manager
 		serverManager, err := NewTLSConfigManager(true, nil, ss.CertPath, ss.KeyPath, false)
@@ -926,9 +929,9 @@ func TestTLSConfigManager_WithRootCAFiles(t *testing.T) {
 			require.NoError(t, serverManager.Close())
 		}()
 
-		// Client manager with empty RootCA pool (explicitly set, no system CAs)
+		// Client manager trusting only an unrelated CA, so it will not trust the server.
 		clientManager, err := NewClientTLSConfigManager(true, nil, false,
-			WithRootCAIncludeSystem(false))
+			WithRootCA(&CAConfig{Paths: []string{otherSS.CACertPath}}))
 		require.NoError(t, err)
 		defer func() {
 			require.NoError(t, clientManager.Close())
@@ -970,7 +973,7 @@ func TestTLSConfigManager_WithRootCAFiles(t *testing.T) {
 		require.True(t, expectedPool.AppendCertsFromPEM(caCert2))
 
 		manager, err := NewClientTLSConfigManager(true, nil, false,
-			WithRootCAFiles(ss1.CACertPath, ss2.CACertPath))
+			WithRootCA(&CAConfig{Paths: []string{ss1.CACertPath, ss2.CACertPath}}))
 		require.NoError(t, err)
 		defer func() {
 			require.NoError(t, manager.Close())
@@ -984,7 +987,7 @@ func TestTLSConfigManager_WithRootCAFiles(t *testing.T) {
 
 	t.Run("error on nonexistent file", func(t *testing.T) {
 		_, err := NewClientTLSConfigManager(true, nil, false,
-			WithRootCAFiles("/nonexistent/ca.pem"))
+			WithRootCA(&CAConfig{Paths: []string{"/nonexistent/ca.pem"}}))
 		require.ErrorIs(t, err, os.ErrNotExist)
 		require.ErrorContains(t, err, "error creating root CA pool: error reading file \"/nonexistent/ca.pem\" for CA store: open /nonexistent/ca.pem: no such file or directory")
 	})
@@ -996,7 +999,7 @@ func TestTLSConfigManager_WithRootCAFiles(t *testing.T) {
 		require.NoError(t, os.WriteFile(tmpFile, []byte("not a valid PEM file"), 0644))
 
 		manager, err := NewClientTLSConfigManager(true, nil, false,
-			WithRootCAFiles(tmpFile))
+			WithRootCA(&CAConfig{Paths: []string{tmpFile}}))
 		require.ErrorContains(t, err, "error creating root CA pool: error adding certificates from \""+tmpFile+"\" to CA store: no valid certificates found")
 		require.Nil(t, manager)
 	})
@@ -1009,7 +1012,7 @@ func TestTLSConfigManager_WithRootCAIncludeSystem(t *testing.T) {
 		require.NoError(t, err)
 
 		manager, err := NewClientTLSConfigManager(true, nil, false,
-			WithRootCAIncludeSystem(true))
+			WithRootCA(&CAConfig{IncludeSystem: true}))
 		require.NoError(t, err)
 		defer func() {
 			require.NoError(t, manager.Close())
@@ -1021,21 +1024,24 @@ func TestTLSConfigManager_WithRootCAIncludeSystem(t *testing.T) {
 		require.True(t, tlsConfig.RootCAs.Equal(expectedPool), "RootCAs should equal system pool")
 	})
 
-	t.Run("excludes system CA pool", func(t *testing.T) {
-		// Expected: empty pool
-		expectedPool := x509.NewCertPool()
-
+	t.Run("trusts no certificates is an error", func(t *testing.T) {
+		// A non-nil root CA config that neither lists paths nor includes the
+		// system pool trusts nothing and is rejected at construction.
 		manager, err := NewClientTLSConfigManager(true, nil, false,
-			WithRootCAIncludeSystem(false))
-		require.NoError(t, err)
-		defer func() {
-			require.NoError(t, manager.Close())
-		}()
+			WithRootCA(&CAConfig{IncludeSystem: false}))
+		require.EqualError(t, err, "root CA configuration trusts no certificates: "+
+			"set paths or enable include-system")
+		require.Nil(t, manager)
+	})
 
-		tlsConfig := manager.TLSConfig()
-		require.NotNil(t, tlsConfig)
-		require.NotNil(t, tlsConfig.RootCAs)
-		require.True(t, tlsConfig.RootCAs.Equal(expectedPool), "RootCAs should be empty pool")
+	t.Run("trusts no certificates is an error even when insecure", func(t *testing.T) {
+		// A non-nil config is validated regardless of allowInsecure, so a
+		// no-trust-anchors config is still rejected at construction.
+		manager, err := NewClientTLSConfigManager(true, nil, true,
+			WithRootCA(&CAConfig{IncludeSystem: false}))
+		require.EqualError(t, err, "root CA configuration trusts no certificates: "+
+			"set paths or enable include-system")
+		require.Nil(t, manager)
 	})
 
 	t.Run("combined with CA files", func(t *testing.T) {
@@ -1049,8 +1055,7 @@ func TestTLSConfigManager_WithRootCAIncludeSystem(t *testing.T) {
 		require.True(t, expectedPool.AppendCertsFromPEM(caCert))
 
 		manager, err := NewClientTLSConfigManager(true, nil, false,
-			WithRootCAIncludeSystem(true),
-			WithRootCAFiles(ss.CACertPath))
+			WithRootCA(&CAConfig{Paths: []string{ss.CACertPath}, IncludeSystem: true}))
 		require.NoError(t, err)
 		defer func() {
 			require.NoError(t, manager.Close())
@@ -1074,7 +1079,8 @@ func TestTLSConfigManager_WithClientCAFiles(t *testing.T) {
 		require.True(t, expectedPool.AppendCertsFromPEM(caCert))
 
 		manager, err := NewTLSConfigManager(true, nil, ss.CertPath, ss.KeyPath, false,
-			WithClientCAFiles(ss.CACertPath))
+			WithClientAuth(tls.RequireAndVerifyClientCert),
+			WithClientCA(&CAConfig{Paths: []string{ss.CACertPath}}))
 		require.NoError(t, err)
 		defer func() {
 			require.NoError(t, manager.Close())
@@ -1091,7 +1097,7 @@ func TestTLSConfigManager_WithClientCAFiles(t *testing.T) {
 
 		// Server manager that requires client certificates.
 		serverManager, err := NewTLSConfigManager(true, nil, ss.CertPath, ss.KeyPath, false,
-			WithClientCAFiles(ss.CACertPath),
+			WithClientCA(&CAConfig{Paths: []string{ss.CACertPath}}),
 			WithClientAuth(tls.RequireAndVerifyClientCert))
 		require.NoError(t, err)
 		defer func() {
@@ -1143,7 +1149,7 @@ func TestTLSConfigManager_WithClientCAFiles(t *testing.T) {
 		// Server manager that requires client certificates
 		serverManager, err := NewTLSConfigManager(true, nil, ss.CertPath, ss.KeyPath, false,
 			WithClientAuth(tls.RequireAndVerifyClientCert),
-			WithClientCAFiles(ss.CACertPath))
+			WithClientCA(&CAConfig{Paths: []string{ss.CACertPath}}))
 		require.NoError(t, err)
 		defer func() {
 			require.NoError(t, serverManager.Close())
@@ -1206,7 +1212,8 @@ func TestTLSConfigManager_WithClientCAFiles(t *testing.T) {
 		require.True(t, expectedPool.AppendCertsFromPEM(caCert2))
 
 		manager, err := NewTLSConfigManager(true, nil, ss1.CertPath, ss1.KeyPath, false,
-			WithClientCAFiles(ss1.CACertPath, ss2.CACertPath))
+			WithClientAuth(tls.RequireAndVerifyClientCert),
+			WithClientCA(&CAConfig{Paths: []string{ss1.CACertPath, ss2.CACertPath}}))
 		require.NoError(t, err)
 		defer func() {
 			require.NoError(t, manager.Close())
@@ -1222,7 +1229,8 @@ func TestTLSConfigManager_WithClientCAFiles(t *testing.T) {
 		ss := selfsigned.NewSelfSignedCert(t)
 
 		_, err := NewTLSConfigManager(true, nil, ss.CertPath, ss.KeyPath, false,
-			WithClientCAFiles("/nonexistent/ca.pem"))
+			WithClientAuth(tls.RequireAndVerifyClientCert),
+			WithClientCA(&CAConfig{Paths: []string{"/nonexistent/ca.pem"}}))
 		require.ErrorIs(t, err, os.ErrNotExist)
 		require.ErrorContains(t, err, "error creating client CA pool: error reading file \"/nonexistent/ca.pem\" for CA store: open /nonexistent/ca.pem: no such file or directory")
 	})
@@ -1236,7 +1244,8 @@ func TestTLSConfigManager_WithClientCAFiles(t *testing.T) {
 		require.NoError(t, os.WriteFile(tmpFile, []byte("not a valid PEM file"), 0644))
 
 		manager, err := NewTLSConfigManager(true, nil, ss.CertPath, ss.KeyPath, false,
-			WithClientCAFiles(tmpFile))
+			WithClientAuth(tls.RequireAndVerifyClientCert),
+			WithClientCA(&CAConfig{Paths: []string{tmpFile}}))
 		require.ErrorContains(t, err, "error creating client CA pool: error adding certificates from \""+tmpFile+"\" to CA store: no valid certificates found")
 		require.Nil(t, manager)
 	})
@@ -1251,7 +1260,8 @@ func TestTLSConfigManager_WithClientCAIncludeSystem(t *testing.T) {
 		require.NoError(t, err)
 
 		manager, err := NewTLSConfigManager(true, nil, ss.CertPath, ss.KeyPath, false,
-			WithClientCAIncludeSystem(true))
+			WithClientAuth(tls.RequireAndVerifyClientCert),
+			WithClientCA(&CAConfig{IncludeSystem: true}))
 		require.NoError(t, err)
 		defer func() {
 			require.NoError(t, manager.Close())
@@ -1263,23 +1273,17 @@ func TestTLSConfigManager_WithClientCAIncludeSystem(t *testing.T) {
 		require.True(t, tlsConfig.ClientCAs.Equal(expectedPool), "ClientCAs should equal system pool")
 	})
 
-	t.Run("excludes system CA pool", func(t *testing.T) {
+	t.Run("trusts no certificates is an error", func(t *testing.T) {
 		ss := selfsigned.NewSelfSignedCert(t)
 
-		// Expected: empty pool
-		expectedPool := x509.NewCertPool()
-
+		// A client CA config that neither lists paths nor includes the system pool
+		// trusts nothing and is rejected at construction.
 		manager, err := NewTLSConfigManager(true, nil, ss.CertPath, ss.KeyPath, false,
-			WithClientCAIncludeSystem(false))
-		require.NoError(t, err)
-		defer func() {
-			require.NoError(t, manager.Close())
-		}()
-
-		tlsConfig := manager.TLSConfig()
-		require.NotNil(t, tlsConfig)
-		require.NotNil(t, tlsConfig.ClientCAs)
-		require.True(t, tlsConfig.ClientCAs.Equal(expectedPool), "ClientCAs should be empty pool")
+			WithClientAuth(tls.RequireAndVerifyClientCert),
+			WithClientCA(&CAConfig{IncludeSystem: false}))
+		require.EqualError(t, err, "client CA configuration trusts no certificates: "+
+			"set paths or enable include-system")
+		require.Nil(t, manager)
 	})
 
 	t.Run("combined with CA files", func(t *testing.T) {
@@ -1293,8 +1297,8 @@ func TestTLSConfigManager_WithClientCAIncludeSystem(t *testing.T) {
 		require.True(t, expectedPool.AppendCertsFromPEM(caCert))
 
 		manager, err := NewTLSConfigManager(true, nil, ss.CertPath, ss.KeyPath, false,
-			WithClientCAIncludeSystem(true),
-			WithClientCAFiles(ss.CACertPath))
+			WithClientAuth(tls.RequireAndVerifyClientCert),
+			WithClientCA(&CAConfig{Paths: []string{ss.CACertPath}, IncludeSystem: true}))
 		require.NoError(t, err)
 		defer func() {
 			require.NoError(t, manager.Close())
@@ -1304,6 +1308,50 @@ func TestTLSConfigManager_WithClientCAIncludeSystem(t *testing.T) {
 		require.NotNil(t, tlsConfig)
 		require.NotNil(t, tlsConfig.ClientCAs)
 		require.True(t, tlsConfig.ClientCAs.Equal(expectedPool), "ClientCAs should contain system + custom CA")
+	})
+
+	t.Run("built without client auth: include-system", func(t *testing.T) {
+		ss := selfsigned.NewSelfSignedCert(t)
+
+		// A non-nil client CA config is validated and built even without client
+		// auth (the pool is simply unused until auth is enabled).
+		expectedPool, err := x509.SystemCertPool()
+		require.NoError(t, err)
+
+		manager, err := NewTLSConfigManager(true, nil, ss.CertPath, ss.KeyPath, false,
+			WithClientCA(&CAConfig{IncludeSystem: true}))
+		require.NoError(t, err)
+		defer func() {
+			require.NoError(t, manager.Close())
+		}()
+
+		tlsConfig := manager.TLSConfig()
+		require.NotNil(t, tlsConfig)
+		require.NotNil(t, tlsConfig.ClientCAs)
+		require.True(t, tlsConfig.ClientCAs.Equal(expectedPool), "ClientCAs should be built even without client auth")
+	})
+
+	t.Run("built without client auth: paths and include-system", func(t *testing.T) {
+		ss := selfsigned.NewSelfSignedCert(t)
+
+		// Build expected pool: system + custom CA.
+		expectedPool, err := x509.SystemCertPool()
+		require.NoError(t, err)
+		caCert, err := os.ReadFile(ss.CACertPath)
+		require.NoError(t, err)
+		require.True(t, expectedPool.AppendCertsFromPEM(caCert))
+
+		manager, err := NewTLSConfigManager(true, nil, ss.CertPath, ss.KeyPath, false,
+			WithClientCA(&CAConfig{Paths: []string{ss.CACertPath}, IncludeSystem: true}))
+		require.NoError(t, err)
+		defer func() {
+			require.NoError(t, manager.Close())
+		}()
+
+		tlsConfig := manager.TLSConfig()
+		require.NotNil(t, tlsConfig)
+		require.NotNil(t, tlsConfig.ClientCAs)
+		require.True(t, tlsConfig.ClientCAs.Equal(expectedPool), "ClientCAs should be built even without client auth")
 	})
 }
 
@@ -1346,7 +1394,7 @@ func TestTLSConfigManager_CAOptionsWithBaseConfig(t *testing.T) {
 
 	// Create manager with different CA file - should override base config
 	manager, err := NewClientTLSConfigManager(true, baseConfig, false,
-		WithRootCAFiles(anotherSS.CACertPath))
+		WithRootCA(&CAConfig{Paths: []string{anotherSS.CACertPath}}))
 	require.NoError(t, err)
 	defer func() {
 		require.NoError(t, manager.Close())
@@ -1356,8 +1404,192 @@ func TestTLSConfigManager_CAOptionsWithBaseConfig(t *testing.T) {
 	require.NotNil(t, tlsConfig)
 	require.NotNil(t, tlsConfig.RootCAs)
 	// The RootCAs should match the new CA, not the base config
-	require.True(t, tlsConfig.RootCAs.Equal(expectedPool), "RootCAs should be overridden by WithRootCAFiles")
+	require.True(t, tlsConfig.RootCAs.Equal(expectedPool), "RootCAs should be overridden by WithRootCA")
 	require.False(t, tlsConfig.RootCAs.Equal(basePool), "RootCAs should not equal base pool")
+}
+
+func TestTLSConfigManager_CAResolution(t *testing.T) {
+	t.Run("root nil defers to base config RootCAs", func(t *testing.T) {
+		ss := selfsigned.NewSelfSignedCert(t)
+
+		// Base config supplies a RootCAs pool. With no WithRootCA, the base pool
+		// should be left in place unchanged.
+		basePool := x509.NewCertPool()
+		caCert, err := os.ReadFile(ss.CACertPath)
+		require.NoError(t, err)
+		require.True(t, basePool.AppendCertsFromPEM(caCert))
+		baseConfig := &tls.Config{RootCAs: basePool}
+
+		manager, err := NewClientTLSConfigManager(true, baseConfig, false)
+		require.NoError(t, err)
+		defer func() {
+			require.NoError(t, manager.Close())
+		}()
+
+		tlsConfig := manager.TLSConfig()
+		require.NotNil(t, tlsConfig)
+		require.NotNil(t, tlsConfig.RootCAs)
+		require.True(t, tlsConfig.RootCAs.Equal(basePool), "RootCAs should equal the base config's pool")
+	})
+
+	t.Run("root no-trust-anchors is an error", func(t *testing.T) {
+		manager, err := NewClientTLSConfigManager(true, nil, false,
+			WithRootCA(&CAConfig{}))
+		require.EqualError(t, err, "root CA configuration trusts no certificates: "+
+			"set paths or enable include-system")
+		require.Nil(t, manager)
+	})
+
+	t.Run("root no-trust-anchors is an error even when insecure", func(t *testing.T) {
+		// A non-nil config is validated regardless of allowInsecure, so a
+		// no-trust-anchors config is still rejected at construction.
+		manager, err := NewClientTLSConfigManager(true, nil, true,
+			WithRootCA(&CAConfig{}))
+		require.EqualError(t, err, "root CA configuration trusts no certificates: "+
+			"set paths or enable include-system")
+		require.Nil(t, manager)
+	})
+
+	t.Run("client nil under client auth defers to base config ClientCAs", func(t *testing.T) {
+		ss := selfsigned.NewSelfSignedCert(t)
+
+		// Base config supplies a ClientCAs pool. With client auth enabled but no
+		// WithClientCA, the base pool should be left in place unchanged.
+		basePool := x509.NewCertPool()
+		caCert, err := os.ReadFile(ss.CACertPath)
+		require.NoError(t, err)
+		require.True(t, basePool.AppendCertsFromPEM(caCert))
+		baseConfig := &tls.Config{ClientCAs: basePool}
+
+		manager, err := NewTLSConfigManager(true, baseConfig, ss.CertPath, ss.KeyPath, false,
+			WithClientAuth(tls.RequireAndVerifyClientCert))
+		require.NoError(t, err)
+		defer func() {
+			require.NoError(t, manager.Close())
+		}()
+
+		tlsConfig := manager.TLSConfig()
+		require.NotNil(t, tlsConfig)
+		require.NotNil(t, tlsConfig.ClientCAs)
+		require.True(t, tlsConfig.ClientCAs.Equal(basePool), "ClientCAs should equal the base config's pool")
+	})
+
+	t.Run("client no-trust-anchors is an error even without client auth", func(t *testing.T) {
+		ss := selfsigned.NewSelfSignedCert(t)
+
+		// A non-nil client CA config is validated regardless of whether client
+		// auth is enabled, so a config that trusts nothing is rejected here even
+		// with the default NoClientCert.
+		manager, err := NewTLSConfigManager(true, nil, ss.CertPath, ss.KeyPath, false,
+			WithClientCA(&CAConfig{}))
+		require.EqualError(t, err, "client CA configuration trusts no certificates: "+
+			"set paths or enable include-system")
+		require.Nil(t, manager)
+	})
+
+	t.Run("client config built even without client auth", func(t *testing.T) {
+		ss := selfsigned.NewSelfSignedCert(t)
+
+		// A non-nil client CA config is built even with the default NoClientCert;
+		// the pool is simply unused until client auth is enabled.
+		expectedPool := x509.NewCertPool()
+		caCert, err := os.ReadFile(ss.CACertPath)
+		require.NoError(t, err)
+		require.True(t, expectedPool.AppendCertsFromPEM(caCert))
+
+		manager, err := NewTLSConfigManager(true, nil, ss.CertPath, ss.KeyPath, false,
+			WithClientCA(&CAConfig{Paths: []string{ss.CACertPath}}))
+		require.NoError(t, err)
+		defer func() {
+			require.NoError(t, manager.Close())
+		}()
+
+		tlsConfig := manager.TLSConfig()
+		require.NotNil(t, tlsConfig)
+		require.NotNil(t, tlsConfig.ClientCAs)
+		require.True(t, tlsConfig.ClientCAs.Equal(expectedPool), "ClientCAs should be built even without client auth")
+	})
+
+	t.Run("client paths without include-system trusts only those paths", func(t *testing.T) {
+		ss := selfsigned.NewSelfSignedCert(t)
+
+		// A non-nil config with Paths but IncludeSystem false (zero value) should
+		// build a pool of only those paths, not the system pool.
+		expectedPool := x509.NewCertPool()
+		caCert, err := os.ReadFile(ss.CACertPath)
+		require.NoError(t, err)
+		require.True(t, expectedPool.AppendCertsFromPEM(caCert))
+
+		manager, err := NewTLSConfigManager(true, nil, ss.CertPath, ss.KeyPath, false,
+			WithClientAuth(tls.RequireAndVerifyClientCert),
+			WithClientCA(&CAConfig{Paths: []string{ss.CACertPath}}))
+		require.NoError(t, err)
+		defer func() {
+			require.NoError(t, manager.Close())
+		}()
+
+		tlsConfig := manager.TLSConfig()
+		require.NotNil(t, tlsConfig)
+		require.NotNil(t, tlsConfig.ClientCAs)
+		require.True(t, tlsConfig.ClientCAs.Equal(expectedPool), "ClientCAs should contain only the configured path")
+	})
+}
+
+func TestTLSConfigManager_ClientAuthOverride(t *testing.T) {
+	// Base config with a non-zero ClientAuth, so we can tell whether an option
+	// overrode it (including overriding it back to the zero value).
+	base := func() *tls.Config {
+		return &tls.Config{ClientAuth: tls.RequireAndVerifyClientCert}
+	}
+
+	t.Run("no option leaves base ClientAuth", func(t *testing.T) {
+		manager, err := NewClientTLSConfigManager(true, base(), false)
+		require.NoError(t, err)
+		defer func() { require.NoError(t, manager.Close()) }()
+		require.Equal(t, tls.RequireAndVerifyClientCert, manager.TLSConfig().ClientAuth)
+	})
+
+	t.Run("WithClientAuth overrides base", func(t *testing.T) {
+		manager, err := NewClientTLSConfigManager(true, base(), false,
+			WithClientAuth(tls.VerifyClientCertIfGiven))
+		require.NoError(t, err)
+		defer func() { require.NoError(t, manager.Close()) }()
+		require.Equal(t, tls.VerifyClientCertIfGiven, manager.TLSConfig().ClientAuth)
+	})
+
+	t.Run("WithClientAuth overrides base with zero value", func(t *testing.T) {
+		manager, err := NewClientTLSConfigManager(true, base(), false,
+			WithClientAuth(tls.NoClientCert))
+		require.NoError(t, err)
+		defer func() { require.NoError(t, manager.Close()) }()
+		require.Equal(t, tls.NoClientCert, manager.TLSConfig().ClientAuth)
+	})
+
+	t.Run("WithClientAuthPtr nil leaves base ClientAuth", func(t *testing.T) {
+		manager, err := NewClientTLSConfigManager(true, base(), false,
+			WithClientAuthPtr(nil))
+		require.NoError(t, err)
+		defer func() { require.NoError(t, manager.Close()) }()
+		require.Equal(t, tls.RequireAndVerifyClientCert, manager.TLSConfig().ClientAuth)
+	})
+
+	t.Run("WithClientAuthPtr non-nil overrides base with zero value", func(t *testing.T) {
+		auth := tls.NoClientCert
+		manager, err := NewClientTLSConfigManager(true, base(), false,
+			WithClientAuthPtr(&auth))
+		require.NoError(t, err)
+		defer func() { require.NoError(t, manager.Close()) }()
+		require.Equal(t, tls.NoClientCert, manager.TLSConfig().ClientAuth)
+	})
+
+	t.Run("WithClientAuthPtr non-nil overrides base with non-zero value", func(t *testing.T) {
+		auth := tls.VerifyClientCertIfGiven
+		manager, err := NewClientTLSConfigManager(true, base(), false,
+			WithClientAuthPtr(&auth))
+		require.NoError(t, err)
+		defer func() { require.NoError(t, manager.Close()) }()
+		require.Equal(t, tls.VerifyClientCertIfGiven, manager.TLSConfig().ClientAuth)
+	})
 }
 
 // testManagerCheckTime is the TLS certificate check time in logging tests.

--- a/services/httpd/config.go
+++ b/services/httpd/config.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/influxdata/influxdb/monitor/diagnostics"
+	"github.com/influxdata/influxdb/pkg/tlsconfig"
 	"github.com/influxdata/influxdb/toml"
 )
 
@@ -32,41 +33,43 @@ const (
 
 // Config represents a configuration for a HTTP service.
 type Config struct {
-	Enabled                  bool              `toml:"enabled"`
-	BindAddress              string            `toml:"bind-address"`
-	AuthEnabled              bool              `toml:"auth-enabled"`
-	LogEnabled               bool              `toml:"log-enabled"`
-	SuppressWriteLog         bool              `toml:"suppress-write-log"`
-	WriteTracing             bool              `toml:"write-tracing"`
-	FluxEnabled              bool              `toml:"flux-enabled"`
-	FluxLogEnabled           bool              `toml:"flux-log-enabled"`
-	FluxTesting              bool              `toml:"flux-testing"`
-	PprofEnabled             bool              `toml:"pprof-enabled"`
-	PprofAuthEnabled         bool              `toml:"pprof-auth-enabled"`
-	DebugPprofEnabled        bool              `toml:"debug-pprof-enabled"`
-	PingAuthEnabled          bool              `toml:"ping-auth-enabled"`
-	PromReadAuthEnabled      bool              `toml:"prom-read-auth-enabled"`
-	HTTPHeaders              map[string]string `toml:"headers"`
-	HTTPSEnabled             bool              `toml:"https-enabled"`
-	HTTPSCertificate         string            `toml:"https-certificate"`
-	HTTPSPrivateKey          string            `toml:"https-private-key"`
-	HTTPSInsecureCertificate bool              `toml:"https-insecure-certificate"`
-	MaxRowLimit              int               `toml:"max-row-limit"`
-	MaxConnectionLimit       int               `toml:"max-connection-limit"`
-	SharedSecret             string            `toml:"shared-secret"`
-	Realm                    string            `toml:"realm"`
-	UnixSocketEnabled        bool              `toml:"unix-socket-enabled"`
-	UnixSocketGroup          *toml.Group       `toml:"unix-socket-group"`
-	UnixSocketPermissions    toml.FileMode     `toml:"unix-socket-permissions"`
-	BindSocket               string            `toml:"bind-socket"`
-	MaxBodySize              toml.SSize        `toml:"max-body-size"`
-	AccessLogPath            string            `toml:"access-log-path"`
-	AccessLogStatusFilters   []StatusFilter    `toml:"access-log-status-filters"`
-	MaxConcurrentWriteLimit  int               `toml:"max-concurrent-write-limit"`
-	MaxEnqueuedWriteLimit    int               `toml:"max-enqueued-write-limit"`
-	EnqueuedWriteTimeout     time.Duration     `toml:"enqueued-write-timeout"`
-	UserQueryBytesEnabled    bool              `toml:"user-query-bytes-enabled"`
-	TLS                      *tls.Config       `toml:"-"`
+	Enabled                  bool                    `toml:"enabled"`
+	BindAddress              string                  `toml:"bind-address"`
+	AuthEnabled              bool                    `toml:"auth-enabled"`
+	LogEnabled               bool                    `toml:"log-enabled"`
+	SuppressWriteLog         bool                    `toml:"suppress-write-log"`
+	WriteTracing             bool                    `toml:"write-tracing"`
+	FluxEnabled              bool                    `toml:"flux-enabled"`
+	FluxLogEnabled           bool                    `toml:"flux-log-enabled"`
+	FluxTesting              bool                    `toml:"flux-testing"`
+	PprofEnabled             bool                    `toml:"pprof-enabled"`
+	PprofAuthEnabled         bool                    `toml:"pprof-auth-enabled"`
+	DebugPprofEnabled        bool                    `toml:"debug-pprof-enabled"`
+	PingAuthEnabled          bool                    `toml:"ping-auth-enabled"`
+	PromReadAuthEnabled      bool                    `toml:"prom-read-auth-enabled"`
+	HTTPHeaders              map[string]string       `toml:"headers"`
+	HTTPSEnabled             bool                    `toml:"https-enabled"`
+	HTTPSCertificate         string                  `toml:"https-certificate"`
+	HTTPSPrivateKey          string                  `toml:"https-private-key"`
+	HTTPSInsecureCertificate bool                    `toml:"https-insecure-certificate"`
+	HTTPSClientAuthType      *toml.TlsClientAuthType `toml:"https-client-auth-type"`
+	HTTPSClientCA            *tlsconfig.CAConfig     `toml:"https-client-ca"`
+	MaxRowLimit              int                     `toml:"max-row-limit"`
+	MaxConnectionLimit       int                     `toml:"max-connection-limit"`
+	SharedSecret             string                  `toml:"shared-secret"`
+	Realm                    string                  `toml:"realm"`
+	UnixSocketEnabled        bool                    `toml:"unix-socket-enabled"`
+	UnixSocketGroup          *toml.Group             `toml:"unix-socket-group"`
+	UnixSocketPermissions    toml.FileMode           `toml:"unix-socket-permissions"`
+	BindSocket               string                  `toml:"bind-socket"`
+	MaxBodySize              toml.SSize              `toml:"max-body-size"`
+	AccessLogPath            string                  `toml:"access-log-path"`
+	AccessLogStatusFilters   []StatusFilter          `toml:"access-log-status-filters"`
+	MaxConcurrentWriteLimit  int                     `toml:"max-concurrent-write-limit"`
+	MaxEnqueuedWriteLimit    int                     `toml:"max-enqueued-write-limit"`
+	EnqueuedWriteTimeout     time.Duration           `toml:"enqueued-write-timeout"`
+	UserQueryBytesEnabled    bool                    `toml:"user-query-bytes-enabled"`
+	TLS                      *tls.Config             `toml:"-"`
 }
 
 // NewConfig returns a new Config with default settings.
@@ -86,14 +89,19 @@ func NewConfig() Config {
 		HTTPSEnabled:             false,
 		HTTPSCertificate:         "/etc/ssl/influxdb.pem",
 		HTTPSInsecureCertificate: false,
-		MaxRowLimit:              0,
-		Realm:                    DefaultRealm,
-		UnixSocketEnabled:        false,
-		UnixSocketPermissions:    0777,
-		BindSocket:               DefaultBindSocket,
-		MaxBodySize:              DefaultMaxBodySize,
-		EnqueuedWriteTimeout:     DefaultEnqueuedWriteTimeout,
-		AccessLogStatusFilters:   make([]StatusFilter, 0),
+		// A nil HTTPSClientAuthType or HTTPSClientCA means "not configured" and
+		// leaves the base TLS config's value in place. When set, tlsconfig
+		// resolves and validates them (see tlsconfig.CAConfig and WithClientAuthPtr).
+		HTTPSClientAuthType:    nil,
+		HTTPSClientCA:          nil,
+		MaxRowLimit:            0,
+		Realm:                  DefaultRealm,
+		UnixSocketEnabled:      false,
+		UnixSocketPermissions:  0777,
+		BindSocket:             DefaultBindSocket,
+		MaxBodySize:            DefaultMaxBodySize,
+		EnqueuedWriteTimeout:   DefaultEnqueuedWriteTimeout,
+		AccessLogStatusFilters: make([]StatusFilter, 0),
 	}
 }
 

--- a/services/httpd/service.go
+++ b/services/httpd/service.go
@@ -69,12 +69,12 @@ type Service struct {
 	unixSocketGroup int
 	bindSocket      string
 
-	// httpsCertificate is the initial TLS certificate to load if https is true. This should not be
+	// httpsCertificate is the initial TLS certificate to load if httpsEnabled is true. This should not be
 	// exposed to client code because a different certificate might be loaded on a config reload.
 	httpsCertificate string
 
-	// httpsPrivateKey is the initial TLS httpsPrivateKey to load if https is true. This should not be
-	// exposed to client code because a httpsPrivateKey certificate might be loaded on a config reload.
+	// httpsPrivateKey is the initial TLS private key to load if httpsEnabled is true. This should not be
+	// exposed to client code because a different private key might be loaded on a config reload.
 	httpsPrivateKey string
 
 	// httpsInsecureCertificate is true if certificate file permissions should be ignored.

--- a/services/httpd/service.go
+++ b/services/httpd/service.go
@@ -61,24 +61,32 @@ type Service struct {
 	// Fields above mu are not protected by mu and should be read-only after being
 	// set in NewService.
 
-	addr  string
-	https bool
+	addr         string
+	httpsEnabled bool
 
 	unixSocket      bool
 	unixSocketPerm  uint32
 	unixSocketGroup int
 	bindSocket      string
 
-	// cert is the initial TLS certificate to load if https is true. This should not be
+	// httpsCertificate is the initial TLS certificate to load if https is true. This should not be
 	// exposed to client code because a different certificate might be loaded on a config reload.
-	cert string
+	httpsCertificate string
 
-	// key is the initial TLS key to load if https is true. This should not be
-	// exposed to client code because a key certificate might be loaded on a config reload.
-	key string
+	// httpsPrivateKey is the initial TLS httpsPrivateKey to load if https is true. This should not be
+	// exposed to client code because a httpsPrivateKey certificate might be loaded on a config reload.
+	httpsPrivateKey string
 
-	// insecureCert is true if certificate file permissions should be ignored.
-	insecureCert bool
+	// httpsInsecureCertificate is true if certificate file permissions should be ignored.
+	httpsInsecureCertificate bool
+
+	// httpsClientAuthType defines the type of client authentication required (aka
+	// mTLS). A nil value leaves the base TLS config's ClientAuth in place.
+	httpsClientAuthType *tls.ClientAuthType
+
+	// httpsClientCA configures the CA pool used to verify client certificates
+	// (aka mTLS). A nil value leaves the base TLS config's client pool in place.
+	httpsClientCA *tlsconfig.CAConfig
 
 	limit     int
 	tlsConfig *tls.Config
@@ -116,19 +124,30 @@ type Service struct {
 // NewService returns a new instance of Service.
 func NewService(c Config) *Service {
 	handler := NewHandler(c)
+
+	// Convert the optional client-auth type to a *tls.ClientAuthType so a nil
+	// (unset) config leaves the base TLS config's ClientAuth in place.
+	var clientAuthType *tls.ClientAuthType
+	if c.HTTPSClientAuthType != nil {
+		auth := tls.ClientAuthType(*c.HTTPSClientAuthType)
+		clientAuthType = &auth
+	}
+
 	s := &Service{
-		addr:           c.BindAddress,
-		https:          c.HTTPSEnabled,
-		cert:           c.HTTPSCertificate,
-		key:            c.HTTPSPrivateKey,
-		insecureCert:   c.HTTPSInsecureCertificate,
-		limit:          c.MaxConnectionLimit,
-		tlsConfig:      c.TLS,
-		err:            make(chan error, 2), // There could be two serve calls that fail.
-		unixSocket:     c.UnixSocketEnabled,
-		unixSocketPerm: uint32(c.UnixSocketPermissions),
-		bindSocket:     c.BindSocket,
-		Handler:        handler,
+		addr:                     c.BindAddress,
+		httpsEnabled:             c.HTTPSEnabled,
+		httpsCertificate:         c.HTTPSCertificate,
+		httpsPrivateKey:          c.HTTPSPrivateKey,
+		httpsInsecureCertificate: c.HTTPSInsecureCertificate,
+		httpsClientAuthType:      clientAuthType,
+		httpsClientCA:            c.HTTPSClientCA,
+		limit:                    c.MaxConnectionLimit,
+		tlsConfig:                c.TLS,
+		err:                      make(chan error, 2), // There could be two serve calls that fail.
+		unixSocket:               c.UnixSocketEnabled,
+		unixSocketPerm:           uint32(c.UnixSocketPermissions),
+		bindSocket:               c.BindSocket,
+		Handler:                  handler,
 		httpServer: http.Server{
 			Handler: handler,
 		},
@@ -159,8 +178,10 @@ func (s *Service) Open() error {
 	s.Handler.Open()
 
 	// Open listener.
-	tm, err := tlsconfig.NewTLSConfigManager(s.https, s.tlsConfig, s.cert, s.key, false,
-		tlsconfig.WithIgnoreFilePermissions(s.insecureCert),
+	tm, err := tlsconfig.NewTLSConfigManager(s.httpsEnabled, s.tlsConfig, s.httpsCertificate, s.httpsPrivateKey, false,
+		tlsconfig.WithIgnoreFilePermissions(s.httpsInsecureCertificate),
+		tlsconfig.WithClientAuthPtr(s.httpsClientAuthType),
+		tlsconfig.WithClientCA(s.httpsClientCA),
 		tlsconfig.WithLogger(s.Logger))
 	if err != nil {
 		return fmt.Errorf("httpd: error creating TLS manager: %w", err)
@@ -174,7 +195,7 @@ func (s *Service) Open() error {
 	}
 	s.Logger.Info("Listening on HTTP",
 		zap.Stringer("addr", s.ln.Addr()),
-		zap.Bool("https", s.https))
+		zap.Bool("https", s.httpsEnabled))
 
 	// Open unix socket listener.
 	if s.unixSocket {
@@ -298,11 +319,11 @@ func (s *Service) PrepareReloadConfig(c Config) (func() error, error) {
 	defer s.mu.Unlock()
 
 	// Let the user know that changing the https-enabled setting doesn't work.
-	if s.https != c.HTTPSEnabled {
+	if s.httpsEnabled != c.HTTPSEnabled {
 		return nil, fmt.Errorf("httpd: can not change https-enabled on a running server")
 	}
 
-	if s.https {
+	if s.httpsEnabled {
 		// Sanity check to make sure we have a tlsManager. It's possible this could happen if a
 		// reload signal is sent to the process after NewService but before Open. By returning an
 		// error here the reload will fail and no changes will be made.

--- a/services/httpd/service_test.go
+++ b/services/httpd/service_test.go
@@ -289,7 +289,7 @@ func TestService_Open_ClientCertAuth(t *testing.T) {
 		}}
 		resp, err := client.Get(pingURI)
 		require.NoError(t, err)
-		defer resp.Body.Close()
+		defer th.CheckedClose(t, resp.Body)()
 		require.NotNil(t, resp.TLS)
 		require.NotEmpty(t, resp.TLS.PeerCertificates, "handshake should have completed with the server cert")
 		require.Equal(t, http.StatusNoContent, resp.StatusCode)
@@ -302,7 +302,8 @@ func TestService_Open_ClientCertAuth(t *testing.T) {
 		}}
 		resp, err := client.Get(pingURI)
 		if resp != nil {
-			resp.Body.Close()
+			// Defer close so we get the important assertions before this.
+			defer th.CheckedClose(t, resp.Body)()
 		}
 		require.Error(t, err, "server should reject a client without a certificate")
 		require.ErrorContains(t, err, "certificate required")
@@ -316,7 +317,8 @@ func TestService_Open_ClientCertAuth(t *testing.T) {
 		}}
 		resp, err := client.Get(pingURI)
 		if resp != nil {
-			resp.Body.Close()
+			// Defer close so we get the important assertions before this.
+			defer th.CheckedClose(t, resp.Body)()
 		}
 		require.Error(t, err, "server should reject a client with an untrusted certificate")
 	})
@@ -376,7 +378,8 @@ func TestService_Open_TLSConfigManager(t *testing.T) {
 
 		resp, err := http.Get(fmt.Sprintf("http://%s/ping", s.Addr()))
 		require.NoError(t, err)
-		resp.Body.Close()
+		// Defer close so it doesn't mask the more important assertions,
+		defer th.CheckedClose(t, resp.Body)()
 		require.Equal(t, http.StatusNoContent, resp.StatusCode)
 		require.Nil(t, resp.TLS)
 	})

--- a/services/httpd/service_test.go
+++ b/services/httpd/service_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/influxdata/influxdb/pkg/testing/selfsigned"
 	"github.com/influxdata/influxdb/pkg/tlsconfig"
 	"github.com/influxdata/influxdb/services/httpd"
+	"github.com/influxdata/influxdb/toml"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 )
@@ -249,6 +250,75 @@ func TestService_VerifyReloadedConfig(t *testing.T) {
 			require.NotEmpty(t, resp.TLS.PeerCertificates)
 			require.Equal(t, expectedSerial, resp.TLS.PeerCertificates[0].SerialNumber)
 		}
+	})
+}
+
+// TestService_Open_ClientCertAuth verifies that, when configured with a client
+// auth type and a client CA, the httpd service enforces mutual TLS: a client
+// presenting a certificate signed by the configured CA is authenticated, while
+// a client that presents no certificate or an untrusted one is rejected during
+// the TLS handshake.
+func TestService_Open_ClientCertAuth(t *testing.T) {
+	// serverSS is the server's HTTPS certificate; clientSS provides the client
+	// certificate and the CA (clientSS.CACertPath) the server is told to trust
+	// for client authentication.
+	serverSS := selfsigned.NewSelfSignedCert(t, selfsigned.WithDNSName("localhost"))
+	clientSS := selfsigned.NewSelfSignedCert(t, selfsigned.WithCASubject("client", "Client CA"))
+
+	authType := toml.TlsClientAuthType(tls.RequireAndVerifyClientCert)
+	s := httpd.NewService(httpd.Config{
+		BindAddress:         "localhost:",
+		HTTPSEnabled:        true,
+		HTTPSCertificate:    serverSS.CertPath,
+		HTTPSPrivateKey:     serverSS.KeyPath,
+		HTTPSClientAuthType: &authType,
+		HTTPSClientCA:       &tlsconfig.CAConfig{Paths: []string{clientSS.CACertPath}},
+		TLS:                 new(tls.Config),
+	})
+	s.WithLogger(zap.NewNop())
+	require.NoError(t, s.Open())
+	defer th.CheckedClose(t, s)()
+
+	pingURI := fmt.Sprintf("https://%s/ping", s.Addr())
+
+	t.Run("client with trusted certificate is authenticated", func(t *testing.T) {
+		// Present the client certificate; skip server-cert verification so the
+		// test isolates client authentication.
+		client := http.Client{Transport: &http.Transport{
+			TLSClientConfig: clientSS.ClientTLSConfig(t, true, true),
+		}}
+		resp, err := client.Get(pingURI)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		require.NotNil(t, resp.TLS)
+		require.NotEmpty(t, resp.TLS.PeerCertificates, "handshake should have completed with the server cert")
+		require.Equal(t, http.StatusNoContent, resp.StatusCode)
+	})
+
+	t.Run("client without certificate is rejected", func(t *testing.T) {
+		// No client certificate presented.
+		client := http.Client{Transport: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		}}
+		resp, err := client.Get(pingURI)
+		if resp != nil {
+			resp.Body.Close()
+		}
+		require.Error(t, err, "server should reject a client without a certificate")
+		require.ErrorContains(t, err, "certificate required")
+	})
+
+	t.Run("client with untrusted certificate is rejected", func(t *testing.T) {
+		// Certificate signed by a CA the server does not trust for clients.
+		otherSS := selfsigned.NewSelfSignedCert(t, selfsigned.WithCASubject("other", "Other CA"))
+		client := http.Client{Transport: &http.Transport{
+			TLSClientConfig: otherSS.ClientTLSConfig(t, true, true),
+		}}
+		resp, err := client.Get(pingURI)
+		if resp != nil {
+			resp.Body.Close()
+		}
+		require.Error(t, err, "server should reject a client with an untrusted certificate")
 	})
 }
 

--- a/services/opentsdb/config.go
+++ b/services/opentsdb/config.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/influxdata/influxdb/monitor/diagnostics"
+	"github.com/influxdata/influxdb/pkg/tlsconfig"
 	"github.com/influxdata/influxdb/toml"
 )
 
@@ -37,20 +38,22 @@ const (
 
 // Config represents the configuration of the OpenTSDB service.
 type Config struct {
-	Enabled             bool          `toml:"enabled"`
-	BindAddress         string        `toml:"bind-address"`
-	Database            string        `toml:"database"`
-	RetentionPolicy     string        `toml:"retention-policy"`
-	ConsistencyLevel    string        `toml:"consistency-level"`
-	TLSEnabled          bool          `toml:"tls-enabled"`
-	Certificate         string        `toml:"certificate"`
-	PrivateKey          string        `toml:"private-key"`
-	InsecureCertificate bool          `toml:"insecure-certificate"`
-	BatchSize           int           `toml:"batch-size"`
-	BatchPending        int           `toml:"batch-pending"`
-	BatchTimeout        toml.Duration `toml:"batch-timeout"`
-	LogPointErrors      bool          `toml:"log-point-errors"`
-	TLS                 *tls.Config   `toml:"-"`
+	Enabled             bool                    `toml:"enabled"`
+	BindAddress         string                  `toml:"bind-address"`
+	Database            string                  `toml:"database"`
+	RetentionPolicy     string                  `toml:"retention-policy"`
+	ConsistencyLevel    string                  `toml:"consistency-level"`
+	TLSEnabled          bool                    `toml:"tls-enabled"`
+	Certificate         string                  `toml:"certificate"`
+	PrivateKey          string                  `toml:"private-key"`
+	InsecureCertificate bool                    `toml:"insecure-certificate"`
+	ClientAuthType      *toml.TlsClientAuthType `toml:"client-auth-type"`
+	ClientCA            *tlsconfig.CAConfig     `toml:"client-ca"`
+	BatchSize           int                     `toml:"batch-size"`
+	BatchPending        int                     `toml:"batch-pending"`
+	BatchTimeout        toml.Duration           `toml:"batch-timeout"`
+	LogPointErrors      bool                    `toml:"log-point-errors"`
+	TLS                 *tls.Config             `toml:"-"`
 }
 
 // Compile-time check that *Config implements toml.Defaulter so it can be used

--- a/services/opentsdb/service.go
+++ b/services/opentsdb/service.go
@@ -58,6 +58,13 @@ type Service struct {
 	privateKey   string
 	insecureCert bool
 
+	// clientAuthType controls TLS client-certificate authentication (mTLS). A
+	// nil value leaves the base TLS config's ClientAuth in place.
+	clientAuthType *tls.ClientAuthType
+	// clientCA configures the CA pool used to verify client certificates. A nil
+	// value leaves the base TLS config's client pool in place.
+	clientCA *tlsconfig.CAConfig
+
 	mu    sync.RWMutex
 	ready bool          // Has the required database been created?
 	done  chan struct{} // Is the service closing or closed?
@@ -91,12 +98,22 @@ func NewService(c Config) (*Service, error) {
 	// Use defaults where necessary.
 	d := c.WithDefaults()
 
+	// Convert the optional client-auth type to a *tls.ClientAuthType so a nil
+	// (unset) config leaves the base TLS config's ClientAuth in place.
+	var clientAuthType *tls.ClientAuthType
+	if d.ClientAuthType != nil {
+		auth := tls.ClientAuthType(*d.ClientAuthType)
+		clientAuthType = &auth
+	}
+
 	s := &Service{
 		tls:             d.TLSEnabled,
 		tlsConfig:       d.TLS,
 		cert:            d.Certificate,
 		privateKey:      d.PrivateKey,
 		insecureCert:    d.InsecureCertificate,
+		clientAuthType:  clientAuthType,
+		clientCA:        d.ClientCA,
 		BindAddress:     d.BindAddress,
 		Database:        d.Database,
 		RetentionPolicy: d.RetentionPolicy,
@@ -137,6 +154,8 @@ func (s *Service) Open() error {
 	// Open listener.
 	cm, err := tlsconfig.NewTLSConfigManager(s.tls, s.tlsConfig, s.cert, s.privateKey, false,
 		tlsconfig.WithIgnoreFilePermissions(s.insecureCert),
+		tlsconfig.WithClientAuthPtr(s.clientAuthType),
+		tlsconfig.WithClientCA(s.clientCA),
 		tlsconfig.WithLogger(s.Logger))
 	if err != nil {
 		return fmt.Errorf("opentsdb: error creating TLS manager: %w", err)

--- a/services/opentsdb/service_test.go
+++ b/services/opentsdb/service_test.go
@@ -1,6 +1,7 @@
 package opentsdb
 
 import (
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"net"
@@ -16,8 +17,12 @@ import (
 	"github.com/influxdata/influxdb/internal"
 	"github.com/influxdata/influxdb/logger"
 	"github.com/influxdata/influxdb/models"
+	"github.com/influxdata/influxdb/pkg/testing/selfsigned"
+	"github.com/influxdata/influxdb/pkg/tlsconfig"
 	"github.com/influxdata/influxdb/services/meta"
+	"github.com/influxdata/influxdb/toml"
 	"github.com/influxdata/influxdb/tsdb"
+	"github.com/stretchr/testify/require"
 )
 
 func Test_Service_OpenClose(t *testing.T) {
@@ -290,4 +295,86 @@ func NewTestService(database string, bind string) *TestService {
 
 func (s *TestService) WritePointsPrivileged(ctx tsdb.WriteContext, database, retentionPolicy string, consistencyLevel models.ConsistencyLevel, points []models.Point) error {
 	return s.WritePointsFn(ctx, database, retentionPolicy, consistencyLevel, points)
+}
+
+// pointsWriterFunc adapts a function to the Service.PointsWriter interface.
+type pointsWriterFunc func(ctx tsdb.WriteContext, database, retentionPolicy string, consistencyLevel models.ConsistencyLevel, points []models.Point) error
+
+func (f pointsWriterFunc) WritePointsPrivileged(ctx tsdb.WriteContext, database, retentionPolicy string, consistencyLevel models.ConsistencyLevel, points []models.Point) error {
+	return f(ctx, database, retentionPolicy, consistencyLevel, points)
+}
+
+// TestService_ClientCertAuth verifies that, when configured with a client auth
+// type and a client CA, the opentsdb service enforces mutual TLS: a client
+// presenting a certificate signed by the configured CA is authenticated, while
+// a client presenting no certificate or an untrusted one is rejected during the
+// TLS handshake.
+func TestService_ClientCertAuth(t *testing.T) {
+	// serverSS is the server's TLS certificate; clientSS provides the client
+	// certificate and the CA (clientSS.CACertPath) the server is told to trust
+	// for client authentication.
+	serverSS := selfsigned.NewSelfSignedCert(t, selfsigned.WithDNSName("localhost"))
+	clientSS := selfsigned.NewSelfSignedCert(t, selfsigned.WithCASubject("client", "Client CA"))
+
+	authType := toml.TlsClientAuthType(tls.RequireAndVerifyClientCert)
+	s, err := NewService(Config{
+		BindAddress:      "127.0.0.1:0",
+		Database:         "db0",
+		ConsistencyLevel: "one",
+		TLSEnabled:       true,
+		Certificate:      serverSS.CertPath,
+		PrivateKey:       serverSS.KeyPath,
+		ClientAuthType:   &authType,
+		ClientCA:         &tlsconfig.CAConfig{Paths: []string{clientSS.CACertPath}},
+		TLS:              new(tls.Config),
+	})
+	require.NoError(t, err)
+
+	// Wire the minimal dependencies so /api/put succeeds once the handshake passes.
+	s.MetaClient = &internal.MetaClientMock{
+		CreateDatabaseFn: func(string) (*meta.DatabaseInfo, error) { return nil, nil },
+	}
+	s.PointsWriter = pointsWriterFunc(func(tsdb.WriteContext, string, string, models.ConsistencyLevel, []models.Point) error {
+		return nil
+	})
+
+	require.NoError(t, s.Open())
+	defer s.Close()
+
+	putURL := "https://" + s.Addr().String() + "/api/put"
+	body := `{"metric":"sys.cpu.nice","timestamp":1346846400,"value":18,"tags":{"host":"web01","dc":"lga"}}`
+
+	post := func(clientTLS *tls.Config) (*http.Response, error) {
+		client := &http.Client{Transport: &http.Transport{TLSClientConfig: clientTLS}}
+		return client.Post(putURL, "application/json", strings.NewReader(body))
+	}
+
+	t.Run("client with trusted certificate is authenticated", func(t *testing.T) {
+		// Present the client certificate; skip server-cert verification so the
+		// test isolates client authentication.
+		resp, err := post(clientSS.ClientTLSConfig(t, true, true))
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		require.NotNil(t, resp.TLS)
+		require.NotEmpty(t, resp.TLS.PeerCertificates, "handshake should have completed with the server cert")
+		require.Equal(t, http.StatusNoContent, resp.StatusCode)
+	})
+
+	t.Run("client without certificate is rejected", func(t *testing.T) {
+		resp, err := post(&tls.Config{InsecureSkipVerify: true})
+		if resp != nil {
+			resp.Body.Close()
+		}
+		require.Error(t, err, "server should reject a client without a certificate")
+		require.ErrorContains(t, err, "certificate required")
+	})
+
+	t.Run("client with untrusted certificate is rejected", func(t *testing.T) {
+		otherSS := selfsigned.NewSelfSignedCert(t, selfsigned.WithCASubject("other", "Other CA"))
+		resp, err := post(otherSS.ClientTLSConfig(t, true, true))
+		if resp != nil {
+			resp.Body.Close()
+		}
+		require.Error(t, err, "server should reject a client with an untrusted certificate")
+	})
 }

--- a/services/subscriber/config.go
+++ b/services/subscriber/config.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/influxdata/influxdb/monitor/diagnostics"
+	"github.com/influxdata/influxdb/pkg/tlsconfig"
 	"github.com/influxdata/influxdb/toml"
 )
 
@@ -37,6 +38,21 @@ type Config struct {
 	// configure the path to the PEM encoded CA certs file. If the
 	// empty string, the default system certs will be used
 	CaCerts string `toml:"ca-certs"`
+
+	// RootCA configures the CA pool used to verify subscription endpoint server
+	// certificates. It is combined with the legacy CaCerts (ca-certs) setting,
+	// which continues to work on its own for backwards compatibility.
+	RootCA *tlsconfig.CAConfig `toml:"root-ca"`
+
+	// Certificate and PrivateKey are the client certificate the subscriber
+	// presents to HTTPS endpoints for mutual TLS. Empty means no client
+	// certificate is presented.
+	Certificate string `toml:"certificate"`
+	PrivateKey  string `toml:"private-key"`
+
+	// InsecureCertificate is true if the client certificate's file permissions
+	// should be ignored when it is loaded.
+	InsecureCertificate bool `toml:"insecure-certificate"`
 
 	// The number of writer goroutines processing the write channel.
 	WriteConcurrency int `toml:"write-concurrency"`
@@ -87,6 +103,27 @@ func (c Config) Validate() error {
 	}
 
 	return nil
+}
+
+// effectiveRootCA combines the RootCA block with the legacy CaCerts (ca-certs)
+// setting into a single *tlsconfig.CAConfig for verifying subscription endpoint
+// server certificates. A nil result leaves the base TLS config's roots in place
+// (Go's system pool). CaCerts is appended to the block's paths so both settings
+// work together, and ca-certs continues to behave as before on its own.
+func (c Config) effectiveRootCA() *tlsconfig.CAConfig {
+	var cc *tlsconfig.CAConfig
+	if c.RootCA != nil {
+		dup := *c.RootCA
+		dup.Paths = append([]string(nil), c.RootCA.Paths...)
+		cc = &dup
+	}
+	if c.CaCerts != "" {
+		if cc == nil {
+			cc = &tlsconfig.CAConfig{}
+		}
+		cc.Paths = append(cc.Paths, c.CaCerts)
+	}
+	return cc
 }
 
 func fileExists(fileName string) bool {

--- a/services/subscriber/http.go
+++ b/services/subscriber/http.go
@@ -4,8 +4,6 @@ import (
 	"bytes"
 	"context"
 	"crypto/tls"
-	"crypto/x509"
-	"os"
 	"time"
 
 	"github.com/influxdata/influxdb/client/v2"
@@ -19,21 +17,20 @@ type HTTP struct {
 
 // NewHTTP returns a new HTTP points writer with default options.
 func NewHTTP(addr string, timeout time.Duration) (*HTTP, error) {
-	return NewHTTPS(addr, timeout, false, "", nil)
+	return NewHTTPS(addr, timeout, nil)
 }
 
-// NewHTTPS returns a new HTTPS points writer with default options and HTTPS configured.
-func NewHTTPS(addr string, timeout time.Duration, unsafeSsl bool, caCerts string, tlsConfig *tls.Config) (*HTTP, error) {
-	tlsConfig, err := createTLSConfig(caCerts, tlsConfig)
-	if err != nil {
-		return nil, err
-	}
-
+// NewHTTPS returns a new HTTPS points writer with default options and HTTPS
+// configured. tlsConfig is the fully-resolved client TLS configuration (root
+// CAs, any client certificate, and InsecureSkipVerify) built by the service via
+// tlsconfig.TLSConfigManager; it may be nil to use Go's defaults. When it
+// carries a manager-backed GetClientCertificate, rotated client certificates
+// are picked up automatically on new connections.
+func NewHTTPS(addr string, timeout time.Duration, tlsConfig *tls.Config) (*HTTP, error) {
 	conf := client.HTTPConfig{
-		Addr:               addr,
-		Timeout:            timeout,
-		InsecureSkipVerify: unsafeSsl,
-		TLSConfig:          tlsConfig,
+		Addr:      addr,
+		Timeout:   timeout,
+		TLSConfig: tlsConfig,
 	}
 
 	c, err := client.NewHTTPClient(conf)
@@ -50,30 +47,4 @@ func (h *HTTP) WritePointsContext(ctx context.Context, request WriteRequest) (de
 		RetentionPolicy: request.RetentionPolicy,
 	})
 	return h.addr, h.c.WriteRawCtx(ctx, bp, bytes.NewReader(request.lineProtocol))
-}
-
-func createTLSConfig(caCerts string, tlsConfig *tls.Config) (*tls.Config, error) {
-	if caCerts == "" {
-		if tlsConfig != nil {
-			return tlsConfig.Clone(), nil
-		}
-		return nil, nil
-	}
-	return loadCaCerts(caCerts, tlsConfig)
-}
-
-func loadCaCerts(caCerts string, tlsConfig *tls.Config) (*tls.Config, error) {
-	caCert, err := os.ReadFile(caCerts)
-	if err != nil {
-		return nil, err
-	}
-
-	out := new(tls.Config)
-	if tlsConfig != nil {
-		out = tlsConfig.Clone()
-	}
-
-	out.RootCAs = x509.NewCertPool()
-	out.RootCAs.AppendCertsFromPEM(caCert)
-	return out, nil
 }

--- a/services/subscriber/mtls_internal_test.go
+++ b/services/subscriber/mtls_internal_test.go
@@ -1,0 +1,156 @@
+package subscriber
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/influxdata/influxdb/pkg/testing/selfsigned"
+	"github.com/influxdata/influxdb/pkg/tlsconfig"
+	"github.com/influxdata/influxdb/services/meta"
+	"github.com/influxdata/influxdb/toml"
+	"github.com/stretchr/testify/require"
+)
+
+// newMTLSServer starts an HTTPS test server that requires and verifies client
+// certificates signed by clientCACertPath. It records whether the last request
+// presented a client certificate.
+func newMTLSServer(t *testing.T, serverCert *selfsigned.Cert, clientCACertPath string, sawClientCert *bool) *httptest.Server {
+	t.Helper()
+
+	clientCAs := x509.NewCertPool()
+	caPEM, err := os.ReadFile(clientCACertPath)
+	require.NoError(t, err)
+	require.True(t, clientCAs.AppendCertsFromPEM(caPEM))
+
+	cert, err := tls.LoadX509KeyPair(serverCert.CertPath, serverCert.KeyPath)
+	require.NoError(t, err)
+
+	var mu sync.Mutex
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		*sawClientCert = r.TLS != nil && len(r.TLS.PeerCertificates) > 0
+		mu.Unlock()
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	srv.TLS = &tls.Config{
+		Certificates: []tls.Certificate{cert},
+		ClientAuth:   tls.RequireAndVerifyClientCert,
+		ClientCAs:    clientCAs,
+	}
+	srv.StartTLS()
+	return srv
+}
+
+// TestHTTP_PresentsClientCertificate verifies that the subscriber presents its
+// configured client certificate on outbound HTTPS connections (the client half
+// of mutual TLS), while trusting the endpoint's server certificate via the
+// legacy ca-certs setting. A writer without a client certificate is rejected.
+func TestHTTP_PresentsClientCertificate(t *testing.T) {
+	// serverSS is the endpoint's server certificate (default SANs include
+	// 127.0.0.1); clientSS provides the subscriber's client certificate and the
+	// CA the endpoint trusts for client authentication.
+	serverSS := selfsigned.NewSelfSignedCert(t)
+	clientSS := selfsigned.NewSelfSignedCert(t, selfsigned.WithCASubject("client", "Client CA"))
+
+	var sawClientCert bool
+	srv := newMTLSServer(t, serverSS, clientSS.CACertPath, &sawClientCert)
+	defer srv.Close()
+
+	// Configure the subscriber the way an operator would: trust the endpoint
+	// server via the legacy ca-certs, and present a client certificate.
+	conf := Config{
+		HTTPTimeout: toml.Duration(5 * time.Second),
+		CaCerts:     serverSS.CACertPath,
+		Certificate: clientSS.CertPath,
+		PrivateKey:  clientSS.KeyPath,
+	}
+
+	newManager := func(withClientCert bool) *tlsconfig.TLSConfigManager {
+		opts := []tlsconfig.TLSConfigManagerOpt{tlsconfig.WithRootCA(conf.effectiveRootCA())}
+		if withClientCert {
+			opts = append(opts, tlsconfig.WithCertificate(conf.Certificate, conf.PrivateKey))
+		}
+		cm, err := tlsconfig.NewClientTLSConfigManager(true, conf.TLS, conf.InsecureSkipVerify, opts...)
+		require.NoError(t, err)
+		return cm
+	}
+
+	t.Run("with client certificate is accepted", func(t *testing.T) {
+		cm := newManager(true)
+		defer cm.Close()
+
+		w, err := NewHTTPS(srv.URL, time.Duration(conf.HTTPTimeout), cm.TLSConfig())
+		require.NoError(t, err)
+
+		_, err = w.WritePointsContext(context.Background(), WriteRequest{
+			Database:     "db0",
+			lineProtocol: []byte("cpu value=1\n"),
+		})
+		require.NoError(t, err)
+		require.True(t, sawClientCert, "server should have received the client certificate")
+	})
+
+	t.Run("without client certificate is rejected", func(t *testing.T) {
+		// Trusts the server, but presents no client certificate.
+		cm := newManager(false)
+		defer cm.Close()
+
+		w, err := NewHTTPS(srv.URL, time.Duration(conf.HTTPTimeout), cm.TLSConfig())
+		require.NoError(t, err)
+
+		_, err = w.WritePointsContext(context.Background(), WriteRequest{
+			Database:     "db0",
+			lineProtocol: []byte("cpu value=1\n"),
+		})
+		require.Error(t, err, "endpoint should reject a client without a certificate")
+	})
+}
+
+// stubMetaClient is a minimal MetaClient for opening the service with no
+// subscriptions.
+type stubMetaClient struct{}
+
+func (stubMetaClient) Databases() []meta.DatabaseInfo    { return nil }
+func (stubMetaClient) WaitForDataChanged() chan struct{} { return make(chan struct{}) }
+
+// TestService_PrepareReloadTLSCertificates verifies the certificate-reload hook:
+// it is a no-op when no client certificate is configured, and returns a working
+// apply function when one is.
+func TestService_PrepareReloadTLSCertificates(t *testing.T) {
+	open := func(t *testing.T, c Config) *Service {
+		t.Helper()
+		s := NewService(c)
+		s.MetaClient = stubMetaClient{}
+		require.NoError(t, s.Open())
+		t.Cleanup(func() { require.NoError(t, s.Close()) })
+		return s
+	}
+
+	t.Run("no client certificate is a no-op", func(t *testing.T) {
+		s := open(t, NewConfig())
+		apply, err := s.PrepareReloadTLSCertificates()
+		require.NoError(t, err)
+		require.NotNil(t, apply)
+		require.NoError(t, apply())
+	})
+
+	t.Run("reloads a configured client certificate", func(t *testing.T) {
+		clientSS := selfsigned.NewSelfSignedCert(t, selfsigned.WithCASubject("client", "Client CA"))
+		c := NewConfig()
+		c.Certificate = clientSS.CertPath
+		c.PrivateKey = clientSS.KeyPath
+
+		s := open(t, c)
+		apply, err := s.PrepareReloadTLSCertificates()
+		require.NoError(t, err)
+		require.NotNil(t, apply)
+		require.NoError(t, apply())
+	})
+}

--- a/services/subscriber/service.go
+++ b/services/subscriber/service.go
@@ -4,6 +4,7 @@ package subscriber // import "github.com/influxdata/influxdb/services/subscriber
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"net/url"
@@ -16,6 +17,7 @@ import (
 	"github.com/influxdata/influxdb/logger"
 	"github.com/influxdata/influxdb/models"
 	"github.com/influxdata/influxdb/monitor"
+	"github.com/influxdata/influxdb/pkg/tlsconfig"
 	"github.com/influxdata/influxdb/services/meta"
 	"go.uber.org/zap"
 )
@@ -119,6 +121,10 @@ type Service struct {
 	conf            Config
 	subs            map[subEntry]*chanWriter
 
+	// tlsManager builds the client TLS configuration for HTTPS writers and owns
+	// the client certificate loader so rotated certificates can be reloaded.
+	tlsManager *tlsconfig.TLSConfigManager
+
 	// subscriptionRouter is not locked by mu
 	router *subscriptionRouter
 }
@@ -149,6 +155,19 @@ func (s *Service) Open() error {
 		if s.MetaClient == nil {
 			return errors.New("no meta store")
 		}
+
+		// Build the client TLS manager once for all HTTPS writers. It resolves
+		// the root CAs (RootCA block plus the legacy ca-certs) and any client
+		// certificate, and owns the certificate loader used for reloads.
+		cm, err := tlsconfig.NewClientTLSConfigManager(true, s.conf.TLS, s.conf.InsecureSkipVerify,
+			tlsconfig.WithCertificate(s.conf.Certificate, s.conf.PrivateKey),
+			tlsconfig.WithRootCA(s.conf.effectiveRootCA()),
+			tlsconfig.WithIgnoreFilePermissions(s.conf.InsecureCertificate),
+			tlsconfig.WithLogger(s.Logger))
+		if err != nil {
+			return fmt.Errorf("subscriber: error creating TLS manager: %w", err)
+		}
+		s.tlsManager = cm
 
 		s.closing = make(chan struct{})
 
@@ -211,8 +230,33 @@ func (s *Service) Close() error {
 		cw.Close()
 	}
 	s.subs = nil
+	if s.tlsManager != nil {
+		if err := s.tlsManager.Close(); err != nil {
+			s.Logger.Warn("error closing TLS manager", zap.Error(err))
+		}
+		s.tlsManager = nil
+	}
 	s.Logger.Info("Closed service")
 	return nil
+}
+
+// PrepareReloadTLSCertificates verifies that the configured client TLS
+// certificate can be reloaded from its current path. On success it returns a
+// function that applies the reloaded certificate; the new certificate is then
+// presented on subsequent HTTPS connections. If no client certificate is
+// configured there is nothing to reload and the returned function is a no-op.
+func (s *Service) PrepareReloadTLSCertificates() (func() error, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.tlsManager == nil || s.tlsManager.TLSCertLoader() == nil {
+		return func() error { return nil }, nil
+	}
+	apply, err := s.tlsManager.PrepareCertificateLoad(s.conf.Certificate, s.conf.PrivateKey)
+	if err != nil {
+		return nil, fmt.Errorf("subscriber: TLS certificate reload failed (%q, %q): %w", s.conf.Certificate, s.conf.PrivateKey, err)
+	}
+	return apply, nil
 }
 
 // WithLogger sets the logger on the service.
@@ -403,7 +447,14 @@ func (s *Service) newPointsWriter(u url.URL) (PointsWriter, error) {
 		if s.conf.InsecureSkipVerify {
 			s.Logger.Warn("'insecure-skip-verify' is true. This will skip all certificate verifications.")
 		}
-		return NewHTTPS(u.String(), time.Duration(s.conf.HTTPTimeout), s.conf.InsecureSkipVerify, s.conf.CaCerts, s.conf.TLS)
+		// Each writer gets its own clone of the manager's config; the clone
+		// shares the certificate loader via GetClientCertificate, so a reloaded
+		// client certificate is picked up on new connections.
+		var tlsConfig *tls.Config
+		if s.tlsManager != nil {
+			tlsConfig = s.tlsManager.TLSConfig()
+		}
+		return NewHTTPS(u.String(), time.Duration(s.conf.HTTPTimeout), tlsConfig)
 	default:
 		return nil, fmt.Errorf("unknown destination scheme %s", u.Scheme)
 	}

--- a/toml/toml.go
+++ b/toml/toml.go
@@ -3,6 +3,7 @@ package toml
 
 import (
 	"bytes"
+	"crypto/tls"
 	"encoding"
 	"errors"
 	"fmt"
@@ -640,6 +641,49 @@ func (g *Group) UnmarshalTOML(data interface{}) error {
 	return errors.New("group must be a name (string) or id (int)")
 }
 
+// TlsClientAuthType is a TOML wrapper around tls.ClientAuthType.
+// It is a simple enum that supports marshaling and unmarshaling as text.
+type TlsClientAuthType tls.ClientAuthType
+
+// MarshalText converts v to a string.
+func (v TlsClientAuthType) MarshalText() ([]byte, error) {
+	// tls.ClientAuthType.String() will marshal invalid values
+	// as an int typecast (e.g. "ClientAuthType(-1)"). This is
+	// desired behavior, because it prevents marshaling from failing
+	// due to an invalid value. Returning an error could make
+	// debugging harder.
+	return []byte(tls.ClientAuthType(v).String()), nil
+}
+
+var tlsClientAuthTypeStrings = []string{
+	tls.NoClientCert:               tls.NoClientCert.String(),
+	tls.RequestClientCert:          tls.RequestClientCert.String(),
+	tls.RequireAnyClientCert:       tls.RequireAnyClientCert.String(),
+	tls.VerifyClientCertIfGiven:    tls.VerifyClientCertIfGiven.String(),
+	tls.RequireAndVerifyClientCert: tls.RequireAndVerifyClientCert.String(),
+}
+
+var ErrInvalidTlsClientAuthType = fmt.Errorf("invalid tls.ClientAuthType (valid values: %s)", strings.Join(tlsClientAuthTypeStrings, ", "))
+
+// UnmarshalText converts the enum name in text to a TlsClientAuthType.
+func (v *TlsClientAuthType) UnmarshalText(text []byte) error {
+	// This makes no attempt to convert the typecase int strings
+	// (e.g. "ClientAuthType(-1)") that MarshalText() can generate for invalid
+	// values. This is desired behavior, because you don't want a security
+	// sensitive setting getting an undefined value from the config file.
+	s := string(text)
+	idx := slices.IndexFunc(tlsClientAuthTypeStrings, func(v string) bool {
+		// Case-insensitive equality check. This doesn't cause any ambiguity,
+		// and reduces a source of frustration when editing configs.
+		return strings.EqualFold(s, v)
+	})
+	if idx < 0 {
+		return fmt.Errorf("%q: %w", s, ErrInvalidTlsClientAuthType)
+	}
+	*v = TlsClientAuthType(idx)
+	return nil
+}
+
 // UnmatchedEnvVars returns the names of environment variables in environ that
 // match the prefix namespace (start with prefix+"_") but are not present in
 // applied. The applied list is typically the result of ApplyEnvOverrides.
@@ -1178,22 +1222,42 @@ func applyEnvOverrides(getenv GetenvFunc, prefix string, spec reflect.Value, str
 
 	value := getEnvValue(getenv, prefix)
 
-	// If we have a pointer, dereference it. For nil pointers to leaf types
-	// (scalars or TextUnmarshaler implementations), allocate the underlying
-	// value when there is a non-empty env var to apply. This allows fields like
-	// httpd.Config.UnixSocketGroup (*toml.Group) to be set purely via env vars
-	// without requiring NewConfig or the TOML file to pre-allocate the pointer.
-	//
-	// Nil pointers to struct types are still skipped because the struct's env
-	// vars target its fields (e.g., INFLUXDB_FOO_BAR), not the struct itself,
-	// so there's no way to detect whether to allocate without probing every
-	// possible field env var.
+	// If we have a pointer, dereference it, allocating a nil pointer when env
+	// vars want to populate it. This lets a pointer field be configured purely
+	// via env vars without NewConfig or the TOML file pre-allocating it.
 	if spec.Kind() == reflect.Pointer {
 		if spec.IsNil() {
-			if len(value) == 0 || !spec.CanSet() || !isLeafType(spec.Type().Elem()) {
+			// Can't allocate through an unsettable value.
+			if !spec.CanSet() {
 				return envOverrideResult{}, nil
 			}
-			spec.Set(reflect.New(spec.Type().Elem()))
+			elemType := spec.Type().Elem()
+			if isLeafType(elemType) {
+				// Leaf types (scalars, TextUnmarshaler) are driven by this
+				// element's own env var (e.g. httpd.Config.UnixSocketGroup, a
+				// *toml.Group). Allocate only when there is a value to apply.
+				if len(value) == 0 {
+					return envOverrideResult{}, nil
+				}
+				spec.Set(reflect.New(elemType))
+			} else {
+				// Non-leaf types (structs) are configured by their fields' env
+				// vars, not a value on the pointer itself. Speculatively
+				// allocate a temporary, apply overrides to it, and keep it only
+				// if a field was actually set; otherwise leave the pointer nil
+				// so an absent sub-config stays absent. This is what lets an
+				// optional sub-config (e.g. a *tlsconfig.CAConfig) be enabled
+				// entirely from env vars.
+				tmp := reflect.New(elemType)
+				result, err := applyEnvOverrides(getenv, prefix, tmp.Elem(), structKey)
+				if err != nil {
+					return envOverrideResult{}, err
+				}
+				if result.Applied {
+					spec.Set(tmp)
+				}
+				return result, nil
+			}
 		}
 		element = spec.Elem()
 	}

--- a/toml/toml.go
+++ b/toml/toml.go
@@ -667,7 +667,7 @@ var ErrInvalidTlsClientAuthType = fmt.Errorf("invalid tls.ClientAuthType (valid 
 
 // UnmarshalText converts the enum name in text to a TlsClientAuthType.
 func (v *TlsClientAuthType) UnmarshalText(text []byte) error {
-	// This makes no attempt to convert the typecase int strings
+	// This makes no attempt to convert the typecast int strings
 	// (e.g. "ClientAuthType(-1)") that MarshalText() can generate for invalid
 	// values. This is desired behavior, because you don't want a security
 	// sensitive setting getting an undefined value from the config file.

--- a/toml/toml_test.go
+++ b/toml/toml_test.go
@@ -2,6 +2,7 @@ package toml_test
 
 import (
 	"bytes"
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"math"
@@ -569,6 +570,154 @@ func TestFileMode_UnmarshalText(t *testing.T) {
 	}
 }
 
+// validClientAuthTypes pairs every valid tls.ClientAuthType with its canonical
+// (exact-match) string form, as produced by tls.ClientAuthType.String().
+var validClientAuthTypes = []struct {
+	val itoml.TlsClientAuthType
+	str string
+}{
+	{itoml.TlsClientAuthType(tls.NoClientCert), "NoClientCert"},
+	{itoml.TlsClientAuthType(tls.RequestClientCert), "RequestClientCert"},
+	{itoml.TlsClientAuthType(tls.RequireAnyClientCert), "RequireAnyClientCert"},
+	{itoml.TlsClientAuthType(tls.VerifyClientCertIfGiven), "VerifyClientCertIfGiven"},
+	{itoml.TlsClientAuthType(tls.RequireAndVerifyClientCert), "RequireAndVerifyClientCert"},
+}
+
+// invalidClientAuthErr returns the exact error text UnmarshalText produces for
+// an unrecognized value, matching its `fmt.Errorf("%q: %w", s, sentinel)` form.
+//
+// The sentinel text is spelled out as a literal on purpose: reusing
+// itoml.ErrInvalidTlsClientAuthType would make the test blind to an accidental
+// change of the error message. Pinning the literal means such a change is
+// caught, and an intentional change forces a deliberate update here.
+func invalidClientAuthErr(value string) string {
+	return fmt.Sprintf("%q: invalid tls.ClientAuthType (valid values: NoClientCert, RequestClientCert, RequireAnyClientCert, VerifyClientCertIfGiven, RequireAndVerifyClientCert)", value)
+}
+
+func TestTlsClientAuthType_MarshalText(t *testing.T) {
+	// Every valid enum value marshals to its canonical string.
+	for _, tc := range validClientAuthTypes {
+		t.Run(tc.str, func(t *testing.T) {
+			b, err := tc.val.MarshalText()
+			require.NoError(t, err)
+			require.Equal(t, tc.str, string(b))
+		})
+	}
+
+	// Invalid values marshal to the typecast form rather than returning an
+	// error, so that a bad in-memory value can never break config writeout.
+	t.Run("invalid", func(t *testing.T) {
+		b, err := itoml.TlsClientAuthType(-1).MarshalText()
+		require.NoError(t, err)
+		require.Equal(t, "ClientAuthType(-1)", string(b))
+	})
+}
+
+func TestTlsClientAuthType_UnmarshalText(t *testing.T) {
+	// Every valid enum value round-trips from its canonical string.
+	for _, tc := range validClientAuthTypes {
+		t.Run(tc.str, func(t *testing.T) {
+			var got itoml.TlsClientAuthType
+			require.NoError(t, got.UnmarshalText([]byte(tc.str)))
+			require.Equal(t, tc.val, got)
+		})
+	}
+
+	// Matching is case-insensitive.
+	t.Run("case-insensitive", func(t *testing.T) {
+		var got itoml.TlsClientAuthType
+		require.NoError(t, got.UnmarshalText([]byte("requireandverifyclientcert")))
+		require.Equal(t, itoml.TlsClientAuthType(tls.RequireAndVerifyClientCert), got)
+	})
+
+	// Invalid strings, including the typecast form MarshalText emits for
+	// invalid values, are rejected with the sentinel error.
+	for _, str := range []string{"bogus", "", "ClientAuthType(-1)"} {
+		t.Run(fmt.Sprintf("invalid/%q", str), func(t *testing.T) {
+			var got itoml.TlsClientAuthType
+			err := got.UnmarshalText([]byte(str))
+			require.ErrorIs(t, err, itoml.ErrInvalidTlsClientAuthType)
+			require.EqualError(t, err, invalidClientAuthErr(str))
+			require.Zero(t, got, "value should be untouched after a failed unmarshal")
+		})
+	}
+}
+
+func TestTlsClientAuthType_TOML(t *testing.T) {
+	type config struct {
+		Auth itoml.TlsClientAuthType `toml:"auth"`
+	}
+
+	t.Run("marshal", func(t *testing.T) {
+		// Encode a value (non-pointer) field: this is the common case and the
+		// one a pointer-receiver MarshalText would silently emit as a raw int.
+		var buf bytes.Buffer
+		c := config{Auth: itoml.TlsClientAuthType(tls.RequireAnyClientCert)}
+		require.NoError(t, toml.NewEncoder(&buf).Encode(c))
+		require.Equal(t, "auth = \"RequireAnyClientCert\"\n", buf.String())
+	})
+
+	for _, tc := range []struct {
+		name string
+		in   string
+		val  string // the quoted config value, for error-text assertions
+		want itoml.TlsClientAuthType
+		ok   bool
+	}{
+		{"exact", `auth = "RequireAndVerifyClientCert"`, "RequireAndVerifyClientCert", itoml.TlsClientAuthType(tls.RequireAndVerifyClientCert), true},
+		{"case-insensitive", `auth = "verifyclientcertifgiven"`, "verifyclientcertifgiven", itoml.TlsClientAuthType(tls.VerifyClientCertIfGiven), true},
+		{"invalid", `auth = "bogus"`, "bogus", 0, false},
+	} {
+		t.Run("unmarshal/"+tc.name, func(t *testing.T) {
+			var c config
+			_, err := toml.Decode(tc.in, &c)
+			if tc.ok {
+				require.NoError(t, err)
+				require.Equal(t, tc.want, c.Auth)
+			} else {
+				// BurntSushi's decoder reports our UnmarshalText error's text
+				// but wraps it in a toml.ParseError that has no Unwrap method,
+				// so errors.Is cannot reach our sentinel through it. Assert the
+				// portion we own rather than the library's wrapper format.
+				require.ErrorContains(t, err, invalidClientAuthErr(tc.val))
+			}
+		})
+	}
+}
+
+func TestTlsClientAuthType_EnvOverride(t *testing.T) {
+	type config struct {
+		Auth itoml.TlsClientAuthType `toml:"auth"`
+	}
+
+	for _, tc := range []struct {
+		name string
+		val  string
+		want itoml.TlsClientAuthType
+		ok   bool
+	}{
+		{"exact", "RequireAnyClientCert", itoml.TlsClientAuthType(tls.RequireAnyClientCert), true},
+		{"case-insensitive", "requestclientcert", itoml.TlsClientAuthType(tls.RequestClientCert), true},
+		{"invalid", "bogus", 0, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var c config
+			env := mapEnv(map[string]string{"X_AUTH": tc.val})
+			applied, err := itoml.ApplyEnvOverrides(env, "X", &c)
+			if tc.ok {
+				require.NoError(t, err)
+				require.Equal(t, []string{"X_AUTH"}, applied)
+				require.Equal(t, tc.want, c.Auth)
+			} else {
+				require.ErrorIs(t, err, itoml.ErrInvalidTlsClientAuthType)
+				// ApplyEnvOverrides wraps our error; assert the owned portion.
+				require.ErrorContains(t, err, invalidClientAuthErr(tc.val))
+				require.Empty(t, applied)
+			}
+		})
+	}
+}
+
 func TestGroup_UnmarshalTOML(t *testing.T) {
 	// Skip this test on windows since it does not support setting the group anyway.
 	if runtime.GOOS == "windows" {
@@ -1000,7 +1149,7 @@ func TestEnvOverride_Builtins(t *testing.T) {
 		"X_NESTED_INT":       "13",
 		"X_NESTEDPTR_STRING": "a nested pointer string",
 		"X_NESTEDPTR_INT":    "14",
-		"X_NILPTR_STRING":    "should be ignored",
+		"X_NILPTR_STRING":    "a nil pointer string",
 		"X_NILPTR_INT":       "99",
 		"X_ES":               "an embedded string",
 		"X__":                "-1", // This value should not be applied to the "ignored" field with toml tag -.
@@ -1174,6 +1323,12 @@ func TestEnvOverride_Builtins(t *testing.T) {
 			Str: "a nested pointer string",
 			Int: 14,
 		},
+		// A nil pointer to a struct is speculatively allocated and populated
+		// when a field env var is present.
+		NilPtr: &nestedConfig{
+			Str: "a nil pointer string",
+			Int: 99,
+		},
 		EmbeddedConfig: EmbeddedConfig{
 			ES: "an embedded string",
 		},
@@ -1241,6 +1396,7 @@ func TestEnvOverride_Builtins(t *testing.T) {
 		"X_NESTEDSLICE_3_INT", "X_NESTEDSLICE_3_STRING",
 		"X_NESTEDSLICE_4_STRING",
 		"X_NESTED_INT", "X_NESTED_STRING",
+		"X_NILPTR_INT", "X_NILPTR_STRING",
 		"X_SIZESLICE2",
 		"X_SIZESLICE3_0", "X_SIZESLICE3_1",
 		"X_SIZESLICE_0", "X_SIZESLICE_1",
@@ -1945,29 +2101,38 @@ func TestEnvOverride_AllocatesPointerWhenGrowingStructSlice(t *testing.T) {
 	}, appliedVars)
 }
 
-func TestEnvOverride_NilPointerToStructSkipped(t *testing.T) {
-	// A nil pointer to a struct is NOT auto-allocated. Struct env vars target
-	// the struct's fields, not the struct itself, so there's no single value
-	// to trigger allocation. Users must initialize such pointers in NewConfig
-	// or via the TOML file.
+func TestEnvOverride_NilPointerToStructAllocated(t *testing.T) {
+	// A nil pointer to a struct is speculatively allocated when a field env var
+	// is present, and left nil otherwise. This lets an optional sub-config be
+	// enabled entirely from env vars without pre-allocating the pointer in
+	// NewConfig or the TOML file.
 	type sub struct {
 		A string `toml:"a"`
+		B string `toml:"b"`
 	}
 	type config struct {
 		Sub *sub `toml:"sub"`
 	}
 
-	env := func(s string) string {
-		if s == "X_SUB_A" {
-			return "value"
-		}
-		return ""
-	}
+	t.Run("allocated when a field env var is set", func(t *testing.T) {
+		env := mapEnv(map[string]string{"X_SUB_A": "value"})
+		var c config
+		appliedVars, err := itoml.ApplyEnvOverrides(env, "X", &c)
+		require.NoError(t, err)
+		require.NotNil(t, c.Sub)
+		require.Equal(t, "value", c.Sub.A)
+		require.Empty(t, c.Sub.B, "unset fields stay at their zero value")
+		require.Equal(t, []string{"X_SUB_A"}, appliedVars)
+	})
 
-	var c config
-	_, err := itoml.ApplyEnvOverrides(env, "X", &c)
-	require.NoError(t, err)
-	require.Nil(t, c.Sub)
+	t.Run("left nil when no field env var is set", func(t *testing.T) {
+		env := mapEnv(map[string]string{"X_UNRELATED": "value"})
+		var c config
+		appliedVars, err := itoml.ApplyEnvOverrides(env, "X", &c)
+		require.NoError(t, err)
+		require.Nil(t, c.Sub, "absent sub-config stays absent (speculative alloc rolled back)")
+		require.Empty(t, appliedVars)
+	})
 }
 
 func TestEnvOverride_FalseGrowFromDefault(t *testing.T) {


### PR DESCRIPTION
- Add mTLS support to httpd, opentsdb, and subscriber services.
- Add certificate reload on SIGHUP to subscriber service.
- TLSConfigManager now takes a single nil-able *CAConfig struct for configuring root CAs and client CAs. This reduces ambiguity and surprise when used with actual configurations. This functionality was previously not exposed through configuration.
- Add toml and environment variable support for tls.ClientAuthType enums.
- ApplyEnvOverrides now supports configuring nested structs through nil pointers. This is necessary to support setting CA configuration through environment variables.
- Add checks for CA stores that don't trust anything.

Closes: #27533