### PR TITLE
chore(ci): push release artifacts to Cloudflare R2 instead of AWS S3 (3.11 backport)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,6 @@ executors:
     working_directory: /tmp/workspace/<< pipeline.id >>
 
 orbs:
-  aws-s3: circleci/aws-s3@2.0.0
   rust: circleci/rust@1.6.1
 
 # Unlike when a commit is pushed to a branch, CircleCI does not automatically
@@ -667,22 +666,23 @@ jobs:
       #   - snapshots
       destination:
         type: string
+    environment:
+      # Newer awscli/boto3 send CRC32 checksum headers that Cloudflare R2
+      # rejects unless checksum calculation is limited to when required.
+      AWS_REQUEST_CHECKSUM_CALCULATION: when_required
     steps:
       - attach_workspace:
           at: /tmp/workspace
-      - aws-s3/sync:
-          arguments:             --acl public-read
-          aws-region:            RELEASE_AWS_REGION
-          aws-access-key-id:     RELEASE_AWS_ACCESS_KEY_ID
-          aws-secret-access-key: RELEASE_AWS_SECRET_ACCESS_KEY
-          from:                  /tmp/workspace/artifacts
-          to:                    s3://dl.influxdata.com/influxdb/<< parameters.destination >>
       - run:
+          name: Upload artifacts to R2
           command: |
-            export AWS_REGION="${RELEASE_AWS_REGION}"
+            pip install --quiet awscli
             export AWS_ACCESS_KEY_ID="${RELEASE_AWS_ACCESS_KEY_ID}"
             export AWS_SECRET_ACCESS_KEY="${RELEASE_AWS_SECRET_ACCESS_KEY}"
-            aws cloudfront create-invalidation --distribution-id "${RELEASE_ARTIFACTS_CLOUDFRONT}" --paths '/influxdb/<< parameters.destination >>/*'
+            aws s3 sync /tmp/workspace/artifacts \
+              "s3://dl-influxdata-com/influxdb/<< parameters.destination >>" \
+              --endpoint-url "${AWS_ENDPOINT_URL_S3}" \
+              --region auto
 
   build-docker:
     parameters:


### PR DESCRIPTION
Backport of influxdata/influxdb_pro#5045 to `3.11`.

## Why

The 3.11.1 release build failed at `publish-packages-releases`, step `S3 Sync`:

```
fatal error: An error occurred (AccessDenied) when calling the ListObjectsV2 operation: Access Denied
```

[Failed job 507249](https://app.circleci.com/pipelines/github/influxdata/influxdb/52694/workflows/16c96950-52d7-49a8-8799-64a13a946a43/jobs/507249)

`3.11` still uploads via `aws-s3/sync` to `s3://dl.influxdata.com`, while `main` moved to Cloudflare R2 on 2026-08-05. The `RELEASE_AWS_*` credentials no longer grant access to the old AWS bucket, so releases cut from `3.11` fail at upload. Every other job passed, including the quay.io image push.

## What

Replaces the `aws-s3` orb sync with an `aws s3 sync` to `s3://dl-influxdata-com` via `AWS_ENDPOINT_URL_S3`, sets `AWS_REQUEST_CHECKSUM_CALCULATION: when_required` for R2 compatibility, and drops the now-unneeded CloudFront invalidation.

This file is the synced counterpart of `oss/.circleci/config.yml` in the monolith; the two were byte-identical on `3.11` before this change, and the monolith backport is influxdata/influxdb_pro#5104.

Once this merges, `v3.11.1` needs to be re-tagged onto the new commit.