### PR TITLE
fix(influxdb3_wal): skip empty WalPeriods during replay to avoid panic

### DIFF
--- a/influxdb3_wal/src/object_store.rs
+++ b/influxdb3_wal/src/object_store.rs
@@ -221,14 +221,11 @@ impl WalObjectStore {
 
                 // add this to the snapshot tracker, so we know what to clear out later if the replay
                 // was a wal file that had a snapshot
-                self.flush_buffer
-                    .lock()
-                    .await
-                    .replay_wal_period(WalPeriod::new(
-                        wal_contents.wal_file_number,
-                        Timestamp::new(wal_contents.min_timestamp_ns),
-                        Timestamp::new(wal_contents.max_timestamp_ns),
-                    ));
+                self.flush_buffer.lock().await.replay_wal_period(
+                    wal_contents.wal_file_number,
+                    wal_contents.min_timestamp_ns,
+                    wal_contents.max_timestamp_ns,
+                );
 
                 match wal_contents.snapshot {
                     // This branch uses so much time
@@ -704,9 +701,29 @@ impl FlushBuffer {
         }
     }
 
-    fn replay_wal_period(&mut self, wal_period: WalPeriod) {
-        self.wal_buffer.wal_file_sequence_number = wal_period.wal_file_number.next();
-        self.snapshot_tracker.add_wal_period(wal_period);
+    fn replay_wal_period(
+        &mut self,
+        wal_file_number: WalFileSequenceNumber,
+        min_timestamp_ns: i64,
+        max_timestamp_ns: i64,
+    ) {
+        self.wal_buffer.wal_file_sequence_number = wal_file_number.next();
+
+        // Old, pre-existing WAL files written before empty WriteBatches were skipped can have
+        // min/max timestamps still at their i64::MAX/i64::MIN fold sentinels when the batch was
+        // empty. Constructing a WalPeriod from those would violate WalPeriod::new's
+        // `min_time <= max_time` invariant and panic, so just skip registering a period for it -
+        // there's no data in it for the snapshot tracker to track anyway.
+        if min_timestamp_ns == i64::MAX && max_timestamp_ns == i64::MIN {
+            warn!(%wal_file_number, "skipping empty WAL period during replay");
+            return;
+        }
+
+        self.snapshot_tracker.add_wal_period(WalPeriod::new(
+            wal_file_number,
+            Timestamp::new(min_timestamp_ns),
+            Timestamp::new(max_timestamp_ns),
+        ));
     }
 
     /// Converts the wal_buffer into contents and resets it. Returns the channels waiting for

--- a/influxdb3_wal/src/object_store/tests.rs
+++ b/influxdb3_wal/src/object_store/tests.rs
@@ -872,6 +872,45 @@ async fn test_wal_file_removal_after_snapshot_worked_out_example() {
     }
 }
 
+#[test_log::test(tokio::test)]
+async fn test_replay_wal_period_skips_empty_sentinel_values() {
+    // Regression test for old, pre-existing WAL files (written before empty WriteBatches
+    // were skipped) that contain an empty batch: min/max timestamps are left at the fold
+    // sentinels (i64::MAX / i64::MIN). Replaying such a file used to panic inside
+    // WalPeriod::new's `assert!(min_time <= max_time)`.
+    let time_provider = Arc::new(MockProvider::new(Time::from_timestamp_nanos(0)));
+    let clone = Arc::clone(&time_provider) as _;
+    let snapshot_tracker = SnapshotTracker::new(1, Gen1Duration::new_1m(), None);
+
+    let mut flush_buffer = FlushBuffer::new(
+        clone,
+        WalBuffer {
+            time_provider: Arc::clone(&time_provider) as _,
+            state: WalBufferState::AcceptingWrites,
+            wal_file_sequence_number: WalFileSequenceNumber(0),
+            op_limit: 10,
+            op_count: 0,
+            database_to_write_batch: Default::default(),
+            write_op_responses: vec![],
+            no_op: None,
+        },
+        snapshot_tracker,
+    );
+
+    // should not panic, and should not register a wal period for the empty file
+    flush_buffer.replay_wal_period(WalFileSequenceNumber::new(1), i64::MAX, i64::MIN);
+    assert_eq!(0, flush_buffer.snapshot_tracker.num_wal_periods());
+    // the wal buffer's sequence number should still advance past the replayed file
+    assert_eq!(
+        WalFileSequenceNumber::new(2),
+        flush_buffer.wal_buffer.wal_file_sequence_number
+    );
+
+    // a normal, non-empty period should still be tracked as usual
+    flush_buffer.replay_wal_period(WalFileSequenceNumber::new(2), 1, 10);
+    assert_eq!(1, flush_buffer.snapshot_tracker.num_wal_periods());
+}
+
 #[derive(Debug, Default)]
 struct TestNotifier {
     notified_writes: parking_lot::Mutex<Vec<Arc<WalContents>>>,


### PR DESCRIPTION
Fixes #26237

## Problem

Old WAL files written before an empty `WriteBatch` was skipped can have their min/max timestamps left at the fold sentinels (`i64::MAX`/`i64::MIN`). `WalPeriod::new()` asserts `min_time <= max_time`, so replaying one of these pre-existing files on startup panics and crashes the server, with no way to get past it short of manually editing/deleting object-store keys.

## Root cause

`WalObjectStore::replay()` calls `FlushBuffer::replay_wal_period`, which built a `WalPeriod::new(...)` unconditionally from each replayed file's min/max timestamps. An empty batch leaves those fields at the sentinel values, tripping the assert. The live flush path (`flush_buffer_into_contents_and_responses`) doesn't hit this because it inserts a no-op before building an empty period via a plain struct literal — so this only affects replay of old, pre-existing files.

## Fix

`replay_wal_period` now takes the raw `(wal_file_number, min_timestamp_ns, max_timestamp_ns)` instead of a pre-built `WalPeriod`, so the guard lives in the one shared function every caller routes through. It still always advances `wal_buffer.wal_file_sequence_number`, but skips constructing/registering a `WalPeriod` when the sentinel case is detected, logging a `warn!` instead. All other replay side effects (`file_notifier.notify`, snapshot cleanup) are unchanged.

## Tests

Added `test_replay_wal_period_skips_empty_sentinel_values` in `influxdb3_wal/src/object_store/tests.rs`, asserting no panic on the sentinel case, that `snapshot_tracker.num_wal_periods()` stays at 0 for it, and that the wal file sequence number still advances; also checks a normal period is still tracked as before.

```
cargo check -p influxdb3_wal              # Finished, no errors
cargo test -p influxdb3_wal --lib object_store   # 7 passed
cargo test -p influxdb3_wal                # 17 passed, 0 failed
```