### PR TITLE
feat: report startup errors on /health and /ready

### DIFF
--- a/cmd/influxd/launcher/cmd.go
+++ b/cmd/influxd/launcher/cmd.go
@@ -22,8 +22,13 @@ import (
 	"github.com/influxdata/influxdb/v2/vault"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
+
+// shutdownTimeout bounds teardown, giving in-progress requests a few seconds
+// to finish. Applies to both the normal exit and the startup-failure path.
+const shutdownTimeout = 2 * time.Second
 
 func errInvalidFlags(flags []string, configFile string) error {
 	return fmt.Errorf(
@@ -122,16 +127,30 @@ func cmdRunE(ctx context.Context, o *InfluxdOpts) func() error {
 		l.log = logger
 
 		// Start the launcher and wait for it to exit on SIGINT or SIGTERM.
-		if err := l.run(signals.WithStandardSignals(ctx), o); err != nil {
-			return err
+		runErr := l.run(signals.WithStandardSignals(ctx), o)
+		if runErr != nil {
+			// Startup failed. Release whatever did come up (PID file, bolt,
+			// sqlite, engine) and hold only the listener open for the
+			// configured window, so the latched error can be retrieved
+			// without pinning state a restart needs.
+			l.holdForStartupError(ctx, o.StartupErrorTimeout)
+		} else {
+			<-l.Done()
 		}
-		<-l.Done()
 
-		// Tear down the launcher, allowing it a few seconds to finish any
-		// in-progress requests.
-		shutdownCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+		// Tear down what is left of the launcher, allowing it a few seconds to
+		// finish any in-progress requests. Derive from the outer ctx, not the
+		// signal-wrapped one, so a SIGTERM does not instantly cancel teardown.
+		shutdownCtx, cancel := context.WithTimeout(ctx, shutdownTimeout)
 		defer cancel()
-		return l.Shutdown(shutdownCtx)
+		serr := l.Shutdown(shutdownCtx)
+		if runErr != nil {
+			if serr != nil {
+				logger.Error("Failed to shut down after startup error", zap.Error(serr))
+			}
+			return runErr // original error, so the exit code reflects the cause
+		}
+		return serr
 	}
 }
 
@@ -145,8 +164,9 @@ type InfluxdOpts struct {
 	TracingType       string
 	ReportingDisabled bool
 
-	PIDFile          string
-	OverwritePIDFile bool
+	PIDFile             string
+	OverwritePIDFile    bool
+	StartupErrorTimeout time.Duration // how long /health and /ready stay up after a failed startup; 0 disables
 
 	AssetsPath string
 	BoltPath   string
@@ -221,8 +241,9 @@ func NewOpts(viper *viper.Viper) *InfluxdOpts {
 		FluxLogEnabled:    false,
 		ReportingDisabled: false,
 
-		PIDFile:          "",
-		OverwritePIDFile: false,
+		PIDFile:             "",
+		OverwritePIDFile:    false,
+		StartupErrorTimeout: 0,
 
 		BoltPath:   filepath.Join(dir, bolt.DefaultFilename),
 		SqLitePath: filepath.Join(dir, sqlite.DefaultFilename),
@@ -349,6 +370,12 @@ func (o *InfluxdOpts) BindCliOpts() []cli.Opt {
 			Flag:    "overwrite-pid-file",
 			Default: o.OverwritePIDFile,
 			Desc:    "overwrite PID file if it already exists instead of exiting",
+		},
+		{
+			DestP:   &o.StartupErrorTimeout,
+			Flag:    "startup-error-timeout",
+			Default: o.StartupErrorTimeout,
+			Desc:    "max duration to keep /health and /ready serving after a failed startup so the error can be retrieved. Set to 0 to exit immediately",
 		},
 		{
 			DestP:   &o.SessionLength,

--- a/cmd/influxd/launcher/cmd_test.go
+++ b/cmd/influxd/launcher/cmd_test.go
@@ -1,11 +1,15 @@
 package launcher
 
 import (
+	"context"
+	"errors"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 )
 
 func TestInvalidFlags(t *testing.T) {
@@ -66,4 +70,170 @@ bind-address = "127.0.0.1:8088"
 			require.ElementsMatch(t, tt.want, got)
 		})
 	}
+}
+
+// TestHoldForStartupError covers the wait that keeps /health and /ready
+// scrapeable after a failed startup. The early-return cases matter as much as
+// the wait itself: each one exists to avoid delaying an exit that nothing can
+// observe.
+func TestHoldForStartupError(t *testing.T) {
+	t.Parallel()
+
+	// newLauncher builds a Launcher with just the fields holdForStartupError
+	// reads. run() is not involved; these cases are about the wait alone.
+	newLauncher := func(serving bool, done <-chan struct{}) *Launcher {
+		return &Launcher{
+			log:         zap.NewNop(),
+			httpServing: serving,
+			doneChan:    done,
+		}
+	}
+
+	// requireReturnsWithin runs hold in a goroutine so a regression fails this
+	// subtest in a second rather than blocking until the package test timeout.
+	requireReturnsWithin := func(t *testing.T, limit time.Duration, hold func()) {
+		t.Helper()
+		returned := make(chan struct{})
+		go func() {
+			defer close(returned)
+			hold()
+		}()
+		select {
+		case <-returned:
+		case <-time.After(limit):
+			t.Fatalf("holdForStartupError did not return within %s", limit)
+		}
+	}
+
+	open := make(chan struct{}) // never closed: Done() will not fire
+	closed := make(chan struct{})
+	close(closed)
+
+	// Each case must return without waiting out the duration: there is either
+	// no wait to make (non-positive d), nothing to scrape, or nothing left to
+	// wait for.
+	immediate := []struct {
+		name    string
+		serving bool
+		done    <-chan struct{}
+		d       time.Duration
+	}{
+		{"duration is zero", true, open, 0},
+		{"duration is negative", true, open, -5 * time.Second},
+		{"nothing is listening", false, open, time.Hour}, // runHTTP failed
+		{"already done", true, closed, time.Hour},
+	}
+	for _, tt := range immediate {
+		t.Run("returns immediately when "+tt.name, func(t *testing.T) {
+			t.Parallel()
+			l := newLauncher(tt.serving, tt.done)
+			requireReturnsWithin(t, time.Second, func() {
+				l.holdForStartupError(context.Background(), tt.d)
+			})
+		})
+	}
+
+	t.Run("a signal cuts the wait short", func(t *testing.T) {
+		t.Parallel()
+		done := make(chan struct{})
+		l := newLauncher(true, done)
+
+		go func() {
+			time.Sleep(10 * time.Millisecond)
+			close(done) // stands in for SIGTERM
+		}()
+
+		requireReturnsWithin(t, time.Second, func() {
+			l.holdForStartupError(context.Background(), time.Hour)
+		})
+	})
+
+	t.Run("waits for the duration when nothing interrupts", func(t *testing.T) {
+		t.Parallel()
+		l := newLauncher(true, open)
+
+		const d = 50 * time.Millisecond
+		start := time.Now()
+		l.holdForStartupError(context.Background(), d)
+		require.GreaterOrEqual(t, time.Since(start), d)
+	})
+
+	// The wait is only useful if what it waits with is the listener alone.
+	// Everything else must already be released, or a supervisor restarting
+	// influxd is blocked on state belonging to the run that just failed.
+	t.Run("releases every subsystem but the listener before waiting", func(t *testing.T) {
+		t.Parallel()
+
+		var stopped []string
+		closer := func(label string) labeledCloser {
+			return labeledCloser{
+				label: label,
+				closer: func(context.Context) error {
+					stopped = append(stopped, label)
+					return nil
+				},
+			}
+		}
+
+		done := make(chan struct{})
+		close(done) // cut the wait short; the teardown precedes it either way
+		l := newLauncher(true, done)
+		l.closers = []labeledCloser{
+			closer(SubsystemPIDFile),
+			closer(SubsystemEngine),
+			closer(SubsystemHTTPServer), // registered last, torn down last
+		}
+
+		l.holdForStartupError(context.Background(), time.Hour)
+		require.Equal(t, []string{SubsystemEngine, SubsystemPIDFile}, stopped,
+			"subsystems tear down in reverse registration order, listener retained")
+
+		require.NoError(t, l.Shutdown(context.Background()))
+		require.Equal(t,
+			[]string{SubsystemEngine, SubsystemPIDFile, SubsystemHTTPServer}, stopped,
+			"Shutdown closes the listener the hold was left with")
+	})
+}
+
+// TestLauncherShutdown_PhasedTeardown covers the contract that lets teardown
+// split around the startup-error hold: every closer runs at most once across
+// the phases, and Shutdown reports the failures from all of them, so one call
+// site can log the whole teardown.
+func TestLauncherShutdown_PhasedTeardown(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	engineErr := errors.New("engine close failed")
+	listenerErr := errors.New("listener close failed")
+
+	var stopped int
+	l := &Launcher{
+		log: zap.NewNop(),
+		closers: []labeledCloser{
+			{label: SubsystemEngine, closer: func(context.Context) error {
+				stopped++
+				return engineErr
+			}},
+			{label: SubsystemHTTPServer, closer: func(context.Context) error {
+				stopped++
+				return listenerErr
+			}},
+		},
+	}
+
+	err := l.shutdownSubsystems(ctx)
+	require.ErrorContains(t, err, engineErr.Error())
+	require.NotContains(t, err.Error(), listenerErr.Error(),
+		"the listener must still be open after the first phase")
+	require.Equal(t, 1, stopped)
+
+	err = l.Shutdown(ctx)
+	require.ErrorContains(t, err, listenerErr.Error())
+	require.ErrorContains(t, err, engineErr.Error(),
+		"Shutdown reports the earlier phase's failures too")
+	require.Equal(t, 2, stopped)
+
+	require.EqualError(t, l.Shutdown(ctx), err.Error(),
+		"a repeated Shutdown returns the same accumulated error")
+	require.Equal(t, 2, stopped, "a repeated Shutdown must not re-run closers")
 }

--- a/cmd/influxd/launcher/export_test.go
+++ b/cmd/influxd/launcher/export_test.go
@@ -1,0 +1,16 @@
+package launcher
+
+import (
+	"context"
+	"time"
+)
+
+// HoldForStartupError exposes holdForStartupError to the external
+// launcher_test package, which exercises the teardown split around the hold
+// against a fully constructed launcher. cmdRunE itself is not directly
+// testable in-process: it calls fluxinit.FluxInit, which panics on a second
+// call, and this package already finalizes the Flux runtime via the
+// fluxinit/static import in launcher_test.go.
+func (m *Launcher) HoldForStartupError(ctx context.Context, d time.Duration) {
+	m.holdForStartupError(ctx, d)
+}

--- a/cmd/influxd/launcher/health_ready_test.go
+++ b/cmd/influxd/launcher/health_ready_test.go
@@ -3,11 +3,25 @@ package launcher_test
 import (
 	"encoding/json"
 	nethttp "net/http"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/influxdata/influxdb/v2/cmd/influxd/launcher"
+	"github.com/influxdata/influxdb/v2/http"
 	"github.com/influxdata/influxdb/v2/kit/check"
 	"github.com/stretchr/testify/require"
+)
+
+const (
+	// engineFailPrefix is what failSubsystem stamps onto the single startup
+	// entry on /health. Derived from the subsystem constant so renaming the
+	// subsystem cannot leave a stale expectation behind.
+	engineFailPrefix = launcher.SubsystemEngine + ": "
+
+	pidFileName = "influxd.pid"
 )
 
 // httpGetJSON issues a GET against url and decodes the JSON body into out.
@@ -31,8 +45,17 @@ func httpGetJSON(t *testing.T, url string, out interface{}) int {
 // and cannot be a decode target, so nested checks decode as
 // BasicResponse.
 type healthBody struct {
-	Name   string                `json:"name"`
-	Status check.Status          `json:"status"`
+	Name    string                `json:"name"`
+	Status  check.Status          `json:"status"`
+	Message string                `json:"message"`
+	Checks  []check.BasicResponse `json:"checks"`
+}
+
+// readyBody mirrors the JSON shape served by /ready. The checks array is
+// populated only when the response is failing (`omitempty`), which is exactly
+// the case the startup-error tests exercise.
+type readyBody struct {
+	Status string                `json:"status"`
 	Checks []check.BasicResponse `json:"checks"`
 }
 
@@ -59,6 +82,7 @@ func TestLauncher_HealthEndpoint(t *testing.T) {
 			// bolt health check. NoopScheduler is *not* used by default
 			// (only set when opts.NoTasks), so task-scheduler is wired.
 			expected: []string{
+				launcher.SubsystemStartup,
 				launcher.SubsystemQuery,
 				launcher.SubsystemInfluxQL,
 				launcher.SubsystemSQLite,
@@ -70,6 +94,7 @@ func TestLauncher_HealthEndpoint(t *testing.T) {
 			name:        "disk_mode",
 			newLauncher: launcher.NewTestLauncherServer,
 			expected: []string{
+				launcher.SubsystemStartup,
 				launcher.SubsystemQuery,
 				launcher.SubsystemInfluxQL,
 				launcher.SubsystemKV,
@@ -88,7 +113,7 @@ func TestLauncher_HealthEndpoint(t *testing.T) {
 			l.SetupOrFail(t)
 
 			var body healthBody
-			status := httpGetJSON(t, l.URL().String()+"/health", &body)
+			status := httpGetJSON(t, l.URL().String()+http.HealthPath, &body)
 			require.Equal(t, nethttp.StatusOK, status)
 			require.Equal(t, check.StatusPass, body.Status)
 
@@ -114,14 +139,13 @@ func TestLauncher_ReadyEndpoint(t *testing.T) {
 	l := launcher.RunAndSetupNewLauncherOrFail(ctx, t)
 	defer l.ShutdownOrFail(t, ctx)
 
-	var body struct {
-		Status string `json:"status"`
-	}
-	status := httpGetJSON(t, l.URL().String()+"/ready", &body)
+	var body readyBody
+	status := httpGetJSON(t, l.URL().String()+http.ReadyPath, &body)
 	require.Equal(t, nethttp.StatusOK, status)
 	require.Equal(t, "ready", body.Status)
 
 	expected := []string{
+		launcher.SubsystemStartup,
 		launcher.SubsystemKV,
 		launcher.SubsystemSQLite,
 		launcher.SubsystemEngine,
@@ -134,4 +158,158 @@ func TestLauncher_ReadyEndpoint(t *testing.T) {
 	got := l.ReadyCheckNames()
 	require.ElementsMatchf(t, expected, got,
 		"unexpected /ready check set: %v", got)
+}
+
+// failEngineOpen points the engine at a regular file so storage engine open
+// fails. The failure lands after runHTTP has established the listener, which
+// is what makes the endpoints scrapeable while the error is latched.
+func failEngineOpen(t *testing.T) launcher.OptSetter {
+	t.Helper()
+	// A regular file where the engine expects a directory.
+	enginePath := filepath.Join(t.TempDir(), "engine-is-a-file")
+	require.NoError(t, os.WriteFile(enginePath, []byte("not a directory"), 0600))
+	return func(o *launcher.InfluxdOpts) { o.EnginePath = enginePath }
+}
+
+// TestLauncher_StartupError_SurfacedOnHealthAndReady verifies that an error
+// aborting startup is retrievable over both endpoints before the process
+// exits. The listener stays up until Shutdown, so the scrape below happens in
+// exactly the window an operator or probe would use.
+func TestLauncher_StartupError_SurfacedOnHealthAndReady(t *testing.T) {
+	l := launcher.NewTestLauncherServer()
+	err := l.Run(t, ctx, failEngineOpen(t))
+	require.Error(t, err, "engine open should have failed")
+	defer l.ShutdownOrFail(t, ctx)
+
+	// The returned error carries the subsystem name, so the exit-code path
+	// and the HTTP path agree on attribution.
+	require.ErrorContains(t, err, launcher.SubsystemEngine)
+
+	t.Run("health", func(t *testing.T) {
+		var body healthBody
+		status := httpGetJSON(t, l.URL().String()+http.HealthPath, &body)
+		require.Equal(t, nethttp.StatusServiceUnavailable, status)
+		require.Equal(t, check.StatusFail, body.Status)
+
+		startup := findCheck(t, body.Checks, launcher.SubsystemStartup)
+		require.Equal(t, check.StatusFail, startup.Status())
+		// /health carries a single startup entry, so the subsystem name must
+		// be in the message or the failure is unattributable. Assert the
+		// prefix explicitly: a regression that drops it is otherwise silent.
+		require.Truef(t, strings.HasPrefix(startup.Message(), engineFailPrefix),
+			"startup message %q should be prefixed with %q",
+			startup.Message(), engineFailPrefix)
+	})
+
+	t.Run("ready", func(t *testing.T) {
+		var body readyBody
+		status := httpGetJSON(t, l.URL().String()+http.ReadyPath, &body)
+		require.Equal(t, nethttp.StatusServiceUnavailable, status)
+
+		// The engine gate carries the unprefixed message: its response is
+		// already stamped with the subsystem name.
+		engine := findCheck(t, body.Checks, launcher.SubsystemEngine)
+		require.Equal(t, check.StatusFail, engine.Status())
+		require.NotEqual(t, check.MsgNotReady, engine.Message(),
+			"engine gate should carry the failure reason, not the default")
+		require.False(t, strings.HasPrefix(engine.Message(), engineFailPrefix),
+			"gate message should not repeat the subsystem name")
+
+		// The catch-all is registered on /ready too. This is what closes the
+		// window in which every gate has fired but a later step failed, which
+		// would otherwise report "ready" until the process exits.
+		startup := findCheck(t, body.Checks, launcher.SubsystemStartup)
+		require.Equal(t, check.StatusFail, startup.Status())
+		require.Contains(t, startup.Message(), engine.Message(),
+			"startup should carry the same cause the gate does")
+	})
+}
+
+// TestLauncher_StartupError_Shutdown verifies that after a failed startup
+// Shutdown's closers still run — the PID file closer is registered early, and
+// a partially-constructed launcher must not prevent it from firing — and that
+// they run at most once, since the startup-failure path and the normal exit
+// path can both call Shutdown and a second teardown would double-close stores.
+//
+// NOTE: this does not cover the cmdRunE change that makes Shutdown run at all
+// on the startup-error path. cmdRunE calls fluxinit.FluxInit, which panics on
+// a second call, and this package already finalizes the Flux runtime via the
+// fluxinit/static import in launcher_test.go. Exercising the real exit path
+// requires a subprocess test.
+func TestLauncher_StartupError_Shutdown(t *testing.T) {
+	// Keep the PID file outside the launcher's own temp dir, which Shutdown
+	// removes wholesale — otherwise the assertion would pass trivially.
+	pidFile := filepath.Join(t.TempDir(), pidFileName)
+
+	l := launcher.NewTestLauncherServer()
+	err := l.Run(t, ctx, failEngineOpen(t), func(o *launcher.InfluxdOpts) {
+		o.PIDFile = pidFile
+	})
+	require.Error(t, err, "engine open should have failed")
+	require.FileExists(t, pidFile, "PID file should exist before shutdown")
+
+	require.NoError(t, l.Launcher.Shutdown(ctx))
+	require.NoFileExists(t, pidFile, "failed startup must not orphan the PID file")
+
+	// A second call must not attempt to remove the now-absent PID file, which
+	// would surface as a teardown error.
+	require.NoError(t, l.Launcher.Shutdown(ctx), "Shutdown should be idempotent")
+
+	l.ShutdownOrFail(t, ctx)
+}
+
+// TestLauncher_StartupError_HoldReleasesSubsystems covers the teardown split
+// around the startup-error hold. Everything but the listener is closed before
+// the process parks, so the state a restart needs — the PID file here, and with
+// it the bolt flock, the sqlite file and the engine directory — is already
+// released while /health is still serving the reason it failed.
+func TestLauncher_StartupError_HoldReleasesSubsystems(t *testing.T) {
+	// Keep the PID file outside the launcher's own temp dir, which teardown
+	// removes wholesale — otherwise the assertion would pass trivially.
+	pidFile := filepath.Join(t.TempDir(), pidFileName)
+
+	l := launcher.NewTestLauncherServer()
+	err := l.Run(t, ctx, failEngineOpen(t), func(o *launcher.InfluxdOpts) {
+		o.PIDFile = pidFile
+	})
+	defer l.ShutdownOrFail(t, ctx)
+	require.Error(t, err, "engine open should have failed")
+	require.FileExists(t, pidFile, "PID file should exist before the hold")
+
+	// The subsystem teardown runs before the wait, so a short window is enough:
+	// what is asserted below is the state an operator scraping during a long
+	// hold would see.
+	l.Launcher.HoldForStartupError(ctx, 50*time.Millisecond)
+
+	require.NoFileExists(t, pidFile,
+		"subsystems must be released before the hold, not after it")
+
+	var body healthBody
+	status := httpGetJSON(t, l.URL().String()+http.HealthPath, &body)
+	require.Equal(t, nethttp.StatusServiceUnavailable, status,
+		"the listener must still serve after the subsystems are torn down")
+	require.Equal(t, check.StatusFail, body.Status)
+
+	// Only the catch-all survives. The subsystems just closed publish their own
+	// checks, and left registered they would report that deliberate teardown as
+	// a fresh failure — and outrank "startup" in the sort, since the top-level
+	// message is taken from the first failing check by name.
+	require.Equal(t,
+		map[string]check.Status{launcher.SubsystemStartup: check.StatusFail},
+		checkNames(body.Checks))
+	require.True(t, strings.HasPrefix(body.Message, engineFailPrefix),
+		"top-level message %q should name the cause, not a teardown symptom",
+		body.Message)
+}
+
+// findCheck returns the named response, failing the test if absent.
+func findCheck(t *testing.T, rs []check.BasicResponse, name string) check.BasicResponse {
+	t.Helper()
+	for _, c := range rs {
+		if c.Name() == name {
+			return c
+		}
+	}
+	require.FailNowf(t, "missing check", "check %q not found in %v", name, checkNames(rs))
+	return check.BasicResponse{}
 }

--- a/cmd/influxd/launcher/launcher.go
+++ b/cmd/influxd/launcher/launcher.go
@@ -10,6 +10,7 @@ import (
 	nethttp "net/http"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -163,6 +164,19 @@ type Launcher struct {
 	tasksReady        *check.ReadyGate
 	schedulerReady    *check.ReadyGate
 	startupProgress   *run.StartupProgressLogger
+
+	// httpServing reports whether runHTTP established a listener. Consulted
+	// by holdForStartupError: with no listener there is nothing to scrape and
+	// waiting only delays the error.
+	httpServing bool
+
+	// shutdownMu guards the closer list and the accumulated teardown state.
+	// Teardown can run in two phases — see shutdownSubsystems — so a closer
+	// is consumed from m.closers as it runs rather than the whole teardown
+	// being gated by a single sync.Once.
+	shutdownMu   sync.Mutex
+	shutdownErrs []string
+	shutdownDone bool
 }
 
 type stoppingScheduler interface {
@@ -195,20 +209,28 @@ func (m *Launcher) ReadyCheckNames() []string {
 	return m.checkHandler.ReadyCheckNames()
 }
 
-// Shutdown shuts down the HTTP server and waits for all services to clean up.
+// Shutdown closes whatever is left of the launcher and waits for all services
+// to clean up. It is the final teardown phase: after it returns, nothing the
+// launcher registered is still running.
+//
+// Every registered closer runs at most once across all calls, because each is
+// consumed as it runs. A caller that cannot tell whether the launcher was
+// already torn down — in whole or, via shutdownSubsystems, in part — can call
+// Shutdown without double-closing a store or reporting a spurious error for
+// already-released state. The returned error accumulates every phase's closer
+// failures, so a single call site can report the whole teardown.
 func (m *Launcher) Shutdown(ctx context.Context) error {
-	var errs []string
-
-	// Shut down subsystems in the reverse order of their registration.
-	for i := len(m.closers); i > 0; i-- {
-		lc := m.closers[i-1]
-		m.log.Info("Stopping subsystem", zap.String("subsystem", lc.label))
-		if err := lc.closer(ctx); err != nil {
-			m.log.Error("Failed to stop subsystem", zap.String("subsystem", lc.label), zap.Error(err))
-			errs = append(errs, err.Error())
-		}
+	m.shutdownMu.Lock()
+	defer m.shutdownMu.Unlock()
+	if m.shutdownDone {
+		return m.shutdownError()
 	}
 
+	m.runClosers(ctx)
+
+	// Safe only here, and not in shutdownSubsystems: the HTTP serve goroutine
+	// is tracked in m.wg and returns only once the server closes, which the
+	// closer above has now done.
 	m.wg.Wait()
 
 	// N.B. We ignore any errors here because Sync is known to fail with EINVAL
@@ -218,14 +240,144 @@ func (m *Launcher) Shutdown(ctx context.Context) error {
 	// See: https://github.com/uber-go/zap/issues/328
 	_ = m.log.Sync()
 
-	if len(errs) > 0 {
-		return fmt.Errorf("failed to shut down server: [%s]", strings.Join(errs, ","))
+	m.shutdownDone = true
+	return m.shutdownError()
+}
+
+// shutdownSubsystems runs every registered closer except the HTTP server's,
+// releasing the PID file, the bolt flock, the sqlite file and the engine
+// directory while leaving the listener — and so /health and /ready — serving.
+// It is the first of the two teardown phases used by holdForStartupError;
+// Shutdown is the second and closes the listener.
+//
+// It deliberately does not wait on m.wg. The HTTP serve goroutine is tracked
+// there and returns only once the server closes, so waiting here would block
+// for exactly as long as the listener is retained.
+func (m *Launcher) shutdownSubsystems(ctx context.Context) error {
+	m.shutdownMu.Lock()
+	defer m.shutdownMu.Unlock()
+	if m.shutdownDone {
+		return m.shutdownError()
 	}
-	return nil
+
+	m.runClosers(ctx, SubsystemHTTPServer)
+	return m.shutdownError()
+}
+
+// runClosers runs the registered closers in reverse registration order,
+// skipping any whose label is in keep, and records each failure. The closers
+// it is about to run are removed from m.closers before any of them run, so no
+// closer can run twice even if one panics. The kept closers stay in
+// registration order, so a later phase still tears down in reverse.
+//
+// Caller must hold shutdownMu.
+func (m *Launcher) runClosers(ctx context.Context, keep ...string) {
+	kept := make([]labeledCloser, 0, len(keep))
+	pending := make([]labeledCloser, 0, len(m.closers))
+	for _, lc := range m.closers {
+		if slices.Contains(keep, lc.label) {
+			kept = append(kept, lc)
+			continue
+		}
+		pending = append(pending, lc)
+	}
+	m.closers = kept
+
+	// Shut down subsystems in the reverse order of their registration.
+	for i := len(pending); i > 0; i-- {
+		lc := pending[i-1]
+		m.log.Info("Stopping subsystem", zap.String("subsystem", lc.label))
+		if err := lc.closer(ctx); err != nil {
+			m.log.Error("Failed to stop subsystem", zap.String("subsystem", lc.label), zap.Error(err))
+			m.shutdownErrs = append(m.shutdownErrs, err.Error())
+		}
+	}
+}
+
+// shutdownError renders the closer failures accumulated across every teardown
+// phase run so far. Caller must hold shutdownMu.
+func (m *Launcher) shutdownError() error {
+	if len(m.shutdownErrs) == 0 {
+		return nil
+	}
+	return fmt.Errorf("failed to shut down server: [%s]", strings.Join(m.shutdownErrs, ","))
 }
 
 func (m *Launcher) Done() <-chan struct{} {
 	return m.doneChan
+}
+
+// failSubsystem logs err, latches it into the subsystem's gate (whose response
+// is already name-stamped, so msg alone), and returns it prefixed with the
+// subsystem name for the single /health startup entry.
+func (m *Launcher) failSubsystem(g *check.ReadyGate, msg string, err error) error {
+	err = fmt.Errorf("%s: %w", msg, err)
+	m.log.Error("Subsystem failed during startup",
+		zap.String("subsystem", g.CheckName()), zap.Error(err))
+	g.Fail(err)
+	return fmt.Errorf("%s: %w", g.CheckName(), err)
+}
+
+// holdForStartupError releases everything the failed process no longer needs
+// and then keeps /health and /ready scrapeable for d, so the latched startup
+// error can be retrieved before the process exits.
+//
+// Teardown is split around the wait. Every subsystem except the HTTP listener
+// is closed first, so the PID file, the bolt flock, the sqlite file and the
+// engine directory are released before the process parks: a supervisor
+// restarting influxd must not be blocked for the whole window by state
+// belonging to a run that already failed. The listener is the only thing the
+// wait needs, and the Shutdown that follows closes it.
+//
+// The check set is narrowed to the catch-all startup gate before that
+// teardown; see retainStartupCheckOnly. Non-check requests are unaffected:
+// the delegate handler is installed as the last statement of a successful
+// run, so on this path there is none and they still get the 503 "starting"
+// body.
+//
+// It returns immediately, tearing nothing down, when d is non-positive or no
+// listener was ever established — there is then nothing to scrape, and the
+// caller's Shutdown does the whole teardown in one phase as before. It also
+// returns once the launcher's context is done, so a signal cuts the wait
+// short. ctx bounds the subsystem teardown only, not the wait; pass the
+// process context rather than a signal-wrapped one so a signal racing the
+// teardown does not truncate it.
+func (m *Launcher) holdForStartupError(ctx context.Context, d time.Duration) {
+	if d <= 0 || !m.httpServing {
+		return
+	}
+
+	m.retainStartupCheckOnly()
+
+	subsysCtx, cancel := context.WithTimeout(ctx, shutdownTimeout)
+	// Errors are logged per subsystem by runClosers and accumulate into the
+	// error the caller's Shutdown returns, so there is nothing to report here.
+	_ = m.shutdownSubsystems(subsysCtx)
+	cancel()
+
+	m.log.Warn("Startup failed; holding /health and /ready open",
+		zap.Duration("duration", d), zap.Int("port", m.httpPort))
+	select {
+	case <-time.After(d):
+	case <-m.Done():
+	}
+}
+
+// retainStartupCheckOnly narrows /health and /ready to the catch-all startup
+// gate, which carries the error that aborted startup.
+//
+// Called before the teardown that precedes the hold, because the subsystems
+// about to be closed publish their own checks: sqlite pings a closed handle,
+// and the bolt probe snapshot ages past its staleness budget once the prober
+// stops. Left registered, both would report a deliberate teardown as a fresh
+// failure. Worse, check responses sort by name, so "shards" and "sqlite" sort
+// ahead of "startup" and /health's top-level message would advertise one of
+// those secondary symptoms instead of the real cause.
+func (m *Launcher) retainStartupCheckOnly() {
+	if m.checkHandler == nil {
+		return
+	}
+	m.checkHandler.RetainOnlyChecks(SubsystemStartup)
 }
 
 func (m *Launcher) run(ctx context.Context, opts *InfluxdOpts) (err error) {
@@ -308,6 +460,20 @@ func (m *Launcher) run(ctx context.Context, opts *InfluxdOpts) (err error) {
 	m.checkHandler.AddNamedReadyCheck(m.startupProgress.ReadyChecker())
 	m.checkHandler.AddNamedHealthCheck(m.startupProgress.HealthChecker())
 
+	// Catch-all gate: passes until an error aborts startup, then carries that
+	// error on both endpoints after run returns and before the process exits.
+	// On /health it is the only startup-failure signal, so failSubsystem
+	// prefixes the responsible subsystem's name onto the message. On /ready it
+	// also closes the window in which every gate has fired but a later step
+	// failed, which would otherwise report "ready" until the process exits.
+	// run's return is named, so the deferred Fail — which ignores nil — covers
+	// every error path below without touching each one.
+	startupGate := check.NewReadyGate(SubsystemStartup)
+	startupGate.Ready()
+	m.checkHandler.AddNamedHealthCheck(startupGate)
+	m.checkHandler.AddNamedReadyCheck(startupGate)
+	defer func() { startupGate.Fail(err) }()
+
 	// Under NoTasks the tasks subsystem and scheduler never start; pre-fire
 	// their gates so /ready does not block forever waiting on subsystems
 	// that will never come up. The gates remain registered and refer to the
@@ -326,6 +492,7 @@ func (m *Launcher) run(ctx context.Context, opts *InfluxdOpts) (err error) {
 	if err != nil {
 		return err
 	}
+	m.httpServing = true
 
 	m.reg = prom.NewRegistry(m.log.With(zap.String("service", "prom_registry")))
 	m.reg.MustRegister(collectors.NewGoCollector())
@@ -426,7 +593,7 @@ func (m *Launcher) run(ctx context.Context, opts *InfluxdOpts) (err error) {
 	} else {
 		// check for 2.x data / state from a prior 2.x
 		if err := checkForPriorVersion(ctx, m.log, opts.BoltPath, opts.EnginePath, ts.BucketService, metaClient); err != nil {
-			os.Exit(1)
+			return m.failSubsystem(m.engineReady, "incompatible prior version detected", err)
 		}
 
 		m.engine = storage.NewEngine(
@@ -444,8 +611,7 @@ func (m *Launcher) run(ctx context.Context, opts *InfluxdOpts) (err error) {
 	// latches into a terminal Fail that surfaces the error.
 	m.startupProgress.Finish(err)
 	if err != nil {
-		m.log.Error("Failed to open engine", zap.Error(err))
-		return err
+		return m.failSubsystem(m.engineReady, "failed to open engine", err)
 	}
 	m.engineReady.Ready()
 	m.closers = append(m.closers, labeledCloser{
@@ -478,8 +644,7 @@ func (m *Launcher) run(ctx context.Context, opts *InfluxdOpts) (err error) {
 	m.reg.MustRegister(replicationsMetrics.PrometheusCollectors()...)
 
 	if err = replicationSvc.Open(ctx); err != nil {
-		m.log.Error("Failed to open replications service", zap.Error(err))
-		return err
+		return m.failSubsystem(m.replicationsReady, "failed to open replications service", err)
 	}
 	m.replicationsReady.Ready()
 	m.closers = append(m.closers, labeledCloser{
@@ -511,8 +676,7 @@ func (m *Launcher) run(ctx context.Context, opts *InfluxdOpts) (err error) {
 		influxdb.WithURLValidator(urlValidator),
 	)
 	if err != nil {
-		m.log.Error("Failed to get query controller dependencies", zap.Error(err))
-		return err
+		return m.failSubsystem(m.queryReady, "failed to get query controller dependencies", err)
 	}
 
 	dependencyList := []flux.Dependency{deps}
@@ -531,8 +695,7 @@ func (m *Launcher) run(ctx context.Context, opts *InfluxdOpts) (err error) {
 		FluxLogEnabled:                  opts.FluxLogEnabled,
 	}, m.log.With(zap.String("service", "storage-reads")))
 	if err != nil {
-		m.log.Error("Failed to create query controller", zap.Error(err))
-		return err
+		return m.failSubsystem(m.queryReady, "failed to create query controller", err)
 	}
 	m.queryReady.Ready()
 	m.closers = append(m.closers, labeledCloser{
@@ -569,7 +732,7 @@ func (m *Launcher) run(ctx context.Context, opts *InfluxdOpts) (err error) {
 		)
 		err = executor.LoadExistingScheduleRuns(ctx)
 		if err != nil {
-			m.log.Fatal("could not load existing scheduled runs", zap.Error(err))
+			return m.failSubsystem(m.tasksReady, "could not load existing scheduled runs", err)
 		}
 		m.executor = executor
 		m.reg.MustRegister(executorMetrics.PrometheusCollectors()...)
@@ -593,10 +756,14 @@ func (m *Launcher) run(ctx context.Context, opts *InfluxdOpts) (err error) {
 						zap.Error(err))
 				}),
 			)
-			sch = treeSch
+			// Check before assigning: on failure treeSch is a nil
+			// *TreeScheduler, and assigning it to the sch interface first
+			// would leave a non-nil interface holding a nil pointer, so the
+			// registered closer's sch.Stop() would panic during Shutdown.
 			if err != nil {
-				m.log.Fatal("could not start task scheduler", zap.Error(err))
+				return m.failSubsystem(m.schedulerReady, "could not start task scheduler", err)
 			}
+			sch = treeSch
 			m.closers = append(m.closers, labeledCloser{
 				label: SubsystemTaskScheduler,
 				closer: func(context.Context) error {
@@ -1178,8 +1345,7 @@ func (m *Launcher) openMetaStores(ctx context.Context, opts *InfluxdOpts) (strin
 		boltClient.Path = opts.BoltPath
 
 		if err := boltClient.Open(ctx); err != nil {
-			m.log.Error("Failed opening bolt", zap.Error(err))
-			return "", err
+			return "", m.failSubsystem(m.kvReady, "failed opening bolt", err)
 		}
 		m.reg.MustRegister(boltClient)
 		procID = boltClient.ID().String()
@@ -1204,16 +1370,14 @@ func (m *Launcher) openMetaStores(ctx context.Context, opts *InfluxdOpts) (strin
 		}
 		sqlStore, err = sqlite.NewSqlStore(opts.SqLitePath, m.log.With(zap.String("service", "sqlite")), sqlite.WithCheckName(SubsystemSQLite))
 		if err != nil {
-			m.log.Error("Failed opening sqlite store", zap.Error(err))
-			return "", err
+			return "", m.failSubsystem(m.sqliteReady, "failed opening sqlite store", err)
 		}
 
 	case MemoryStore:
 		kvStore = inmem.NewKVStore()
 		sqlStore, err = sqlite.NewSqlStore(sqlite.InmemPath, m.log.With(zap.String("service", "sqlite")), sqlite.WithCheckName(SubsystemSQLite))
 		if err != nil {
-			m.log.Error("Failed opening sqlite store", zap.Error(err))
-			return "", err
+			return "", m.failSubsystem(m.sqliteReady, "failed opening sqlite store", err)
 		}
 
 	default:
@@ -1240,8 +1404,7 @@ func (m *Launcher) openMetaStores(ctx context.Context, opts *InfluxdOpts) (strin
 		all.Migrations[:]...,
 	)
 	if err != nil {
-		m.log.Error("Failed to initialize kv migrator", zap.Error(err))
-		return "", err
+		return "", m.failSubsystem(m.kvReady, "failed to initialize kv migrator", err)
 	}
 	sqlMigrator := sqlite.NewMigrator(sqlStore, m.log.With(zap.String("service", "SQL migrations")))
 
@@ -1253,13 +1416,11 @@ func (m *Launcher) openMetaStores(ctx context.Context, opts *InfluxdOpts) (strin
 		sqlMigrator.SetBackupPath(fmt.Sprintf(backupPattern, opts.SqLitePath, info.Version))
 	}
 	if err := kvMigrator.Up(ctx); err != nil {
-		m.log.Error("Failed to apply KV migrations", zap.Error(err))
-		return "", err
+		return "", m.failSubsystem(m.kvReady, "failed to apply KV migrations", err)
 	}
 	m.kvReady.Ready()
 	if err := sqlMigrator.Up(ctx, sqliteMigrations.AllUp); err != nil {
-		m.log.Error("Failed to apply SQL migrations", zap.Error(err))
-		return "", err
+		return "", m.failSubsystem(m.sqliteReady, "failed to apply SQL migrations", err)
 	}
 	m.sqliteReady.Ready()
 

--- a/cmd/influxd/launcher/subsystems.go
+++ b/cmd/influxd/launcher/subsystems.go
@@ -20,4 +20,9 @@ const (
 	SubsystemSQLite        = "sqlite"
 	SubsystemHTTPServer    = "http-server"
 	SubsystemShards        = "shards"
+
+	// SubsystemStartup names the catch-all check that carries whatever error
+	// aborted startup. Unlike the others it describes no single subsystem;
+	// Launcher.failSubsystem prefixes the responsible one onto the message.
+	SubsystemStartup = "startup"
 )

--- a/http/check_handler.go
+++ b/http/check_handler.go
@@ -118,6 +118,11 @@ func (h *HealthReadyHandler) AddNamedHealthCheck(nc check.NamedChecker) {
 	h.check.AddNamedHealthCheck(nc)
 }
 
+// RetainOnlyChecks drops every registered health and ready check except
+// those named in names. See check.Check.RetainOnly for the semantics and
+// the terminal-state use it exists for.
+func (h *HealthReadyHandler) RetainOnlyChecks(names ...string) { h.check.RetainOnly(names...) }
+
 // ReadyCheckNames returns the names of currently-registered ready checks
 // in registration order.
 func (h *HealthReadyHandler) ReadyCheckNames() []string { return h.check.ReadyCheckNames() }

--- a/kit/check/check.go
+++ b/kit/check/check.go
@@ -79,6 +79,49 @@ func (c *Check) AddNamedReadyCheck(nc NamedChecker) {
 	c.readyNames = append(c.readyNames, nc.CheckName())
 }
 
+// RetainOnly drops every registered health and ready check whose name is not
+// in names, preserving registration order. An anonymous health check — one
+// registered via AddHealthCheck with a Checker that does not implement
+// NamedChecker — has no name to match against and is always dropped.
+//
+// Intended for terminal states, where most registered checks describe
+// subsystems that have been deliberately torn down. Left registered, those
+// checks report the teardown as a fresh failure and, because responses sort
+// by name, can outrank the one response that explains why the process is
+// terminal. There is no way to restore a dropped check; re-register it if it
+// is needed again.
+func (c *Check) RetainOnly(names ...string) {
+	keep := make(map[string]bool, len(names))
+	for _, n := range names {
+		keep[n] = true
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.healthChecks, _ = retainNamed(c.healthChecks, keep)
+	c.readyChecks, c.readyNames = retainNamed(c.readyChecks, keep)
+}
+
+// retainNamed returns the checks whose CheckName is in keep, in their
+// original order, along with those names. A check that does not implement
+// NamedChecker cannot be matched and is dropped, so the returned names line
+// up one-to-one with the returned checks.
+func retainNamed(checks []Checker, keep map[string]bool) ([]Checker, []string) {
+	var (
+		kept  []Checker
+		names []string
+	)
+	for _, ch := range checks {
+		nc, ok := ch.(NamedChecker)
+		if !ok || !keep[nc.CheckName()] {
+			continue
+		}
+		kept = append(kept, ch)
+		names = append(names, nc.CheckName())
+	}
+	return kept, names
+}
+
 // ReadyCheckNames returns the names of currently-registered ready checks
 // in registration order. All ready checks are required to be named, so
 // no entry is ever empty.

--- a/kit/check/check_test.go
+++ b/kit/check/check_test.go
@@ -169,6 +169,60 @@ func TestAddHealthCheck_NamedCheckerDispatch(t *testing.T) {
 	require.Equal(t, "alpha", resp.Checks()[0].Name())
 }
 
+func TestCheck_RetainOnly(t *testing.T) {
+	// "drop" fails on /health so a regression that leaves it registered is
+	// visible in the aggregate, not just in the name list.
+	newCheck := func() *Check {
+		c := NewCheck()
+		c.AddNamedHealthCheck(Named("keep", mockFail("")))
+		c.AddNamedHealthCheck(Named("drop", mockFail("")))
+		c.AddHealthCheck(mockPass("anonymous")) // no CheckName to match on
+		c.AddNamedReadyCheck(Named("keep", mockFail("")))
+		c.AddNamedReadyCheck(Named("drop", mockPass("")))
+		return c
+	}
+
+	t.Run("keeps the named checks and drops the rest", func(t *testing.T) {
+		c := newCheck()
+		c.RetainOnly("keep")
+
+		require.Equal(t, []string{"keep"}, c.ReadyCheckNames())
+		require.Equal(t, []string{"keep"}, checkedNames(c.CheckHealth(context.Background())))
+		require.Equal(t, []string{"keep"}, checkedNames(c.CheckReady(context.Background())))
+	})
+
+	t.Run("the retained failure is what the aggregate reports", func(t *testing.T) {
+		// The point of narrowing: a dropped check can no longer outrank the
+		// one response that explains the terminal state.
+		c := newCheck()
+		c.RetainOnly("keep")
+		require.Equal(t, StatusFail, c.CheckHealth(context.Background()).Status())
+	})
+
+	t.Run("an unmatched name retains nothing", func(t *testing.T) {
+		c := newCheck()
+		c.RetainOnly("absent")
+		require.Empty(t, c.ReadyCheckNames())
+		require.Empty(t, checkedNames(c.CheckHealth(context.Background())))
+	})
+
+	t.Run("retaining several preserves registration order", func(t *testing.T) {
+		c := newCheck()
+		c.RetainOnly("drop", "keep") // argument order must not matter
+		require.Equal(t, []string{"keep", "drop"}, c.ReadyCheckNames())
+	})
+}
+
+// checkedNames returns the names of a response's nested checks, in the order
+// the aggregate reports them.
+func checkedNames(r Response) []string {
+	out := make([]string, 0, len(r.Checks()))
+	for _, c := range r.Checks() {
+		out = append(out, c.Name())
+	}
+	return out
+}
+
 func ExampleNewCheck() {
 	h := NewCheck()
 	h.CheckHealth(context.Background())

--- a/kit/check/helpers.go
+++ b/kit/check/helpers.go
@@ -147,12 +147,18 @@ func BoundDeadline(ctx context.Context, max time.Duration) (context.Context, con
 	return context.WithTimeout(ctx, max)
 }
 
+// MsgNotReady is the message a ReadyGate reports when it has been neither
+// fired by Ready nor failed by Fail.
+const MsgNotReady = "not ready"
+
 // ReadyGate is a NamedChecker that reports StatusFail until Ready is called,
 // after which it reports StatusPass. It is intended for gating readiness on
-// subsystem init phases that complete once at startup.
+// subsystem init phases that complete once at startup. A gate also carries a
+// terminal failure; see Fail.
 type ReadyGate struct {
-	name  string
-	ready atomic.Bool
+	name    string
+	ready   atomic.Bool
+	failMsg atomic.Pointer[string] // terminal startup failure
 }
 
 // NewReadyGate returns a ReadyGate that initially reports StatusFail.
@@ -164,13 +170,16 @@ func NewReadyGate(name string) *ReadyGate {
 func (g *ReadyGate) CheckName() string { return g.name }
 
 // Check returns StatusPass once Ready has been called, otherwise StatusFail.
-// The response is stamped with the gate's name to satisfy the NamedChecker
-// contract.
+// A terminal failure latched by Fail outranks both. The response is stamped
+// with the gate's name to satisfy the NamedChecker contract.
 func (g *ReadyGate) Check(context.Context) Response {
+	if msg := g.failMsg.Load(); msg != nil {
+		return NamedFail(g.name, *msg)
+	}
 	if g.ready.Load() {
 		return NamedPass(g.name)
 	}
-	return NamedFail(g.name, "not ready")
+	return NamedFail(g.name, MsgNotReady)
 }
 
 // Ready flips the gate to report StatusPass.
@@ -178,3 +187,19 @@ func (g *ReadyGate) Ready() { g.ready.Store(true) }
 
 // Unready flips the gate to report StatusFail.
 func (g *ReadyGate) Unready() { g.ready.Store(false) }
+
+// Fail latches a terminal startup failure carrying err's message, which Check
+// reports from then on. The first error wins, so a later generic error cannot
+// overwrite the specific cause. A nil err is ignored.
+//
+// Fail is for startup failures only: it outranks Ready and Unready
+// permanently, which is correct for a subsystem that failed to construct
+// because there is nothing to recover into. Use Unready for a condition the
+// subsystem can come back from.
+func (g *ReadyGate) Fail(err error) {
+	if err == nil {
+		return
+	}
+	msg := err.Error()
+	g.failMsg.CompareAndSwap(nil, &msg)
+}

--- a/kit/check/helpers_test.go
+++ b/kit/check/helpers_test.go
@@ -3,6 +3,9 @@ package check
 import (
 	"context"
 	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -10,18 +13,30 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Fixtures shared by the ReadyGate tests. Declared once so a typo cannot make
+// an assertion agree with a value the gate never produced.
+const (
+	gateName = "engine"
+
+	// latchedMsg is the terminal error latched by Fail; firstMsg and secondMsg
+	// exercise first-error-wins.
+	latchedMsg = "boom"
+	firstMsg   = "root cause"
+	secondMsg  = "later generic error"
+)
+
 func TestReadyGate_CheckName(t *testing.T) {
-	g := NewReadyGate("engine")
-	require.Equal(t, "engine", g.CheckName())
+	g := NewReadyGate(gateName)
+	require.Equal(t, gateName, g.CheckName())
 }
 
 func TestReadyGate_Check(t *testing.T) {
-	g := NewReadyGate("engine")
+	g := NewReadyGate(gateName)
 
 	// Initially fails with "not ready".
 	resp := g.Check(context.Background())
 	require.Equal(t, StatusFail, resp.Status())
-	require.Equal(t, "not ready", resp.Message())
+	require.Equal(t, MsgNotReady, resp.Message())
 
 	// After Ready() it passes.
 	g.Ready()
@@ -31,7 +46,7 @@ func TestReadyGate_Check(t *testing.T) {
 }
 
 func TestReadyGate_UnreadyRoundTrip(t *testing.T) {
-	g := NewReadyGate("engine")
+	g := NewReadyGate(gateName)
 
 	g.Ready()
 	resp := g.Check(context.Background())
@@ -40,8 +55,8 @@ func TestReadyGate_UnreadyRoundTrip(t *testing.T) {
 	g.Unready()
 	resp = g.Check(context.Background())
 	require.Equal(t, StatusFail, resp.Status())
-	require.Equal(t, "not ready", resp.Message())
-	require.Equal(t, "engine", resp.Name())
+	require.Equal(t, MsgNotReady, resp.Message())
+	require.Equal(t, gateName, resp.Name())
 }
 
 func TestBoundDeadline(t *testing.T) {
@@ -116,19 +131,124 @@ func TestError(t *testing.T) {
 func TestReadyGate_IntegrationWithCheck_NamedWrapping(t *testing.T) {
 	// Verify that when a *ReadyGate is added to *Check, the resulting
 	// response uses the gate's configured name.
-	const gateName = "metastores"
+	const metastoresGate = "metastores"
 	c := NewCheck()
-	gate := NewReadyGate(gateName)
+	gate := NewReadyGate(metastoresGate)
 	c.AddNamedReadyCheck(gate)
 
 	resp := c.CheckReady(context.Background())
 	require.Equal(t, StatusFail, resp.Status())
 	require.Len(t, resp.Checks(), 1)
-	require.Equal(t, gateName, resp.Checks()[0].Name())
+	require.Equal(t, metastoresGate, resp.Checks()[0].Name())
 
 	gate.Ready()
 	resp = c.CheckReady(context.Background())
 	require.Equal(t, StatusPass, resp.Status())
 	require.Len(t, resp.Checks(), 1)
-	require.Equal(t, gateName, resp.Checks()[0].Name())
+	require.Equal(t, metastoresGate, resp.Checks()[0].Name())
+
+	// A latched failure keeps the gate's name and replaces the message.
+	gate.Fail(errors.New(latchedMsg))
+	resp = c.CheckReady(context.Background())
+	require.Equal(t, StatusFail, resp.Status())
+	require.Len(t, resp.Checks(), 1)
+	require.Equal(t, metastoresGate, resp.Checks()[0].Name())
+	require.Equal(t, latchedMsg, resp.Checks()[0].Message())
+}
+
+func TestReadyGate_Fail(t *testing.T) {
+	// Every ordering of Ready/Unready around Fail must land on the same
+	// terminal response: a failed gate never reports ready again, which is
+	// what makes Fail startup-only.
+	orderings := []struct {
+		name string
+		ops  func(*ReadyGate)
+	}{
+		{"beats unready", func(g *ReadyGate) { g.Fail(errors.New(latchedMsg)) }},
+		{"beats ready", func(g *ReadyGate) { g.Ready(); g.Fail(errors.New(latchedMsg)) }},
+		{"terminal: Ready cannot clear it", func(g *ReadyGate) { g.Fail(errors.New(latchedMsg)); g.Ready() }},
+		{"terminal: Unready keeps the message", func(g *ReadyGate) { g.Fail(errors.New(latchedMsg)); g.Unready() }},
+	}
+	for _, tt := range orderings {
+		t.Run(tt.name, func(t *testing.T) {
+			g := NewReadyGate(gateName)
+			tt.ops(g)
+
+			resp := g.Check(context.Background())
+			require.Equal(t, StatusFail, resp.Status())
+			require.Equal(t, latchedMsg, resp.Message(),
+				"Ready/Unready must not replace the cause with the default message")
+			require.Equal(t, gateName, resp.Name())
+		})
+	}
+
+	t.Run("first error wins", func(t *testing.T) {
+		g := NewReadyGate(gateName)
+		g.Fail(errors.New(firstMsg))
+		g.Fail(errors.New(secondMsg))
+
+		resp := g.Check(context.Background())
+		require.Equal(t, firstMsg, resp.Message())
+	})
+
+	t.Run("nil is ignored", func(t *testing.T) {
+		g := NewReadyGate(gateName)
+		g.Ready()
+		g.Fail(nil)
+
+		resp := g.Check(context.Background())
+		require.Equal(t, StatusPass, resp.Status())
+	})
+}
+
+// TestReadyGate_Fail_Concurrent hammers Fail from many goroutines against
+// concurrent Check calls and asserts exactly one message survives. Uses the
+// RWMutex-synchronized start so every goroutine is released at once, which
+// maximizes contention on the CompareAndSwap.
+func TestReadyGate_Fail_Concurrent(t *testing.T) {
+	const goroutines = 64
+
+	g := NewReadyGate(gateName)
+
+	// Build the errors up front so goroutines do no allocation before racing.
+	errs := make([]error, goroutines)
+	for i := range errs {
+		errs[i] = fmt.Errorf("failure %d", i)
+	}
+
+	var mu sync.RWMutex
+	var concurrency, maxConcurrency atomic.Int64
+
+	var wg sync.WaitGroup
+	mu.Lock()
+	for i := range goroutines {
+		wg.Add(1)
+		go func(idx int) {
+			mu.RLock()
+			defer mu.RUnlock()
+			defer wg.Done()
+
+			c := concurrency.Add(1)
+			if old := maxConcurrency.Load(); c > old {
+				maxConcurrency.CompareAndSwap(old, c)
+			}
+
+			g.Fail(errs[idx])
+			// Read concurrently with the writes; the race detector covers
+			// the latchedMsg pointer, and the response must always be coherent.
+			resp := g.Check(context.Background())
+			assert.Equal(t, StatusFail, resp.Status())
+			assert.NotEmpty(t, resp.Message())
+
+			concurrency.Add(-1)
+		}(i)
+	}
+	mu.Unlock() // Release to start all goroutines simultaneously.
+	wg.Wait()
+	t.Logf("max concurrency: %d", maxConcurrency.Load())
+
+	// Exactly one of the messages survived, and it never changes afterwards.
+	final := g.Check(context.Background()).Message()
+	require.Regexp(t, `^failure \d+$`, final)
+	require.Equal(t, final, g.Check(context.Background()).Message())
 }


### PR DESCRIPTION
influxd exited on a startup failure before anything could scrape the reason, and some failures called log.Fatal or os.Exit, skipping cleanup of the PID file and the meta stores. A startup error now latches into a "startup" check registered on both endpoints, and the fatal exits are replaced with error returns so teardown always runs.

The new --startup-error-timeout keeps the listener open for that long after a failed startup so the error can be retrieved. It defaults to 0, which exits immediately, as before. Teardown is split around the wait: every subsystem except the HTTP listener closes first, so a restart is not blocked by the PID file, the bolt flock, the sqlite file, or the engine directory belonging to a run that already failed.

/ready also stopped reporting "ready" after a failure late in startup. Every ready gate has fired by then, so the startup check is what closes that window.

kit/check gains ReadyGate.Fail, which latches a terminal error on a subsystem's /ready entry, and Check.RetainOnly, which drops the checks for subsystems that have been torn down so they do not report that teardown as a fresh failure.