### PR TITLE
chore(sync): influxdb_pro 2026-08-06 (3.11)

### DIFF
--- a/core/iox_time/src/lib.rs
+++ b/core/iox_time/src/lib.rs
@@ -21,18 +21,22 @@ pub struct Time(DateTime<Utc>);
 impl Add<Duration> for Time {
     type Output = Self;
 
+    /// Saturates at [`Time::MAX`]: a std [`Duration`] can exceed chrono's
+    /// representable range, so overflow is reachable from user-supplied
+    /// durations and must not panic. Use [`Time::checked_add`] to detect it.
     fn add(self, rhs: Duration) -> Self::Output {
-        let duration = chrono::Duration::from_std(rhs).unwrap();
-        Self(self.0 + duration)
+        self.checked_add(rhs).unwrap_or(Self::MAX)
     }
 }
 
 impl Sub<Duration> for Time {
     type Output = Self;
 
+    /// Saturates at [`Time::MIN`]: a std [`Duration`] can exceed chrono's
+    /// representable range, so overflow is reachable from user-supplied
+    /// durations and must not panic. Use [`Time::checked_sub`] to detect it.
     fn sub(self, rhs: Duration) -> Self::Output {
-        let duration = chrono::Duration::from_std(rhs).unwrap();
-        Self(self.0 - duration)
+        self.checked_sub(rhs).unwrap_or(Self::MIN)
     }
 }
 
@@ -685,6 +689,13 @@ mod test {
         assert!(chrono::Duration::from_std(duration).is_err());
         assert!(time.checked_add(duration).is_none());
         assert!(time.checked_sub(duration).is_none());
+
+        // The Add/Sub operators saturate instead of panicking, both when the
+        // duration exceeds chrono's range and when the result would overflow.
+        assert_eq!(time + duration, Time::MAX);
+        assert_eq!(time - duration, Time::MIN);
+        assert_eq!(Time::MAX + Duration::from_nanos(1), Time::MAX);
+        assert_eq!(Time::MIN - Duration::from_nanos(1), Time::MIN);
     }
 
     #[test]

--- a/deny.toml
+++ b/deny.toml
@@ -92,6 +92,14 @@ ignore = [
     # upstream datafusion-udf-wasm bump.
     "RUSTSEC-2026-0188",
     #
+    # wasmtime 41.0.4 stores can mix up type indices between engines
+    # (https://rustsec.org/advisories/RUSTSEC-2026-0222). Same transitive path via
+    # datafusion-udf-wasm; only reachable if a Wasm UDF is loaded, and UDFs are
+    # disabled by default (udfs_enabled = false). The 41.x line has no patched
+    # release. The fix requires wasmtime >=46.0.2, which needs an upstream
+    # datafusion-udf-wasm bump to a DataFusion 52 rev.
+    "RUSTSEC-2026-0222",
+    #
     # TODO: update wasmtime-wasi via datafusion-udf-wasm to a patched version (>=45.0.3; >=46.0.1 is also fixed)
     #
     # pyo3 0.24-0.28 out-of-bounds read in Iterator::nth/nth_back on

--- a/influxdb3/src/commands/serve.rs
+++ b/influxdb3/src/commands/serve.rs
@@ -286,7 +286,10 @@ pub struct Config {
     )]
     pub admin_token_recovery_bind_address: Option<SocketAddr>,
 
-    /// Size of memory pool used during query exec.
+    /// Memory budget for query execution. Queries whose sorts, joins, and
+    /// aggregations exceed the pool fail with a resource exhausted error
+    /// instead of taking down the process; a larger pool admits bigger
+    /// queries at the expense of memory left for caches and ingest.
     ///
     /// Specify either a percentage of the total available memory (e.g. `20%`)
     /// or an absolute size with an explicit unit suffix (e.g. `8gb`). Bare
@@ -368,8 +371,13 @@ pub struct Config {
     )]
     pub wal_flush_interval: humantime::Duration,
 
-    /// The number of WAL files to attempt to remove in a snapshot. This times the interval will
-    /// determine how often snapshot is taken.
+    /// Number of WAL files accumulated before a snapshot persists their data
+    /// and removes them; with --wal-flush-interval this sets snapshot
+    /// cadence. Larger batches snapshot less often and more efficiently
+    /// (less per-snapshot overhead, fewer files for the compactor to
+    /// merge). Smaller batches keep fewer un-snapshotted WAL files on the
+    /// query path, let the compactor see new data sooner, and shorten
+    /// restart replay, at the cost of more frequent snapshots.
     #[clap(
         long = "wal-files-per-snapshot",
         visible_alias = "wal-snapshot-size",
