### PR TITLE
chore(sync): influxdb_pro 2026-07-14 (v3.10.4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,7 +444,7 @@ dependencies = [
 
 [[package]]
 name = "arrow_util"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -541,7 +541,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "authz"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -655,7 +655,7 @@ dependencies = [
 
 [[package]]
 name = "backoff"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "rand 0.9.4",
  "snafu 0.9.0",
@@ -1078,7 +1078,7 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "catalog_cache"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "bytes",
  "criterion 0.8.2",
@@ -1222,14 +1222,14 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli_types"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "tokio",
 ]
 
 [[package]]
 name = "client_util"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "http 1.4.0",
  "iox_http_util",
@@ -1832,7 +1832,7 @@ dependencies = [
 
 [[package]]
 name = "data_types"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -2566,7 +2566,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion_util"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -2661,7 +2661,7 @@ dependencies = [
 
 [[package]]
 name = "dml"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "arrow_util",
  "data_types",
@@ -2773,7 +2773,7 @@ dependencies = [
 
 [[package]]
 name = "error_reporting"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "datafusion",
  "snafu 0.9.0",
@@ -2803,7 +2803,7 @@ dependencies = [
 
 [[package]]
 name = "executor"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "futures",
  "metric",
@@ -2884,7 +2884,7 @@ dependencies = [
 
 [[package]]
 name = "flightsql"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -3091,7 +3091,7 @@ dependencies = [
 
 [[package]]
 name = "futures_test_utils"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "clap",
  "futures",
@@ -3102,7 +3102,7 @@ dependencies = [
 
 [[package]]
 name = "generated_types"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "bytes",
  "pbjson",
@@ -3756,7 +3756,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb2_client"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "bytes",
  "futures",
@@ -3775,7 +3775,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3867,7 +3867,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_authz"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "async-trait",
  "authz",
@@ -3885,7 +3885,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_cache"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3920,7 +3920,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_catalog"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "ahash 0.8.12",
  "anyhow",
@@ -3977,7 +3977,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_clap_blocks"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4014,7 +4014,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_client"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "bytes",
  "flate2",
@@ -4035,7 +4035,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_commands"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4062,7 +4062,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_id"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "criterion 0.5.1",
  "indexmap 2.14.0",
@@ -4074,7 +4074,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_internal_api"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4095,7 +4095,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_load_generator"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4125,7 +4125,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_process"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "iox_time",
  "uuid",
@@ -4133,7 +4133,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_processing_engine"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4177,7 +4177,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_py_api"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -4205,7 +4205,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_query_executor"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4256,7 +4256,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_server"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4343,7 +4343,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_shutdown"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "futures",
  "futures-util",
@@ -4358,14 +4358,14 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_startup"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "chrono",
 ]
 
 [[package]]
 name = "influxdb3_sys_events"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4384,7 +4384,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_system_tables"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4416,7 +4416,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_telemetry"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "futures",
  "futures-util",
@@ -4437,7 +4437,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_test_helpers"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4450,7 +4450,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_types"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4470,7 +4470,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_wal"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "async-trait",
  "bitcode",
@@ -4499,7 +4499,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_write"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4569,7 +4569,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb_influxql_parser"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "assert_matches",
  "chrono",
@@ -4586,7 +4586,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb_iox_client"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -4615,7 +4615,7 @@ dependencies = [
 
 [[package]]
 name = "ingester_query_grpc"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "base64 0.22.1",
  "data_types",
@@ -4681,7 +4681,7 @@ checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
 
 [[package]]
 name = "iox_http"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -4701,7 +4701,7 @@ dependencies = [
 
 [[package]]
 name = "iox_http_util"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "futures",
  "http 1.4.0",
@@ -4712,7 +4712,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "arrow",
  "arrow_util",
@@ -4761,7 +4761,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query_influxql"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "arrow",
  "assert_matches",
@@ -4788,7 +4788,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query_influxql_rewrite"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "influxdb_influxql_parser",
  "thiserror 2.0.18",
@@ -4796,7 +4796,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query_params"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "arrow",
  "assert_matches",
@@ -4810,7 +4810,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query_udf"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "datafusion-udf-wasm-host",
  "datafusion-udf-wasm-query",
@@ -4821,7 +4821,7 @@ dependencies = [
 
 [[package]]
 name = "iox_system_tables"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4831,7 +4831,7 @@ dependencies = [
 
 [[package]]
 name = "iox_time"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "chrono",
  "parking_lot",
@@ -4840,7 +4840,7 @@ dependencies = [
 
 [[package]]
 name = "iox_v1_query_api"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4954,7 +4954,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jemalloc_pprof_http"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "http-body-util",
  "hyper 1.9.0",
@@ -4967,7 +4967,7 @@ dependencies = [
 
 [[package]]
 name = "jemalloc_stats"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "futures",
  "snafu 0.9.0",
@@ -5160,7 +5160,7 @@ dependencies = [
 
 [[package]]
 name = "linear_buffer"
-version = "3.10.3"
+version = "3.10.4"
 
 [[package]]
 name = "linux-raw-sys"
@@ -5204,7 +5204,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "logfmt"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "humantime",
  "parking_lot",
@@ -5303,14 +5303,14 @@ dependencies = [
 
 [[package]]
 name = "metric"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "parking_lot",
 ]
 
 [[package]]
 name = "metric_exporters"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "metric",
  "mockito",
@@ -5435,7 +5435,7 @@ checksum = "9252111cf132ba0929b6f8e030cac2a24b507f3a4d6db6fb2896f27b354c714b"
 
 [[package]]
 name = "mutable_batch"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "arrow",
  "arrow_util",
@@ -5453,7 +5453,7 @@ dependencies = [
 
 [[package]]
 name = "mutable_batch_lp"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "arrow_util",
  "assert_matches",
@@ -5469,7 +5469,7 @@ dependencies = [
 
 [[package]]
 name = "mutable_batch_pb"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "arrow_util",
  "criterion 0.8.2",
@@ -5707,7 +5707,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_limit"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5719,7 +5719,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_mem_cache"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5747,7 +5747,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_metrics"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "async-trait",
  "bloom2",
@@ -5772,7 +5772,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_mock"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5786,7 +5786,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_size_hinting"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "chrono",
  "http 1.4.0",
@@ -5796,7 +5796,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_utils"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "async-trait",
  "backon",
@@ -5810,7 +5810,7 @@ dependencies = [
 
 [[package]]
 name = "observability_deps"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "tracing",
 ]
@@ -5875,7 +5875,7 @@ dependencies = [
 
 [[package]]
 name = "panic_logging"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "metric",
  "test_helpers",
@@ -5950,7 +5950,7 @@ dependencies = [
 
 [[package]]
 name = "parquet_file"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "arrow",
  "arrow_util",
@@ -5981,7 +5981,7 @@ dependencies = [
 
 [[package]]
 name = "partition"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "arrow",
  "assert_matches",
@@ -6278,7 +6278,7 @@ dependencies = [
 
 [[package]]
 name = "predicate"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6622,7 +6622,7 @@ dependencies = [
 
 [[package]]
 name = "query_functions"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "arrow",
  "chrono",
@@ -7332,7 +7332,7 @@ dependencies = [
 
 [[package]]
 name = "schema"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "arrow",
  "base64 0.22.1",
@@ -7515,7 +7515,7 @@ dependencies = [
 
 [[package]]
 name = "service_common"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -7529,7 +7529,7 @@ dependencies = [
 
 [[package]]
 name = "service_grpc_flight"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -7605,7 +7605,7 @@ dependencies = [
 
 [[package]]
 name = "sharder"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "criterion 0.8.2",
  "data_types",
@@ -7752,9 +7752,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 dependencies = [
  "lock_api",
 ]
@@ -8127,7 +8127,7 @@ dependencies = [
 
 [[package]]
 name = "table_batch"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "arrow_util",
  "bitvec",
@@ -8223,7 +8223,7 @@ dependencies = [
 
 [[package]]
 name = "test_helpers"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "async-trait",
  "dotenvy",
@@ -8242,7 +8242,7 @@ dependencies = [
 
 [[package]]
 name = "test_helpers_authz"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "futures",
  "generated_types",
@@ -8515,7 +8515,7 @@ dependencies = [
 
 [[package]]
 name = "tokio_metrics_bridge"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "metric",
  "parking_lot",
@@ -8524,7 +8524,7 @@ dependencies = [
 
 [[package]]
 name = "tokio_watchdog"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "metric",
  "test_helpers",
@@ -8747,7 +8747,7 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tower_trailer"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "futures",
  "http 1.4.0",
@@ -8759,7 +8759,7 @@ dependencies = [
 
 [[package]]
 name = "trace"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "chrono",
  "parking_lot",
@@ -8769,7 +8769,7 @@ dependencies = [
 
 [[package]]
 name = "trace_exporters"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8786,7 +8786,7 @@ dependencies = [
 
 [[package]]
 name = "trace_http"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "bytes",
  "futures",
@@ -8881,7 +8881,7 @@ dependencies = [
 
 [[package]]
 name = "tracker"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "futures",
  "hashbrown 0.14.5",
@@ -8901,7 +8901,7 @@ dependencies = [
 
 [[package]]
 name = "trogging"
-version = "3.10.3"
+version = "3.10.4"
 dependencies = [
  "clap",
  "logfmt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,7 +127,7 @@ exclude = [
 #
 # For porting to the actual OSS repo (influxdb), this would need to change to `-nightly`, i.e., by
 # stripping the `-oss`.
-version = "3.10.3"
+version = "3.10.4"
 authors = ["InfluxData OSS Developers"]
 edition = "2024"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
OSS sync of `oss/` from influxdb_pro for the **v3.10.4** patch release. Delta since the 2026-07-07 sync: version bump to 3.10.4 and the `spin` lockfile update (lockfile + manifest only). cargo check/fmt/lock all pass; enterprise-leak check clean (the one flagged line is a pre-existing doc comment). Companion to the enterprise release carrying the EAR#6946 compactor fix (#4488).