### PR TITLE
chore(deny): ignore new advisories and update yanked spin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7752,9 +7752,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 dependencies = [
  "lock_api",
 ]

--- a/deny.toml
+++ b/deny.toml
@@ -89,6 +89,27 @@ ignore = [
     # to PyCFunction::new_closure, or PyCFunction::new_closure_bound.
     # Neither of these methods are used in this code.
     "RUSTSEC-2026-0177",
+    #
+    # wasmtime-wasi 41.0.4: WASI hard links and renames bypass FilePerms for the
+    # destination. Only reachable if a Wasm UDF is loaded with WASI filesystem
+    # preopens granted; UDFs are disabled by default. Remove when wasmtime-wasi
+    # updates via datafusion-udf-wasm.
+    "RUSTSEC-2026-0188",
+    #
+    # quick-xml < 0.41 DoS advisories: quadratic time checking duplicate attribute
+    # names (RUSTSEC-2026-0194) and unbounded namespace-declaration allocation in
+    # NsReader (RUSTSEC-2026-0195). Our affected copy (0.38.4) is pinned transitively
+    # by object_store, which only parses XML from the configured object store's own
+    # API responses (S3/Azure) -- not attacker-supplied documents -- so exposure is
+    # low. Remove both when object_store updates to quick-xml >=0.41.0.
+    "RUSTSEC-2026-0194",
+    "RUSTSEC-2026-0195",
+    #
+    # crossbeam-epoch: invalid pointer dereference in the `fmt::Pointer` impl for
+    # `Atomic`/`Shared` when the underlying pointer is invalid. Only reachable by
+    # formatting a dangling `Atomic`/`Shared` with `{:p}`, which this code does not
+    # do. Remove when the transitive crossbeam-epoch dependency updates.
+    "RUSTSEC-2026-0204",
 ]
 git-fetch-with-cli = true
 


### PR DESCRIPTION
Public `main` is red on `cargo-deny` (5 errors), blocking every PR. Fixes:
- yanked `spin` 0.9.8 -> `cargo update` to 0.9.9
- ignore `RUSTSEC-2026-0188` (wasmtime-wasi), `-0194`/`-0195` (quick-xml DoS), `-0204` (crossbeam-epoch `fmt::Pointer`), each with justification

Ignores mirror `influxdb_pro`'s canonical `oss/deny.toml` (0204 added there in influxdata/influxdb_pro#4572), so they stay consistent through the next oss-sync.