### PR TITLE
chore: bump install script default versions (core 3.10.1, ent 3.10.4)

### DIFF
--- a/install_influxdb.sh
+++ b/install_influxdb.sh
@@ -167,8 +167,8 @@ PORT=8181
 # Set the default (latest) version here. Users may specify a version using the
 # --version arg (handled below)
 INFLUXDB_VERSION_FLAG_SET="0"
-INFLUXDB_OSS_VERSION="3.10.0"
-INFLUXDB_ENT_VERSION="3.10.0"
+INFLUXDB_OSS_VERSION="3.10.1"
+INFLUXDB_ENT_VERSION="3.10.4"
 
 EDITION="Core"
 EDITION_TAG="core"


### PR DESCRIPTION
Points the install script defaults at the latest published patch of each edition:
- `INFLUXDB_OSS_VERSION`: 3.10.0 -> **3.10.1** (latest core)
- `INFLUXDB_ENT_VERSION`: 3.10.0 -> **3.10.4** (latest enterprise; carries the EAR#6946 compactor data-loss fix)

The two are independent constants (core install uses OSS, `enterprise` uses ENT), so they version independently -- no core 3.10.4 build exists or is needed.