### PR TITLE
feat: add max-time-range limit for SELECT queries

### DIFF
--- a/cmd/influxd/run/server.go
+++ b/cmd/influxd/run/server.go
@@ -248,6 +248,7 @@ func NewServer(c *Config, buildInfo *BuildInfo) (*Server, error) {
 		MaxSelectPointN:     c.Coordinator.MaxSelectPointN,
 		MaxSelectSeriesN:    c.Coordinator.MaxSelectSeriesN,
 		MaxSelectBucketsN:   c.Coordinator.MaxSelectBucketsN,
+		MaxTimeRange:        time.Duration(c.Coordinator.MaxTimeRange),
 	}
 	s.QueryExecutor.TaskManager.QueryTimeout = time.Duration(c.Coordinator.QueryTimeout)
 	s.QueryExecutor.TaskManager.LogQueriesAfter = time.Duration(c.Coordinator.LogQueriesAfter)

--- a/coordinator/config.go
+++ b/coordinator/config.go
@@ -37,6 +37,7 @@ type Config struct {
 	MaxSelectPointN      int           `toml:"max-select-point"`
 	MaxSelectSeriesN     int           `toml:"max-select-series"`
 	MaxSelectBucketsN    int           `toml:"max-select-buckets"`
+	MaxTimeRange         toml.Duration `toml:"max-time-range"`
 	TerminationQueryLog  bool          `toml:"termination-query-log"`
 }
 
@@ -64,5 +65,6 @@ func (c Config) Diagnostics() (*diagnostics.Diagnostics, error) {
 		"max-select-point":       c.MaxSelectPointN,
 		"max-select-series":      c.MaxSelectSeriesN,
 		"max-select-buckets":     c.MaxSelectBucketsN,
+		"max-time-range":         c.MaxTimeRange,
 	}), nil
 }

--- a/coordinator/config_test.go
+++ b/coordinator/config_test.go
@@ -6,19 +6,19 @@ import (
 
 	"github.com/BurntSushi/toml"
 	"github.com/influxdata/influxdb/coordinator"
+	"github.com/stretchr/testify/require"
 )
 
 func TestConfig_Parse(t *testing.T) {
 	// Parse configuration.
 	var c coordinator.Config
-	if _, err := toml.Decode(`
+	_, err := toml.Decode(`
 write-timeout = "20s"
-`, &c); err != nil {
-		t.Fatal(err)
-	}
+max-time-range = "72h"
+`, &c)
+	require.NoError(t, err)
 
 	// Validate configuration.
-	if time.Duration(c.WriteTimeout) != 20*time.Second {
-		t.Fatalf("unexpected write timeout s: %s", c.WriteTimeout)
-	}
+	require.Equal(t, 20*time.Second, time.Duration(c.WriteTimeout))
+	require.Equal(t, 72*time.Hour, time.Duration(c.MaxTimeRange))
 }

--- a/coordinator/statement_executor.go
+++ b/coordinator/statement_executor.go
@@ -58,6 +58,7 @@ type StatementExecutor struct {
 	MaxSelectPointN   int
 	MaxSelectSeriesN  int
 	MaxSelectBucketsN int
+	MaxTimeRange      time.Duration
 }
 
 // ExecuteStatement executes the given statement with the given execution context.
