### PR TITLE
chore: update install script to 3.10.5

### DIFF
--- a/install_influxdb.sh
+++ b/install_influxdb.sh
@@ -167,8 +167,8 @@ PORT=8181
 # Set the default (latest) version here. Users may specify a version using the
 # --version arg (handled below)
 INFLUXDB_VERSION_FLAG_SET="0"
-INFLUXDB_OSS_VERSION="3.9.1"
-INFLUXDB_ENT_VERSION="3.9.1"
+INFLUXDB_OSS_VERSION="3.10.5"
+INFLUXDB_ENT_VERSION="3.10.5"
 
 EDITION="Core"
 EDITION_TAG="core"


### PR DESCRIPTION
Bumps the installer default to the latest 3.10.5 release for both core and enterprise:

- `INFLUXDB_OSS_VERSION`: 3.9.1 -> 3.10.5
- `INFLUXDB_ENT_VERSION`: 3.9.1 -> 3.10.5

The current `main` value (3.9.1) is stale -- a prior oss-sync reverted an earlier manual bump. 3.10.5 core + enterprise artifacts are published and verified.