### PR TITLE
opentsdb: wait for handleConn on Close to fix shutdown race and leak

### DIFF
--- a/services/opentsdb/service.go
+++ b/services/opentsdb/service.go
@@ -197,7 +197,7 @@ func (s *Service) Open() error {
 
 // Close closes the openTSDB service.
 func (s *Service) Close() error {
-	if wait, err := func() (bool, error) {
+	wait, err := func() (bool, error) {
 		s.mu.Lock()
 		defer s.mu.Unlock()
 
@@ -206,29 +206,30 @@ func (s *Service) Close() error {
 		}
 		close(s.done)
 
-		// Close the listeners.
+		// Close the listeners and TLS manager, but keep going on error: s.done
+		// is closed, so the goroutines must still be awaited before Close returns.
+		var errs []error
 		if err := s.ln.Close(); err != nil {
-			return false, err
+			errs = append(errs, err)
 		}
 		if err := s.httpln.Close(); err != nil {
-			return false, err
+			errs = append(errs, err)
 		}
 		if s.tlsManager != nil {
 			tm := s.tlsManager
 			s.tlsManager = nil
 			if err := tm.Close(); err != nil {
-				return false, err
+				errs = append(errs, err)
 			}
 		}
 
 		if s.batcher != nil {
 			s.batcher.Stop()
 		}
-		return true, nil
-	}(); err != nil {
+		return true, errors.Join(errs...)
+	}()
+	if !wait {
 		return err
-	} else if !wait {
-		return nil
 	}
 	s.wg.Wait()
 
@@ -236,7 +237,7 @@ func (s *Service) Close() error {
 	s.done = nil
 	s.mu.Unlock()
 
-	return nil
+	return err
 }
 
 // PrepareReloadTLSCertificates verifies that the configured TLS certificate can be reloaded.
@@ -369,13 +370,17 @@ func (s *Service) serve() {
 			continue
 		}
 
-		// Handle connection in separate goroutine.
+		// Handle connection in separate goroutine. Track it so Close waits for
+		// in-flight connections instead of returning and mutating Service fields
+		// while handleConn is still reading them.
+		s.wg.Add(1)
 		go s.handleConn(conn)
 	}
 }
 
 // handleConn processes conn. This is run in a separate goroutine.
 func (s *Service) handleConn(conn net.Conn) {
+	defer s.wg.Done()
 	defer atomic.AddInt64(&s.stats.ActiveConnections, -1)
 	atomic.AddInt64(&s.stats.ActiveConnections, 1)
 	atomic.AddInt64(&s.stats.HandledConnections, 1)
@@ -394,14 +399,19 @@ func (s *Service) handleConn(conn net.Conn) {
 	// If no HTTP parsing error occurred then process as HTTP.
 	if err == nil {
 		atomic.AddInt64(&s.stats.HTTPConnectionsHandled, 1)
-		s.httpln.ch <- conn
+		// chanListener.Close closes done without draining ch, so an unguarded
+		// send would park forever on shutdown (leaking this goroutine and its
+		// socket, and deadlocking Close's Wait). Drop the connection instead.
+		select {
+		case s.httpln.ch <- conn:
+		case <-s.httpln.done:
+			conn.Close()
+		}
 		return
 	}
 
 	// Otherwise handle in telnet format.
-	s.wg.Add(1)
 	s.handleTelnetConn(conn)
-	s.wg.Done()
 }
 
 // handleTelnetConn accepts OpenTSDB's telnet protocol.

--- a/services/opentsdb/service_test.go
+++ b/services/opentsdb/service_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"reflect"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -258,6 +259,56 @@ func TestService_HTTP(t *testing.T) {
 	if !called {
 		t.Fatal("points writer not called")
 	}
+}
+
+// TestService_CloseWithConnectionsInFlight ensures Close waits for in-flight
+// handleConn goroutines and does not deadlock when a connection reaches the HTTP
+// handoff during shutdown. Under -race it also guards the shutdown data race
+// between handleConn and Close mutating Service fields.
+func TestService_CloseWithConnectionsInFlight(t *testing.T) {
+	t.Parallel()
+
+	s := NewTestService(t, "db0", "127.0.0.1:0")
+	require.NoError(t, s.Service.Open())
+	s.WritePointsFn = func(tsdb.WriteContext, string, string, models.ConsistencyLevel, []models.Point) error {
+		return nil
+	}
+	addr := s.Service.Addr().String()
+
+	stop := make(chan struct{})
+	var dialers sync.WaitGroup
+	for i := 0; i < 8; i++ {
+		dialers.Add(1)
+		go func() {
+			defer dialers.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+				}
+				conn, err := net.Dial("tcp", addr)
+				if err != nil {
+					return
+				}
+				_, _ = conn.Write([]byte("POST /api/put HTTP/1.1\r\nHost: x\r\nContent-Length: 2\r\n\r\n{}"))
+				_ = conn.Close()
+			}
+		}()
+	}
+	time.Sleep(20 * time.Millisecond) // let connections start flowing
+
+	done := make(chan error, 1)
+	go func() { done <- s.Service.Close() }()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(15 * time.Second):
+		t.Fatal("Close deadlocked with connections in flight")
+	}
+
+	close(stop)
+	dialers.Wait()
 }
 
 type TestService struct {


### PR DESCRIPTION
`Service.Close()` waits on `s.wg` and then mutates `Service` fields, but
`serve()` dispatched connections with a bare `go s.handleConn(conn)` that `s.wg`
never tracked. So `Close()` could return and write `s.done`/`s.tlsManager` while
a `handleConn` goroutine was still reading them, which surfaces as an
intermittent `-race` failure in CI. A connection accepted during shutdown also
parked forever on the unguarded `s.httpln.ch <- conn`, leaking the goroutine and
its socket.

- `serve()` now `s.wg.Add(1)` before `go s.handleConn`, and `handleConn` runs
  `defer s.wg.Done()`, so `Close()` waits for in-flight connections.
- The HTTP handoff selects on `s.httpln.done`, so a connection arriving during
  shutdown is dropped instead of parking (this is also why a bare `wg.Add` alone
  would deadlock `Close`).
- Removed the now-redundant `wg.Add(1)`/`Done()` around `handleTelnetConn` (an
  `Add` racing `Close`'s `Wait`), and `Close()` no longer returns early on a
  listener-close error, so the goroutines are always awaited.

Added `TestService_CloseWithConnectionsInFlight`, which under `-race` exercises
the shutdown race with connections in flight. `go build`, `go vet`, `gofmt`, and
`go test -race ./services/opentsdb/` pass.

Closes #27544