@@ -419,10 +420,11 @@ func (e *StatementExecutor) executeDropUserStatement(q *influxql.DropUserStateme
 
 func (e *StatementExecutor) executeExplainStatement(ctx *query.ExecutionContext, q *influxql.ExplainStatement) (models.Rows, error) {
 	opt := query.SelectOptions{
-		NodeID:      ctx.ExecutionOptions.NodeID,
-		MaxSeriesN:  e.MaxSelectSeriesN,
-		MaxBucketsN: e.MaxSelectBucketsN,
-		Authorizer:  ctx.Authorizer,
+		NodeID:       ctx.ExecutionOptions.NodeID,
+		MaxSeriesN:   e.MaxSelectSeriesN,
+		MaxBucketsN:  e.MaxSelectBucketsN,
+		MaxTimeRange: e.MaxTimeRange,
+		Authorizer:   ctx.Authorizer,
 	}
 
 	// Prepare the query for execution, but do not actually execute it.
@@ -636,11 +638,12 @@ func (e *StatementExecutor) executeSelectStatement(ctx *query.ExecutionContext, 
 
 func (e *StatementExecutor) createIterators(ctx context.Context, stmt *influxql.SelectStatement, opt query.ExecutionOptions) (query.Cursor, error) {
 	sopt := query.SelectOptions{
-		NodeID:      opt.NodeID,
-		MaxSeriesN:  e.MaxSelectSeriesN,
-		MaxPointN:   e.MaxSelectPointN,
-		MaxBucketsN: e.MaxSelectBucketsN,
-		Authorizer:  opt.Authorizer,
+		NodeID:       opt.NodeID,
+		MaxSeriesN:   e.MaxSelectSeriesN,
+		MaxPointN:    e.MaxSelectPointN,
+		MaxBucketsN:  e.MaxSelectBucketsN,
+		MaxTimeRange: e.MaxTimeRange,
+		Authorizer:   opt.Authorizer,
 	}
 
 	// Create a set of iterators from a selection.

--- a/etc/config.sample.toml
+++ b/etc/config.sample.toml
@@ -257,6 +257,12 @@
   # number of buckets unlimited.
   # max-select-buckets = 0
 
+  # The maximum time range a single SELECT statement may cover.  A query whose time range exceeds this
+  # limit returns an error.  A query with no upper time bound is measured up to now(); a query with no
+  # lower time bound is treated as covering all time and will exceed any non-zero limit.  This can help
+  # prevent queries that scan an excessive time span.  A value of 0 disables the limit.
+  # max-time-range = "0s"
+
   # Whether to print a list of running queries when a data node receives a SIGTERM (sent when a process
   # exceeds a container memory limit, or by the kill command.
   # termination-query-log = false

--- a/query/compile.go
+++ b/query/compile.go
@@ -31,6 +31,13 @@ type compiledStatement struct {
 	// TimeRange is the TimeRange for selecting data.
 	TimeRange influxql.TimeRange
 
+	// OpenUpperBound is true when the statement had no explicit upper time
+	// bound. During preprocessing the upper bound is resolved to now() for
+	// aggregate queries or to the maximum representable time for raw queries;
+	// this flag records that the bound was originally open so that range limits
+	// can measure it up to now() without depending on that resolved value.
+	OpenUpperBound bool
+
 	// Interval holds the time grouping interval.
 	Interval Interval
 
@@ -169,6 +176,7 @@ func (c *compiledStatement) preprocess(stmt *influxql.SelectStatement) error {
 		c.TimeRange.Min = time.Unix(0, influxql.MinTime).UTC()
 	}
 	if c.TimeRange.Max.IsZero() {
+		c.OpenUpperBound = true
 		// If the interval is non-zero, then we have an aggregate query and
 		// need to limit the maximum time to now() for backwards compatibility
 		// and usability.
@@ -1147,6 +1155,25 @@ func (c *compiledStatement) Prepare(shardMapper ShardMapper, sopt SelectOptions)
 			} else {
 				timeRange.Min = time.Unix(0, last-int64(interval)*int64(sopt.MaxBucketsN-1))
 			}
+		}
+	}
+
+	// Enforce the maximum time range a query may span, if configured. The range
+	// is measured against the shard-mapping time range so that an aggregate
+	// query whose open lower bound has already been constrained by the bucket
+	// limit above is measured by its effective window rather than by all of
+	// time. An open upper bound (no explicit end time) is measured up to now(),
+	// matching how aggregate queries default their max time; the query still
+	// scans any data beyond now(). A query with no lower bound that the bucket
+	// limit did not constrain spans the full possible range and is therefore
+	// rejected when this limit is set.
+	if sopt.MaxTimeRange > 0 {
+		maxT := timeRange.MaxTime()
+		if c.OpenUpperBound {
+			maxT = c.Options.Now
+		}
+		if d := maxT.Sub(timeRange.MinTime()); d > sopt.MaxTimeRange {
+			return nil, fmt.Errorf("max-time-range limit exceeded: (%s/%s)", d, sopt.MaxTimeRange)
 		}
 	}
 

--- a/query/compile_test.go
+++ b/query/compile_test.go
@@ -2,9 +2,11 @@ package query_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/influxdata/influxdb/query"
 	"github.com/influxdata/influxql"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCompile_Success(t *testing.T) {
@@ -433,6 +435,128 @@ func TestPrepare_MapShardsTimeRange(t *testing.T) {
 
 			if _, err := c.Prepare(&shardMapper, query.SelectOptions{}); err != nil {
 				t.Fatalf("unexpected error: %s", err)
+			}
+		})
+	}
+}
+
+func TestPrepare_MaxTimeRange(t *testing.T) {
+	// Fixed reference time so that now()-relative queries are deterministic.
+	now := mustParseTime("2018-09-03T16:00:00Z")
+
+	for _, tt := range []struct {
+		name         string
+		s            string
+		maxTimeRange time.Duration
+		maxBucketsN  int
+		wantErr      bool
+	}{
+		{
+			name:         "explicit range wider than limit",
+			s:            `SELECT value FROM cpu WHERE time >= '2018-09-03T00:00:00Z' AND time <= '2018-09-05T00:00:00Z'`,
+			maxTimeRange: 24 * time.Hour,
+			wantErr:      true,
+		},
+		{
+			name:         "explicit range within limit",
+			s:            `SELECT value FROM cpu WHERE time >= '2018-09-03T00:00:00Z' AND time <= '2018-09-05T00:00:00Z'`,
+			maxTimeRange: 72 * time.Hour,
+			wantErr:      false,
+		},
+		{
+			// An inverted range (min after max) yields a negative span, which
+			// can never exceed a positive limit, so the check is a no-op. The
+			// query matches no data downstream regardless.
+			name:         "inverted range is not rejected",
+			s:            `SELECT value FROM cpu WHERE time >= '2018-09-05T00:00:00Z' AND time <= '2018-09-03T00:00:00Z'`,
+			maxTimeRange: 24 * time.Hour,
+			wantErr:      false,
+		},
+		{
+			name:         "limit disabled ignores wide range",
+			s:            `SELECT value FROM cpu`,
+			maxTimeRange: 0,
+			wantErr:      false,
+		},
+		{
+			name:         "open upper bound measured up to now",
+			s:            `SELECT value FROM cpu WHERE time > now() - 5m`,
+			maxTimeRange: time.Hour,
+			wantErr:      false,
+		},
+		{
+			name:         "explicit future upper bound is not capped",
+			s:            `SELECT value FROM cpu WHERE time > now() - 5m AND time < now() + 2h`,
+			maxTimeRange: time.Hour,
+			wantErr:      true,
+		},
+		{
+			name:         "unbounded query is rejected",
+			s:            `SELECT value FROM cpu`,
+			maxTimeRange: 24 * time.Hour,
+			wantErr:      true,
+		},
+		{
+			// Aggregate queries resolve an open upper bound to now() rather than
+			// to the maximum representable time, so exercise that path too.
+			name:         "aggregate explicit range wider than limit",
+			s:            `SELECT mean(value) FROM cpu WHERE time >= '2018-09-03T00:00:00Z' AND time <= '2018-09-05T00:00:00Z' GROUP BY time(10m)`,
+			maxTimeRange: 24 * time.Hour,
+			wantErr:      true,
+		},
+		{
+			name:         "aggregate explicit range within limit",
+			s:            `SELECT mean(value) FROM cpu WHERE time >= '2018-09-03T00:00:00Z' AND time <= '2018-09-05T00:00:00Z' GROUP BY time(10m)`,
+			maxTimeRange: 72 * time.Hour,
+			wantErr:      false,
+		},
+		{
+			name:         "aggregate open upper bound measured up to now",
+			s:            `SELECT mean(value) FROM cpu WHERE time > now() - 5m GROUP BY time(1m)`,
+			maxTimeRange: time.Hour,
+			wantErr:      false,
+		},
+		{
+			// With no lower bound but a bucket limit, the shard time range is
+			// constrained to a finite window, so the query stays within a small
+			// limit rather than being measured as spanning all of time.
+			name:         "aggregate no lower bound constrained by bucket limit",
+			s:            `SELECT mean(value) FROM cpu GROUP BY time(1m)`,
+			maxTimeRange: time.Hour,
+			maxBucketsN:  10,
+			wantErr:      false,
+		},
+		{
+			// Without a bucket limit to constrain the open lower bound, the same
+			// query spans all of time and is rejected.
+			name:         "aggregate no lower bound without bucket limit is rejected",
+			s:            `SELECT mean(value) FROM cpu GROUP BY time(1m)`,
+			maxTimeRange: time.Hour,
+			wantErr:      true,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			stmt, err := influxql.ParseStatement(tt.s)
+			require.NoError(t, err)
+			s := stmt.(*influxql.SelectStatement)
+
+			c, err := query.Compile(s, query.CompileOptions{Now: now})
+			require.NoError(t, err)
+
+			shardMapper := ShardMapper{
+				MapShardsFn: func(_ influxql.Sources, _ influxql.TimeRange) query.ShardGroup {
+					return &ShardGroup{
+						Fields: map[string]influxql.DataType{"value": influxql.Float},
+					}
+				},
+			}
+
+			_, err = c.Prepare(&shardMapper, query.SelectOptions{MaxTimeRange: tt.maxTimeRange, MaxBucketsN: tt.maxBucketsN})
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "max-time-range limit exceeded")
+			} else {
+				require.NoError(t, err)
 			}
 		})
 	}

--- a/query/select.go
+++ b/query/select.go
@@ -39,6 +39,9 @@ type SelectOptions struct {
 
 	// Maximum number of buckets for a statement.
 	MaxBucketsN int
+
+	// Maximum time range a statement may cover. Zero disables the limit.
+	MaxTimeRange time.Duration
 }
 
 // ShardMapper retrieves and maps shards into an IteratorCreator that can later be


### PR DESCRIPTION
Add a max-time-range coordinator config option that rejects a SELECT whose time range spans more than the configured duration. A value of 0 disables the limit, so behavior is unchanged by default.

Closes https://github.com/influxdata/feature-requests/issues/142
