### PR TITLE
chore(sync): influxdb_pro 2026-07-14 (v3.9.10)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,7 +444,7 @@ dependencies = [
 
 [[package]]
 name = "arrow_util"
-version = "3.9.8"
+version = "3.9.10"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -541,7 +541,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "authz"
-version = "3.9.8"
+version = "3.9.10"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -655,7 +655,7 @@ dependencies = [
 
 [[package]]
 name = "backoff"
-version = "3.9.8"
+version = "3.9.10"
 dependencies = [
  "rand 0.9.2",
  "snafu 0.9.0",
@@ -1069,7 +1069,7 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "catalog_cache"
-version = "3.9.8"
+version = "3.9.10"
 dependencies = [
  "bytes",
  "criterion 0.8.2",
@@ -1207,7 +1207,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "client_util"
-version = "3.9.8"
+version = "3.9.10"
 dependencies = [
  "http 1.4.0",
  "iox_http_util",
@@ -1785,7 +1785,7 @@ dependencies = [
 
 [[package]]
 name = "data_types"
-version = "3.9.8"
+version = "3.9.10"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -2518,7 +2518,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion_util"
-version = "3.9.8"
+version = "3.9.10"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -2602,7 +2602,7 @@ dependencies = [
 
 [[package]]
 name = "dml"
-version = "3.9.8"
+version = "3.9.10"
 dependencies = [
  "arrow_util",
  "data_types",
@@ -2714,7 +2714,7 @@ dependencies = [
 
 [[package]]
 name = "error_reporting"
-version = "3.9.8"
+version = "3.9.10"
 dependencies = [
  "datafusion",
  "snafu 0.9.0",
@@ -2744,7 +2744,7 @@ dependencies = [
 
 [[package]]
 name = "executor"
-version = "3.9.8"
+version = "3.9.10"
 dependencies = [
  "futures",
  "metric",
@@ -2825,7 +2825,7 @@ dependencies = [
 
 [[package]]
 name = "flightsql"
-version = "3.9.8"
+version = "3.9.10"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -3032,7 +3032,7 @@ dependencies = [
 
 [[package]]
 name = "futures_test_utils"
-version = "3.9.8"
+version = "3.9.10"
 dependencies = [
  "clap",
  "futures",
@@ -3043,7 +3043,7 @@ dependencies = [
 
 [[package]]
 name = "generated_types"
-version = "3.9.8"
+version = "3.9.10"
 dependencies = [
  "bytes",
  "pbjson",
@@ -3692,7 +3692,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb2_client"
-version = "3.9.8"
+version = "3.9.10"
 dependencies = [
  "bytes",
  "futures",
@@ -3711,7 +3711,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3"
-version = "3.9.8"
+version = "3.9.10"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3801,7 +3801,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_authz"
-version = "3.9.8"
+version = "3.9.10"
 dependencies = [
  "async-trait",
  "authz",
@@ -3818,7 +3818,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_cache"
-version = "3.9.8"
+version = "3.9.10"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3853,7 +3853,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_catalog"
-version = "3.9.8"
+version = "3.9.10"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3905,7 +3905,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_clap_blocks"
-version = "3.9.8"
+version = "3.9.10"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3942,7 +3942,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_client"
-version = "3.9.8"
+version = "3.9.10"
 dependencies = [
  "bytes",
  "hashbrown 0.14.5",
@@ -3962,7 +3962,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_commands"
-version = "3.9.8"
+version = "3.9.10"
 dependencies = [
  "anyhow",
  "clap",
@@ -3981,7 +3981,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_id"
-version = "3.9.8"
+version = "3.9.10"
 dependencies = [
  "indexmap 2.13.0",
  "serde",
@@ -3991,7 +3991,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_internal_api"
-version = "3.9.8"
+version = "3.9.10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4012,7 +4012,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_load_generator"
-version = "3.9.8"
+version = "3.9.10"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4041,7 +4041,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_process"
-version = "3.9.8"
+version = "3.9.10"
 dependencies = [
  "iox_time",
  "uuid",
@@ -4049,7 +4049,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_processing_engine"
-version = "3.9.8"
+version = "3.9.10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4094,7 +4094,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_py_api"
-version = "3.9.8"
+version = "3.9.10"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -4122,7 +4122,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_query_executor"
-version = "3.9.8"
+version = "3.9.10"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4172,7 +4172,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_server"
-version = "3.9.8"
+version = "3.9.10"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4255,7 +4255,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_shutdown"
-version = "3.9.8"
+version = "3.9.10"
 dependencies = [
  "futures",
  "futures-util",
@@ -4270,14 +4270,14 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_startup"
-version = "3.9.8"
+version = "3.9.10"
 dependencies = [
  "chrono",
 ]
 
 [[package]]
 name = "influxdb3_sys_events"
-version = "3.9.8"
+version = "3.9.10"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4296,7 +4296,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_system_tables"
-version = "3.9.8"
+version = "3.9.10"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4328,7 +4328,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_telemetry"
-version = "3.9.8"
+version = "3.9.10"
 dependencies = [
  "futures",
  "futures-util",
@@ -4349,7 +4349,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_test_helpers"
-version = "3.9.8"
+version = "3.9.10"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4362,7 +4362,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_types"
-version = "3.9.8"
+version = "3.9.10"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4382,7 +4382,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_wal"
-version = "3.9.8"
+version = "3.9.10"
 dependencies = [
  "async-trait",
  "bitcode",
@@ -4410,7 +4410,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_write"
-version = "3.9.8"
+version = "3.9.10"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4479,7 +4479,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb_influxql_parser"
-version = "3.9.8"
+version = "3.9.10"
 dependencies = [
  "assert_matches",
  "chrono",
@@ -4496,7 +4496,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb_iox_client"
-version = "3.9.8"
+version = "3.9.10"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -4525,7 +4525,7 @@ dependencies = [
 
 [[package]]
 name = "ingester_query_grpc"
-version = "3.9.8"
+version = "3.9.10"
 dependencies = [
  "base64 0.22.1",
  "data_types",
@@ -4582,7 +4582,7 @@ checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
 
 [[package]]
 name = "iox_http"
-version = "3.9.8"
+version = "3.9.10"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -4602,7 +4602,7 @@ dependencies = [
 
 [[package]]
 name = "iox_http_util"
-version = "3.9.8"
+version = "3.9.10"
 dependencies = [
  "futures",
  "http 1.4.0",
@@ -4613,7 +4613,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query"
-version = "3.9.8"
+version = "3.9.10"
 dependencies = [
  "arrow",
  "arrow_util",
@@ -4662,7 +4662,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query_influxql"
-version = "3.9.8"
+version = "3.9.10"
 dependencies = [
  "arrow",
  "assert_matches",
@@ -4689,7 +4689,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query_influxql_rewrite"
-version = "3.9.8"
+version = "3.9.10"
 dependencies = [
  "influxdb_influxql_parser",
  "thiserror 2.0.18",
@@ -4697,7 +4697,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query_params"
-version = "3.9.8"
+version = "3.9.10"
 dependencies = [
  "arrow",
  "assert_matches",
@@ -4711,7 +4711,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query_udf"
-version = "3.9.8"
+version = "3.9.10"
 dependencies = [
  "datafusion-udf-wasm-host",
  "datafusion-udf-wasm-query",
@@ -4722,7 +4722,7 @@ dependencies = [
 
 [[package]]
 name = "iox_system_tables"
-version = "3.9.8"
+version = "3.9.10"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4732,7 +4732,7 @@ dependencies = [
 
 [[package]]
 name = "iox_time"
-version = "3.9.8"
+version = "3.9.10"
 dependencies = [
  "chrono",
  "parking_lot",
@@ -4741,7 +4741,7 @@ dependencies = [
 
 [[package]]
 name = "iox_v1_query_api"
-version = "3.9.8"
+version = "3.9.10"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4855,7 +4855,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jemalloc_stats"
-version = "3.9.8"
+version = "3.9.10"
 dependencies = [
  "snafu 0.9.0",
  "tikv-jemalloc-ctl",
@@ -5000,7 +5000,7 @@ dependencies = [
 
 [[package]]
 name = "linear_buffer"
-version = "3.9.8"
+version = "3.9.10"
 
 [[package]]
 name = "linux-raw-sys"
@@ -5044,7 +5044,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "logfmt"
-version = "3.9.8"
+version = "3.9.10"
 dependencies = [
  "humantime",
  "parking_lot",
@@ -5152,14 +5152,14 @@ dependencies = [
 
 [[package]]
 name = "metric"
-version = "3.9.8"
+version = "3.9.10"
 dependencies = [
  "parking_lot",
 ]
 
 [[package]]
 name = "metric_exporters"
-version = "3.9.8"
+version = "3.9.10"
 dependencies = [
  "metric",
  "mockito",
@@ -5284,7 +5284,7 @@ checksum = "9252111cf132ba0929b6f8e030cac2a24b507f3a4d6db6fb2896f27b354c714b"
 
 [[package]]
 name = "mutable_batch"
-version = "3.9.8"
+version = "3.9.10"
 dependencies = [
  "arrow",
  "arrow_util",
@@ -5302,7 +5302,7 @@ dependencies = [
 
 [[package]]
 name = "mutable_batch_lp"
-version = "3.9.8"
+version = "3.9.10"
 dependencies = [
  "arrow_util",
  "assert_matches",
@@ -5318,7 +5318,7 @@ dependencies = [
 
 [[package]]
 name = "mutable_batch_pb"
-version = "3.9.8"
+version = "3.9.10"
 dependencies = [
  "arrow_util",
  "criterion 0.8.2",
@@ -5556,7 +5556,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_limit"
-version = "3.9.8"
+version = "3.9.10"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5568,7 +5568,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_mem_cache"
-version = "3.9.8"
+version = "3.9.10"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5595,7 +5595,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_metrics"
-version = "3.9.8"
+version = "3.9.10"
 dependencies = [
  "async-trait",
  "bloom2",
@@ -5620,7 +5620,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_mock"
-version = "3.9.8"
+version = "3.9.10"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5634,7 +5634,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_size_hinting"
-version = "3.9.8"
+version = "3.9.10"
 dependencies = [
  "chrono",
  "http 1.4.0",
@@ -5644,7 +5644,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_utils"
-version = "3.9.8"
+version = "3.9.10"
 dependencies = [
  "async-trait",
  "backon",
@@ -5657,7 +5657,7 @@ dependencies = [
 
 [[package]]
 name = "observability_deps"
-version = "3.9.8"
+version = "3.9.10"
 dependencies = [
  "tracing",
 ]
@@ -5722,7 +5722,7 @@ dependencies = [
 
 [[package]]
 name = "panic_logging"
-version = "3.9.8"
+version = "3.9.10"
 dependencies = [
  "metric",
  "test_helpers",
@@ -5797,7 +5797,7 @@ dependencies = [
 
 [[package]]
 name = "parquet_file"
-version = "3.9.8"
+version = "3.9.10"
 dependencies = [
  "arrow",
  "arrow_util",
@@ -5826,7 +5826,7 @@ dependencies = [
 
 [[package]]
 name = "partition"
-version = "3.9.8"
+version = "3.9.10"
 dependencies = [
  "arrow",
  "assert_matches",
@@ -6123,7 +6123,7 @@ dependencies = [
 
 [[package]]
 name = "predicate"
-version = "3.9.8"
+version = "3.9.10"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6469,7 +6469,7 @@ dependencies = [
 
 [[package]]
 name = "query_functions"
-version = "3.9.8"
+version = "3.9.10"
 dependencies = [
  "arrow",
  "chrono",
@@ -7152,7 +7152,7 @@ dependencies = [
 
 [[package]]
 name = "schema"
-version = "3.9.8"
+version = "3.9.10"
 dependencies = [
  "arrow",
  "base64 0.22.1",
@@ -7335,7 +7335,7 @@ dependencies = [
 
 [[package]]
 name = "service_common"
-version = "3.9.8"
+version = "3.9.10"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -7349,7 +7349,7 @@ dependencies = [
 
 [[package]]
 name = "service_grpc_flight"
-version = "3.9.8"
+version = "3.9.10"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -7416,7 +7416,7 @@ dependencies = [
 
 [[package]]
 name = "sharder"
-version = "3.9.8"
+version = "3.9.10"
 dependencies = [
  "criterion 0.8.2",
  "data_types",
@@ -7563,9 +7563,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 dependencies = [
  "lock_api",
 ]
@@ -7938,7 +7938,7 @@ dependencies = [
 
 [[package]]
 name = "table_batch"
-version = "3.9.8"
+version = "3.9.10"
 dependencies = [
  "arrow_util",
  "bitvec",
@@ -8024,7 +8024,7 @@ dependencies = [
 
 [[package]]
 name = "test_helpers"
-version = "3.9.8"
+version = "3.9.10"
 dependencies = [
  "async-trait",
  "dotenvy",
@@ -8043,7 +8043,7 @@ dependencies = [
 
 [[package]]
 name = "test_helpers_authz"
-version = "3.9.8"
+version = "3.9.10"
 dependencies = [
  "futures",
  "generated_types",
@@ -8316,7 +8316,7 @@ dependencies = [
 
 [[package]]
 name = "tokio_metrics_bridge"
-version = "3.9.8"
+version = "3.9.10"
 dependencies = [
  "metric",
  "parking_lot",
@@ -8325,7 +8325,7 @@ dependencies = [
 
 [[package]]
 name = "tokio_watchdog"
-version = "3.9.8"
+version = "3.9.10"
 dependencies = [
  "metric",
  "test_helpers",
@@ -8548,7 +8548,7 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tower_trailer"
-version = "3.9.8"
+version = "3.9.10"
 dependencies = [
  "futures",
  "http 1.4.0",
@@ -8560,7 +8560,7 @@ dependencies = [
 
 [[package]]
 name = "trace"
-version = "3.9.8"
+version = "3.9.10"
 dependencies = [
  "chrono",
  "parking_lot",
@@ -8570,7 +8570,7 @@ dependencies = [
 
 [[package]]
 name = "trace_exporters"
-version = "3.9.8"
+version = "3.9.10"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8587,7 +8587,7 @@ dependencies = [
 
 [[package]]
 name = "trace_http"
-version = "3.9.8"
+version = "3.9.10"
 dependencies = [
  "bytes",
  "futures",
@@ -8682,7 +8682,7 @@ dependencies = [
 
 [[package]]
 name = "tracker"
-version = "3.9.8"
+version = "3.9.10"
 dependencies = [
  "futures",
  "hashbrown 0.14.5",
@@ -8702,7 +8702,7 @@ dependencies = [
 
 [[package]]
 name = "trogging"
-version = "3.9.8"
+version = "3.9.10"
 dependencies = [
  "clap",
  "logfmt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,7 +125,7 @@ exclude = [
 #
 # For porting to the actual OSS repo (influxdb), this would need to change to `-nightly`, i.e., by
 # stripping the `-oss`.
-version = "3.9.8"
+version = "3.9.10"
 authors = ["InfluxData OSS Developers"]
 edition = "2024"
 license = "MIT OR Apache-2.0"

--- a/influxdb3_catalog/src/object_store.rs
+++ b/influxdb3_catalog/src/object_store.rs
@@ -1,6 +1,8 @@
 pub(crate) mod versions;
 
 use anyhow::anyhow;
+use object_store::{GetOptions, GetRange, ObjectStore};
+use observability_deps::tracing::error;
 pub use versions::v2::*;
 
 #[derive(Debug, thiserror::Error)]
@@ -34,3 +36,32 @@ pub const CATALOG_LOG_FILE_EXTENSION: &str = "catalog";
 
 /// File extension for catalog files
 pub const CATALOG_SNAPSHOT_FILE_EXTENSION: &str = "catalog.snapshot";
+
+/// Gather diagnostics for a HEAD request that failed for a reason other than the object not
+/// existing.
+///
+/// Error responses to HEAD requests carry no body, so the object store's error code (for
+/// example S3's `ExpiredToken`) is absent from `head_error`. Error responses to GET requests
+/// do carry it, so issue a single-byte ranged GET for the same path and log the outcome.
+///
+/// The diagnostic is also returned so callers can attach it to the propagated error: the
+/// first catalog load runs before the tracing subscriber is installed, so on that path the
+/// returned string is the only way the diagnostic reaches the operator.
+pub(crate) async fn log_failed_head_diagnostics(
+    store: &dyn ObjectStore,
+    path: &object_store::path::Path,
+    head_error: &object_store::Error,
+) -> String {
+    let options = GetOptions {
+        range: Some(GetRange::Bounded(0..1)),
+        ..Default::default()
+    };
+    let diagnostics = match store.get_opts(path, options).await {
+        Err(get_error) => format!(
+            "diagnostic ranged GET issued after the HEAD failure also failed, and its error may carry the object store's error body: {get_error:?}"
+        ),
+        Ok(_) => "diagnostic ranged GET issued after the HEAD failure succeeded; the failure appears specific to HEAD requests".to_string(),
+    };
+    error!(%path, head_error = ?head_error, "{diagnostics}");
+    diagnostics
+}

--- a/influxdb3_catalog/src/object_store/versions/v1.rs
+++ b/influxdb3_catalog/src/object_store/versions/v1.rs
@@ -13,7 +13,9 @@ use crate::catalog::versions::v1::{InnerCatalog, Snapshot};
 use crate::snapshot::versions::v3::CatalogSnapshot;
 use crate::{
     catalog::CatalogSequenceNumber,
-    object_store::{CATALOG_LOG_FILE_EXTENSION, PersistCatalogResult, Result},
+    object_store::{
+        CATALOG_LOG_FILE_EXTENSION, PersistCatalogResult, Result, log_failed_head_diagnostics,
+    },
     serialize::versions::v1::{load_catalog, serialize_catalog_file},
 };
 
@@ -149,15 +151,16 @@ impl ObjectStoreCatalog {
     /// the catalog has been initialized, and is used to check if there is a Core catalog on server
     /// start.
     pub(crate) async fn checkpoint_exists(&self) -> Result<bool> {
-        match self
-            .store
-            .head(&CatalogFilePath::checkpoint(&self.prefix))
-            .await
-        {
+        let path = CatalogFilePath::checkpoint(&self.prefix);
+        match self.store.head(&path).await {
             Ok(_) => Ok(true),
             // nothing there, so we don't need to migrate:
             Err(object_store::Error::NotFound { .. }) => Ok(false),
-            Err(error) => Err(error)?,
+            Err(error) => {
+                let diagnostics =
+                    log_failed_head_diagnostics(self.store.as_ref(), &path, &error).await;
+                Err(anyhow::Error::new(error).context(diagnostics))?
+            }
         }
     }
 }

--- a/influxdb3_catalog/src/object_store/versions/v2.rs
+++ b/influxdb3_catalog/src/object_store/versions/v2.rs
@@ -13,7 +13,9 @@ use crate::catalog::versions::v2::{InnerCatalog, Snapshot, log::OrderedCatalogBa
 use crate::snapshot::versions::v4::CatalogSnapshot;
 use crate::{
     catalog::CatalogSequenceNumber,
-    object_store::{CATALOG_LOG_FILE_EXTENSION, PersistCatalogResult, Result},
+    object_store::{
+        CATALOG_LOG_FILE_EXTENSION, PersistCatalogResult, Result, log_failed_head_diagnostics,
+    },
     serialize::versions::v2::{
         load_catalog, serialize_catalog_file, verify_and_deserialize_catalog_file,
     },
@@ -233,15 +235,16 @@ impl ObjectStoreCatalog {
     /// the catalog has been initialized, and is used to check if there is a Core catalog on server
     /// start.
     pub(crate) async fn checkpoint_exists(&self) -> Result<bool> {
-        match self
-            .store
-            .head(&CatalogFilePath::checkpoint(&self.prefix))
-            .await
-        {
+        let path = CatalogFilePath::checkpoint(&self.prefix);
+        match self.store.head(&path).await {
             Ok(_) => Ok(true),
             // nothing there, so we don't need to migrate:
             Err(object_store::Error::NotFound { .. }) => Ok(false),
-            Err(error) => Err(error)?,
+            Err(error) => {
+                let diagnostics =
+                    log_failed_head_diagnostics(self.store.as_ref(), &path, &error).await;
+                Err(anyhow::Error::new(error).context(diagnostics))?
+            }
         }
     }
 }

--- a/influxdb3_catalog/src/object_store/versions/v2/tests.rs
+++ b/influxdb3_catalog/src/object_store/versions/v2/tests.rs
@@ -210,3 +210,63 @@ async fn persist_and_load_newest_catalog() {
     // // my_db
     // assert!(!catalog.db_exists(DbId::from(0)));
 }
+
+#[test_log::test(tokio::test)]
+async fn checkpoint_exists_logs_diagnostics_on_head_failure() {
+    use influxdb3_test_helpers::object_store::mock::{self, MockCall, MockStore};
+    use object_store::{GetOptions, GetRange};
+
+    use super::CatalogFilePath;
+
+    let store = MockStore::new()
+        .mock_next(MockCall::Head {
+            params: CatalogFilePath::checkpoint("test_host").into(),
+            barriers: vec![],
+            res: Err(mock::err()),
+        })
+        // a HEAD error response carries no body, so the failed HEAD must be followed by a
+        // single-byte ranged GET, whose error response can carry the store's error body
+        .mock_next(MockCall::GetOpts {
+            params: (
+                CatalogFilePath::checkpoint("test_host").into(),
+                GetOptions {
+                    range: Some(GetRange::Bounded(0..1)),
+                    ..Default::default()
+                }
+                .into(),
+            ),
+            barriers: vec![],
+            res: Err(mock::err()),
+        });
+    let catalog = ObjectStoreCatalog::new("test_host", 10, store.as_store());
+
+    let error = catalog
+        .checkpoint_exists()
+        .await
+        .expect_err("the HEAD error should be propagated");
+    // the first catalog load runs before logging is initialized, so the diagnostic must
+    // travel inside the propagated error, not just the log line
+    let rendered = format!("{error}");
+    assert!(
+        rendered.contains("diagnostic ranged GET"),
+        "diagnostics missing from error: {rendered}"
+    );
+}
+
+#[test_log::test(tokio::test)]
+async fn checkpoint_exists_no_diagnostics_when_not_found() {
+    use influxdb3_test_helpers::object_store::mock::{self, MockCall, MockStore};
+
+    use super::CatalogFilePath;
+
+    // no GET is mocked: MockStore panics on any unexpected call, so this also verifies that
+    // a NotFound HEAD does not trigger the diagnostic GET
+    let store = MockStore::new().mock_next(MockCall::Head {
+        params: CatalogFilePath::checkpoint("test_host").into(),
+        barriers: vec![],
+        res: Err(mock::not_found("test_host/catalog/v2/snapshot")),
+    });
+    let catalog = ObjectStoreCatalog::new("test_host", 10, store.as_store());
+
+    assert!(!catalog.checkpoint_exists().await.unwrap());
+}


### PR DESCRIPTION
OSS sync of `oss/` from influxdb_pro for the **v3.9.10** patch release. Delta since the 2026-07-07 sync: version bump to 3.9.10, the `spin` lockfile update, and a catalog `object_store` change. cargo check/fmt/lock all pass; enterprise-leak check clean (the one flagged line is a pre-existing doc comment). Companion to the enterprise release carrying the EAR#6946 compactor fix (#4488).