@@ -379,8 +387,9 @@ pub struct Config {
     )]
     pub wal_files_per_snapshot: usize,
 
-    /// The maximum number of writes requests that can be buffered before a flush must be run
-    /// and succeed.
+    /// Nominal cap on write requests buffered awaiting a WAL flush. Write
+    /// buffer memory is bounded by --force-snapshot-mem-size, not this
+    /// count, so raising or lowering it has little practical effect.
     #[clap(
         long = "wal-max-buffered-writes",
         visible_alias = "wal-max-write-buffer-size",
@@ -453,7 +462,10 @@ pub struct Config {
     #[clap(flatten)]
     pub node_id: NodeId,
 
-    /// Maximum number of table indices to cache in memory.
+    /// Maximum number of table indices to cache in memory. Queries against
+    /// tables whose index is not cached must first load it from object
+    /// store; a larger cache speeds cold queries across many tables at the
+    /// cost of memory.
     ///
     /// Defaults to 100 entries. Set to 0 for unlimited cache size.
     #[clap(
@@ -512,9 +524,14 @@ pub struct Config {
     )]
     pub parquet_mem_cache_size: Option<LegacyMemorySizeMb>,
 
-    /// The percentage of entries to prune during a prune operation on the in-memory Parquet cache.
+    /// The percentage of cache entries (by count, not bytes) evicted, oldest
+    /// access first, when the in-memory Parquet cache exceeds its size.
+    /// Higher values free memory in bigger steps but drop more cached data
+    /// at once (temporarily lowering hit rate); lower values need more prune
+    /// cycles to get back under budget.
     ///
-    /// This must be a number between 0 and 1.
+    /// Expressed as a fraction of 1 — e.g. 0.1 evicts 10%. Must be greater
+    /// than 0 and less than 1.
     #[clap(
         long = "parquet-mem-cache-prune-percentage",
         env = "INFLUXDB3_PARQUET_MEM_CACHE_PRUNE_PERCENTAGE",
@@ -523,7 +540,9 @@ pub struct Config {
     )]
     pub parquet_mem_cache_prune_percentage: ParquetCachePrunePercent,
 
-    /// The interval on which to check if the in-memory Parquet cache needs to be pruned.
+    /// The interval on which to check if the in-memory Parquet cache needs
+    /// to be pruned. Longer intervals mean the cache can overshoot its size
+    /// budget for longer between checks.
     ///
     /// Enter as a human-readable time, e.g., "1s", "100ms", "1m", etc.
     #[clap(
