### PR TITLE
fix: trim leading or trailing whitespace on DB and RP names

### DIFF
--- a/coordinator/statement_executor.go
+++ b/coordinator/statement_executor.go
@@ -264,23 +264,11 @@ func (e *StatementExecutor) executeCreateContinuousQueryStatement(q *influxql.Cr
 }
 
 func (e *StatementExecutor) executeCreateDatabaseStatement(stmt *influxql.CreateDatabaseStatement) error {
-	if !meta.ValidName(stmt.Name) {
-		// TODO This should probably be in `(*meta.Data).CreateDatabase`
-		// but can't go there until 1.1 is used everywhere
-		return meta.ErrInvalidName
-	}
-
+	// Name validation is performed by the meta client's create methods, which
+	// are the common chokepoint for every creation path.
 	if !stmt.RetentionPolicyCreate {
 		_, err := e.MetaClient.CreateDatabase(stmt.Name)
 		return err
-	}
-
-	// If we're doing, for example, CREATE DATABASE "db" WITH DURATION 1d then
-	// the name will not yet be set. We only need to validate non-empty
-	// retention policy names, such as in the statement:
-	// 	CREATE DATABASE "db" WITH DURATION 1d NAME "xyz"
-	if stmt.RetentionPolicyName != "" && !meta.ValidName(stmt.RetentionPolicyName) {
-		return meta.ErrInvalidName
 	}
 
 	spec := meta.RetentionPolicySpec{
@@ -296,12 +284,7 @@ func (e *StatementExecutor) executeCreateDatabaseStatement(stmt *influxql.Create
 }
 
 func (e *StatementExecutor) executeCreateRetentionPolicyStatement(stmt *influxql.CreateRetentionPolicyStatement) error {
-	if !meta.ValidName(stmt.Name) {
-		// TODO This should probably be in `(*meta.Data).CreateRetentionPolicy`
-		// but can't go there until 1.1 is used everywhere
-		return meta.ErrInvalidName
-	}
-
+	// Name validation is performed by the meta client's CreateRetentionPolicy.
 	spec := meta.RetentionPolicySpec{
 		Name:               stmt.Name,
 		Duration:           &stmt.Duration,

--- a/services/httpd/handler.go
+++ b/services/httpd/handler.go
@@ -1226,12 +1226,8 @@ func (h *Handler) servePostCreateBucketV2(w http.ResponseWriter, r *http.Request
 		h.httpError(w, fmt.Sprintf("buckets - two retention policies specified: %q differs from %q", rp, brd.Rp), http.StatusBadRequest)
 		return
 	}
-	// We only need to validate non-empty
-	// retention policy names
-	if rp != "" && !meta.ValidName(rp) {
-		h.httpError(w, fmt.Sprintf("buckets - retention policy %q: %s", rp, meta.ErrInvalidName.Error()), http.StatusBadRequest)
-		return
-	}
+	// The retention policy name is validated by the meta client's create
+	// methods called below.
 
 	var dur, sgDur time.Duration
 	if len(brd.RetentionRules) > 0 {

--- a/services/httpd/handler_test.go
+++ b/services/httpd/handler_test.go
@@ -2072,10 +2072,11 @@ func TestHandler_CreateDeleteBuckets(t *testing.T) {
 	}
 
 	createRp := func(database string, spec *meta.RetentionPolicySpec, makeDefault bool) (*meta.RetentionPolicyInfo, error) {
-		// Mirror the real meta.Client, which now validates names.
-		if _, ok := meta.ValidName(spec.Name); !ok {
+		trimmed, ok := meta.ValidName(spec.Name)
+		if !ok {
 			return nil, meta.ErrInvalidName
 		}
+		spec.Name = trimmed
 		return &meta.RetentionPolicyInfo{
 			Name:               spec.Name,
 			ReplicaN:           *spec.ReplicaN,

--- a/services/httpd/handler_test.go
+++ b/services/httpd/handler_test.go
@@ -1993,7 +1993,7 @@ func TestHandler_CreateDeleteBuckets(t *testing.T) {
 				SchemaType: "implicit",
 			},
 			status: http.StatusBadRequest,
-			errMsg: `buckets - retention policy "/": invalid name`,
+			errMsg: `buckets - cannot create bucket "mydb//": invalid name`,
 		},
 		{
 			url:    "/api/v2/buckets/" + existingDb + "%2f" + goodRp,
@@ -2072,6 +2072,10 @@ func TestHandler_CreateDeleteBuckets(t *testing.T) {
 	}
 
 	createRp := func(database string, spec *meta.RetentionPolicySpec, makeDefault bool) (*meta.RetentionPolicyInfo, error) {
+		// Mirror the real meta.Client, which now validates names.
+		if _, ok := meta.ValidName(spec.Name); !ok {
+			return nil, meta.ErrInvalidName
+		}
 		return &meta.RetentionPolicyInfo{
 			Name:               spec.Name,
 			ReplicaN:           *spec.ReplicaN,
@@ -2117,12 +2121,15 @@ func TestHandler_CreateDeleteBuckets(t *testing.T) {
 		CreateRetentionPolicyFn: createRp,
 		CreateDatabaseWithRetentionPolicyFn: func(name string, spec *meta.RetentionPolicySpec) (*meta.DatabaseInfo, error) {
 			rpi, err := createRp(name, spec, true)
+			if err != nil {
+				return nil, err
+			}
 			return &meta.DatabaseInfo{
 				Name:                   name,
 				DefaultRetentionPolicy: spec.Name,
 				RetentionPolicies:      []meta.RetentionPolicyInfo{*rpi},
 				ContinuousQueries:      nil,
-			}, err
+			}, nil
 		},
 		DropRetentionPolicyFn:   dropDeleteRp,
 		UpdateRetentionPolicyFn: updateRp,

--- a/services/meta/client.go
+++ b/services/meta/client.go
@@ -168,6 +168,11 @@ func (c *Client) Databases() []DatabaseInfo {
 
 // CreateDatabase creates a database or returns it if it already exists.
 func (c *Client) CreateDatabase(name string) (*DatabaseInfo, error) {
+	name, ok := ValidName(name)
+	if !ok {
+		return nil, ErrInvalidName
+	}
+
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
@@ -212,6 +217,20 @@ func (c *Client) CreateDatabase(name string) (*DatabaseInfo, error) {
 func (c *Client) CreateDatabaseWithRetentionPolicy(name string, spec *RetentionPolicySpec) (*DatabaseInfo, error) {
 	if spec == nil {
 		return nil, errors.New("CreateDatabaseWithRetentionPolicy called with nil spec")
+	}
+
+	name, ok := ValidName(name)
+	if !ok {
+		return nil, ErrInvalidName
+	}
+	// An empty spec name defaults to DefaultRetentionPolicyName downstream, so
+	// only validate it when the caller supplied one.
+	if spec.Name != "" {
+		trimmed, ok := ValidName(spec.Name)
+		if !ok {
+			return nil, ErrInvalidName
+		}
+		spec.Name = trimmed
 	}
 
 	c.mu.Lock()
@@ -284,6 +303,20 @@ func (c *Client) DropDatabase(name string) error {
 
 // CreateRetentionPolicy creates a retention policy on the specified database.
 func (c *Client) CreateRetentionPolicy(database string, spec *RetentionPolicySpec, makeDefault bool) (*RetentionPolicyInfo, error) {
+	database, ok := ValidName(database)
+	if !ok {
+		return nil, ErrInvalidName
+	}
+	// An empty spec name defaults to DefaultRetentionPolicyName downstream, so
+	// only validate it when the caller supplied one.
+	if spec.Name != "" {
+		trimmed, ok := ValidName(spec.Name)
+		if !ok {
+			return nil, ErrInvalidName
+		}
+		spec.Name = trimmed
+	}
+
 	c.mu.Lock()
 	defer c.mu.Unlock()
 

--- a/services/meta/client_validname_test.go
+++ b/services/meta/client_validname_test.go
@@ -1,0 +1,173 @@
+package meta_test
+
+import (
+	"fmt"
+	"os"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/influxdata/influxdb/services/meta"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// hourSpec returns a minimal, valid retention policy spec with the given name.
+func hourSpec(name string) *meta.RetentionPolicySpec {
+	dur := time.Hour
+	replicaN := 1
+	return &meta.RetentionPolicySpec{
+		Name:     name,
+		Duration: &dur,
+		ReplicaN: &replicaN,
+	}
+}
+
+func TestMetaClient_CreateDatabase_RejectsInvalidName(t *testing.T) {
+	t.Parallel()
+
+	d, c := newClient()
+	defer os.RemoveAll(d)
+	defer c.Close()
+
+	for _, name := range []string{"", "   ", "bad/name", `bad\name`, ".", ".."} {
+		_, err := c.CreateDatabase(name)
+		require.ErrorIsf(t, err, meta.ErrInvalidName, "CreateDatabase(%q)", name)
+	}
+	require.Empty(t, c.Databases(), "no database should have been created")
+}
+
+func TestMetaClient_CreateDatabase_TrimsWhitespace(t *testing.T) {
+	t.Parallel()
+
+	d, c := newClient()
+	defer os.RemoveAll(d)
+	defer c.Close()
+
+	db, err := c.CreateDatabase("  db0  ")
+	require.NoError(t, err)
+	require.NotNil(t, db)
+	assert.Equal(t, "db0", db.Name, "stored name should be trimmed")
+
+	// The trimmed name is what is stored and matched; lookups do not trim.
+	assert.NotNil(t, c.Database("db0"))
+	assert.Nil(t, c.Database("  db0  "))
+
+	// Re-creating with a differently-padded form resolves to the same database.
+	db2, err := c.CreateDatabase(" db0 ")
+	require.NoError(t, err)
+	assert.Equal(t, "db0", db2.Name)
+	require.Len(t, c.Databases(), 1, "padded name must not create a duplicate")
+}
+
+func TestMetaClient_CreateDatabaseWithRetentionPolicy_TrimsAndValidates(t *testing.T) {
+	t.Parallel()
+
+	d, c := newClient()
+	defer os.RemoveAll(d)
+	defer c.Close()
+
+	db, err := c.CreateDatabaseWithRetentionPolicy("  db0  ", hourSpec("  rp0  "))
+	require.NoError(t, err)
+	require.NotNil(t, db)
+	assert.Equal(t, "db0", db.Name, "database name should be trimmed")
+	assert.Equal(t, "rp0", db.DefaultRetentionPolicy, "retention policy name should be trimmed")
+
+	// Invalid database name is rejected and creates nothing new.
+	_, err = c.CreateDatabaseWithRetentionPolicy("bad/db", hourSpec("rp0"))
+	require.ErrorIs(t, err, meta.ErrInvalidName)
+
+	// Invalid retention policy name is rejected before the database is created.
+	_, err = c.CreateDatabaseWithRetentionPolicy("dbx", hourSpec("bad/rp"))
+	require.ErrorIs(t, err, meta.ErrInvalidName)
+	assert.Nil(t, c.Database("dbx"), "database must not be created when the RP name is invalid")
+}
+
+func TestMetaClient_CreateRetentionPolicy_TrimsAndValidates(t *testing.T) {
+	t.Parallel()
+
+	d, c := newClient()
+	defer os.RemoveAll(d)
+	defer c.Close()
+
+	_, err := c.CreateDatabase("db0")
+	require.NoError(t, err)
+
+	// The RP name is trimmed and stored trimmed.
+	rpi, err := c.CreateRetentionPolicy("db0", hourSpec("  rp0  "), false)
+	require.NoError(t, err)
+	require.NotNil(t, rpi)
+	assert.Equal(t, "rp0", rpi.Name)
+
+	got, err := c.RetentionPolicy("db0", "rp0")
+	require.NoError(t, err)
+	require.NotNil(t, got)
+
+	// The database argument is also trimmed, so a padded reference resolves.
+	rpi, err = c.CreateRetentionPolicy("  db0  ", hourSpec("rp1"), false)
+	require.NoError(t, err)
+	assert.Equal(t, "rp1", rpi.Name)
+
+	// Invalid RP name is rejected.
+	_, err = c.CreateRetentionPolicy("db0", hourSpec("bad/rp"), false)
+	require.ErrorIs(t, err, meta.ErrInvalidName)
+
+	// Invalid database name is rejected.
+	_, err = c.CreateRetentionPolicy("bad/db", hourSpec("rp2"), false)
+	require.ErrorIs(t, err, meta.ErrInvalidName)
+}
+
+// TestMetaClient_ConcurrentCreate hammers the create methods concurrently to
+// stress the client's mutex for deadlocks and races (run with -race). All
+// goroutines start together via an RWMutex so they contend maximally.
+func TestMetaClient_ConcurrentCreate(t *testing.T) {
+	t.Parallel()
+
+	d, c := newClient()
+	defer os.RemoveAll(d)
+	defer c.Close()
+
+	const numItems = 64
+
+	// Build the padded names upfront so trimming is also exercised under contention.
+	names := make([]string, numItems)
+	for i := range numItems {
+		names[i] = fmt.Sprintf("  db%03d  ", i)
+	}
+
+	var mu sync.RWMutex
+	var concurrency, maxConcurrency atomic.Int64
+
+	var wg sync.WaitGroup
+	mu.Lock()
+	for i := range numItems {
+		wg.Add(1)
+		go func(idx int) {
+			mu.RLock()
+			defer mu.RUnlock()
+			defer wg.Done()
+
+			cur := concurrency.Add(1)
+			if old := maxConcurrency.Load(); cur > old {
+				maxConcurrency.CompareAndSwap(old, cur)
+			}
+
+			if _, err := c.CreateDatabase(names[idx]); err != nil {
+				t.Errorf("CreateDatabase(%q): %v", names[idx], err)
+			}
+
+			concurrency.Add(-1)
+		}(i)
+	}
+	mu.Unlock() // release all goroutines simultaneously
+	wg.Wait()
+	t.Logf("max concurrency: %d", maxConcurrency.Load())
+
+	// Every database must exist exactly once, stored under its trimmed name.
+	for i := range numItems {
+		name := fmt.Sprintf("db%03d", i)
+		assert.NotNilf(t, c.Database(name), "database %q missing", name)
+	}
+	assert.Len(t, c.Databases(), numItems, "expected exactly %d databases", numItems)
+}

--- a/services/meta/data.go
+++ b/services/meta/data.go
@@ -1863,15 +1863,19 @@ func UnmarshalTime(v int64) time.Time {
 	return time.Unix(0, v).UTC()
 }
 
-// ValidName checks to see if the given name can would be valid for DB/RP name
-func ValidName(name string) bool {
+// ValidName trims leading and trailing whitespace from name and reports whether
+// the trimmed result would be a valid DB/RP name. Callers must use the returned
+// (trimmed) name for existence checks and persistence so that, for example,
+// " foo " and "foo" refer to the same database or retention policy.
+func ValidName(name string) (string, bool) {
+	name = strings.TrimSpace(name)
 	for _, r := range name {
 		if !unicode.IsPrint(r) {
-			return false
+			return name, false
 		}
 	}
 
-	return name != "" &&
+	return name, name != "" &&
 		name != "." &&
 		name != ".." &&
 		!strings.ContainsAny(name, `/\`)

--- a/services/meta/validname_test.go
+++ b/services/meta/validname_test.go
@@ -1,0 +1,41 @@
+package meta_test
+
+import (
+	"testing"
+
+	"github.com/influxdata/influxdb/services/meta"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidName(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		input  string
+		want   string
+		wantOK bool
+	}{
+		{name: "simple", input: "foo", want: "foo", wantOK: true},
+		{name: "trims surrounding spaces", input: "  foo  ", want: "foo", wantOK: true},
+		{name: "trims tabs and newlines", input: "\t foo \n", want: "foo", wantOK: true},
+		{name: "inner space preserved", input: " foo bar ", want: "foo bar", wantOK: true},
+		{name: "unicode is valid", input: "  méäsûré  ", want: "méäsûré", wantOK: true},
+		{name: "empty is invalid", input: "", want: "", wantOK: false},
+		{name: "all whitespace trims to empty and is invalid", input: "   ", want: "", wantOK: false},
+		{name: "dot is invalid", input: ".", want: ".", wantOK: false},
+		{name: "dot dot is invalid", input: "..", want: "..", wantOK: false},
+		{name: "trims to dot and is invalid", input: "  .  ", want: ".", wantOK: false},
+		{name: "forward slash is invalid", input: "foo/bar", want: "foo/bar", wantOK: false},
+		{name: "back slash is invalid", input: `foo\bar`, want: `foo\bar`, wantOK: false},
+		{name: "non-printable is invalid", input: "foo\x00bar", want: "foo\x00bar", wantOK: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := meta.ValidName(tt.input)
+			assert.Equal(t, tt.wantOK, ok, "validity mismatch for %q", tt.input)
+			assert.Equal(t, tt.want, got, "trimmed name mismatch for %q", tt.input)
+		})
+	}
+}


### PR DESCRIPTION
Trim leading and trailing whitespace on DB and RP names before comparison or creation.  " foo  " will become "foo" Upgrading to this functionality should only be done to instances without such existing DB & RP names

Closes https://github.com/influxdata/feature-requests/issues/219
