### PR TITLE
fix: release TSM cursor references once when a Flux query is cancelled

### DIFF
--- a/storage/flux/reader.go
+++ b/storage/flux/reader.go
@@ -49,10 +49,11 @@ func (err *GroupCursorError) Error() string {
 type storageTable interface {
 	flux.Table
 	Close()
-	Cancel()
-	// awaitAbandoned must be called before Close on any table the producer is
-	// giving up on, so that a consumer cannot still be inside advance().
-	awaitAbandoned(done <-chan struct{})
+	// abandon must be called instead of Close on any table the producer is
+	// giving up on, so that a consumer cannot still be inside advance() when
+	// the table's cursors are torn down. Close is only for tables whose
+	// consumer has already signalled completion via done.
+	abandon(done <-chan struct{})
 	Statistics() cursors.CursorStats
 }
 
@@ -230,15 +231,15 @@ READ:
 
 		if !table.Empty() {
 			if err := f(table); err != nil {
-				table.awaitAbandoned(done)
-				table.Close()
+				table.abandon(done)
 				table = nil
 				return err
 			}
 			select {
 			case <-done:
 			case <-fi.ctx.Done():
-				table.awaitAbandoned(done)
+				table.abandon(done)
+				table = nil
 				break READ
 			}
 		}
@@ -375,15 +376,15 @@ READ:
 		gc = nil
 
 		if err := f(table); err != nil {
-			table.awaitAbandoned(done)
-			table.Close()
+			table.abandon(done)
 			table = nil
 			return err
 		}
 		select {
 		case <-done:
 		case <-gi.ctx.Done():
-			table.awaitAbandoned(done)
+			table.abandon(done)
+			table = nil
 			break READ
 		}
 
@@ -838,15 +839,15 @@ READ:
 
 		if !table.Empty() {
 			if err := f(table); err != nil {
-				table.awaitAbandoned(done)
-				table.Close()
+				table.abandon(done)
 				table = nil
 				return err
 			}
 			select {
 			case <-done:
 			case <-wai.ctx.Done():
-				table.awaitAbandoned(done)
+				table.abandon(done)
+				table = nil
 				break READ
 			}
 		}

--- a/storage/flux/reader.go
+++ b/storage/flux/reader.go
@@ -50,6 +50,9 @@ type storageTable interface {
 	flux.Table
 	Close()
 	Cancel()
+	// awaitAbandoned must be called before Close on any table the producer is
+	// giving up on, so that a consumer cannot still be inside advance().
+	awaitAbandoned(done <-chan struct{})
 	Statistics() cursors.CursorStats
 }
 
@@ -227,6 +230,7 @@ READ:
 
 		if !table.Empty() {
 			if err := f(table); err != nil {
+				table.awaitAbandoned(done)
 				table.Close()
 				table = nil
 				return err
@@ -234,7 +238,7 @@ READ:
 			select {
 			case <-done:
 			case <-fi.ctx.Done():
-				table.Cancel()
+				table.awaitAbandoned(done)
 				break READ
 			}
 		}
@@ -371,6 +375,7 @@ READ:
 		gc = nil
 
 		if err := f(table); err != nil {
+			table.awaitAbandoned(done)
 			table.Close()
 			table = nil
 			return err
@@ -378,7 +383,7 @@ READ:
 		select {
 		case <-done:
 		case <-gi.ctx.Done():
-			table.Cancel()
+			table.awaitAbandoned(done)
 			break READ
 		}
 
@@ -833,6 +838,7 @@ READ:
 
 		if !table.Empty() {
 			if err := f(table); err != nil {
+				table.awaitAbandoned(done)
 				table.Close()
 				table = nil
 				return err
@@ -840,7 +846,7 @@ READ:
 			select {
 			case <-done:
 			case <-wai.ctx.Done():
-				table.Cancel()
+				table.awaitAbandoned(done)
 				break READ
 			}
 		}

--- a/storage/flux/reader.go
+++ b/storage/flux/reader.go
@@ -183,11 +183,18 @@ func (fi *filterIterator) handleRead(f func(flux.Table) error, rs storage.Result
 	var (
 		cur   cursors.Cursor
 		table storageTable
+		// tableDone is table's done channel, kept alongside it so the deferred
+		// cleanup can settle ownership. The defer sees a non-nil table only
+		// when a panic unwinds out of f(table) or the code around it - every
+		// ordinary exit abandons or closes and nils table first - and on that
+		// path a queued consumer may still be draining, so a bare Close would
+		// recreate the concurrent close the abandon protocol prevents.
+		tableDone chan struct{}
 	)
 
 	defer func() {
 		if table != nil {
-			table.Close()
+			table.abandon(tableDone)
 		}
 		if cur != nil {
 			cur.Close()
@@ -207,6 +214,7 @@ READ:
 		bnds := fi.spec.Bounds
 		key := defaultGroupKeyForSeries(rs.Tags(), bnds)
 		done := make(chan struct{})
+		tableDone = done
 		switch typedCur := cur.(type) {
 		case cursors.IntegerArrayCursor:
 			cols, defs := determineTableColsForSeries(rs.Tags(), flux.TInt)
@@ -316,11 +324,14 @@ func (gi *groupIterator) handleRead(f func(flux.Table) error, rs storage.GroupRe
 		gc    storage.GroupCursor
 		cur   cursors.Cursor
 		table storageTable
+		// tableDone pairs with table so the deferred cleanup can abandon on
+		// panic unwind; see the comment in filterIterator.handleRead.
+		tableDone chan struct{}
 	)
 
 	defer func() {
 		if table != nil {
-			table.Close()
+			table.abandon(tableDone)
 		}
 		if cur != nil {
 			cur.Close()
@@ -351,6 +362,7 @@ READ:
 		bnds := gi.spec.Bounds
 		key := groupKeyForGroup(gc.PartitionKeyVals(), &gi.spec, bnds)
 		done := make(chan struct{})
+		tableDone = done
 		switch typedCur := cur.(type) {
 		case cursors.IntegerArrayCursor:
 			cols, defs := determineTableColsForGroup(gc.Keys(), flux.TInt, gc.Aggregate(), key)
@@ -731,11 +743,14 @@ func (wai *windowAggregateIterator) handleRead(f func(flux.Table) error, rs stor
 	var (
 		cur   cursors.Cursor
 		table storageTable
+		// tableDone pairs with table so the deferred cleanup can abandon on
+		// panic unwind; see the comment in filterIterator.handleRead.
+		tableDone chan struct{}
 	)
 
 	defer func() {
 		if table != nil {
-			table.Close()
+			table.abandon(tableDone)
 		}
 		if cur != nil {
 			cur.Close()
@@ -755,6 +770,7 @@ READ:
 		bnds := wai.spec.Bounds
 		key := defaultGroupKeyForSeries(rs.Tags(), bnds)
 		done := make(chan struct{})
+		tableDone = done
 		hasTimeCol := timeColumn != ""
 		switch typedCur := cur.(type) {
 		case cursors.IntegerArrayCursor:

--- a/storage/flux/table.gen.go
+++ b/storage/flux/table.gen.go
@@ -66,6 +66,17 @@ func (t *floatTable) Close() {
 	t.mu.Unlock()
 }
 
+// abandon relinquishes a table the producer is giving up on before the
+// consumer has finished with it: it settles ownership with any in-flight
+// consumer, then closes the table. It is the only safe way to close such a
+// table; see (*table).awaitAbandoned for the ownership protocol. A table whose
+// consumer has already signalled completion via done is closed with Close
+// directly.
+func (t *floatTable) abandon(done <-chan struct{}) {
+	t.awaitAbandoned(done)
+	t.Close()
+}
+
 func (t *floatTable) Statistics() cursors.CursorStats {
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -703,6 +714,17 @@ func (t *floatGroupTable) Close() {
 	t.mu.Unlock()
 }
 
+// abandon relinquishes a table the producer is giving up on before the
+// consumer has finished with it: it settles ownership with any in-flight
+// consumer, then closes the table. It is the only safe way to close such a
+// table; see (*table).awaitAbandoned for the ownership protocol. A table whose
+// consumer has already signalled completion via done is closed with Close
+// directly.
+func (t *floatGroupTable) abandon(done <-chan struct{}) {
+	t.awaitAbandoned(done)
+	t.Close()
+}
+
 func (t *floatGroupTable) Do(f func(flux.ColReader) error) error {
 	return t.do(f, t.advance)
 }
@@ -1045,6 +1067,17 @@ func (t *integerTable) Close() {
 		t.cur = nil
 	}
 	t.mu.Unlock()
+}
+
+// abandon relinquishes a table the producer is giving up on before the
+// consumer has finished with it: it settles ownership with any in-flight
+// consumer, then closes the table. It is the only safe way to close such a
+// table; see (*table).awaitAbandoned for the ownership protocol. A table whose
+// consumer has already signalled completion via done is closed with Close
+// directly.
+func (t *integerTable) abandon(done <-chan struct{}) {
+	t.awaitAbandoned(done)
+	t.Close()
 }
 
 func (t *integerTable) Statistics() cursors.CursorStats {
@@ -1686,6 +1719,17 @@ func (t *integerGroupTable) Close() {
 	t.mu.Unlock()
 }
 
+// abandon relinquishes a table the producer is giving up on before the
+// consumer has finished with it: it settles ownership with any in-flight
+// consumer, then closes the table. It is the only safe way to close such a
+// table; see (*table).awaitAbandoned for the ownership protocol. A table whose
+// consumer has already signalled completion via done is closed with Close
+// directly.
+func (t *integerGroupTable) abandon(done <-chan struct{}) {
+	t.awaitAbandoned(done)
+	t.Close()
+}
+
 func (t *integerGroupTable) Do(f func(flux.ColReader) error) error {
 	return t.do(f, t.advance)
 }
@@ -2029,6 +2073,17 @@ func (t *unsignedTable) Close() {
 		t.cur = nil
 	}
 	t.mu.Unlock()
+}
+
+// abandon relinquishes a table the producer is giving up on before the
+// consumer has finished with it: it settles ownership with any in-flight
+// consumer, then closes the table. It is the only safe way to close such a
+// table; see (*table).awaitAbandoned for the ownership protocol. A table whose
+// consumer has already signalled completion via done is closed with Close
+// directly.
+func (t *unsignedTable) abandon(done <-chan struct{}) {
+	t.awaitAbandoned(done)
+	t.Close()
 }
 
 func (t *unsignedTable) Statistics() cursors.CursorStats {
@@ -2668,6 +2723,17 @@ func (t *unsignedGroupTable) Close() {
 	t.mu.Unlock()
 }
 
+// abandon relinquishes a table the producer is giving up on before the
+// consumer has finished with it: it settles ownership with any in-flight
+// consumer, then closes the table. It is the only safe way to close such a
+// table; see (*table).awaitAbandoned for the ownership protocol. A table whose
+// consumer has already signalled completion via done is closed with Close
+// directly.
+func (t *unsignedGroupTable) abandon(done <-chan struct{}) {
+	t.awaitAbandoned(done)
+	t.Close()
+}
+
 func (t *unsignedGroupTable) Do(f func(flux.ColReader) error) error {
 	return t.do(f, t.advance)
 }
@@ -3010,6 +3076,17 @@ func (t *stringTable) Close() {
 		t.cur = nil
 	}
 	t.mu.Unlock()
+}
+
+// abandon relinquishes a table the producer is giving up on before the
+// consumer has finished with it: it settles ownership with any in-flight
+// consumer, then closes the table. It is the only safe way to close such a
+// table; see (*table).awaitAbandoned for the ownership protocol. A table whose
+// consumer has already signalled completion via done is closed with Close
+// directly.
+func (t *stringTable) abandon(done <-chan struct{}) {
+	t.awaitAbandoned(done)
+	t.Close()
 }
 
 func (t *stringTable) Statistics() cursors.CursorStats {
@@ -3649,6 +3726,17 @@ func (t *stringGroupTable) Close() {
 	t.mu.Unlock()
 }
 
+// abandon relinquishes a table the producer is giving up on before the
+// consumer has finished with it: it settles ownership with any in-flight
+// consumer, then closes the table. It is the only safe way to close such a
+// table; see (*table).awaitAbandoned for the ownership protocol. A table whose
+// consumer has already signalled completion via done is closed with Close
+// directly.
+func (t *stringGroupTable) abandon(done <-chan struct{}) {
+	t.awaitAbandoned(done)
+	t.Close()
+}
+
 func (t *stringGroupTable) Do(f func(flux.ColReader) error) error {
 	return t.do(f, t.advance)
 }
@@ -3935,6 +4023,17 @@ func (t *booleanTable) Close() {
 		t.cur = nil
 	}
 	t.mu.Unlock()
+}
+
+// abandon relinquishes a table the producer is giving up on before the
+// consumer has finished with it: it settles ownership with any in-flight
+// consumer, then closes the table. It is the only safe way to close such a
+// table; see (*table).awaitAbandoned for the ownership protocol. A table whose
+// consumer has already signalled completion via done is closed with Close
+// directly.
+func (t *booleanTable) abandon(done <-chan struct{}) {
+	t.awaitAbandoned(done)
+	t.Close()
 }
 
 func (t *booleanTable) Statistics() cursors.CursorStats {
@@ -4572,6 +4671,17 @@ func (t *booleanGroupTable) Close() {
 		t.gc = nil
 	}
 	t.mu.Unlock()
+}
+
+// abandon relinquishes a table the producer is giving up on before the
+// consumer has finished with it: it settles ownership with any in-flight
+// consumer, then closes the table. It is the only safe way to close such a
+// table; see (*table).awaitAbandoned for the ownership protocol. A table whose
+// consumer has already signalled completion via done is closed with Close
+// directly.
+func (t *booleanGroupTable) abandon(done <-chan struct{}) {
+	t.awaitAbandoned(done)
+	t.Close()
 }
 
 func (t *booleanGroupTable) Do(f func(flux.ColReader) error) error {

--- a/storage/flux/table.gen.go.tmpl
+++ b/storage/flux/table.gen.go.tmpl
@@ -61,6 +61,17 @@ func (t *{{.name}}Table) Close() {
 	t.mu.Unlock()
 }
 
+// abandon relinquishes a table the producer is giving up on before the
+// consumer has finished with it: it settles ownership with any in-flight
+// consumer, then closes the table. It is the only safe way to close such a
+// table; see (*table).awaitAbandoned for the ownership protocol. A table whose
+// consumer has already signalled completion via done is closed with Close
+// directly.
+func (t *{{.name}}Table) abandon(done <-chan struct{}) {
+	t.awaitAbandoned(done)
+	t.Close()
+}
+
 func (t *{{.name}}Table) Statistics() cursors.CursorStats {
 	t.mu.Lock()
 	defer t.mu.Unlock()
@@ -698,6 +709,17 @@ func (t *{{.name}}GroupTable) Close() {
 		t.gc = nil
 	}
 	t.mu.Unlock()
+}
+
+// abandon relinquishes a table the producer is giving up on before the
+// consumer has finished with it: it settles ownership with any in-flight
+// consumer, then closes the table. It is the only safe way to close such a
+// table; see (*table).awaitAbandoned for the ownership protocol. A table whose
+// consumer has already signalled completion via done is closed with Close
+// directly.
+func (t *{{.name}}GroupTable) abandon(done <-chan struct{}) {
+	t.awaitAbandoned(done)
+	t.Close()
 }
 
 func (t *{{.name}}GroupTable) Do(f func(flux.ColReader) error) error {

--- a/storage/flux/table.go
+++ b/storage/flux/table.go
@@ -74,9 +74,11 @@ func (t *table) init(advance func() bool) {
 	t.empty = !advance() && t.err == nil
 }
 
-// awaitAbandoned makes it safe for the producer to close a table it is giving up
-// on, whether because the query context was cancelled or because the consumer
-// rejected the table.
+// awaitAbandoned is the ownership-settling half of abandon (table.gen.go): it
+// makes it safe for the producer to close a table it is giving up on, whether
+// because the query context was cancelled or because the consumer rejected the
+// table. Producers never call it directly - they call abandon, which pairs it
+// with Close.
 //
 // The producer cannot simply close. advance() runs on the consumer's goroutine
 // and touches the same cursor Close() tears down, so closing underneath it

--- a/storage/flux/table.go
+++ b/storage/flux/table.go
@@ -108,8 +108,10 @@ func (t *table) awaitAbandoned(done <-chan struct{}) {
 	}
 
 	// do() or Done() claimed it first, and both defer closeDone, so done is
-	// guaranteed to close. The wait is bounded by at most one advance() call,
-	// since do() checks isCancelled() before each iteration.
+	// guaranteed to close. The wait is bounded by at most one advance() call
+	// plus one f(colBufs) delivery of that buffer: do() checks isCancelled()
+	// before each iteration, but a cancel landing during advance() still pays
+	// the loop body - including the downstream callback - for that buffer.
 	<-done
 }
 

--- a/storage/flux/table.go
+++ b/storage/flux/table.go
@@ -31,7 +31,7 @@ type table struct {
 
 	err error
 
-	cancelled, used int32
+	cancelled, used atomic.Bool
 	cache           *tagsCache
 	alloc           memory.Allocator
 }
@@ -63,21 +63,58 @@ func (t *table) Err() error           { return t.err }
 func (t *table) Empty() bool          { return t.empty }
 
 func (t *table) Cancel() {
-	atomic.StoreInt32(&t.cancelled, 1)
+	t.cancelled.Store(true)
 }
 
 func (t *table) isCancelled() bool {
-	return atomic.LoadInt32(&t.cancelled) != 0
+	return t.cancelled.Load()
 }
 
 func (t *table) init(advance func() bool) {
 	t.empty = !advance() && t.err == nil
 }
 
+// awaitAbandoned makes it safe for the producer to close a table it is giving up
+// on, whether because the query context was cancelled or because the consumer
+// rejected the table.
+//
+// The producer cannot simply close. advance() runs on the consumer's goroutine
+// and touches the same cursor Close() tears down, so closing underneath it
+// releases that cursor's TSM file references twice, which drives
+// TSMReader.refsWG negative. WaitGroup.Add decrements before it panics, so the
+// reader is then permanently unusable and every later query touching it fails.
+//
+// The producer also cannot simply wait for done. A table can be dropped without
+// ever being consumed - consecutiveTransport abandons its queue on error or
+// finish, and done is closed only by do() or by Done() via processMsg.Ack() - so
+// an unconditional wait can block forever.
+//
+// The used CAS already arbitrates ownership, so reuse it: whoever wins it owns
+// the table and is responsible for closing done. do() and Done() are the other
+// two claimants.
+func (t *table) awaitAbandoned(done <-chan struct{}) {
+	// Ask any running consumer to stop at its next iteration boundary, so the
+	// wait below is as short as possible.
+	t.Cancel()
+
+	if t.used.CompareAndSwap(false, true) {
+		// We claimed the table first. do()'s opening act is this same CAS and it
+		// touches nothing beforehand, so no consumer can ever run against this
+		// table and there is nothing to wait for.
+		t.closeDone()
+		return
+	}
+
+	// do() or Done() claimed it first, and both defer closeDone, so done is
+	// guaranteed to close. The wait is bounded by at most one advance() call,
+	// since do() checks isCancelled() before each iteration.
+	<-done
+}
+
 func (t *table) do(f func(flux.ColReader) error, advance func() bool) error {
 	// Mark this table as having been used. If this doesn't
 	// succeed, then this has already been invoked somewhere else.
-	if !atomic.CompareAndSwapInt32(&t.used, 0, 1) {
+	if !t.used.CompareAndSwap(false, true) {
 		return errors.New("table already used")
 	}
 	defer t.closeDone()
@@ -105,7 +142,7 @@ func (t *table) do(f func(flux.ColReader) error, advance func() bool) error {
 func (t *table) Done() {
 	// Mark the table as having been used. If this has already
 	// been done, then nothing needs to be done.
-	if atomic.CompareAndSwapInt32(&t.used, 0, 1) {
+	if t.used.CompareAndSwap(false, true) {
 		defer t.closeDone()
 	}
 

--- a/storage/flux/table.go
+++ b/storage/flux/table.go
@@ -9,6 +9,7 @@ import (
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/array"
 	"github.com/influxdata/flux/arrow"
+	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/memory"
 	"github.com/influxdata/influxdb/v2/models"
@@ -119,6 +120,21 @@ func (t *table) do(f func(flux.ColReader) error, advance func() bool) error {
 	// Mark this table as having been used. If this doesn't
 	// succeed, then this has already been invoked somewhere else.
 	if !t.used.CompareAndSwap(false, true) {
+		if t.isCancelled() {
+			// The producer abandoned this table before any consumer claimed
+			// it (abandon Cancels before taking the CAS, so losing the CAS
+			// here always observes the flag), meaning this Do comes from a
+			// dispatcher draining its queue after the query terminated.
+			// Report that rather than an internal error: the query controller
+			// maps codes.Canceled to a 4xx, while a plain error surfaces as a
+			// 500 - and on cancellation this error can win the race to be the
+			// query's reported error, since handleRead itself returns
+			// rs.Err(), which may be nil.
+			return &flux.Error{
+				Code: codes.Canceled,
+				Msg:  "storage table was abandoned because the query terminated",
+			}
+		}
 		return errors.New("table already used")
 	}
 	defer t.closeDone()

--- a/storage/flux/table_abandon_error_test.go
+++ b/storage/flux/table_abandon_error_test.go
@@ -1,0 +1,76 @@
+package storageflux
+
+import (
+	"testing"
+
+	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/codes"
+	"github.com/influxdata/flux/execute"
+	kiterrors "github.com/influxdata/influxdb/v2/kit/platform/errors"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests pin the error a consumer sees when it claims a table too late:
+// losing the used CAS to an abandoning producer must report cancellation
+// (codes.Canceled), because on cancellation this error can win the race to be
+// the query's reported error and the controller maps it to a 4xx. Losing the
+// CAS to another consumer - a genuine misuse - must keep the internal error.
+
+// newBareTable builds a *table with no cursor and no buffer, sufficient for
+// exercising the used-CAS claim paths. empty is set so a successful do() does
+// not touch colBufs.
+func newBareTable() (*table, chan struct{}) {
+	done := make(chan struct{})
+	cols := []flux.ColMeta{{Label: execute.DefaultValueColLabel, Type: flux.TFloat}}
+	tbl := newTable(done, execute.Bounds{}, nil, cols, make([][]byte, len(cols)), nil, nil)
+	tbl.empty = true
+	return &tbl, done
+}
+
+func nopColReader(flux.ColReader) error { return nil }
+func noAdvance() bool                   { return false }
+
+func TestTable_DoAfterAbandonReturnsCancelled(t *testing.T) {
+	tbl, done := newBareTable()
+	tbl.awaitAbandoned(done)
+
+	err := tbl.do(nopColReader, noAdvance)
+	var ferr *flux.Error
+	require.ErrorAs(t, err, &ferr)
+	require.Equal(t, codes.Canceled, ferr.Code)
+}
+
+// TestTable_DoTwiceReturnsAlreadyUsed is the control: losing the CAS to a
+// consumer, not an abandoning producer, is still the internal misuse error.
+func TestTable_DoTwiceReturnsAlreadyUsed(t *testing.T) {
+	tbl, _ := newBareTable()
+	require.NoError(t, tbl.do(nopColReader, noAdvance))
+
+	err := tbl.do(nopColReader, noAdvance)
+	require.EqualError(t, err, "table already used")
+	var ferr *flux.Error
+	require.NotErrorAs(t, err, &ferr, "double use must not be reported as cancellation")
+}
+
+func TestWindowTableRow_DoAfterAbandonReturnsCancelled(t *testing.T) {
+	done := make(chan struct{})
+	row := &windowTableRow{done: done}
+	row.abandon(done)
+
+	err := row.Do(nopColReader)
+	var ferr *flux.Error
+	require.ErrorAs(t, err, &ferr)
+	require.Equal(t, codes.Canceled, ferr.Code)
+}
+
+// TestWindowTableRow_DoAfterDoneReturnsAlreadyRead is the control: a row
+// claimed by Done without abandonment keeps the internal misuse error.
+func TestWindowTableRow_DoAfterDoneReturnsAlreadyRead(t *testing.T) {
+	row := &windowTableRow{done: make(chan struct{})}
+	row.Done()
+
+	err := row.Do(nopColReader)
+	var kerr *kiterrors.Error
+	require.ErrorAs(t, err, &kerr)
+	require.Equal(t, kiterrors.EInternal, kerr.Code)
+}

--- a/storage/flux/table_cancel_race_test.go
+++ b/storage/flux/table_cancel_race_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/memory"
+	"github.com/influxdata/flux/plan"
 	"github.com/influxdata/flux/values"
 	"github.com/influxdata/influxdb/v2/inmem"
 	"github.com/influxdata/influxdb/v2/kit/platform"
@@ -24,6 +25,7 @@ import (
 	"github.com/influxdata/influxdb/v2/storage"
 	storageflux "github.com/influxdata/influxdb/v2/storage/flux"
 	"github.com/influxdata/influxdb/v2/tsdb"
+	"github.com/influxdata/influxdb/v2/tsdb/engine/tsm1"
 	"github.com/influxdata/influxdb/v2/v1/services/meta"
 	storagev1 "github.com/influxdata/influxdb/v2/v1/services/storage"
 	"github.com/stretchr/testify/require"
@@ -35,6 +37,14 @@ import (
 // group.
 type MultiShardSetupFunc func(org, bucket platform.ID) (*datagen.Spec, datagen.TimeRange)
 
+// multiShardReader augments StorageReader with the handles needed to inspect
+// TSM reader reference counts after a query.
+type multiShardReader struct {
+	*StorageReader
+	tsdbStore storage.TSDBStore
+	shardIDs  []uint64
+}
+
 // NewMultiShardStorageReader is NewStorageReader with a shard group duration
 // short enough that the data range spans several shard groups. Every series is
 // written into every group, so a single series spans multiple shards and
@@ -42,17 +52,16 @@ type MultiShardSetupFunc func(org, bucket platform.ID) (*datagen.Spec, datagen.T
 //
 // That is what makes floatMultiShardArrayCursor.nextArrayCursor reachable: it
 // returns early while len(c.itrs) == 0, so with the single-shard harness the
-// consumer goroutine never closes a KeyCursor and the refcount is never
-// double-released.
+// consumer goroutine never closes a KeyCursor.
 //
 // This duplicates NewStorageReader's setup rather than refactoring it, to keep
-// the ~3900 lines of existing tests in table_test.go untouched.
-func NewMultiShardStorageReader(tb testing.TB, shardGroupDuration time.Duration, setupFn MultiShardSetupFunc) *StorageReader {
+// the existing tests in table_test.go untouched.
+func NewMultiShardStorageReader(tb testing.TB, shardGroupDuration time.Duration, setupFn MultiShardSetupFunc) *multiShardReader {
 	tb.Helper()
 
 	rootDir := tb.TempDir()
 
-	var closers []closerFunc
+	var closers []func()
 	closeAll := func() {
 		for _, c := range closers {
 			c()
@@ -103,7 +112,7 @@ func NewMultiShardStorageReader(tb testing.TB, shardGroupDuration time.Duration,
 
 	// Walk the range one shard group at a time, writing the slice of the
 	// series that falls inside each group.
-	shards := 0
+	var shardIDs []uint64
 	for cur := tr.Start; cur.Before(tr.End); {
 		sgi, err := metaClient.CreateShardGroup(bucket.String(), rp.Name, cur)
 		if err != nil {
@@ -121,17 +130,15 @@ func NewMultiShardStorageReader(tb testing.TB, shardGroupDuration time.Duration,
 			closeAll()
 			tb.Fatalf("failed to create shard directory: %s", err)
 		}
-		sg := datagen.NewSeriesGeneratorFromSpec(spec, groupRange)
-		if err := writeShard(sfile, sg, id, shardPath); err != nil {
+		if err := writeShard(sfile, datagen.NewSeriesGeneratorFromSpec(spec, groupRange), id, shardPath); err != nil {
 			closeAll()
 			tb.Fatalf("failed to write shard %d: %s", id, err)
 		}
 
-		shards++
+		shardIDs = append(shardIDs, id)
 		cur = sgi.EndTime
 	}
-	require.Greater(tb, shards, 1, "harness must produce more than one shard")
-	tb.Logf("wrote %d shards", shards)
+	require.Greater(tb, len(shardIDs), 1, "harness must produce more than one shard")
 
 	for i, p := range sfile.Partitions() {
 		c := tsdb.NewSeriesPartitionCompactor()
@@ -157,19 +164,21 @@ func NewMultiShardStorageReader(tb testing.TB, shardGroupDuration time.Duration,
 	})
 
 	store := storagev1.NewStore(engine.TSDBStore(), engine.MetaClient())
-	return &StorageReader{
-		Org:    org,
-		Bucket: bucket,
-		Bounds: execute.Bounds{
-			Start: values.ConvertTime(tr.Start),
-			Stop:  values.ConvertTime(tr.End),
+	return &multiShardReader{
+		StorageReader: &StorageReader{
+			Org:    org,
+			Bucket: bucket,
+			Bounds: execute.Bounds{
+				Start: values.ConvertTime(tr.Start),
+				Stop:  values.ConvertTime(tr.End),
+			},
+			Close:         closeAll,
+			StorageReader: storageflux.NewReader(store),
 		},
-		Close:         closeAll,
-		StorageReader: storageflux.NewReader(store),
+		tsdbStore: engine.TSDBStore(),
+		shardIDs:  shardIDs,
 	}
 }
-
-type closerFunc func()
 
 func maxTime(a, b time.Time) time.Time {
 	if a.After(b) {
@@ -185,17 +194,496 @@ func minTime(a, b time.Time) time.Time {
 	return b
 }
 
-// TestStorageReader_ReadFilter_CancelDuringDeferredConsume shows that
-// storage/flux lets two goroutines close the same cursor chain concurrently,
-// which is the reachability half of the "sync: negative WaitGroup counter"
-// panics in EAR-6049 and EAR-7019. The other half - that a concurrent
-// KeyCursor.Close double-releases its locations and drives TSMReader.refsWG
-// negative - is proved directly by TestKeyCursor_ConcurrentClose in
-// tsdb/engine/tsm1.
+// filterSpec is the standard full-range read used by these tests.
+func (r *multiShardReader) filterSpec() query.ReadFilterSpec {
+	return query.ReadFilterSpec{
+		OrganizationID: r.Org,
+		BucketID:       r.Bucket,
+		Bounds:         r.Bounds,
+	}
+}
+
+func newAlloc() *memory.ResourceAllocator {
+	return &memory.ResourceAllocator{Allocator: arrowmem.DefaultAllocator}
+}
+
+// inUseFiles returns the paths of every TSM file still holding a reference.
+func (r *multiShardReader) inUseFiles(tb testing.TB) []string {
+	tb.Helper()
+	var inUse []string
+	for _, sh := range r.tsdbStore.Shards(r.shardIDs) {
+		eng, err := sh.Engine()
+		require.NoError(tb, err)
+		tsmEng, ok := eng.(*tsm1.Engine)
+		require.True(tb, ok, "expected a tsm1 engine, got %T", eng)
+		for _, f := range tsmEng.FileStore.Files() {
+			if f.InUse() {
+				inUse = append(inUse, f.Path())
+			}
+		}
+	}
+	return inUse
+}
+
+// requireReferencesReleased asserts that every TSM reader reference taken by a
+// query has been released.
 //
-// storage/flux hands each table to the caller and then waits for the table to
-// signal completion, but on context cancellation it abandons that wait
-// (reader.go, filterIterator.handleRead and groupIterator.handleRead):
+// This is the strongest single invariant available for this class of bug: it
+// catches both a double release (which drives the count negative and panics
+// before this runs) and a leak (which leaves the count above zero and would
+// later park FileStore.Close in refsWG.Wait()).
+//
+// Polled rather than asserted once, because a background compaction may
+// legitimately hold a reference for a short time. A genuine leak never drains.
+func (r *multiShardReader) requireReferencesReleased(tb testing.TB) {
+	tb.Helper()
+	var last []string
+	require.Eventually(tb, func() bool {
+		last = r.inUseFiles(tb)
+		return len(last) == 0
+	}, 15*time.Second, 25*time.Millisecond,
+		"TSM references were never released; still in use: %v", last)
+}
+
+// closeBounded shuts the reader down with a deadline. Aborting KeyCursor.Close's
+// release loop leaks references, which parks FileStore.Close in
+// refsWG.Wait() forever; bound it so that shows up as a reported failure rather
+// than a test-binary timeout.
+func (r *multiShardReader) closeBounded(tb testing.TB) {
+	tb.Helper()
+	closed := make(chan struct{})
+	go func() {
+		defer close(closed)
+		r.Close()
+	}()
+	select {
+	case <-closed:
+	case <-time.After(20 * time.Second):
+		tb.Error("SHUTDOWN HANG: reader.Close did not return; TSMReader.Close is " +
+			"parked in refsWG.Wait() on leaked references")
+	}
+}
+
+// smallSpec is a modest data set: 6 one-hour shard groups, 50 series, one point
+// per second. Enough that a table spans several buffers and every series spans
+// every shard.
+func smallSpec() (time.Duration, MultiShardSetupFunc) {
+	return time.Hour, func(org, bucket platform.ID) (*datagen.Spec, datagen.TimeRange) {
+		spec := Spec(org, bucket,
+			MeasurementSpec("m0",
+				FloatArrayValuesSequence("f0", time.Second, []float64{1.0, 2.0, 3.0, 4.0}),
+				TagValuesSequence("t0", "a-%s", 0, 50),
+			),
+		)
+		return spec, TimeRange("2019-11-25T00:00:00Z", "2019-11-25T06:00:00Z")
+	}
+}
+
+// largeGroupSpec is a wide data set: 6 one-hour shard groups, 500 series in a
+// single measurement, one point per 10s. Used to measure how long a table can
+// occupy a consumer goroutine, since that is what a fix which waits for the
+// consumer would have to wait for.
+func largeGroupSpec() (time.Duration, MultiShardSetupFunc) {
+	return time.Hour, func(org, bucket platform.ID) (*datagen.Spec, datagen.TimeRange) {
+		spec := Spec(org, bucket,
+			MeasurementSpec("m0",
+				FloatArrayValuesSequence("f0", 10*time.Second, []float64{1.0, 2.0, 3.0, 4.0}),
+				TagValuesSequence("t0", "a-%s", 0, 500),
+			),
+		)
+		return spec, TimeRange("2019-11-25T00:00:00Z", "2019-11-25T06:00:00Z")
+	}
+}
+
+// TestStorageReader_CancelTeardownLatency measures the wait that an
+// ownership-transfer fix would add to query teardown, and bounds it.
+//
+// Today cancellation returns immediately: handleRead does `break READ` and
+// abandons the consumer, which keeps draining anyway - unsafely, which is the
+// bug. A fix that waits for the consumer instead makes teardown latency equal to
+// however long the consumer still needs.
+//
+// The concern was xGroupTable.advance(): for an aggregate it drains every series
+// in the group across every shard in a single call (table.gen.go, the
+// AccumulateMore/advanceCursor loop), and table.do only checks isCancelled()
+// *between* advance() calls, so Cancel() cannot interrupt it. If that drain
+// happened on the consumer goroutine, waiting for it would delay a cancelled
+// query's response by the cost of a whole group, and the fix would need
+// isCancelled() checks pushed down into those inner loops - a change across the
+// generated templates rather than three call sites.
+//
+// This test measures where that cost actually falls: time spent constructing the
+// table (on handleRead's own goroutine, before the handoff) versus time the
+// consumer still needs after the handoff.
+func TestStorageReader_CancelTeardownLatency(t *testing.T) {
+	dur, setup := largeGroupSpec()
+	reader := NewMultiShardStorageReader(t, dur, setup)
+	defer reader.closeBounded(t)
+
+	// maxConsumerDrain bounds the wait an ownership-transfer fix would add.
+	// Generous: the point is to catch a whole-group drain landing here, not to
+	// pin down a precise duration.
+	const maxConsumerDrain = 2 * time.Second
+
+	for _, tc := range []struct {
+		name string
+		read func(ctx context.Context) (query.TableIterator, error)
+	}{
+		{"ReadFilter", func(ctx context.Context) (query.TableIterator, error) {
+			return reader.ReadFilter(ctx, reader.filterSpec(), newAlloc())
+		}},
+		{"ReadGroup/aggregate", func(ctx context.Context) (query.TableIterator, error) {
+			return reader.ReadGroup(ctx, query.ReadGroupSpec{
+				ReadFilterSpec:  reader.filterSpec(),
+				GroupMode:       query.GroupModeBy,
+				GroupKeys:       []string{"_measurement"},
+				AggregateMethod: storageflux.CountKind,
+			}, newAlloc())
+		}},
+		{"ReadGroup/no-aggregate", func(ctx context.Context) (query.TableIterator, error) {
+			return reader.ReadGroup(ctx, query.ReadGroupSpec{
+				ReadFilterSpec: reader.filterSpec(),
+				GroupMode:      query.GroupModeBy,
+				GroupKeys:      []string{"_measurement"},
+			}, newAlloc())
+		}},
+		{"ReadWindowAggregate", func(ctx context.Context) (query.TableIterator, error) {
+			return reader.ReadWindowAggregate(ctx, query.ReadWindowAggregateSpec{
+				ReadFilterSpec: reader.filterSpec(),
+				Window: execute.Window{
+					Every:  flux.ConvertDuration(30 * time.Second),
+					Period: flux.ConvertDuration(30 * time.Second),
+				},
+				Aggregates: []plan.ProcedureKind{storageflux.CountKind},
+			}, newAlloc())
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			ti, err := tc.read(ctx)
+			require.NoError(t, err)
+
+			var (
+				mu       sync.Mutex
+				drain    time.Duration
+				buffers  int
+				wg       sync.WaitGroup
+				handedAt time.Time
+			)
+
+			start := time.Now()
+			_ = ti.Do(func(tbl flux.Table) error {
+				// Everything before this point - including the table
+				// constructor, which is where a group aggregate does its
+				// draining - ran on this goroutine.
+				handedAt = time.Now()
+				wg.Go(func() {
+					t0 := time.Now()
+					defer func() {
+						d := time.Since(t0)
+						mu.Lock()
+						if d > drain {
+							drain = d
+						}
+						mu.Unlock()
+						// A recovered panic here is the underlying bug, not a
+						// latency signal; the other tests cover it.
+						_ = recover()
+					}()
+					_ = tbl.Do(func(flux.ColReader) error {
+						mu.Lock()
+						buffers++
+						mu.Unlock()
+						return nil
+					})
+				})
+				// Cancel as soon as the first table is handed off, so the
+				// measured drain is what teardown would have to wait for.
+				cancel()
+				return nil
+			})
+			returned := time.Since(start)
+			wg.Wait()
+
+			mu.Lock()
+			d, b := drain, buffers
+			mu.Unlock()
+
+			t.Logf("table construction (pre-handoff, on handleRead's goroutine): %s", handedAt.Sub(start))
+			t.Logf("handleRead returned after: %s", returned)
+			t.Logf("post-handoff consumer drain: %s over %d buffer(s)  <-- the wait a fix would add", d, b)
+
+			require.Less(t, d, maxConsumerDrain,
+				"a cancelled query's consumer needs %s after handoff; waiting for it "+
+					"would delay teardown by that much, so Cancel() must be able to "+
+					"interrupt the drain (isCancelled() checks inside advance()'s inner loops)", d)
+		})
+	}
+}
+
+// panicRecorder collects panics recovered on consumer goroutines, the way
+// flux's poolDispatcher recovers them in production.
+type panicRecorder struct {
+	mu     sync.Mutex
+	counts map[string]int
+}
+
+func newPanicRecorder() *panicRecorder {
+	return &panicRecorder{counts: make(map[string]int)}
+}
+
+func (p *panicRecorder) record(r any) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.counts[fmt.Sprint(r)]++
+}
+
+func (p *panicRecorder) report(tb testing.TB) {
+	tb.Helper()
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	for msg, n := range p.counts {
+		tb.Logf("recovered %4d x %s", n, msg)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Test 1 - liveness. Must hold before and after the fix.
+// ---------------------------------------------------------------------------
+
+// TestStorageReader_CancelWithUnconsumedTable guards against the obvious but
+// wrong fix for the cursor close race: making handleRead wait for `done`
+// unconditionally instead of bailing out on ctx.Done().
+//
+// That would deadlock. consecutiveTransport.processMessages (flux
+// execute/transport.go:248-270) abandons its queue on error or finish, and
+// `done` is closed only by table.do's defer or by table.Done() via
+// processMsg.Ack(). A table dropped from the queue gets neither, so `done`
+// never closes.
+//
+// This test models exactly that: the Do callback accepts the table and never
+// consumes it, never calls Done, and the context is then cancelled. handleRead
+// must still return. Any fix that waits for a consumer which will never run
+// will hang here.
+func TestStorageReader_CancelWithUnconsumedTable(t *testing.T) {
+	dur, setup := smallSpec()
+	reader := NewMultiShardStorageReader(t, dur, setup)
+	defer reader.closeBounded(t)
+
+	for _, tc := range []struct {
+		name string
+		read func(ctx context.Context) (query.TableIterator, error)
+	}{
+		{"ReadFilter", func(ctx context.Context) (query.TableIterator, error) {
+			return reader.ReadFilter(ctx, reader.filterSpec(), newAlloc())
+		}},
+		{"ReadGroup", func(ctx context.Context) (query.TableIterator, error) {
+			return reader.ReadGroup(ctx, query.ReadGroupSpec{
+				ReadFilterSpec: reader.filterSpec(),
+				GroupMode:      query.GroupModeBy,
+				GroupKeys:      []string{"_measurement"},
+			}, newAlloc())
+		}},
+		{"ReadWindowAggregate", func(ctx context.Context) (query.TableIterator, error) {
+			return reader.ReadWindowAggregate(ctx, query.ReadWindowAggregateSpec{
+				ReadFilterSpec: reader.filterSpec(),
+				Window: execute.Window{
+					Every:  flux.ConvertDuration(30 * time.Second),
+					Period: flux.ConvertDuration(30 * time.Second),
+				},
+				Aggregates: []plan.ProcedureKind{storageflux.CountKind},
+			}, newAlloc())
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			ti, err := tc.read(ctx)
+			require.NoError(t, err)
+
+			returned := make(chan error, 1)
+			go func() {
+				returned <- ti.Do(func(tbl flux.Table) error {
+					// A transport that queues the table and is then abandoned:
+					// neither Do nor Done is ever called on it.
+					return nil
+				})
+			}()
+
+			cancel()
+
+			select {
+			case <-returned:
+			case <-time.After(30 * time.Second):
+				t.Fatal("handleRead did not return after cancellation with an " +
+					"unconsumed table: the wait for `done` is unbounded")
+			}
+
+			reader.requireReferencesReleased(t)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Test 2 - reference count invariant across every exit path.
+// ---------------------------------------------------------------------------
+
+// TestStorageReader_ReferencesReleased asserts that a query releases every TSM
+// reader reference it takes, on all of the exits handleRead has: normal
+// completion, a consumer error, an f(table) error, and cancellation.
+//
+// The deterministic scenarios must pass today and after the fix. The two
+// concurrent scenarios are the ones this bug can violate; they may pass by luck
+// today and must be deterministic after the fix.
+func TestStorageReader_ReferencesReleased(t *testing.T) {
+	dur, setup := smallSpec()
+	reader := NewMultiShardStorageReader(t, dur, setup)
+	defer reader.closeBounded(t)
+
+	for _, tc := range []struct {
+		name       string
+		concurrent bool
+		// run drives one full read to completion, including any consumer
+		// goroutines it starts.
+		run func(t *testing.T, rec *panicRecorder)
+	}{
+		{
+			name: "consumed inline",
+			run: func(t *testing.T, rec *panicRecorder) {
+				ti, err := reader.ReadFilter(context.Background(), reader.filterSpec(), newAlloc())
+				require.NoError(t, err)
+				require.NoError(t, ti.Do(func(tbl flux.Table) error {
+					return tbl.Do(func(flux.ColReader) error { return nil })
+				}))
+			},
+		},
+		{
+			name: "consumer returns error",
+			run: func(t *testing.T, rec *panicRecorder) {
+				ti, err := reader.ReadFilter(context.Background(), reader.filterSpec(), newAlloc())
+				require.NoError(t, err)
+				// Error from inside the ColReader callback: table.do aborts
+				// mid-advance and returns the error up through handleRead.
+				err = ti.Do(func(tbl flux.Table) error {
+					return tbl.Do(func(flux.ColReader) error {
+						return fmt.Errorf("consumer failed")
+					})
+				})
+				require.Error(t, err)
+			},
+		},
+		{
+			name: "f(table) returns error inline",
+			run: func(t *testing.T, rec *panicRecorder) {
+				ti, err := reader.ReadFilter(context.Background(), reader.filterSpec(), newAlloc())
+				require.NoError(t, err)
+				// Exercises handleRead's `if err := f(table); err != nil`
+				// branch with no consumer in flight.
+				err = ti.Do(func(tbl flux.Table) error {
+					return fmt.Errorf("downstream rejected the table")
+				})
+				require.Error(t, err)
+			},
+		},
+		{
+			name:       "cancelled during deferred consume",
+			concurrent: true,
+			run: func(t *testing.T, rec *panicRecorder) {
+				ctx, cancel := context.WithCancel(context.Background())
+				defer cancel()
+				ti, err := reader.ReadFilter(ctx, reader.filterSpec(), newAlloc())
+				require.NoError(t, err)
+
+				var wg sync.WaitGroup
+				go func() {
+					time.Sleep(200 * time.Microsecond)
+					cancel()
+				}()
+				_ = ti.Do(func(tbl flux.Table) error {
+					wg.Go(func() {
+						defer func() {
+							if r := recover(); r != nil {
+								rec.record(r)
+							}
+						}()
+						_ = tbl.Do(func(flux.ColReader) error { return nil })
+					})
+					return nil
+				})
+				wg.Wait()
+			},
+		},
+		{
+			// NOT a reachable production path - kept to pin the invariant that
+			// makes it unreachable, so that a change in flux is noticed here.
+			//
+			// handleRead's `if err := f(table); err != nil { table.Close() }`
+			// (reader.go:229, :373, :835) does not wait for `done`, so it is
+			// only safe because a callback that errors has not queued the
+			// table. consecutiveTransport.Process guarantees that: it returns
+			// t.err() from its `select { case <-t.finished: }` *before*
+			// pushMsg, and returns nil unconditionally afterwards. The
+			// multi-transformation branch of Source.processTable is safe for a
+			// different reason - execute.CopyTable consumes the storage table
+			// inline before any copy is queued.
+			//
+			// Violating that invariant, as this case deliberately does, faults
+			// deterministically. If flux ever grows a path that queues a table
+			// and then reports an error, this becomes a live bug and handleRead
+			// must wait on this path too.
+			name:       "f(table) errors after deferred consume starts (contract violation)",
+			concurrent: true,
+			run: func(t *testing.T, rec *panicRecorder) {
+				ti, err := reader.ReadFilter(context.Background(), reader.filterSpec(), newAlloc())
+				require.NoError(t, err)
+
+				var wg sync.WaitGroup
+				err = ti.Do(func(tbl flux.Table) error {
+					wg.Go(func() {
+						defer func() {
+							if r := recover(); r != nil {
+								rec.record(r)
+							}
+						}()
+						_ = tbl.Do(func(flux.ColReader) error { return nil })
+					})
+					return fmt.Errorf("downstream rejected the table")
+				})
+				wg.Wait()
+				require.Error(t, err)
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			rec := newPanicRecorder()
+			// Repeat the concurrent cases: the damaging interleaving is narrow.
+			iterations := 1
+			if tc.concurrent {
+				iterations = 100
+			}
+			for range iterations {
+				tc.run(t, rec)
+			}
+			rec.report(t)
+			reader.requireReferencesReleased(t)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Tests 3 and 4 - race coverage for the remaining close paths and variants.
+// ---------------------------------------------------------------------------
+
+// TestStorageReader_CancelDuringDeferredConsume shows that storage/flux lets two
+// goroutines close the same cursor chain concurrently, across all three
+// handleRead variants and both of their unsynchronised close paths.
+//
+// storage/flux hands each table to the caller and then waits for it to signal
+// completion, but abandons that wait on cancellation (reader.go:236, :380,
+// :842):
 //
 //	select {
 //	case <-done:
@@ -204,151 +692,128 @@ func minTime(a, b time.Time) time.Time {
 //	    break READ
 //	}
 //
-// table.Cancel only sets an atomic flag, which table.do checks between
-// iterations, so it does not stop an in-flight advance(). handleRead's deferred
-// cleanup then calls table.Close() while the consumer is still inside advance()
-// on another goroutine. floatTable guards t.cur with t.mu in Close() but not in
-// advance(), so the mutex protects only one side.
+// and on an f(table) error it does not wait at all (reader.go:229, :373, :835).
+// table.Cancel only sets an atomic flag, checked between advance() iterations,
+// so it does not stop an advance already in flight. The deferred table.Close()
+// then runs concurrently with it.
 //
-// That interleaving is real because flux does not consume tables inline:
+// The interleaving is real because flux does not consume tables inline:
 // consecutiveTransport queues the table and a poolDispatcher goroutine calls
-// Do() later. This test models that handoff - the Do callback starts a
-// goroutine and returns immediately - and cancels the context asynchronously,
-// which is what a query timeout, a client disconnect, a response size limit, or
-// an aborted join branch does in production. EAR-6049's stacks are exactly this
-// shape: poolDispatcher.doWork -> ... -> consecutiveTransportTable.Do ->
-// floatTable.do -> floatTable.advance.
+// Do() later. This test models that handoff - the Do callback starts a goroutine
+// and returns immediately.
 //
-// The series here span several shards so that advance() reaches
+// Series span several shards so advance() reaches
 // floatMultiShardArrayCursor.nextArrayCursor, which closes the cursor chain
-// itself; with a single shard it returns early on len(c.itrs) == 0 and the
-// consumer never closes anything.
+// itself; with one shard it returns early on len(c.itrs) == 0 and the consumer
+// never closes anything.
 //
-// Observed under -race: writes in floatArrayAscendingCursor.Close against reads
-// in its Next, and a write of t.cur against advance()'s read of it. It also
+// Under -race this reports writes in floatArrayAscendingCursor.Close against
+// reads in its Next, and a write of t.cur against advance()'s read. It also
 // faults outright, because Close clears c.tsm.keyCursor while nextTSM() is
-// dereferencing it. Finally, recovering those panics - as flux's dispatcher does
-// in production - leaves the release loop half finished, so references leak and
-// shutdown parks in TSMReader.refsWG.Wait(); that is the reported hang.
+// dereferencing it.
 //
-// This test does not by itself produce the negative counter. That needs
+// It does not by itself produce the negative WaitGroup counter: that needs
 // table.Close() to land inside one of the few brief nextArrayCursor() calls per
-// table rather than anywhere in Next(), a much narrower window. See
-// TestKeyCursor_ConcurrentClose for the deterministic version.
-func TestStorageReader_ReadFilter_CancelDuringDeferredConsume(t *testing.T) {
-	// One shard group per hour across six hours, so every series is spread
-	// over six shards.
-	reader := NewMultiShardStorageReader(t, time.Hour, func(org, bucket platform.ID) (*datagen.Spec, datagen.TimeRange) {
-		spec := Spec(org, bucket,
-			MeasurementSpec("m0",
-				FloatArrayValuesSequence("f0", time.Second, []float64{1.0, 2.0, 3.0, 4.0}),
-				TagValuesSequence("t0", "a-%s", 0, 50),
-			),
-		)
-		tr := TimeRange("2019-11-25T00:00:00Z", "2019-11-25T06:00:00Z")
-		return spec, tr
-	})
-	// Not deferred directly: aborting KeyCursor.Close's release loop leaks
-	// references, so FileStore.Close blocks forever in TSMReader.refsWG.Wait().
-	// That hang is itself one of the reported symptoms, so bound it and report
-	// it rather than letting it fail the run as a timeout.
-	defer func() {
-		closed := make(chan struct{})
-		go func() {
-			defer close(closed)
-			reader.Close()
-		}()
-		select {
-		case <-closed:
-		case <-time.After(15 * time.Second):
-			t.Log("SHUTDOWN HANG: reader.Close did not return; TSMReader.Close is " +
-				"parked in refsWG.Wait() on leaked references")
-		}
-	}()
+// table rather than anywhere in Next(). See TestKeyCursor_ConcurrentClose in
+// tsdb/engine/tsm1 for the deterministic version.
+func TestStorageReader_CancelDuringDeferredConsume(t *testing.T) {
+	dur, setup := smallSpec()
+	reader := NewMultiShardStorageReader(t, dur, setup)
+	defer reader.closeBounded(t)
 
-	var tables, buffers int64
-
-	// Flux recovers panics raised on dispatcher goroutines
-	// (execute.poolDispatcher.recover), which is why these incidents present as
-	// persistent query failure rather than a crashed process. Recovering here
-	// is therefore faithful to production, and it also lets the run continue
-	// past the first faulting interleaving so the rarer refcount corruption can
-	// surface instead of the process dying on a nil dereference.
-	var mu sync.Mutex
-	panics := make(map[string]int)
-	recordPanic := func(r any) {
-		mu.Lock()
-		defer mu.Unlock()
-		panics[fmt.Sprint(r)]++
+	reads := map[string]func(ctx context.Context) (query.TableIterator, error){
+		"ReadFilter": func(ctx context.Context) (query.TableIterator, error) {
+			return reader.ReadFilter(ctx, reader.filterSpec(), newAlloc())
+		},
+		"ReadGroup": func(ctx context.Context) (query.TableIterator, error) {
+			return reader.ReadGroup(ctx, query.ReadGroupSpec{
+				ReadFilterSpec: reader.filterSpec(),
+				GroupMode:      query.GroupModeBy,
+				GroupKeys:      []string{"_measurement"},
+			}, newAlloc())
+		},
+		"ReadWindowAggregate": func(ctx context.Context) (query.TableIterator, error) {
+			return reader.ReadWindowAggregate(ctx, query.ReadWindowAggregateSpec{
+				ReadFilterSpec: reader.filterSpec(),
+				Window: execute.Window{
+					Every:  flux.ConvertDuration(30 * time.Second),
+					Period: flux.ConvertDuration(30 * time.Second),
+				},
+				Aggregates: []plan.ProcedureKind{storageflux.CountKind},
+			}, newAlloc())
+		},
 	}
 
-	// The double-release window is narrower than the nil-dereference one: both
-	// goroutines must read c.seeks as non-nil before either clears it. So run
-	// many attempts, in parallel, sweeping the cancellation offset so it lands
-	// at many different points inside the read.
-	const (
-		workers = 8
-		rounds  = 250
-	)
-	attempt := func(worker, round int) {
-		alloc := &memory.ResourceAllocator{Allocator: arrowmem.DefaultAllocator}
+	// abandonCancel abandons the table by cancelling the context;
+	// abandonError abandons it by rejecting it from the Do callback.
+	for _, abandon := range []string{"cancel", "f-error"} {
+		for name, read := range reads {
+			t.Run(abandon+"/"+name, func(t *testing.T) {
+				rec := newPanicRecorder()
+				var tables, buffers int64
 
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
+				const (
+					workers = 4
+					rounds  = 60
+				)
+				attempt := func(worker, round int) {
+					ctx, cancel := context.WithCancel(context.Background())
+					defer cancel()
 
-		ti, err := reader.ReadFilter(ctx, query.ReadFilterSpec{
-			OrganizationID: reader.Org,
-			BucketID:       reader.Bucket,
-			Bounds:         reader.Bounds,
-		}, alloc)
-		if err != nil {
-			recordPanic(fmt.Sprintf("ReadFilter: %v", err))
-			return
-		}
-
-		var wg sync.WaitGroup
-		defer wg.Wait()
-
-		// Stagger per worker as well as per round so the offsets interleave.
-		go func() {
-			time.Sleep(time.Duration(round*20+worker*7) * time.Microsecond)
-			cancel()
-		}()
-
-		// Deliberately ignored: cancelling mid-read is expected to surface an
-		// error here. The failure this test looks for is a race report or a
-		// panic, not a returned error.
-		_ = ti.Do(func(tbl flux.Table) error {
-			atomic.AddInt64(&tables, 1)
-			wg.Go(func() {
-				defer func() {
-					if r := recover(); r != nil {
-						recordPanic(r)
+					ti, err := read(ctx)
+					if err != nil {
+						rec.record(fmt.Sprintf("read: %v", err))
+						return
 					}
-				}()
-				_ = tbl.Do(func(flux.ColReader) error {
-					atomic.AddInt64(&buffers, 1)
-					return nil
-				})
+
+					var wg sync.WaitGroup
+					defer wg.Wait()
+
+					if abandon == "cancel" {
+						// Stagger per worker and round so the cancellation
+						// lands at many different points inside the read.
+						go func() {
+							time.Sleep(time.Duration(round*20+worker*7) * time.Microsecond)
+							cancel()
+						}()
+					}
+
+					// Deliberately ignored: abandoning a table mid-read is
+					// expected to surface an error. This test looks for a race
+					// report or a panic, not a returned error.
+					_ = ti.Do(func(tbl flux.Table) error {
+						atomic.AddInt64(&tables, 1)
+						wg.Go(func() {
+							defer func() {
+								if r := recover(); r != nil {
+									rec.record(r)
+								}
+							}()
+							_ = tbl.Do(func(flux.ColReader) error {
+								atomic.AddInt64(&buffers, 1)
+								return nil
+							})
+						})
+						if abandon == "f-error" {
+							return fmt.Errorf("downstream rejected the table")
+						}
+						return nil
+					})
+				}
+
+				var workerWG sync.WaitGroup
+				for w := range workers {
+					workerWG.Go(func() {
+						for r := range rounds {
+							attempt(w, r)
+						}
+					})
+				}
+				workerWG.Wait()
+
+				t.Logf("tables=%d buffers=%d", atomic.LoadInt64(&tables), atomic.LoadInt64(&buffers))
+				rec.report(t)
 			})
-			return nil
-		})
-	}
-
-	var workerWG sync.WaitGroup
-	for w := range workers {
-		workerWG.Go(func() {
-			for r := range rounds {
-				attempt(w, r)
-			}
-		})
-	}
-	workerWG.Wait()
-
-	t.Logf("consumed tables=%d buffers=%d", atomic.LoadInt64(&tables), atomic.LoadInt64(&buffers))
-	mu.Lock()
-	defer mu.Unlock()
-	for msg, n := range panics {
-		t.Logf("recovered %4d x %s", n, msg)
+		}
 	}
 }

--- a/storage/flux/table_cancel_race_test.go
+++ b/storage/flux/table_cancel_race_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/influxdata/influxdb/v2/tsdb/engine/tsm1"
 	"github.com/influxdata/influxdb/v2/v1/services/meta"
 	storagev1 "github.com/influxdata/influxdb/v2/v1/services/storage"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -84,9 +85,10 @@ func NewMultiShardStorageReader(tb testing.TB, shardGroupDuration time.Duration,
 	metaClient := meta.NewClient(meta.NewConfig(), kvStore)
 	require.NoError(tb, metaClient.Open())
 	closers = append(closers, func() {
-		if err := metaClient.Close(); err != nil {
-			tb.Errorf("close meta client: %s", err)
-		}
+		// assert rather than require: closers run inside closeBounded's
+		// watchdog goroutine, and require.FailNow is only legal on the
+		// goroutine running the test.
+		assert.NoError(tb, metaClient.Close(), "close meta client")
 	})
 
 	idgen := mock.NewMockIDGenerator()
@@ -144,9 +146,7 @@ func NewMultiShardStorageReader(tb testing.TB, shardGroupDuration time.Duration,
 	engine := storage.NewEngine(enginePath, storage.NewConfig(), storage.WithMetaClient(metaClient))
 	require.NoError(tb, engine.Open(context.Background()), "failed to open storage engine")
 	closers = append(closers, func() {
-		if err := engine.Close(); err != nil {
-			tb.Errorf("close engine: %s", err)
-		}
+		assert.NoError(tb, engine.Close(), "close engine")
 	})
 
 	store := storagev1.NewStore(engine.TSDBStore(), engine.MetaClient())
@@ -250,7 +250,7 @@ func (r *multiShardReader) closeBounded(tb testing.TB) {
 	select {
 	case <-closed:
 	case <-time.After(20 * time.Second):
-		tb.Error("SHUTDOWN HANG: reader.Close did not return; TSMReader.Close is " +
+		require.Fail(tb, "SHUTDOWN HANG: reader.Close did not return; TSMReader.Close is "+
 			"parked in refsWG.Wait() on leaked references")
 	}
 }
@@ -516,7 +516,7 @@ func TestStorageReader_CancelWithUnconsumedTable(t *testing.T) {
 			select {
 			case <-returned:
 			case <-time.After(30 * time.Second):
-				t.Fatal("handleRead did not return after cancellation with an " +
+				require.Fail(t, "handleRead did not return after cancellation with an "+
 					"unconsumed table: the wait for `done` is unbounded")
 			}
 

--- a/storage/flux/table_cancel_race_test.go
+++ b/storage/flux/table_cancel_race_test.go
@@ -312,10 +312,16 @@ func TestStorageReader_CancelTeardownLatency(t *testing.T) {
 	reader := NewMultiShardStorageReader(t, dur, setup)
 	defer reader.closeBounded(t)
 
-	// maxConsumerDrain bounds the wait an ownership-transfer fix would add.
-	// Generous: the point is to catch a whole-group drain landing here, not to
-	// pin down a precise duration.
-	const maxConsumerDrain = 2 * time.Second
+	// maxConsumerDrain bounds the wait the ownership-transfer fix adds to a
+	// cancelled query's teardown. It is a tripwire for catastrophic
+	// regressions - a wait that scales with the remaining data or blocks on
+	// the downstream - not a precise performance gate: the measured drain is
+	// normally milliseconds (see the logs below), but a loaded or -race CI
+	// runner can stretch one advance() plus one downstream callback well past
+	// a tight bound, and a wall-clock assertion that flakes gets ignored.
+	// Regressions smaller than this tripwire show up in the logged
+	// construction-vs-drain split.
+	const maxConsumerDrain = 10 * time.Second
 
 	for _, tc := range []struct {
 		name string

--- a/storage/flux/table_cancel_race_test.go
+++ b/storage/flux/table_cancel_race_test.go
@@ -233,16 +233,20 @@ func (r *multiShardReader) inUseFiles(tb testing.TB) []string {
 // before this runs) and a leak (which leaves the count above zero and would
 // later park FileStore.Close in refsWG.Wait()).
 //
-// Polled rather than asserted once, because a background compaction may
-// legitimately hold a reference for a short time. A genuine leak never drains.
+// The only legitimate transient holder of a reference is a background
+// compaction, and SetCompactionsEnabled(false) blocks until any in-flight
+// compaction has finished and released its references. Draining that first
+// makes a single assertion deterministic: anything still referenced afterwards
+// is a leaked query reference. Compactions stay disabled, which is harmless
+// here - the harness data is fully written during setup and the tests only
+// query - and repeated calls are no-ops.
 func (r *multiShardReader) requireReferencesReleased(tb testing.TB) {
 	tb.Helper()
-	var last []string
-	require.Eventually(tb, func() bool {
-		last = r.inUseFiles(tb)
-		return len(last) == 0
-	}, 15*time.Second, 25*time.Millisecond,
-		"TSM references were never released; still in use: %v", last)
+	for _, sh := range r.tsdbStore.Shards(r.shardIDs) {
+		sh.SetCompactionsEnabled(false)
+	}
+	require.Empty(tb, r.inUseFiles(tb),
+		"TSM references leaked: still in use after queries completed and compactions drained")
 }
 
 // closeBounded shuts the reader down with a deadline. Aborting KeyCursor.Close's

--- a/storage/flux/table_cancel_race_test.go
+++ b/storage/flux/table_cancel_race_test.go
@@ -295,12 +295,13 @@ func largeGroupSpec() (time.Duration, MultiShardSetupFunc) {
 	}
 }
 
-// TestStorageReader_CancelTeardownLatency measures the wait that an
-// ownership-transfer fix would add to query teardown, and bounds it.
+// TestStorageReader_CancelTeardownLatency measures the wait that the
+// ownership-transfer fix (table.awaitAbandoned) adds to query teardown, and
+// bounds it.
 //
-// Today cancellation returns immediately: handleRead does `break READ` and
-// abandons the consumer, which keeps draining anyway - unsafely, which is the
-// bug. A fix that waits for the consumer instead makes teardown latency equal to
+// Before the fix, cancellation returned immediately: handleRead did `break READ`
+// and abandoned the consumer, which kept draining anyway - unsafely, which was
+// the bug. Waiting for the consumer instead makes teardown latency equal to
 // however long the consumer still needs.
 //
 // The concern was xGroupTable.advance(): for an aggregate it drains every series
@@ -308,7 +309,7 @@ func largeGroupSpec() (time.Duration, MultiShardSetupFunc) {
 // AccumulateMore/advanceCursor loop), and table.do only checks isCancelled()
 // *between* advance() calls, so Cancel() cannot interrupt it. If that drain
 // happened on the consumer goroutine, waiting for it would delay a cancelled
-// query's response by the cost of a whole group, and the fix would need
+// query's response by the cost of a whole group, and the fix would have needed
 // isCancelled() checks pushed down into those inner loops - a change across the
 // generated templates rather than three call sites.
 //
@@ -535,9 +536,9 @@ func TestStorageReader_CancelWithUnconsumedTable(t *testing.T) {
 // reader reference it takes, on all of the exits handleRead has: normal
 // completion, a consumer error, an f(table) error, and cancellation.
 //
-// The deterministic scenarios must pass today and after the fix. The two
-// concurrent scenarios are the ones this bug can violate; they may pass by luck
-// today and must be deterministic after the fix.
+// The deterministic scenarios held even before the fix. The two concurrent
+// scenarios are the ones the bug could violate; they passed only by luck before
+// awaitAbandoned and must now pass deterministically.
 func TestStorageReader_ReferencesReleased(t *testing.T) {
 	dur, setup := smallSpec()
 	reader := NewMultiShardStorageReader(t, dur, setup)
@@ -617,23 +618,22 @@ func TestStorageReader_ReferencesReleased(t *testing.T) {
 			},
 		},
 		{
-			// NOT a reachable production path - kept to pin the invariant that
-			// makes it unreachable, so that a change in flux is noticed here.
+			// NOT a reachable production path - flux's contract makes it
+			// unreachable: consecutiveTransport.Process returns t.err() from
+			// its `select { case <-t.finished: }` *before* pushMsg, and
+			// returns nil unconditionally afterwards, so a callback that
+			// errors has not queued the table. The multi-transformation
+			// branch of Source.processTable is safe for a different reason -
+			// execute.CopyTable consumes the storage table inline before any
+			// copy is queued.
 			//
-			// handleRead's `if err := f(table); err != nil { table.Close() }`
-			// (reader.go:229, :373, :835) does not wait for `done`, so it is
-			// only safe because a callback that errors has not queued the
-			// table. consecutiveTransport.Process guarantees that: it returns
-			// t.err() from its `select { case <-t.finished: }` *before*
-			// pushMsg, and returns nil unconditionally afterwards. The
-			// multi-transformation branch of Source.processTable is safe for a
-			// different reason - execute.CopyTable consumes the storage table
-			// inline before any copy is queued.
-			//
-			// Violating that invariant, as this case deliberately does, faults
-			// deterministically. If flux ever grows a path that queues a table
-			// and then reports an error, this becomes a live bug and handleRead
-			// must wait on this path too.
+			// handleRead used to lean on that contract: its f(table) error
+			// branch closed the table without waiting for `done`, so this
+			// case - which deliberately violates the contract by consuming
+			// the table on another goroutine and then erroring - faulted
+			// deterministically. Those branches now call awaitAbandoned
+			// before Close, so it must pass even under the violation. Kept
+			// so a regression of that stronger guarantee is noticed here.
 			name:       "f(table) errors after deferred consume starts (contract violation)",
 			concurrent: true,
 			run: func(t *testing.T, rec *panicRecorder) {
@@ -677,13 +677,12 @@ func TestStorageReader_ReferencesReleased(t *testing.T) {
 // Tests 3 and 4 - race coverage for the remaining close paths and variants.
 // ---------------------------------------------------------------------------
 
-// TestStorageReader_CancelDuringDeferredConsume shows that storage/flux lets two
-// goroutines close the same cursor chain concurrently, across all three
-// handleRead variants and both of their unsynchronised close paths.
+// TestStorageReader_CancelDuringDeferredConsume shows that storage/flux used to
+// let two goroutines close the same cursor chain concurrently, across all three
+// handleRead variants and both of their previously unsynchronised close paths.
 //
 // storage/flux hands each table to the caller and then waits for it to signal
-// completion, but abandons that wait on cancellation (reader.go:236, :380,
-// :842):
+// completion, but used to abandon that wait on cancellation:
 //
 //	select {
 //	case <-done:
@@ -692,10 +691,11 @@ func TestStorageReader_ReferencesReleased(t *testing.T) {
 //	    break READ
 //	}
 //
-// and on an f(table) error it does not wait at all (reader.go:229, :373, :835).
-// table.Cancel only sets an atomic flag, checked between advance() iterations,
-// so it does not stop an advance already in flight. The deferred table.Close()
-// then runs concurrently with it.
+// and on an f(table) error it did not wait at all. table.Cancel only sets an
+// atomic flag, checked between advance() iterations, so it does not stop an
+// advance already in flight. The deferred table.Close() then ran concurrently
+// with it. Both paths now settle ownership through table.awaitAbandoned before
+// closing; this test is the regression guard for that.
 //
 // The interleaving is real because flux does not consume tables inline:
 // consecutiveTransport queues the table and a poolDispatcher goroutine calls
@@ -707,12 +707,12 @@ func TestStorageReader_ReferencesReleased(t *testing.T) {
 // itself; with one shard it returns early on len(c.itrs) == 0 and the consumer
 // never closes anything.
 //
-// Under -race this reports writes in floatArrayAscendingCursor.Close against
-// reads in its Next, and a write of t.cur against advance()'s read. It also
-// faults outright, because Close clears c.tsm.keyCursor while nextTSM() is
-// dereferencing it.
+// Before the fix, -race reported writes in floatArrayAscendingCursor.Close
+// against reads in its Next, and a write of t.cur against advance()'s read. It
+// also faulted outright, because Close cleared c.tsm.keyCursor while nextTSM()
+// was dereferencing it.
 //
-// It does not by itself produce the negative WaitGroup counter: that needs
+// It did not by itself produce the negative WaitGroup counter: that needs
 // table.Close() to land inside one of the few brief nextArrayCursor() calls per
 // table rather than anywhere in Next(). See TestKeyCursor_ConcurrentClose in
 // tsdb/engine/tsm1 for the deterministic version.

--- a/storage/flux/table_cancel_race_test.go
+++ b/storage/flux/table_cancel_race_test.go
@@ -68,6 +68,16 @@ func NewMultiShardStorageReader(tb testing.TB, shardGroupDuration time.Duration,
 		}
 	}
 
+	// require.* calls FailNow without running closeAll, so a guarded Cleanup
+	// covers every failure exit below. On success the reader owns closeAll
+	// (returned as its Close) and this becomes a no-op.
+	built := false
+	tb.Cleanup(func() {
+		if !built {
+			closeAll()
+		}
+	})
+
 	kvStore := inmem.NewKVStore()
 	require.NoError(tb, kvStore.CreateBucket(context.Background(), meta.BucketName))
 
@@ -88,23 +98,15 @@ func NewMultiShardStorageReader(tb testing.TB, shardGroupDuration time.Duration,
 		Name:               meta.DefaultRetentionPolicyName,
 		ShardGroupDuration: shardGroupDuration,
 	}
-	if _, err := metaClient.CreateDatabaseWithRetentionPolicy(bucket.String(), rp); err != nil {
-		closeAll()
-		tb.Fatalf("failed to create database: %s", err)
-	}
+	_, err := metaClient.CreateDatabaseWithRetentionPolicy(bucket.String(), rp)
+	require.NoError(tb, err, "failed to create database")
 
 	enginePath := filepath.Join(rootDir, "engine")
 	dbPath := filepath.Join(enginePath, "data", bucket.String())
-	if err := os.MkdirAll(dbPath, 0700); err != nil {
-		closeAll()
-		tb.Fatalf("failed to create data directory: %s", err)
-	}
+	require.NoError(tb, os.MkdirAll(dbPath, 0700), "failed to create data directory")
 
 	sfile := tsdb.NewSeriesFile(filepath.Join(dbPath, tsdb.SeriesFileDirectory))
-	if err := sfile.Open(); err != nil {
-		closeAll()
-		tb.Fatalf("failed to open series file: %s", err)
-	}
+	require.NoError(tb, sfile.Open(), "failed to open series file")
 	defer sfile.Close()
 	sfile.DisableCompactions()
 
@@ -115,10 +117,7 @@ func NewMultiShardStorageReader(tb testing.TB, shardGroupDuration time.Duration,
 	var shardIDs []uint64
 	for cur := tr.Start; cur.Before(tr.End); {
 		sgi, err := metaClient.CreateShardGroup(bucket.String(), rp.Name, cur)
-		if err != nil {
-			closeAll()
-			tb.Fatalf("failed to create shard group at %s: %s", cur, err)
-		}
+		require.NoError(tb, err, "failed to create shard group at %s", cur)
 
 		groupRange := datagen.TimeRange{
 			Start: maxTime(sgi.StartTime, tr.Start),
@@ -126,14 +125,10 @@ func NewMultiShardStorageReader(tb testing.TB, shardGroupDuration time.Duration,
 		}
 
 		id := sgi.Shards[0].ID
-		if err := os.MkdirAll(filepath.Join(shardPath, strconv.FormatUint(id, 10)), 0700); err != nil {
-			closeAll()
-			tb.Fatalf("failed to create shard directory: %s", err)
-		}
-		if err := writeShard(sfile, datagen.NewSeriesGeneratorFromSpec(spec, groupRange), id, shardPath); err != nil {
-			closeAll()
-			tb.Fatalf("failed to write shard %d: %s", id, err)
-		}
+		require.NoError(tb, os.MkdirAll(filepath.Join(shardPath, strconv.FormatUint(id, 10)), 0700),
+			"failed to create shard directory")
+		require.NoError(tb, writeShard(sfile, datagen.NewSeriesGeneratorFromSpec(spec, groupRange), id, shardPath),
+			"failed to write shard %d", id)
 
 		shardIDs = append(shardIDs, id)
 		cur = sgi.EndTime
@@ -142,21 +137,12 @@ func NewMultiShardStorageReader(tb testing.TB, shardGroupDuration time.Duration,
 
 	for i, p := range sfile.Partitions() {
 		c := tsdb.NewSeriesPartitionCompactor()
-		if err := c.Compact(p); err != nil {
-			closeAll()
-			tb.Fatalf("failed to compact series file %d: %s", i, err)
-		}
+		require.NoError(tb, c.Compact(p), "failed to compact series file %d", i)
 	}
-	if err := sfile.Close(); err != nil {
-		closeAll()
-		tb.Fatalf("failed to close series file: %s", err)
-	}
+	require.NoError(tb, sfile.Close(), "failed to close series file")
 
 	engine := storage.NewEngine(enginePath, storage.NewConfig(), storage.WithMetaClient(metaClient))
-	if err := engine.Open(context.Background()); err != nil {
-		closeAll()
-		tb.Fatalf("failed to open storage engine: %s", err)
-	}
+	require.NoError(tb, engine.Open(context.Background()), "failed to open storage engine")
 	closers = append(closers, func() {
 		if err := engine.Close(); err != nil {
 			tb.Errorf("close engine: %s", err)
@@ -164,6 +150,7 @@ func NewMultiShardStorageReader(tb testing.TB, shardGroupDuration time.Duration,
 	})
 
 	store := storagev1.NewStore(engine.TSDBStore(), engine.MetaClient())
+	built = true
 	return &multiShardReader{
 		StorageReader: &StorageReader{
 			Org:    org,

--- a/storage/flux/table_cancel_race_test.go
+++ b/storage/flux/table_cancel_race_test.go
@@ -654,6 +654,42 @@ func TestStorageReader_ReferencesReleased(t *testing.T) {
 				require.Error(t, err)
 			},
 		},
+		{
+			// A panic escaping f(table) unwinds through handleRead's deferred
+			// cleanup while a deferred consumer may still be draining the
+			// table. This is the only path that can reach that defer with a
+			// non-nil table, so the defer must settle ownership via abandon
+			// rather than bare-close - a bare Close here recreates the
+			// concurrent close the abandon protocol exists to prevent.
+			name:       "f(table) panics after deferred consume starts",
+			concurrent: true,
+			run: func(t *testing.T, rec *panicRecorder) {
+				ti, err := reader.ReadFilter(context.Background(), reader.filterSpec(), newAlloc())
+				require.NoError(t, err)
+
+				var wg sync.WaitGroup
+				func() {
+					defer func() {
+						// The panic must propagate out of ti.Do - handleRead's
+						// defer cleans up but does not recover - the way flux's
+						// executionState.recover then catches it in production.
+						require.NotNil(t, recover(), "expected the source panic to propagate")
+					}()
+					_ = ti.Do(func(tbl flux.Table) error {
+						wg.Go(func() {
+							defer func() {
+								if r := recover(); r != nil {
+									rec.record(r)
+								}
+							}()
+							_ = tbl.Do(func(flux.ColReader) error { return nil })
+						})
+						panic("source panic after handoff")
+					})
+				}()
+				wg.Wait()
+			},
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			rec := newPanicRecorder()

--- a/storage/flux/table_cancel_race_test.go
+++ b/storage/flux/table_cancel_race_test.go
@@ -296,7 +296,7 @@ func largeGroupSpec() (time.Duration, MultiShardSetupFunc) {
 }
 
 // TestStorageReader_CancelTeardownLatency measures the wait that the
-// ownership-transfer fix (table.awaitAbandoned) adds to query teardown, and
+// ownership-transfer fix (table.abandon) adds to query teardown, and
 // bounds it.
 //
 // Before the fix, cancellation returned immediately: handleRead did `break READ`
@@ -538,7 +538,7 @@ func TestStorageReader_CancelWithUnconsumedTable(t *testing.T) {
 //
 // The deterministic scenarios held even before the fix. The two concurrent
 // scenarios are the ones the bug could violate; they passed only by luck before
-// awaitAbandoned and must now pass deterministically.
+// table.abandon and must now pass deterministically.
 func TestStorageReader_ReferencesReleased(t *testing.T) {
 	dur, setup := smallSpec()
 	reader := NewMultiShardStorageReader(t, dur, setup)
@@ -631,9 +631,10 @@ func TestStorageReader_ReferencesReleased(t *testing.T) {
 			// branch closed the table without waiting for `done`, so this
 			// case - which deliberately violates the contract by consuming
 			// the table on another goroutine and then erroring - faulted
-			// deterministically. Those branches now call awaitAbandoned
-			// before Close, so it must pass even under the violation. Kept
-			// so a regression of that stronger guarantee is noticed here.
+			// deterministically. Those branches now abandon the table,
+			// settling ownership with any in-flight consumer before closing,
+			// so it must pass even under the violation. Kept so a regression
+			// of that stronger guarantee is noticed here.
 			name:       "f(table) errors after deferred consume starts (contract violation)",
 			concurrent: true,
 			run: func(t *testing.T, rec *panicRecorder) {
@@ -694,8 +695,9 @@ func TestStorageReader_ReferencesReleased(t *testing.T) {
 // and on an f(table) error it did not wait at all. table.Cancel only sets an
 // atomic flag, checked between advance() iterations, so it does not stop an
 // advance already in flight. The deferred table.Close() then ran concurrently
-// with it. Both paths now settle ownership through table.awaitAbandoned before
-// closing; this test is the regression guard for that.
+// with it. Both paths now go through table.abandon, which settles ownership
+// with any in-flight consumer before closing; this test is the regression
+// guard for that.
 //
 // The interleaving is real because flux does not consume tables inline:
 // consecutiveTransport queues the table and a poolDispatcher goroutine calls

--- a/storage/flux/table_cancel_race_test.go
+++ b/storage/flux/table_cancel_race_test.go
@@ -1,0 +1,354 @@
+package storageflux_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	arrowmem "github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/memory"
+	"github.com/influxdata/flux/values"
+	"github.com/influxdata/influxdb/v2/inmem"
+	"github.com/influxdata/influxdb/v2/kit/platform"
+	"github.com/influxdata/influxdb/v2/mock"
+	datagen "github.com/influxdata/influxdb/v2/pkg/data/gen"
+	"github.com/influxdata/influxdb/v2/query"
+	"github.com/influxdata/influxdb/v2/storage"
+	storageflux "github.com/influxdata/influxdb/v2/storage/flux"
+	"github.com/influxdata/influxdb/v2/tsdb"
+	"github.com/influxdata/influxdb/v2/v1/services/meta"
+	storagev1 "github.com/influxdata/influxdb/v2/v1/services/storage"
+	"github.com/stretchr/testify/require"
+)
+
+// MultiShardSetupFunc returns a generator spec plus the overall time range to
+// generate. Unlike SetupFunc it hands back the spec rather than a built
+// generator, because NewMultiShardStorageReader needs one generator per shard
+// group.
+type MultiShardSetupFunc func(org, bucket platform.ID) (*datagen.Spec, datagen.TimeRange)
+
+// NewMultiShardStorageReader is NewStorageReader with a shard group duration
+// short enough that the data range spans several shard groups. Every series is
+// written into every group, so a single series spans multiple shards and
+// row.Query carries one cursor iterator per shard.
+//
+// That is what makes floatMultiShardArrayCursor.nextArrayCursor reachable: it
+// returns early while len(c.itrs) == 0, so with the single-shard harness the
+// consumer goroutine never closes a KeyCursor and the refcount is never
+// double-released.
+//
+// This duplicates NewStorageReader's setup rather than refactoring it, to keep
+// the ~3900 lines of existing tests in table_test.go untouched.
+func NewMultiShardStorageReader(tb testing.TB, shardGroupDuration time.Duration, setupFn MultiShardSetupFunc) *StorageReader {
+	tb.Helper()
+
+	rootDir := tb.TempDir()
+
+	var closers []closerFunc
+	closeAll := func() {
+		for _, c := range closers {
+			c()
+		}
+	}
+
+	kvStore := inmem.NewKVStore()
+	require.NoError(tb, kvStore.CreateBucket(context.Background(), meta.BucketName))
+
+	metaClient := meta.NewClient(meta.NewConfig(), kvStore)
+	require.NoError(tb, metaClient.Open())
+	closers = append(closers, func() {
+		if err := metaClient.Close(); err != nil {
+			tb.Errorf("close meta client: %s", err)
+		}
+	})
+
+	idgen := mock.NewMockIDGenerator()
+	org, bucket := idgen.ID(), idgen.ID()
+
+	spec, tr := setupFn(org, bucket)
+
+	rp := &meta.RetentionPolicySpec{
+		Name:               meta.DefaultRetentionPolicyName,
+		ShardGroupDuration: shardGroupDuration,
+	}
+	if _, err := metaClient.CreateDatabaseWithRetentionPolicy(bucket.String(), rp); err != nil {
+		closeAll()
+		tb.Fatalf("failed to create database: %s", err)
+	}
+
+	enginePath := filepath.Join(rootDir, "engine")
+	dbPath := filepath.Join(enginePath, "data", bucket.String())
+	if err := os.MkdirAll(dbPath, 0700); err != nil {
+		closeAll()
+		tb.Fatalf("failed to create data directory: %s", err)
+	}
+
+	sfile := tsdb.NewSeriesFile(filepath.Join(dbPath, tsdb.SeriesFileDirectory))
+	if err := sfile.Open(); err != nil {
+		closeAll()
+		tb.Fatalf("failed to open series file: %s", err)
+	}
+	defer sfile.Close()
+	sfile.DisableCompactions()
+
+	shardPath := filepath.Join(dbPath, rp.Name)
+
+	// Walk the range one shard group at a time, writing the slice of the
+	// series that falls inside each group.
+	shards := 0
+	for cur := tr.Start; cur.Before(tr.End); {
+		sgi, err := metaClient.CreateShardGroup(bucket.String(), rp.Name, cur)
+		if err != nil {
+			closeAll()
+			tb.Fatalf("failed to create shard group at %s: %s", cur, err)
+		}
+
+		groupRange := datagen.TimeRange{
+			Start: maxTime(sgi.StartTime, tr.Start),
+			End:   minTime(sgi.EndTime, tr.End),
+		}
+
+		id := sgi.Shards[0].ID
+		if err := os.MkdirAll(filepath.Join(shardPath, strconv.FormatUint(id, 10)), 0700); err != nil {
+			closeAll()
+			tb.Fatalf("failed to create shard directory: %s", err)
+		}
+		sg := datagen.NewSeriesGeneratorFromSpec(spec, groupRange)
+		if err := writeShard(sfile, sg, id, shardPath); err != nil {
+			closeAll()
+			tb.Fatalf("failed to write shard %d: %s", id, err)
+		}
+
+		shards++
+		cur = sgi.EndTime
+	}
+	require.Greater(tb, shards, 1, "harness must produce more than one shard")
+	tb.Logf("wrote %d shards", shards)
+
+	for i, p := range sfile.Partitions() {
+		c := tsdb.NewSeriesPartitionCompactor()
+		if err := c.Compact(p); err != nil {
+			closeAll()
+			tb.Fatalf("failed to compact series file %d: %s", i, err)
+		}
+	}
+	if err := sfile.Close(); err != nil {
+		closeAll()
+		tb.Fatalf("failed to close series file: %s", err)
+	}
+
+	engine := storage.NewEngine(enginePath, storage.NewConfig(), storage.WithMetaClient(metaClient))
+	if err := engine.Open(context.Background()); err != nil {
+		closeAll()
+		tb.Fatalf("failed to open storage engine: %s", err)
+	}
+	closers = append(closers, func() {
+		if err := engine.Close(); err != nil {
+			tb.Errorf("close engine: %s", err)
+		}
+	})
+
+	store := storagev1.NewStore(engine.TSDBStore(), engine.MetaClient())
+	return &StorageReader{
+		Org:    org,
+		Bucket: bucket,
+		Bounds: execute.Bounds{
+			Start: values.ConvertTime(tr.Start),
+			Stop:  values.ConvertTime(tr.End),
+		},
+		Close:         closeAll,
+		StorageReader: storageflux.NewReader(store),
+	}
+}
+
+type closerFunc func()
+
+func maxTime(a, b time.Time) time.Time {
+	if a.After(b) {
+		return a
+	}
+	return b
+}
+
+func minTime(a, b time.Time) time.Time {
+	if a.Before(b) {
+		return a
+	}
+	return b
+}
+
+// TestStorageReader_ReadFilter_CancelDuringDeferredConsume shows that
+// storage/flux lets two goroutines close the same cursor chain concurrently,
+// which is the reachability half of the "sync: negative WaitGroup counter"
+// panics in EAR-6049 and EAR-7019. The other half - that a concurrent
+// KeyCursor.Close double-releases its locations and drives TSMReader.refsWG
+// negative - is proved directly by TestKeyCursor_ConcurrentClose in
+// tsdb/engine/tsm1.
+//
+// storage/flux hands each table to the caller and then waits for the table to
+// signal completion, but on context cancellation it abandons that wait
+// (reader.go, filterIterator.handleRead and groupIterator.handleRead):
+//
+//	select {
+//	case <-done:
+//	case <-fi.ctx.Done():
+//	    table.Cancel()
+//	    break READ
+//	}
+//
+// table.Cancel only sets an atomic flag, which table.do checks between
+// iterations, so it does not stop an in-flight advance(). handleRead's deferred
+// cleanup then calls table.Close() while the consumer is still inside advance()
+// on another goroutine. floatTable guards t.cur with t.mu in Close() but not in
+// advance(), so the mutex protects only one side.
+//
+// That interleaving is real because flux does not consume tables inline:
+// consecutiveTransport queues the table and a poolDispatcher goroutine calls
+// Do() later. This test models that handoff - the Do callback starts a
+// goroutine and returns immediately - and cancels the context asynchronously,
+// which is what a query timeout, a client disconnect, a response size limit, or
+// an aborted join branch does in production. EAR-6049's stacks are exactly this
+// shape: poolDispatcher.doWork -> ... -> consecutiveTransportTable.Do ->
+// floatTable.do -> floatTable.advance.
+//
+// The series here span several shards so that advance() reaches
+// floatMultiShardArrayCursor.nextArrayCursor, which closes the cursor chain
+// itself; with a single shard it returns early on len(c.itrs) == 0 and the
+// consumer never closes anything.
+//
+// Observed under -race: writes in floatArrayAscendingCursor.Close against reads
+// in its Next, and a write of t.cur against advance()'s read of it. It also
+// faults outright, because Close clears c.tsm.keyCursor while nextTSM() is
+// dereferencing it. Finally, recovering those panics - as flux's dispatcher does
+// in production - leaves the release loop half finished, so references leak and
+// shutdown parks in TSMReader.refsWG.Wait(); that is the reported hang.
+//
+// This test does not by itself produce the negative counter. That needs
+// table.Close() to land inside one of the few brief nextArrayCursor() calls per
+// table rather than anywhere in Next(), a much narrower window. See
+// TestKeyCursor_ConcurrentClose for the deterministic version.
+func TestStorageReader_ReadFilter_CancelDuringDeferredConsume(t *testing.T) {
+	// One shard group per hour across six hours, so every series is spread
+	// over six shards.
+	reader := NewMultiShardStorageReader(t, time.Hour, func(org, bucket platform.ID) (*datagen.Spec, datagen.TimeRange) {
+		spec := Spec(org, bucket,
+			MeasurementSpec("m0",
+				FloatArrayValuesSequence("f0", time.Second, []float64{1.0, 2.0, 3.0, 4.0}),
+				TagValuesSequence("t0", "a-%s", 0, 50),
+			),
+		)
+		tr := TimeRange("2019-11-25T00:00:00Z", "2019-11-25T06:00:00Z")
+		return spec, tr
+	})
+	// Not deferred directly: aborting KeyCursor.Close's release loop leaks
+	// references, so FileStore.Close blocks forever in TSMReader.refsWG.Wait().
+	// That hang is itself one of the reported symptoms, so bound it and report
+	// it rather than letting it fail the run as a timeout.
+	defer func() {
+		closed := make(chan struct{})
+		go func() {
+			defer close(closed)
+			reader.Close()
+		}()
+		select {
+		case <-closed:
+		case <-time.After(15 * time.Second):
+			t.Log("SHUTDOWN HANG: reader.Close did not return; TSMReader.Close is " +
+				"parked in refsWG.Wait() on leaked references")
+		}
+	}()
+
+	var tables, buffers int64
+
+	// Flux recovers panics raised on dispatcher goroutines
+	// (execute.poolDispatcher.recover), which is why these incidents present as
+	// persistent query failure rather than a crashed process. Recovering here
+	// is therefore faithful to production, and it also lets the run continue
+	// past the first faulting interleaving so the rarer refcount corruption can
+	// surface instead of the process dying on a nil dereference.
+	var mu sync.Mutex
+	panics := make(map[string]int)
+	recordPanic := func(r any) {
+		mu.Lock()
+		defer mu.Unlock()
+		panics[fmt.Sprint(r)]++
+	}
+
+	// The double-release window is narrower than the nil-dereference one: both
+	// goroutines must read c.seeks as non-nil before either clears it. So run
+	// many attempts, in parallel, sweeping the cancellation offset so it lands
+	// at many different points inside the read.
+	const (
+		workers = 8
+		rounds  = 250
+	)
+	attempt := func(worker, round int) {
+		alloc := &memory.ResourceAllocator{Allocator: arrowmem.DefaultAllocator}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		ti, err := reader.ReadFilter(ctx, query.ReadFilterSpec{
+			OrganizationID: reader.Org,
+			BucketID:       reader.Bucket,
+			Bounds:         reader.Bounds,
+		}, alloc)
+		if err != nil {
+			recordPanic(fmt.Sprintf("ReadFilter: %v", err))
+			return
+		}
+
+		var wg sync.WaitGroup
+		defer wg.Wait()
+
+		// Stagger per worker as well as per round so the offsets interleave.
+		go func() {
+			time.Sleep(time.Duration(round*20+worker*7) * time.Microsecond)
+			cancel()
+		}()
+
+		// Deliberately ignored: cancelling mid-read is expected to surface an
+		// error here. The failure this test looks for is a race report or a
+		// panic, not a returned error.
+		_ = ti.Do(func(tbl flux.Table) error {
+			atomic.AddInt64(&tables, 1)
+			wg.Go(func() {
+				defer func() {
+					if r := recover(); r != nil {
+						recordPanic(r)
+					}
+				}()
+				_ = tbl.Do(func(flux.ColReader) error {
+					atomic.AddInt64(&buffers, 1)
+					return nil
+				})
+			})
+			return nil
+		})
+	}
+
+	var workerWG sync.WaitGroup
+	for w := range workers {
+		workerWG.Go(func() {
+			for r := range rounds {
+				attempt(w, r)
+			}
+		})
+	}
+	workerWG.Wait()
+
+	t.Logf("consumed tables=%d buffers=%d", atomic.LoadInt64(&tables), atomic.LoadInt64(&buffers))
+	mu.Lock()
+	defer mu.Unlock()
+	for msg, n := range panics {
+		t.Logf("recovered %4d x %s", n, msg)
+	}
+}

--- a/storage/flux/table_internal_test.go
+++ b/storage/flux/table_internal_test.go
@@ -1,7 +1,5 @@
 package storageflux
 
-import "sync/atomic"
-
 func (t *table) IsDone() bool {
-	return atomic.LoadInt32(&t.used) != 0
+	return t.used.Load()
 }

--- a/storage/flux/window.go
+++ b/storage/flux/window.go
@@ -9,6 +9,7 @@ import (
 	"github.com/influxdata/flux"
 	"github.com/influxdata/flux/array"
 	"github.com/influxdata/flux/arrow"
+	"github.com/influxdata/flux/codes"
 	"github.com/influxdata/flux/execute"
 	"github.com/influxdata/flux/values"
 	"github.com/influxdata/influxdb/v2/kit/platform/errors"
@@ -126,9 +127,12 @@ func (w *windowTableSplitter) getTimeColumnIndex(label string) (int, error) {
 }
 
 type windowTableRow struct {
-	used   atomic.Bool
-	buffer arrow.TableBuffer
-	done   chan struct{}
+	used atomic.Bool
+	// abandoned records that the splitter gave up on this row, so a late Do
+	// can report cancellation instead of an internal error.
+	abandoned atomic.Bool
+	buffer    arrow.TableBuffer
+	done      chan struct{}
 }
 
 func (w *windowTableRow) Key() flux.GroupKey {
@@ -141,6 +145,14 @@ func (w *windowTableRow) Cols() []flux.ColMeta {
 
 func (w *windowTableRow) Do(f func(flux.ColReader) error) error {
 	if !w.used.CompareAndSwap(false, true) {
+		if w.abandoned.Load() {
+			// See (*table).do: the splitter abandoned this row because the
+			// query terminated; report cancellation, not an internal error.
+			return &flux.Error{
+				Code: codes.Canceled,
+				Msg:  "window table was abandoned because the query terminated",
+			}
+		}
 		return &errors.Error{
 			Code: errors.EInternal,
 			Msg:  "table already read",
@@ -171,6 +183,10 @@ func (w *windowTableRow) Done() {
 // is still reading. The slices in this buffer retain the input table's arrays, so
 // an unreleased row pins the whole input allocation, not just its own slice.
 func (w *windowTableRow) abandon(done <-chan struct{}) {
+	// The store is sequenced before Done's CAS, so any Do that loses that CAS
+	// to us observes the flag and reports cancellation.
+	w.abandoned.Store(true)
+
 	// Done claims the row and releases the buffer when no consumer has claimed
 	// it, and is a no-op when one already owns it.
 	w.Done()

--- a/storage/flux/window.go
+++ b/storage/flux/window.go
@@ -101,6 +101,7 @@ func (w *windowTableSplitter) Do(f func(flux.Table) error) error {
 			select {
 			case <-done:
 			case <-w.ctx.Done():
+				table.awaitAbandoned(done)
 				return w.ctx.Err()
 			}
 		}
@@ -125,7 +126,7 @@ func (w *windowTableSplitter) getTimeColumnIndex(label string) (int, error) {
 }
 
 type windowTableRow struct {
-	used   int32
+	used   atomic.Bool
 	buffer arrow.TableBuffer
 	done   chan struct{}
 }
@@ -139,7 +140,7 @@ func (w *windowTableRow) Cols() []flux.ColMeta {
 }
 
 func (w *windowTableRow) Do(f func(flux.ColReader) error) error {
-	if !atomic.CompareAndSwapInt32(&w.used, 0, 1) {
+	if !w.used.CompareAndSwap(false, true) {
 		return &errors.Error{
 			Code: errors.EInternal,
 			Msg:  "table already read",
@@ -153,10 +154,28 @@ func (w *windowTableRow) Do(f func(flux.ColReader) error) error {
 }
 
 func (w *windowTableRow) Done() {
-	if atomic.CompareAndSwapInt32(&w.used, 0, 1) {
+	if w.used.CompareAndSwap(false, true) {
 		w.buffer.Release()
 		close(w.done)
 	}
+}
+
+// awaitAbandoned settles ownership of a row the splitter is giving up on, so that
+// the buffer is released exactly once.
+//
+// This mirrors (*table).awaitAbandoned, for the same reason: waiting on done
+// unconditionally is unsafe because nothing guarantees a consumer will ever claim
+// this row, and closing without waiting would release a buffer the consumer is
+// still reading. The slices in this buffer retain the input table's arrays, so an
+// unreleased row pins the whole input allocation, not just its own slice.
+func (w *windowTableRow) awaitAbandoned(done <-chan struct{}) {
+	// Done claims the row and releases the buffer when no consumer has claimed
+	// it, and is a no-op when one already owns it.
+	w.Done()
+
+	// Whichever of Do or Done won the claim closes done, so this is bounded: if
+	// we just won it above, done is already closed.
+	<-done
 }
 
 func (w *windowTableRow) Empty() bool {

--- a/storage/flux/window.go
+++ b/storage/flux/window.go
@@ -101,7 +101,7 @@ func (w *windowTableSplitter) Do(f func(flux.Table) error) error {
 			select {
 			case <-done:
 			case <-w.ctx.Done():
-				table.awaitAbandoned(done)
+				table.abandon(done)
 				return w.ctx.Err()
 			}
 		}
@@ -160,15 +160,17 @@ func (w *windowTableRow) Done() {
 	}
 }
 
-// awaitAbandoned settles ownership of a row the splitter is giving up on, so that
-// the buffer is released exactly once.
+// abandon settles ownership of a row the splitter is giving up on, so that
+// the buffer is released exactly once. Unlike the storageTable implementations
+// there is no separate Close to pair with: releasing the buffer, done by
+// whichever of Do or Done claims the row, is this type's teardown.
 //
-// This mirrors (*table).awaitAbandoned, for the same reason: waiting on done
-// unconditionally is unsafe because nothing guarantees a consumer will ever claim
-// this row, and closing without waiting would release a buffer the consumer is
-// still reading. The slices in this buffer retain the input table's arrays, so an
-// unreleased row pins the whole input allocation, not just its own slice.
-func (w *windowTableRow) awaitAbandoned(done <-chan struct{}) {
+// This mirrors the storageTable abandon method, for the same reason: waiting on
+// done unconditionally is unsafe because nothing guarantees a consumer will ever
+// claim this row, and closing without waiting would release a buffer the consumer
+// is still reading. The slices in this buffer retain the input table's arrays, so
+// an unreleased row pins the whole input allocation, not just its own slice.
+func (w *windowTableRow) abandon(done <-chan struct{}) {
 	// Done claims the row and releases the buffer when no consumer has claimed
 	// it, and is a no-op when one already owns it.
 	w.Done()

--- a/storage/flux/window_cancel_test.go
+++ b/storage/flux/window_cancel_test.go
@@ -69,7 +69,7 @@ func newSplitWindowsInput(alloc memory.Allocator, rows int) *splitWindowsInput {
 }
 
 // TestSplitWindows_CancelReleasesBuffer covers the same defect in splitWindows
-// that awaitAbandoned fixes in handleRead: the producer stops waiting for the
+// that abandon fixes in handleRead: the producer stops waiting for the
 // consumer on context cancellation and walks away from a table nobody owns.
 //
 // windowTableRow's buffer is released by whichever of Do or Done claims the

--- a/storage/flux/window_cancel_test.go
+++ b/storage/flux/window_cancel_test.go
@@ -1,0 +1,126 @@
+package storageflux
+
+import (
+	"context"
+	"testing"
+
+	arrowmem "github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/array"
+	"github.com/influxdata/flux/arrow"
+	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/memory"
+	"github.com/influxdata/flux/values"
+	"github.com/stretchr/testify/require"
+)
+
+// splitWindowsInput is a minimal flux.Table over a single buffer, standing in for
+// the window table that windowAggregateIterator hands to splitWindows at
+// reader.go:720.
+type splitWindowsInput struct {
+	buf arrow.TableBuffer
+}
+
+func (t *splitWindowsInput) Key() flux.GroupKey   { return t.buf.GroupKey }
+func (t *splitWindowsInput) Cols() []flux.ColMeta { return t.buf.Columns }
+func (t *splitWindowsInput) Empty() bool          { return false }
+func (t *splitWindowsInput) Done()                { t.buf.Release() }
+func (t *splitWindowsInput) Do(f func(flux.ColReader) error) error {
+	return f(&t.buf)
+}
+
+// newSplitWindowsInput builds an input table with the column layout
+// splitWindows requires: _start, _stop, _time, _value.
+func newSplitWindowsInput(alloc memory.Allocator, rows int) *splitWindowsInput {
+	starts := make([]int64, rows)
+	stops := make([]int64, rows)
+	times := make([]int64, rows)
+	vals := make([]float64, rows)
+	for i := range rows {
+		starts[i] = int64(i * 10)
+		stops[i] = int64(i*10 + 10)
+		times[i] = int64(i * 10)
+		vals[i] = float64(i)
+	}
+
+	cols := []flux.ColMeta{
+		{Label: execute.DefaultStartColLabel, Type: flux.TTime},
+		{Label: execute.DefaultStopColLabel, Type: flux.TTime},
+		{Label: execute.DefaultTimeColLabel, Type: flux.TTime},
+		{Label: execute.DefaultValueColLabel, Type: flux.TFloat},
+	}
+	key := execute.NewGroupKey(
+		[]flux.ColMeta{cols[startColIdx], cols[stopColIdx]},
+		[]values.Value{values.NewTime(0), values.NewTime(values.Time(rows * 10))},
+	)
+
+	return &splitWindowsInput{
+		buf: arrow.TableBuffer{
+			GroupKey: key,
+			Columns:  cols,
+			Values: []array.Array{
+				arrow.NewInt(starts, alloc),
+				arrow.NewInt(stops, alloc),
+				arrow.NewInt(times, alloc),
+				arrow.NewFloat(vals, alloc),
+			},
+		},
+	}
+}
+
+// TestSplitWindows_CancelReleasesBuffer covers the same defect in splitWindows
+// that awaitAbandoned fixes in handleRead: the producer stops waiting for the
+// consumer on context cancellation and walks away from a table nobody owns.
+//
+// windowTableRow's buffer is released by whichever of Do or Done claims the
+// table. Abandoning it without claiming means neither runs, so the sliced arrays
+// keep the input buffer's arrow allocation referenced for as long as the query
+// lives.
+//
+// This is milder than the handleRead case - windowTableRow holds an in-memory
+// buffer, not a cursor, so there is no double release and no TSM reference count
+// to corrupt - but it is the same failure to settle ownership, and
+// windowTableRow already carries the same used/Do/Done CAS structure to settle it
+// with.
+//
+// The checked allocator is what makes the leak observable: it reports any arrow
+// buffer still outstanding when the test ends.
+func TestSplitWindows_CancelReleasesBuffer(t *testing.T) {
+	mem := arrowmem.NewCheckedAllocator(arrowmem.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
+
+	alloc := &memory.ResourceAllocator{Allocator: mem}
+	in := newSplitWindowsInput(alloc, 8)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Model flux's handoff: the callback accepts the table and returns without
+	// consuming it, as consecutiveTransport does when it queues a table for a
+	// dispatcher goroutine. Cancelling then drives splitWindows down its
+	// abandonment path while that table is still unclaimed.
+	err := splitWindows(ctx, alloc, in, false, func(tbl flux.Table) error {
+		cancel()
+		return nil
+	})
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+// TestSplitWindows_ConsumedReleasesBuffer is the control: when every table is
+// consumed normally, nothing is outstanding. This must hold before and after the
+// fix, and guards against a fix that over-releases.
+func TestSplitWindows_ConsumedReleasesBuffer(t *testing.T) {
+	mem := arrowmem.NewCheckedAllocator(arrowmem.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
+
+	alloc := &memory.ResourceAllocator{Allocator: mem}
+	in := newSplitWindowsInput(alloc, 8)
+
+	tables := 0
+	err := splitWindows(context.Background(), alloc, in, false, func(tbl flux.Table) error {
+		tables++
+		return tbl.Do(func(flux.ColReader) error { return nil })
+	})
+	require.NoError(t, err)
+	require.Equal(t, 8, tables)
+}

--- a/tsdb/engine/tsm1/array_cursor_iterator.gen.go
+++ b/tsdb/engine/tsm1/array_cursor_iterator.gen.go
@@ -26,6 +26,11 @@ func (q *arrayCursorIterator) buildFloatArrayCursor(ctx context.Context, name []
 		}
 		err = q.asc.Float.reset(opt.SeekTime(), opt.StopTime(), cacheValues, keyCursor)
 		if err != nil {
+			// reset takes ownership of keyCursor before the read that can fail,
+			// so on error the references it holds are ours to release. Nothing
+			// else can: the cursor is only reachable through this pooled struct,
+			// and CursorIterator has no teardown hook.
+			q.asc.Float.Close()
 			return nil, err
 		}
 		return q.asc.Float, nil
@@ -35,6 +40,7 @@ func (q *arrayCursorIterator) buildFloatArrayCursor(ctx context.Context, name []
 		}
 		err = q.desc.Float.reset(opt.SeekTime(), opt.StopTime(), cacheValues, keyCursor)
 		if err != nil {
+			q.desc.Float.Close()
 			return nil, err
 		}
 		return q.desc.Float, nil
@@ -53,6 +59,11 @@ func (q *arrayCursorIterator) buildIntegerArrayCursor(ctx context.Context, name 
 		}
 		err = q.asc.Integer.reset(opt.SeekTime(), opt.StopTime(), cacheValues, keyCursor)
 		if err != nil {
+			// reset takes ownership of keyCursor before the read that can fail,
+			// so on error the references it holds are ours to release. Nothing
+			// else can: the cursor is only reachable through this pooled struct,
+			// and CursorIterator has no teardown hook.
+			q.asc.Integer.Close()
 			return nil, err
 		}
 		return q.asc.Integer, nil
@@ -62,6 +73,7 @@ func (q *arrayCursorIterator) buildIntegerArrayCursor(ctx context.Context, name 
 		}
 		err = q.desc.Integer.reset(opt.SeekTime(), opt.StopTime(), cacheValues, keyCursor)
 		if err != nil {
+			q.desc.Integer.Close()
 			return nil, err
 		}
 		return q.desc.Integer, nil
@@ -80,6 +92,11 @@ func (q *arrayCursorIterator) buildUnsignedArrayCursor(ctx context.Context, name
 		}
 		err = q.asc.Unsigned.reset(opt.SeekTime(), opt.StopTime(), cacheValues, keyCursor)
 		if err != nil {
+			// reset takes ownership of keyCursor before the read that can fail,
+			// so on error the references it holds are ours to release. Nothing
+			// else can: the cursor is only reachable through this pooled struct,
+			// and CursorIterator has no teardown hook.
+			q.asc.Unsigned.Close()
 			return nil, err
 		}
 		return q.asc.Unsigned, nil
@@ -89,6 +106,7 @@ func (q *arrayCursorIterator) buildUnsignedArrayCursor(ctx context.Context, name
 		}
 		err = q.desc.Unsigned.reset(opt.SeekTime(), opt.StopTime(), cacheValues, keyCursor)
 		if err != nil {
+			q.desc.Unsigned.Close()
 			return nil, err
 		}
 		return q.desc.Unsigned, nil
@@ -107,6 +125,11 @@ func (q *arrayCursorIterator) buildStringArrayCursor(ctx context.Context, name [
 		}
 		err = q.asc.String.reset(opt.SeekTime(), opt.StopTime(), cacheValues, keyCursor)
 		if err != nil {
+			// reset takes ownership of keyCursor before the read that can fail,
+			// so on error the references it holds are ours to release. Nothing
+			// else can: the cursor is only reachable through this pooled struct,
+			// and CursorIterator has no teardown hook.
+			q.asc.String.Close()
 			return nil, err
 		}
 		return q.asc.String, nil
@@ -116,6 +139,7 @@ func (q *arrayCursorIterator) buildStringArrayCursor(ctx context.Context, name [
 		}
 		err = q.desc.String.reset(opt.SeekTime(), opt.StopTime(), cacheValues, keyCursor)
 		if err != nil {
+			q.desc.String.Close()
 			return nil, err
 		}
 		return q.desc.String, nil
@@ -134,6 +158,11 @@ func (q *arrayCursorIterator) buildBooleanArrayCursor(ctx context.Context, name 
 		}
 		err = q.asc.Boolean.reset(opt.SeekTime(), opt.StopTime(), cacheValues, keyCursor)
 		if err != nil {
+			// reset takes ownership of keyCursor before the read that can fail,
+			// so on error the references it holds are ours to release. Nothing
+			// else can: the cursor is only reachable through this pooled struct,
+			// and CursorIterator has no teardown hook.
+			q.asc.Boolean.Close()
 			return nil, err
 		}
 		return q.asc.Boolean, nil
@@ -143,6 +172,7 @@ func (q *arrayCursorIterator) buildBooleanArrayCursor(ctx context.Context, name 
 		}
 		err = q.desc.Boolean.reset(opt.SeekTime(), opt.StopTime(), cacheValues, keyCursor)
 		if err != nil {
+			q.desc.Boolean.Close()
 			return nil, err
 		}
 		return q.desc.Boolean, nil

--- a/tsdb/engine/tsm1/array_cursor_iterator.gen.go.tmpl
+++ b/tsdb/engine/tsm1/array_cursor_iterator.gen.go.tmpl
@@ -22,6 +22,11 @@ func (q *arrayCursorIterator) build{{.Name}}ArrayCursor(ctx context.Context, nam
 		}
 		err = q.asc.{{.Name}}.reset(opt.SeekTime(), opt.StopTime(), cacheValues, keyCursor)
 		if err != nil {
+		    // reset takes ownership of keyCursor before the read that can fail,
+		    // so on error the references it holds are ours to release. Nothing
+		    // else can: the cursor is only reachable through this pooled struct,
+		    // and CursorIterator has no teardown hook.
+		    q.asc.{{.Name}}.Close()
 		    return nil, err
 		}
 		return q.asc.{{.Name}}, nil
@@ -31,6 +36,7 @@ func (q *arrayCursorIterator) build{{.Name}}ArrayCursor(ctx context.Context, nam
 		}
 		err = q.desc.{{.Name}}.reset(opt.SeekTime(), opt.StopTime(), cacheValues, keyCursor)
 		if err != nil {
+		    q.desc.{{.Name}}.Close()
 		    return nil, err
 		}
 		return q.desc.{{.Name}}, nil

--- a/tsdb/engine/tsm1/array_cursor_reset_error_test.go
+++ b/tsdb/engine/tsm1/array_cursor_reset_error_test.go
@@ -1,0 +1,148 @@
+package tsm1_test
+
+import (
+	"context"
+	"encoding/binary"
+	"math"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/influxdata/influxdb/v2/models"
+	"github.com/influxdata/influxdb/v2/tsdb"
+	"github.com/stretchr/testify/require"
+)
+
+// corruptTSMBlocks overwrites the block region of a TSM file with 0xFF so that
+// every block's type byte is invalid and any block read fails deterministically.
+// The index and footer are left intact, so the file still opens: the FileStore
+// reads only the index at open time.
+//
+// This is deliberate fault injection against the frozen TSM layout: a 5-byte
+// header (magic + version) precedes the blocks, and the footer's final 8 bytes
+// hold the index offset. Corrupting the type byte rather than relying on a CRC
+// mismatch matters because the array block readers skip the stored CRC
+// (mmapAccessor.readFloatArrayBlock decodes from entry.Offset+4 without
+// verifying it), so zeroed data could decode as an empty block with no error.
+func corruptTSMBlocks(tb testing.TB, path string) {
+	tb.Helper()
+
+	b, err := os.ReadFile(path)
+	require.NoError(tb, err)
+
+	require.Greater(tb, len(b), 13, "TSM file %s too small to hold a block", path)
+	indexOfs := binary.BigEndian.Uint64(b[len(b)-8:])
+	require.Greater(tb, indexOfs, uint64(5), "TSM file %s has no block region", path)
+	require.LessOrEqual(tb, indexOfs, uint64(len(b)-8), "TSM file %s has an invalid index offset", path)
+
+	for i := uint64(5); i < indexOfs; i++ {
+		b[i] = 0xFF
+	}
+	require.NoError(tb, os.WriteFile(path, b, 0666))
+}
+
+// TestArrayCursor_ResetError_ReleasesTSMReferences covers the reset-error path
+// in buildXArrayCursor: reset takes ownership of a Ref'd KeyCursor before the
+// block read that can fail, so on error the cursor build must release the
+// KeyCursor's TSM references itself - nothing else can, since the pooled
+// cursor is unreachable to the caller and CursorIterator has no teardown hook.
+//
+// Without that release, a corrupt block does not just fail the query: every
+// TSM file the KeyCursor touched keeps a reference forever. The files can
+// never be deleted and FileStore.Close parks in refsWG.Wait(), so the shard
+// can neither drop nor close - with no panic or log line pointing at the
+// cause. The bounded close at the end turns that hang into a reported failure.
+//
+// Only the float cursors are exercised: the build/reset/close stanza is
+// generated identically for all five types from the same template, so per-type
+// repetition would add runtime without adding coverage. Ascending and
+// descending are separate pooled cursors and are both covered.
+func TestArrayCursor_ResetError_ReleasesTSMReferences(t *testing.T) {
+	for _, index := range tsdb.RegisteredIndexes() {
+		t.Run(index, func(t *testing.T) {
+			for _, tc := range []struct {
+				name      string
+				ascending bool
+			}{
+				{"ascending", true},
+				{"descending", false},
+			} {
+				t.Run(tc.name, func(t *testing.T) {
+					e := MustOpenEngine(t, index)
+
+					require.NoError(t, e.WritePointsString(
+						"cpu,host=A value=1.1 1000000000",
+						"cpu,host=A value=1.2 2000000000",
+					))
+					e.MustWriteSnapshot()
+
+					var tsmPaths []string
+					for _, f := range e.FileStore.Files() {
+						tsmPaths = append(tsmPaths, f.Path())
+					}
+					require.NotEmpty(t, tsmPaths, "snapshot did not produce a TSM file")
+
+					for _, p := range tsmPaths {
+						corruptTSMBlocks(t, p)
+					}
+
+					// Reopen so the FileStore maps the corrupted bytes; opening
+					// succeeds because only the intact index is read.
+					require.NoError(t, e.Reopen())
+
+					// Compactions against the corrupt blocks would fail and
+					// retry while holding references of their own; disable them
+					// so the only reference traffic is the cursor build's.
+					e.SetCompactionsEnabled(false)
+
+					iter, err := e.CreateCursorIterator(context.Background())
+					require.NoError(t, err)
+
+					cur, err := iter.Next(context.Background(), &tsdb.CursorRequest{
+						Name:      []byte("cpu"),
+						Tags:      models.NewTags(map[string]string{"host": "A"}),
+						Field:     "value",
+						Ascending: tc.ascending,
+						StartTime: math.MinInt64,
+						EndTime:   math.MaxInt64,
+					})
+					require.Error(t, err, "reading a corrupt block must fail the cursor build")
+					require.Nil(t, cur)
+
+					var inUse []string
+					for _, f := range e.FileStore.Files() {
+						if f.InUse() {
+							inUse = append(inUse, f.Path())
+						}
+					}
+
+					// A leaked reference parks FileStore.Close in refsWG.Wait()
+					// forever. Close the FileStore - not the whole engine, whose
+					// fieldset does not tolerate the harness cleanup's second
+					// Close - with a deadline. This must happen before any
+					// assertion can fail the test: FileStore.Close nils f.files
+					// before waiting, so once it has run (even hung), the harness
+					// cleanup's engine Close is a no-op on the FileStore and the
+					// binary exits with a reported failure instead of wedging in
+					// cleanup on the leaked references. The error is asserted on
+					// the test goroutine; the buffered channel carries it out of
+					// the closing goroutine.
+					var closeHung bool
+					closeErr := make(chan error, 1)
+					go func() {
+						closeErr <- e.FileStore.Close()
+					}()
+					select {
+					case err := <-closeErr:
+						require.NoError(t, err)
+					case <-time.After(20 * time.Second):
+						closeHung = true
+					}
+
+					require.Empty(t, inUse, "failed cursor build leaked TSM references")
+					require.False(t, closeHung, "FileStore close hung: leaked TSM references parked it in refsWG.Wait()")
+				})
+			}
+		})
+	}
+}

--- a/tsdb/engine/tsm1/file_store.go
+++ b/tsdb/engine/tsm1/file_store.go
@@ -1464,6 +1464,9 @@ type KeyCursor struct {
 	// decrement through the size of seeks slice.
 	pos       int
 	ascending bool
+
+	// closed guards the release loop in Close so that it runs exactly once.
+	closed atomic.Bool
 }
 
 type location struct {
@@ -1538,7 +1541,23 @@ func newKeyCursor(ctx context.Context, fs *FileStore, key []byte, t int64, ascen
 }
 
 // Close removes all references on the cursor.
+//
+// Close is idempotent and safe to call concurrently. Without the guard, the
+// release loop below reads c.seeks and only afterwards clears it, so two callers
+// could both run it and Unref every location twice. That drives
+// TSMReader.refsWG negative, and because WaitGroup.Add decrements before it
+// panics, the reader is left permanently unusable: every later Ref or Unref on
+// it panics for the remaining life of the process.
+//
+// Callers are expected to close exactly once - this is a backstop, not a licence
+// to close from two places. It matters because every cursor wrapper in
+// storage/reads forwards Close by embedding, so any caller mistake at any
+// wrapper depth arrives here.
 func (c *KeyCursor) Close() {
+	if !c.closed.CompareAndSwap(false, true) {
+		return
+	}
+
 	// Remove all of our in-use references since we're done
 	for _, f := range c.seeks {
 		f.r.Unref()

--- a/tsdb/engine/tsm1/key_cursor_bench_test.go
+++ b/tsdb/engine/tsm1/key_cursor_bench_test.go
@@ -51,7 +51,9 @@ func BenchmarkKeyCursor_OpenClose(b *testing.B) {
 			ctx := context.Background()
 
 			// Confirm the fixture really produces the intended fan-out, so a
-			// silently-empty cursor cannot make this look fast.
+			// silently thin store cannot make this look fast. The warm-up
+			// cursor also takes one create/close cycle out of the timed loop.
+			require.Equal(b, files, fs.Count())
 			c := fs.KeyCursor(ctx, key, 0, true)
 			c.Close()
 

--- a/tsdb/engine/tsm1/key_cursor_bench_test.go
+++ b/tsdb/engine/tsm1/key_cursor_bench_test.go
@@ -1,0 +1,66 @@
+package tsm1_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/influxdata/influxdb/v2/tsdb/engine/tsm1"
+	"github.com/stretchr/testify/require"
+)
+
+// BenchmarkKeyCursor_OpenClose measures the create-and-close cycle a query
+// performs once per series-field per shard.
+//
+// KeyCursor.Close sits on the hot path of both query engines - ten call sites in
+// array_cursor.gen.go for the Flux read path, and ten in iterator.gen.go for
+// InfluxQL, which is the 1.x primary read path. A guard added there is therefore
+// worth measuring rather than reasoning about, even though the guard is a single
+// atomic compare-and-swap.
+//
+// Close's existing cost is O(locations): one Unref, itself an atomic, per TSM
+// file the cursor spans. The file counts below bracket how much a fixed O(1)
+// guard can matter - its relative cost is largest at one file and shrinks from
+// there. Creation is included because that is the real unit of work, and because
+// measuring Close alone would magnify a constant against an artificially small
+// denominator.
+//
+// No parallel variant: KeyCursors are per-query objects, so concurrent closes
+// touch distinct cursors and do not contend on the guard. What a parallel
+// benchmark would actually measure is FileStore.fastMu and allocator contention
+// during creation, which this change does not affect.
+func BenchmarkKeyCursor_OpenClose(b *testing.B) {
+	for _, files := range []int{1, 8, 32} {
+		b.Run(fmt.Sprintf("files=%d", files), func(b *testing.B) {
+			dir := b.TempDir()
+
+			// One TSM file per keyValues entry, all holding the same key at
+			// increasing timestamps, so a cursor seeking from 0 ascending spans
+			// every file and Close has `files` locations to release.
+			data := make([]keyValues, files)
+			for i := range data {
+				data[i] = keyValues{"cpu", []tsm1.Value{tsm1.NewValue(int64(i), float64(i))}}
+			}
+			_, err := newFileDir(b, dir, data...)
+			require.NoError(b, err)
+
+			fs := newTestFileStore(b, dir)
+			require.NoError(b, fs.Open(context.Background()))
+
+			key := []byte("cpu")
+			ctx := context.Background()
+
+			// Confirm the fixture really produces the intended fan-out, so a
+			// silently-empty cursor cannot make this look fast.
+			c := fs.KeyCursor(ctx, key, 0, true)
+			c.Close()
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for range b.N {
+				c := fs.KeyCursor(ctx, key, 0, true)
+				c.Close()
+			}
+		})
+	}
+}

--- a/tsdb/engine/tsm1/key_cursor_concurrent_test.go
+++ b/tsdb/engine/tsm1/key_cursor_concurrent_test.go
@@ -80,16 +80,14 @@ func TestKeyCursor_ConcurrentClose(t *testing.T) {
 
 	panics := make(chan any, iterations*closers)
 
-	for i := 0; i < iterations; i++ {
+	for range iterations {
 		c := fs.KeyCursor(context.Background(), []byte("cpu"), 0, true)
 
 		var wg sync.WaitGroup
 		start := make(chan struct{})
 
-		for j := 0; j < closers; j++ {
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
+		for range closers {
+			wg.Go(func() {
 				defer func() {
 					if r := recover(); r != nil {
 						panics <- r
@@ -97,7 +95,7 @@ func TestKeyCursor_ConcurrentClose(t *testing.T) {
 				}()
 				<-start // release both goroutines together
 				c.Close()
-			}()
+			})
 		}
 
 		close(start)

--- a/tsdb/engine/tsm1/key_cursor_concurrent_test.go
+++ b/tsdb/engine/tsm1/key_cursor_concurrent_test.go
@@ -112,7 +112,8 @@ func TestKeyCursor_ConcurrentClose(t *testing.T) {
 
 	if r, ok := <-panics; ok {
 		// The FileStore is now unusable; do not attempt to close it.
-		t.Fatalf("concurrent KeyCursor.Close corrupted a TSMReader reference count: %v", r)
+		require.Failf(t, "concurrent KeyCursor.Close corrupted a TSMReader reference count",
+			"panic: %v", r)
 	}
 
 	require.NoError(t, fs.Close())

--- a/tsdb/engine/tsm1/key_cursor_concurrent_test.go
+++ b/tsdb/engine/tsm1/key_cursor_concurrent_test.go
@@ -11,29 +11,30 @@ import (
 )
 
 // TestKeyCursor_ConcurrentClose reproduces the "sync: negative WaitGroup counter"
-// panic seen in EAR-7019 and EAR-6049.
+// panic seen in EAR-7019 and EAR-6049, now prevented by the `closed` guard in
+// KeyCursor.Close.
 //
-// KeyCursor.Close releases a reference for every location in c.seeks and only
-// afterwards clears the slice:
+// Before the guard, Close released a reference for every location in c.seeks
+// and only afterwards cleared the slice:
 //
 //	for _, f := range c.seeks {
 //		f.r.Unref()
 //	}
 //	c.seeks = nil
 //
-// The read and the clear are not atomic, so two goroutines closing the same
-// cursor can both observe a populated c.seeks and both run the release loop.
-// Every TSMReader involved is then Unref'd twice. That drives its reference
-// count negative and permanently poisons the WaitGroup guarding its lifetime,
-// after which *every* subsequent Ref or Unref on that reader panics for the
+// The read and the clear were not atomic, so two goroutines closing the same
+// cursor could both observe a populated c.seeks and both run the release loop.
+// Every TSMReader involved was then Unref'd twice. That drove its reference
+// count negative and permanently poisoned the WaitGroup guarding its lifetime,
+// after which *every* subsequent Ref or Unref on that reader panicked for the
 // remaining life of the process -- which is why a single occurrence produced
 // days of continuous query failures.
 //
 // floatArrayAscendingCursor.Close has the same non-atomic check-then-clear on
-// c.tsm.keyCursor, so it does not prevent the second entry either.
+// c.tsm.keyCursor, so it did not prevent the second entry either.
 //
-// Concurrent Close is reachable in production. storage/flux/reader.go abandons
-// a table when the query context is cancelled:
+// Concurrent Close was reachable in production. storage/flux/reader.go used to
+// abandon a table when the query context was cancelled:
 //
 //	case <-gi.ctx.Done():
 //		table.Cancel()
@@ -41,11 +42,13 @@ import (
 //
 // table.Cancel only sets an atomic flag; it does not interrupt an advance()
 // already in flight on the Flux dispatcher goroutine. Deferred cleanup then
-// calls table.Close() -> cur.Close() on the storage goroutine while the
-// dispatcher is still inside advance() -> cursor.Next() -> nextArrayCursor(),
-// whose first action is to close the same cursor chain.
+// called table.Close() -> cur.Close() on the storage goroutine while the
+// dispatcher was still inside advance() -> cursor.Next() -> nextArrayCursor(),
+// whose first action is to close the same cursor chain. That overlap is now
+// prevented at the source by table.awaitAbandoned (storage/flux/table.go); the
+// guard in KeyCursor.Close is the backstop this test pins down.
 //
-// Run with -race to also surface the underlying data race on c.seeks.
+// Run with -race: before the guard it also surfaced the data race on c.seeks.
 func TestKeyCursor_ConcurrentClose(t *testing.T) {
 	// Several TSM files for the same key so that each cursor holds several
 	// locations, matching the production shape where one bad close corrupts

--- a/tsdb/engine/tsm1/key_cursor_concurrent_test.go
+++ b/tsdb/engine/tsm1/key_cursor_concurrent_test.go
@@ -45,7 +45,7 @@ import (
 // called table.Close() -> cur.Close() on the storage goroutine while the
 // dispatcher was still inside advance() -> cursor.Next() -> nextArrayCursor(),
 // whose first action is to close the same cursor chain. That overlap is now
-// prevented at the source by table.awaitAbandoned (storage/flux/table.go); the
+// prevented at the source by table.abandon (storage/flux); the
 // guard in KeyCursor.Close is the backstop this test pins down.
 //
 // Run with -race: before the guard it also surfaced the data race on c.seeks.

--- a/tsdb/engine/tsm1/key_cursor_concurrent_test.go
+++ b/tsdb/engine/tsm1/key_cursor_concurrent_test.go
@@ -1,0 +1,116 @@
+package tsm1_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/influxdata/influxdb/v2/tsdb"
+	"github.com/influxdata/influxdb/v2/tsdb/engine/tsm1"
+	"github.com/stretchr/testify/require"
+)
+
+// TestKeyCursor_ConcurrentClose reproduces the "sync: negative WaitGroup counter"
+// panic seen in EAR-7019 and EAR-6049.
+//
+// KeyCursor.Close releases a reference for every location in c.seeks and only
+// afterwards clears the slice:
+//
+//	for _, f := range c.seeks {
+//		f.r.Unref()
+//	}
+//	c.seeks = nil
+//
+// The read and the clear are not atomic, so two goroutines closing the same
+// cursor can both observe a populated c.seeks and both run the release loop.
+// Every TSMReader involved is then Unref'd twice. That drives its reference
+// count negative and permanently poisons the WaitGroup guarding its lifetime,
+// after which *every* subsequent Ref or Unref on that reader panics for the
+// remaining life of the process -- which is why a single occurrence produced
+// days of continuous query failures.
+//
+// floatArrayAscendingCursor.Close has the same non-atomic check-then-clear on
+// c.tsm.keyCursor, so it does not prevent the second entry either.
+//
+// Concurrent Close is reachable in production. storage/flux/reader.go abandons
+// a table when the query context is cancelled:
+//
+//	case <-gi.ctx.Done():
+//		table.Cancel()
+//		break READ
+//
+// table.Cancel only sets an atomic flag; it does not interrupt an advance()
+// already in flight on the Flux dispatcher goroutine. Deferred cleanup then
+// calls table.Close() -> cur.Close() on the storage goroutine while the
+// dispatcher is still inside advance() -> cursor.Next() -> nextArrayCursor(),
+// whose first action is to close the same cursor chain.
+//
+// Run with -race to also surface the underlying data race on c.seeks.
+func TestKeyCursor_ConcurrentClose(t *testing.T) {
+	// Several TSM files for the same key so that each cursor holds several
+	// locations, matching the production shape where one bad close corrupts
+	// the reference counts of multiple readers at once.
+	data := []keyValues{
+		{"cpu", []tsm1.Value{tsm1.NewValue(0, 1.0)}},
+		{"cpu", []tsm1.Value{tsm1.NewValue(1, 2.0)}},
+		{"cpu", []tsm1.Value{tsm1.NewValue(2, 3.0)}},
+		{"cpu", []tsm1.Value{tsm1.NewValue(3, 4.0)}},
+	}
+
+	dir := t.TempDir()
+	_, err := newFileDir(t, dir, data...)
+	require.NoError(t, err)
+
+	// Deliberately not newTestFileStore: once a reader's WaitGroup has gone
+	// negative, TSMReader.Close blocks in refsWG.Wait() forever. Registering a
+	// cleanup that closes the FileStore would hang the test run instead of
+	// failing it, so the store is closed explicitly only on success.
+	fs := tsm1.NewFileStore(dir, tsdb.EngineTags{})
+	require.NoError(t, fs.Open(context.Background()))
+
+	// The race window is narrow, so try repeatedly with a fresh cursor each
+	// time. In practice the detector or the panic fires well inside this.
+	const (
+		iterations = 500
+		closers    = 2
+	)
+
+	panics := make(chan any, iterations*closers)
+
+	for i := 0; i < iterations; i++ {
+		c := fs.KeyCursor(context.Background(), []byte("cpu"), 0, true)
+
+		var wg sync.WaitGroup
+		start := make(chan struct{})
+
+		for j := 0; j < closers; j++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				defer func() {
+					if r := recover(); r != nil {
+						panics <- r
+					}
+				}()
+				<-start // release both goroutines together
+				c.Close()
+			}()
+		}
+
+		close(start)
+		wg.Wait()
+
+		if len(panics) > 0 {
+			break
+		}
+	}
+
+	close(panics)
+
+	if r, ok := <-panics; ok {
+		// The FileStore is now unusable; do not attempt to close it.
+		t.Fatalf("concurrent KeyCursor.Close corrupted a TSMReader reference count: %v", r)
+	}
+
+	require.NoError(t, fs.Close())
+}


### PR DESCRIPTION
On context cancellation storage/flux stopped waiting for a table's
consumer but closed the table anyway, so table.Close() could race
advance() on a dispatcher goroutine. Both reach KeyCursor.Close(), which
releases every location before clearing c.seeks, so each TSM file was
Unref'd twice. That leaves TSMReader.refsWG negative -- WaitGroup.Add
decrements before it panics -- poisoning the reader for the life of the
process and failing every later query against that shard.

Transfer ownership via the `used` CAS the table already has: claim the
table when no consumer can run, otherwise wait for done, which is then
guaranteed to close. Waiting unconditionally would deadlock, since
consecutiveTransport drops queued messages on error without Ack'ing them.
Also make KeyCursor.Close idempotent as a backstop, and release the
cursor stranded when an array cursor's reset() fails.

Closes: #27570