@@ -580,7 +599,9 @@ pub struct Config {
     #[clap(flatten)]
     pub processing_engine_config: ProcessingEngineConfig,
 
-    /// Threshold for internal buffer.
+    /// Memory used by the write buffer at which a snapshot is forced to free
+    /// memory. Lower thresholds snapshot earlier — lower OOM risk during
+    /// write bursts, but more, smaller persisted files.
     ///
     /// Specify either a percentage of the total available memory (e.g. `70%`)
     /// or an absolute size with an explicit unit suffix (e.g. `1000mb`). Bare
@@ -1947,7 +1968,7 @@ async fn initialize_admin_token_from_file(catalog: &Catalog, token_file: &PathBu
 
     // Create admin token with computed hash and name
     match catalog
-        .create_named_admin_token_with_hash(name.clone(), hash, expiry_millis)
+        .create_named_admin_token_with_hash(name.clone(), hash.clone(), expiry_millis)
         .await
     {
         Ok(()) => {
@@ -1960,6 +1981,33 @@ async fn initialize_admin_token_from_file(catalog: &Catalog, token_file: &PathBu
                 existing_name
             );
             Ok(())
+        }
+        Err(CatalogError::TokenHashAlreadyExists) => {
+            if let Some(existing_token) =
+                influxdb3_authz::TokenProvider::get_token(catalog, hash.clone())
+            {
+                if existing_token.name.as_ref() == name && existing_token.is_admin() {
+                    info!(
+                        "Admin token '{}' with same token value already exists, skipping initialization",
+                        name
+                    );
+                    Ok(())
+                } else {
+                    let err = CatalogError::unexpected(format!(
+                        "Token hash collision: admin token file refers to token '{name}', but its hash is already used by existing token '{}' (admin={})",
+                        existing_token.name,
+                        existing_token.is_admin()
+                    ));
+                    error!("{}", err);
+                    Err(Error::TokenError(err))
+                }
+            } else {
+                let err = CatalogError::unexpected(format!(
+                    "Token hash collision: admin token file refers to token '{name}', but its hash is already registered in the catalog"
+                ));
+                error!("{}", err);
+                Err(Error::TokenError(err))
+            }
         }
         Err(e) => Err(Error::TokenError(e)),
     }

--- a/influxdb3/src/help/serve_all.txt
+++ b/influxdb3/src/help/serve_all.txt
@@ -185,12 +185,19 @@ Examples:
                                                  [env: INFLUXDB3_RETENTION_CHECK_INTERVAL=]
 
 {}
-  --wal-flush-interval <INTERVAL>                Interval to flush data to WAL file [default: 1s]
+  --wal-flush-interval <INTERVAL>                Interval to flush data to WAL file; shorter intervals
+                                                 acknowledge writes sooner but produce smaller WAL files
+                                                 and more object-store requests [default: 1s]
                                                    [env: INFLUXDB3_WAL_FLUSH_INTERVAL=]
-  --wal-files-per-snapshot <N>                   Number of WAL files per snapshot [default: 600]
+  --wal-files-per-snapshot <N>                   Number of WAL files per snapshot; larger batches snapshot
+                                                 more efficiently, smaller batches keep the query path and
+                                                 compactor more current
+                                                 [default: 600]
                                                    [aliases: wal-snapshot-size]
                                                    [env: INFLUXDB3_WAL_FILES_PER_SNAPSHOT=]
-  --wal-max-buffered-writes <N>                  Max write requests in buffer [default: 100000]
+  --wal-max-buffered-writes <N>                  Nominal cap on write requests awaiting flush; memory is
+                                                 bounded by --force-snapshot-mem-size, not this count
+                                                 [default: 100000]
                                                    [aliases: wal-max-write-buffer-size]
                                                    [env: INFLUXDB3_WAL_MAX_BUFFERED_WRITES=]
   --wal-replay-concurrency-limit <LIMIT>         Concurrency limit during WAL replay [default: max(num_cpus, 10)]
@@ -216,9 +223,13 @@ Examples:
                                                    [env: INFLUXDB3_MAX_HTTP_REQUEST_SIZE=]
 
 {}
-  --exec-mem-pool-size <SIZE>                         Memory pool size for query execution [default: 20%]
+  --exec-mem-pool-size <SIZE>                         Memory budget for query execution; queries exceeding it
+                                                      fail with a resource exhausted error instead of OOMing
+                                                      [default: 20%]
+                                                        [aliases: exec-mem-pool-bytes]
                                                         [env: INFLUXDB3_EXEC_MEM_POOL_SIZE=]
-  --force-snapshot-mem-size <SIZE>                    Internal buffer threshold [default: 50%]
+  --force-snapshot-mem-size <SIZE>                    Write-buffer memory at which a snapshot is forced to free
+                                                      memory [default: 50%]
                                                         [env: INFLUXDB3_FORCE_SNAPSHOT_MEM_SIZE=]
   --file-cache-size <SIZE>                            In-memory data file cache size [default: 20%]
                                                         [env: INFLUXDB3_FILE_CACHE_SIZE=]

--- a/influxdb3_catalog/src/catalog.rs
+++ b/influxdb3_catalog/src/catalog.rs
@@ -257,6 +257,12 @@ impl TokenRepository {
         hash: Vec<u8>,
         updated_at: i64,
     ) -> Result<()> {
+        if let Some(existing_id) = self.hash_to_id(hash.clone())
+            && existing_id != token_id
+        {
+            return Err(CatalogError::TokenHashAlreadyExists);
+        }
+
         let mut token_info = self
             .repo
             .get_by_id(&token_id)

--- a/influxdb3_catalog/src/catalog/versions/v3/catalog.rs
+++ b/influxdb3_catalog/src/catalog/versions/v3/catalog.rs
@@ -1617,7 +1617,7 @@ impl Catalog {
         token_hash: Vec<u8>,
     ) -> Option<PermissionAttributes> {
         let inner = self.inner.read();
-        let token_id = inner.tokens.hash_to_id(token_hash)?;
+        let token_id = inner.tokens.hash_to_id(&token_hash)?;
         let resource_id = inner.databases.name_to_id(db_name)?;
         inner.token_permissions.get_permission(
             ResourceType::Database,

--- a/influxdb3_catalog/src/catalog/versions/v3/events.rs
+++ b/influxdb3_catalog/src/catalog/versions/v3/events.rs
@@ -248,7 +248,7 @@ impl CatalogUpdate {
 /// Carries the broadcasted update plus the ACK channel back to the
 /// broadcaster. Dropping this fires the ACK, i.e., after the subscriber
 /// is done processing the events; the broadcaster's `send_update` returns
-/// once every non-stopped subscriber has ACK'd.
+/// once every live (non-stopped, non-closed) subscriber has ACK'd.
 ///
 /// Subscribers should drop the message promptly. The broadcaster waits
 /// for every ACK before returning, so any inline work between `recv` and
@@ -370,24 +370,31 @@ pub(crate) struct CatalogSubscriptions {
 }
 
 impl CatalogSubscriptions {
-    /// Panics on duplicate `name` — one subscription per named component is
-    /// the contract; duplicates should fail loudly at server startup.
+    /// One subscription per named component is the contract. Components
+    /// normally subscribe once and hold the receiver for the life of the
+    /// process, so a duplicate name is unusual. When it does happen and the
+    /// prior receiver has already been dropped, the slot is stale, not a
+    /// conflict: reclaim it so a component that re-subscribes under the same
+    /// name -- today only the compactor, on primary-lease re-election -- does
+    /// not collide with its own dropped slot. A duplicate whose receiver is
+    /// still live is a genuine bug and still panics.
     pub(crate) fn subscribe(&mut self, name: &'static str) -> CatalogUpdateReceiver {
         let (tx, rx) = mpsc::channel(CATALOG_SUBSCRIPTION_BUFFER_SIZE);
         let stopped = Arc::new(AtomicBool::new(false));
         let stop_signal = Arc::new(Notify::new());
-        assert!(
-            self.subscriptions
-                .insert(
-                    name,
-                    CatalogUpdateSender {
-                        tx,
-                        stopped: Arc::clone(&stopped),
-                        stop_signal: Arc::clone(&stop_signal),
-                    },
-                )
-                .is_none(),
-            "duplicate catalog subscription name: {name}",
+        if let Some(existing) = self.subscriptions.get(name) {
+            assert!(
+                existing.is_closed(),
+                "duplicate catalog subscription name: {name}",
+            );
+        }
+        self.subscriptions.insert(
+            name,
+            CatalogUpdateSender {
+                tx,
+                stopped: Arc::clone(&stopped),
+                stop_signal: Arc::clone(&stop_signal),
+            },
         );
         CatalogUpdateReceiver {
             rx,
@@ -396,9 +403,10 @@ impl CatalogSubscriptions {
         }
     }
 
-    /// Completes once every subscriber has either dropped its
+    /// Completes once every live subscriber has either dropped its
     /// [`CatalogUpdateMessage`] (firing the ACK) or transitioned to stopped
-    /// while the message was in flight.
+    /// while the message was in flight. Subscribers whose receiver has already
+    /// been dropped (closed) are skipped, not awaited.
     pub(crate) async fn send_update(
         &self,
         update: Arc<CatalogUpdate>,
@@ -406,16 +414,31 @@ impl CatalogSubscriptions {
         let futures = self
             .subscriptions
             .iter()
-            .filter(|(_, sub)| !sub.is_stopped())
+            // Skip stopped subscribers (opted out) and closed ones (whose
+            // receiver has been dropped, e.g. a component shutting down).
+            // Sending to a closed channel would otherwise fail the whole
+            // broadcast, and thus the catalog write driving it. A closed slot
+            // is simply skipped; it lingers harmlessly until the process ends
+            // (or, if the name is ever re-subscribed, is reclaimed then).
+            .filter(|(_, sub)| !sub.is_stopped() && !sub.is_closed())
             .map(|(name, sub)| {
                 let update = Arc::clone(&update);
                 let name = *name;
                 let sub = sub.clone();
                 async move {
                     let (tx, ack_rx) = oneshot::channel();
-                    sub.send(CatalogUpdateMessage::new(update, tx))
+                    if sub
+                        .send(CatalogUpdateMessage::new(update, tx))
                         .await
-                        .with_context(|| format!("failed to send update to {name}"))?;
+                        .is_err()
+                    {
+                        // Receiver dropped between the is_closed() filter and
+                        // now. A send error can only mean the subscriber is
+                        // gone -- exactly the teardown case the filter already
+                        // tolerates -- so skip it rather than fail the whole
+                        // broadcast (and the catalog write driving it).
+                        return Ok::<(), anyhow::Error>(());
+                    }
 
                     // Race: subscriber may call `stop()` between the filter
                     // above and now. Register as a `Notified` waiter *before*

--- a/influxdb3_catalog/src/catalog/versions/v3/events/tests.rs
+++ b/influxdb3_catalog/src/catalog/versions/v3/events/tests.rs
@@ -199,18 +199,37 @@ async fn stopped_subscriber_is_skipped() {
 }
 
 #[tokio::test]
-async fn closed_subscriber_causes_send_failure() {
+async fn closed_subscriber_is_skipped_not_fatal() {
     let mut subs = CatalogSubscriptions::default();
     let mut rx = subs.subscribe("closed");
     rx.close();
     drop(rx);
 
-    let err = subs
-        .send_update(sample_update())
+    // A subscriber whose receiver is gone must not fail the broadcast (and thus
+    // the catalog write that drives it) -- its stale slot is simply skipped.
+    subs.send_update(sample_update())
         .await
-        .expect_err("send_update should fail when subscriber channel is closed");
-    let msg = format!("{err:#}");
-    assert!(msg.contains("closed"), "unexpected error: {msg}");
+        .expect("send_update skips a closed subscriber instead of failing");
+}
+
+#[tokio::test]
+async fn resubscribe_after_drop_reclaims_slot() {
+    let mut subs = CatalogSubscriptions::default();
+
+    // First subscriber tears down, dropping its receiver without unsubscribing.
+    let rx = subs.subscribe("a");
+    drop(rx);
+
+    // Re-subscribing under the same name must reclaim the stale slot rather
+    // than panic on the duplicate.
+    let mut rx2 = subs.subscribe("a");
+
+    // The reclaimed subscription is live and receives broadcasts.
+    let broadcast = tokio::spawn(async move { subs.send_update(sample_update()).await });
+    let received = rx2.recv().await.expect("resubscribed receiver gets update");
+    assert_eq!(received.events().count(), 1);
+    drop(received);
+    broadcast.await.unwrap().unwrap();
 }
 
 #[tokio::test]

--- a/influxdb3_catalog/src/catalog/versions/v3/ops/token.rs
+++ b/influxdb3_catalog/src/catalog/versions/v3/ops/token.rs
@@ -45,6 +45,10 @@ impl CatalogOp for CreateAdminTokenOp {
             return Err(CatalogError::TokenNameAlreadyExists(args.name.clone()));
         }
 
+        if catalog.tokens.hash_to_id(&args.hash).is_some() {
+            return Err(CatalogError::TokenHashAlreadyExists);
+        }
+
         let token_id = catalog.tokens.repo().next_id();
         records.push(&CreateAdminToken {
             token_id: token_id.get(),
@@ -96,6 +100,12 @@ impl CatalogOp for RegenerateAdminTokenOp {
     ) -> Result<Self, CatalogError> {
         if catalog.tokens.repo().get_by_id(&args.token_id).is_none() {
             return Err(CatalogError::MissingAdminTokenToUpdate);
+        }
+
+        if let Some(existing_id) = catalog.tokens.hash_to_id(&args.new_hash)
+            && existing_id != args.token_id
+        {
+            return Err(CatalogError::TokenHashAlreadyExists);
         }
 
         records.push(&RegenerateAdminToken {
@@ -190,6 +200,10 @@ impl CatalogOp for CreateResourceScopedTokenOp {
     ) -> Result<Self, CatalogError> {
         if catalog.tokens.repo().get_by_name(&args.name).is_some() {
             return Err(CatalogError::TokenNameAlreadyExists(args.name.clone()));
+        }
+
+        if catalog.tokens.hash_to_id(&args.hash).is_some() {
+            return Err(CatalogError::TokenHashAlreadyExists);
         }
 
         let token_id = catalog.tokens.repo().next_id();

--- a/influxdb3_catalog/src/catalog/versions/v3/ops/token/tests.rs
+++ b/influxdb3_catalog/src/catalog/versions/v3/ops/token/tests.rs
@@ -198,3 +198,169 @@ fn prepare_create_resource_scoped_token() {
         influxdb3_authz::Actions::Database(_)
     ));
 }
+
+#[test]
+fn prepare_create_admin_token_duplicate_hash() {
+    let mut catalog = test_catalog();
+
+    // Create first token with a specific hash
+    let mut batch = RecordBatch::new(1);
+    CreateAdminTokenOp::prepare(
+        &CreateAdminTokenArgs {
+            name: "admin1".to_string(),
+            hash: vec![1, 2, 3],
+            created_at: 1000,
+            updated_at: None,
+            expiry: None,
+            description: None,
+            created_by: None,
+            updated_by: None,
+        },
+        &catalog,
+        &mut batch,
+    )
+    .unwrap();
+    apply_batch(&batch, &mut catalog);
+
+    // Try to create second token with the same hash
+    batch = RecordBatch::new(1);
+    let result = CreateAdminTokenOp::prepare(
+        &CreateAdminTokenArgs {
+            name: "admin2".to_string(),
+            hash: vec![1, 2, 3],
+            created_at: 2000,
+            updated_at: None,
+            expiry: None,
+            description: None,
+            created_by: None,
+            updated_by: None,
+        },
+        &catalog,
+        &mut batch,
+    );
+    assert!(matches!(result, Err(CatalogError::TokenHashAlreadyExists)));
+}
+
+#[test]
+fn prepare_create_resource_scoped_token_duplicate_hash() {
+    let mut catalog = test_catalog();
+
+    // Need a database for permission resolution
+    let mut batch = RecordBatch::new(1);
+    CreateDatabaseOp::prepare(
+        &CreateDatabaseArgs {
+            name: "mydb".to_string(),
+            retention_period: None,
+        },
+        &catalog,
+        &mut batch,
+    )
+    .unwrap();
+    apply_batch(&batch, &mut catalog);
+
+    // Create first token
+    batch = RecordBatch::new(1);
+    CreateResourceScopedTokenOp::prepare(
+        &CreateResourceScopedTokenArgs {
+            name: "token1".to_string(),
+            hash: vec![10, 11, 12],
+            created_at: 1000,
+            updated_at: None,
+            expiry: None,
+            description: None,
+            created_by: None,
+            updated_by: None,
+            permissions: vec![WirePermission {
+                resource_type: WireResourceType::Database,
+                resource_identifier: WireResourceIdent::Database(vec![0]),
+                actions: WireActions::Database(DatabaseActions::READ),
+                resource_names: vec![],
+            }],
+        },
+        &catalog,
+        &mut batch,
+    )
+    .unwrap();
+    apply_batch(&batch, &mut catalog);
+
+    // Try creating another token with the same hash
+    batch = RecordBatch::new(1);
+    let result = CreateResourceScopedTokenOp::prepare(
+        &CreateResourceScopedTokenArgs {
+            name: "token2".to_string(),
+            hash: vec![10, 11, 12],
+            created_at: 2000,
+            updated_at: None,
+            expiry: None,
+            description: None,
+            created_by: None,
+            updated_by: None,
+            permissions: vec![WirePermission {
+                resource_type: WireResourceType::Database,
+                resource_identifier: WireResourceIdent::Database(vec![0]),
+                actions: WireActions::Database(DatabaseActions::READ),
+                resource_names: vec![],
+            }],
+        },
+        &catalog,
+        &mut batch,
+    );
+    assert!(matches!(result, Err(CatalogError::TokenHashAlreadyExists)));
+}
+
+#[test]
+fn prepare_regenerate_admin_token_duplicate_hash() {
+    let mut catalog = test_catalog();
+
+    // Create first admin token
+    let mut batch = RecordBatch::new(1);
+    let op1 = CreateAdminTokenOp::prepare(
+        &CreateAdminTokenArgs {
+            name: "admin1".to_string(),
+            hash: vec![1, 2, 3],
+            created_at: 1000,
+            updated_at: None,
+            expiry: None,
+            description: None,
+            created_by: None,
+            updated_by: None,
+        },
+        &catalog,
+        &mut batch,
+    )
+    .unwrap();
+    apply_batch(&batch, &mut catalog);
+    let token1 = op1.output(&catalog);
+
+    // Create second admin token with a different hash
+    batch = RecordBatch::new(1);
+    let _op2 = CreateAdminTokenOp::prepare(
+        &CreateAdminTokenArgs {
+            name: "admin2".to_string(),
+            hash: vec![4, 5, 6],
+            created_at: 1000,
+            updated_at: None,
+            expiry: None,
+            description: None,
+            created_by: None,
+            updated_by: None,
+        },
+        &catalog,
+        &mut batch,
+    )
+    .unwrap();
+    apply_batch(&batch, &mut catalog);
+
+    // Try to regenerate token1's hash to match token2's hash
+    batch = RecordBatch::new(1);
+    let result = RegenerateAdminTokenOp::prepare(
+        &RegenerateAdminTokenArgs {
+            token_id: token1.id,
+            new_hash: vec![4, 5, 6],
+            updated_at: 2000,
+        },
+        &catalog,
+        &mut batch,
+    );
+    assert!(matches!(result, Err(CatalogError::TokenHashAlreadyExists)));
+}

--- a/influxdb3_catalog/src/catalog/versions/v3/schema/tokens.rs
+++ b/influxdb3_catalog/src/catalog/versions/v3/schema/tokens.rs
@@ -35,8 +35,8 @@ impl TokenRepository {
         self.repo.get_by_id(&id)
     }
 
-    pub(crate) fn hash_to_id(&self, hash: Vec<u8>) -> Option<TokenId> {
-        self.hash_lookup_map.get_by_right(&hash).copied()
+    pub(crate) fn hash_to_id(&self, hash: &[u8]) -> Option<TokenId> {
+        self.hash_lookup_map.get_by_right(hash).copied()
     }
 
     pub(crate) fn add_token(&mut self, token_id: TokenId, token_info: TokenInfo) -> Result<()> {
@@ -52,6 +52,12 @@ impl TokenRepository {
         hash: Vec<u8>,
         updated_at: i64,
     ) -> Result<()> {
+        if let Some(existing_id) = self.hash_to_id(&hash)
+            && existing_id != token_id
+        {
+            return Err(CatalogError::TokenHashAlreadyExists);
+        }
+
         let mut token_info = self
             .repo
             .get_by_id(&token_id)

--- a/influxdb3_catalog/src/error.rs
+++ b/influxdb3_catalog/src/error.rs
@@ -261,6 +261,9 @@ pub enum CatalogError {
     #[error("token name already exists, {0}")]
     TokenNameAlreadyExists(String),
 
+    #[error("token hash already exists")]
+    TokenHashAlreadyExists,
+
     #[error("missing admin token, cannot update")]
     MissingAdminTokenToUpdate,
 

--- a/influxdb3_internal_api/src/sll.rs
+++ b/influxdb3_internal_api/src/sll.rs
@@ -143,6 +143,32 @@ pub enum SystemEvent {
         duration_ms: u64,
     },
 
+    // ── parquet_cleanup ───────────────────────────────────────────────
+    /// A post-upgrade cleanup attempt completed successfully. Node-scoped:
+    /// one primary compactor walks the whole cluster object store. A dry run
+    /// reports matches while `files_deleted` and `bytes_reclaimed` remain 0.
+    ParquetCleanupSuccess {
+        /// `"delete"` or `"dry_run"`.
+        cleanup_mode: &'static str,
+        files_matched: u64,
+        bytes_matched: u64,
+        files_deleted: u64,
+        bytes_reclaimed: u64,
+        duration_ms: u64,
+    },
+    /// A post-upgrade cleanup reached a durable terminal failure. Counts
+    /// reflect progress persisted before the failure; `error_code` is a
+    /// static category and never includes an object-store path or message.
+    ParquetCleanupError {
+        cleanup_mode: &'static str,
+        files_matched: u64,
+        bytes_matched: u64,
+        files_deleted: u64,
+        bytes_reclaimed: u64,
+        error_code: &'static str,
+        duration_ms: u64,
+    },
+
     // ── compaction_planned ────────────────────────────────────────────
     /// The compactor produced one or more plans for a database in this
     /// planning cycle. One emission per (cycle, database).

--- a/influxdb3_internal_api/src/sll/tests.rs
+++ b/influxdb3_internal_api/src/sll/tests.rs
@@ -68,6 +68,14 @@ fn noop_sink_accepts_any_event() {
         bytes_reclaimed: 1,
         duration_ms: 1,
     });
+    sink.emit(SystemEvent::ParquetCleanupSuccess {
+        cleanup_mode: "dry_run",
+        files_matched: 1,
+        bytes_matched: 1,
+        files_deleted: 0,
+        bytes_reclaimed: 0,
+        duration_ms: 1,
+    });
     sink.emit(SystemEvent::CompactionPlannedSuccess {
         database_id: 1,
         groups_planned: 1,

--- a/influxdb3_server/src/http.rs
+++ b/influxdb3_server/src/http.rs
@@ -661,6 +661,7 @@ impl IntoResponse for CatalogError {
             }
             Self::AlreadyExists
             | Self::AlreadyDeleted(_)
+            | Self::TokenHashAlreadyExists
             | Self::NodeNotFullyStopped { .. }
             | Self::NodeModeNotRemovable { .. }
             | Self::NodeInQueryGroup { .. } => Either::Right(StatusCode::CONFLICT),

--- a/install_influxdb.sh
+++ b/install_influxdb.sh
@@ -72,7 +72,7 @@
 # CONFIGURATION OPTIONS:
 #   Command Line Arguments:
 #     [enterprise]        Install Enterprise edition (default: Core)
-#     --version VERSION   Specify InfluxDB version (default: 3.8.0)
+#     --version VERSION   Specify InfluxDB version (default: 3.11.0)
 #
 #   Interactive Prompts (Binary Installation):
 #     Installation Type:  Docker Compose or Binary
@@ -167,8 +167,8 @@ PORT=8181
 # Set the default (latest) version here. Users may specify a version using the
 # --version arg (handled below)
 INFLUXDB_VERSION_FLAG_SET="0"
-INFLUXDB_OSS_VERSION="3.10.5"
-INFLUXDB_ENT_VERSION="3.10.5"
+INFLUXDB_OSS_VERSION="3.11.0"
+INFLUXDB_ENT_VERSION="3.11.0"
 
 EDITION="Core"
 EDITION_TAG="core"


### PR DESCRIPTION
chore(sync): influxdb_pro 2026-08-06

Source: fb4ecafb43fc6b37ca69db770cda9445e5ba3113

Commits:
- `4e2e2864cd` fix(catalog): self-healing subscription registry and ordered compactor teardown (influxdata/influxdb_pro#5007) (influxdata/influxdb_pro#5052)
- `29692a77dd` feat: API and CLI to remove migrated Parquet data after PachaTree upgrade (influxdata/influxdb_pro#5008) (influxdata/influxdb_pro#5064)
- `f125ec63f5` docs(cli): clarify prune-percentage is a fraction of 1
- `3efaf38636` docs(cli): describe user-visible effects in serve option help (influxdata/influxdb_pro#4824)
- `dc6800e913` fix(iox_time): saturate Time add/sub instead of panicking on overflow (influxdata/influxdb_pro#4988) (influxdata/influxdb_pro#5027)
- `84d706794c` fix:  duplicate admin token bug (influxdata/influxdb_pro#4711) (influxdata/influxdb_pro#4997)
- `43b825550a` chore: fix cargo-audit failure due to RUSTSEC-2026-0222 (influxdata/influxdb_pro#4971) (influxdata/influxdb_pro#4999)
- `1ca4c5f19f` chore: update install script to 3.11 (influxdata/influxdb_pro#4943)
- `e5242f505d` chore: bump to 3.11.0 for release
- `4d853e1c75` fix: drop the unused windows linker block from oss/.cargo/config.toml (influxdata/influxdb_pro#4931)
- `75fc15651e` chore(release): bump to 3.11-rc.2 (influxdata/influxdb_pro#4927)

Co-authored-by: Cannon Palms <cpalms@influxdata.com>
Co-authored-by: epgif <epg@influxdata.com>
Co-authored-by: Jeffrey Smith II <jsmith@influxdata.com>
Co-authored-by: Paul Dix <paul@pauldix.net>
Co-authored-by: Phil Bracikowski <13472206+philjb@users.noreply.github.com>
Co-authored-by: Phil Bracikowski <pbracikowski+git@influxdata.com>
Co-authored-by: praveen-influx <pkumar@influxdata.com>
Co-authored-by: Reid Kaufmann <73494261+reidkaufmann@users.noreply.github.com>
Co-authored-by: Reid Kaufmann <reidk@influxdata.com>

