### PR TITLE
chore: bump version to 3.11.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,7 +444,7 @@ dependencies = [
 
 [[package]]
 name = "arrow_util"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -541,7 +541,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "authz"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -655,7 +655,7 @@ dependencies = [
 
 [[package]]
 name = "backoff"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "rand 0.9.4",
  "snafu 0.9.0",
@@ -1087,7 +1087,7 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "catalog_cache"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "bytes",
  "criterion 0.8.2",
@@ -1231,14 +1231,14 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli_types"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "tokio",
 ]
 
 [[package]]
 name = "client_util"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "http 1.4.2",
  "iox_http_util",
@@ -1841,7 +1841,7 @@ dependencies = [
 
 [[package]]
 name = "data_types"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -2575,7 +2575,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion_util"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -2670,7 +2670,7 @@ dependencies = [
 
 [[package]]
 name = "dml"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "arrow_util",
  "data_types",
@@ -2782,7 +2782,7 @@ dependencies = [
 
 [[package]]
 name = "error_reporting"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "datafusion",
  "snafu 0.9.0",
@@ -2812,7 +2812,7 @@ dependencies = [
 
 [[package]]
 name = "executor"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "futures",
  "metric",
@@ -2893,7 +2893,7 @@ dependencies = [
 
 [[package]]
 name = "flightsql"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -3100,7 +3100,7 @@ dependencies = [
 
 [[package]]
 name = "futures_test_utils"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "clap",
  "futures",
@@ -3111,7 +3111,7 @@ dependencies = [
 
 [[package]]
 name = "generated_types"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "bytes",
  "pbjson",
@@ -3765,7 +3765,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb2_client"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "bytes",
  "futures",
@@ -3784,7 +3784,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3878,7 +3878,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_authz"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "async-trait",
  "authz",
@@ -3896,7 +3896,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_cache"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3931,7 +3931,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_catalog"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "ahash 0.8.12",
  "anyhow",
@@ -3988,7 +3988,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_clap_blocks"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4025,7 +4025,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_client"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "bytes",
  "flate2",
@@ -4046,7 +4046,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_commands"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4074,7 +4074,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_id"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "criterion 0.5.1",
  "indexmap 2.14.0",
@@ -4086,7 +4086,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_internal_api"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4107,7 +4107,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_process"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "iox_time",
  "uuid",
@@ -4115,7 +4115,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_processing_engine"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -4163,7 +4163,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_processing_engine_telemetry"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "hashbrown 0.14.5",
  "influxdb3_catalog",
@@ -4173,7 +4173,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_py_api"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -4197,7 +4197,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_query_executor"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4248,7 +4248,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_server"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4335,7 +4335,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_shutdown"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "futures",
  "futures-util",
@@ -4350,14 +4350,14 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_startup"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "chrono",
 ]
 
 [[package]]
 name = "influxdb3_sys_events"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4376,7 +4376,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_system_tables"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4408,7 +4408,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_telemetry"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "futures",
  "futures-util",
@@ -4429,7 +4429,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_test_helpers"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4442,7 +4442,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_types"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4462,7 +4462,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_wal"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "async-trait",
  "bitcode",
@@ -4491,7 +4491,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_write"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4561,7 +4561,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb_influxql_parser"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "assert_matches",
  "chrono",
@@ -4578,7 +4578,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb_iox_client"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -4607,7 +4607,7 @@ dependencies = [
 
 [[package]]
 name = "ingester_query_grpc"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "base64 0.22.1",
  "data_types",
@@ -4673,7 +4673,7 @@ checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
 
 [[package]]
 name = "iox_http"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -4693,7 +4693,7 @@ dependencies = [
 
 [[package]]
 name = "iox_http_util"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "futures",
  "http 1.4.2",
@@ -4704,7 +4704,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "arrow",
  "arrow_util",
@@ -4753,7 +4753,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query_influxql"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "arrow",
  "assert_matches",
@@ -4780,7 +4780,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query_influxql_rewrite"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "influxdb_influxql_parser",
  "thiserror 2.0.18",
@@ -4788,7 +4788,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query_params"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "arrow",
  "assert_matches",
@@ -4802,7 +4802,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query_udf"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "datafusion-udf-wasm-host",
  "datafusion-udf-wasm-query",
@@ -4813,7 +4813,7 @@ dependencies = [
 
 [[package]]
 name = "iox_system_tables"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4823,7 +4823,7 @@ dependencies = [
 
 [[package]]
 name = "iox_time"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "chrono",
  "parking_lot",
@@ -4832,7 +4832,7 @@ dependencies = [
 
 [[package]]
 name = "iox_v1_query_api"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4946,7 +4946,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jemalloc_pprof_http"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "http-body-util",
  "hyper 1.11.0",
@@ -4959,7 +4959,7 @@ dependencies = [
 
 [[package]]
 name = "jemalloc_stats"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "futures",
  "snafu 0.9.0",
@@ -5152,7 +5152,7 @@ dependencies = [
 
 [[package]]
 name = "linear_buffer"
-version = "3.11.0"
+version = "3.11.1"
 
 [[package]]
 name = "linux-raw-sys"
@@ -5196,7 +5196,7 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "logfmt"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "humantime",
  "parking_lot",
@@ -5295,14 +5295,14 @@ dependencies = [
 
 [[package]]
 name = "metric"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "parking_lot",
 ]
 
 [[package]]
 name = "metric_exporters"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "metric",
  "mockito",
@@ -5427,7 +5427,7 @@ checksum = "9252111cf132ba0929b6f8e030cac2a24b507f3a4d6db6fb2896f27b354c714b"
 
 [[package]]
 name = "mutable_batch"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "arrow",
  "arrow_util",
@@ -5445,7 +5445,7 @@ dependencies = [
 
 [[package]]
 name = "mutable_batch_lp"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "arrow_util",
  "assert_matches",
@@ -5461,7 +5461,7 @@ dependencies = [
 
 [[package]]
 name = "mutable_batch_pb"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "arrow_util",
  "criterion 0.8.2",
@@ -5699,7 +5699,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_limit"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5711,7 +5711,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_mem_cache"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5739,7 +5739,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_metrics"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "async-trait",
  "bloom2",
@@ -5764,7 +5764,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_mock"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5778,7 +5778,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_size_hinting"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "chrono",
  "http 1.4.2",
@@ -5788,7 +5788,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_utils"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "async-trait",
  "backon",
@@ -5802,7 +5802,7 @@ dependencies = [
 
 [[package]]
 name = "observability_deps"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "tracing",
 ]
@@ -5876,7 +5876,7 @@ dependencies = [
 
 [[package]]
 name = "panic_logging"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "metric",
  "test_helpers",
@@ -5951,7 +5951,7 @@ dependencies = [
 
 [[package]]
 name = "parquet_file"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "arrow",
  "arrow_util",
@@ -5982,7 +5982,7 @@ dependencies = [
 
 [[package]]
 name = "partition"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "arrow",
  "assert_matches",
@@ -6279,7 +6279,7 @@ dependencies = [
 
 [[package]]
 name = "predicate"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6622,7 +6622,7 @@ dependencies = [
 
 [[package]]
 name = "query_functions"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "arrow",
  "chrono",
@@ -7332,7 +7332,7 @@ dependencies = [
 
 [[package]]
 name = "schema"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "arrow",
  "base64 0.22.1",
@@ -7516,7 +7516,7 @@ dependencies = [
 
 [[package]]
 name = "service_common"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -7530,7 +7530,7 @@ dependencies = [
 
 [[package]]
 name = "service_grpc_flight"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -7606,7 +7606,7 @@ dependencies = [
 
 [[package]]
 name = "sharder"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "criterion 0.8.2",
  "data_types",
@@ -8128,7 +8128,7 @@ dependencies = [
 
 [[package]]
 name = "table_batch"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "arrow_util",
  "bitvec",
@@ -8224,7 +8224,7 @@ dependencies = [
 
 [[package]]
 name = "test_helpers"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "async-trait",
  "dotenvy",
@@ -8243,7 +8243,7 @@ dependencies = [
 
 [[package]]
 name = "test_helpers_authz"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "futures",
  "generated_types",
@@ -8528,7 +8528,7 @@ dependencies = [
 
 [[package]]
 name = "tokio_metrics_bridge"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "metric",
  "parking_lot",
@@ -8537,7 +8537,7 @@ dependencies = [
 
 [[package]]
 name = "tokio_watchdog"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "metric",
  "test_helpers",
@@ -8760,7 +8760,7 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tower_trailer"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "futures",
  "http 1.4.2",
@@ -8772,7 +8772,7 @@ dependencies = [
 
 [[package]]
 name = "trace"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "chrono",
  "parking_lot",
@@ -8782,7 +8782,7 @@ dependencies = [
 
 [[package]]
 name = "trace_exporters"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8799,7 +8799,7 @@ dependencies = [
 
 [[package]]
 name = "trace_http"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "bytes",
  "futures",
@@ -8894,7 +8894,7 @@ dependencies = [
 
 [[package]]
 name = "tracker"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "futures",
  "hashbrown 0.14.5",
@@ -8914,7 +8914,7 @@ dependencies = [
 
 [[package]]
 name = "trogging"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "clap",
  "logfmt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,7 +127,7 @@ exclude = [
 #
 # For porting to the actual OSS repo (influxdb), this would need to change to `-nightly`, i.e., by
 # stripping the `-oss`.
-version = "3.11.0"
+version = "3.11.1"
 authors = ["InfluxData OSS Developers"]
 edition = "2024"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Version bump for 3.11.1.

Sets `[workspace.package] version` to `3.11.1` and updates `Cargo.lock`.

Follows the 2026-08-06 sync (#27580).