### PR TITLE
ci: push release artifacts to Cloudflare R2 instead of AWS S3 (2.x)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,6 @@
 version: "2.1"
 
 orbs:
-  aws-s3:    circleci/aws-s3@2.0.0
   terraform: circleci/terraform@2.1.0
 
 parameters:
@@ -557,6 +556,10 @@ jobs:
   publish-packages:
     docker:
       - image: cimg/python:3.6
+    environment:
+      # Newer awscli/boto3 send CRC32 checksum headers that Cloudflare R2
+      # rejects unless checksum calculation is limited to when required.
+      AWS_REQUEST_CHECKSUM_CALCULATION: when_required
     steps:
       - attach_workspace:
           at: /tmp/workspace
@@ -564,13 +567,14 @@ jobs:
           name: Install AWS CLI
           command: |
             pip install awscli
-      - aws-s3/sync:
-          arguments:             --acl public-read
-          aws-region:            RELEASE_AWS_REGION
-          aws-access-key-id:     RELEASE_AWS_ACCESS_KEY_ID
-          aws-secret-access-key: RELEASE_AWS_SECRET_ACCESS_KEY
-          from:                  /tmp/workspace/artifacts
-          to:                    s3://dl.influxdata.com/influxdb/releases
+      - run:
+          name: Upload packages to R2
+          command: |
+            export AWS_ACCESS_KEY_ID="${RELEASE_AWS_ACCESS_KEY_ID}"
+            export AWS_SECRET_ACCESS_KEY="${RELEASE_AWS_SECRET_ACCESS_KEY}"
+            aws s3 sync /tmp/workspace/artifacts s3://dl-influxdata-com/influxdb/releases \
+              --endpoint-url "${AWS_ENDPOINT_URL_S3}" \
+              --region auto
 
   build-docker-nightly:
     parameters:
@@ -905,29 +909,41 @@ jobs:
         type: string
     docker:
       - image: cimg/python:3.6
+    environment:
+      # Newer awscli/boto3 send CRC32 checksum headers that Cloudflare R2
+      # rejects unless checksum calculation is limited to when required.
+      AWS_REQUEST_CHECKSUM_CALCULATION: when_required
     steps:
       - attach_workspace:
           at: /tmp/workspace
+      - run:
+          name: Install AWS CLI
+          command: |
+            pip install awscli
       - when:
           condition:
             equal: [ << parameters.workflow >>, release ]
           steps:
-            - aws-s3/copy:
-                aws-region:            RELEASE_AWS_REGION
-                aws-access-key-id:     RELEASE_AWS_ACCESS_KEY_ID
-                aws-secret-access-key: RELEASE_AWS_SECRET_ACCESS_KEY
-                to:                    s3://dl.influxdata.com/influxdb/releases/CHANGELOG.<< pipeline.git.tag >>.md
-                from:                  /tmp/workspace/CHANGELOG.md
+            - run:
+                name: Upload CHANGELOG to R2
+                command: |
+                  export AWS_ACCESS_KEY_ID="${RELEASE_AWS_ACCESS_KEY_ID}"
+                  export AWS_SECRET_ACCESS_KEY="${RELEASE_AWS_SECRET_ACCESS_KEY}"
+                  aws s3 cp /tmp/workspace/CHANGELOG.md "s3://dl-influxdata-com/influxdb/releases/CHANGELOG.<< pipeline.git.tag >>.md" \
+                    --endpoint-url "${AWS_ENDPOINT_URL_S3}" \
+                    --region auto
       - when:
           condition:
             equal: [ << parameters.workflow >>, nightly ]
           steps:
-            - aws-s3/copy:
-                aws-region:            RELEASE_AWS_REGION
-                aws-access-key-id:     RELEASE_AWS_ACCESS_KEY_ID
-                aws-secret-access-key: RELEASE_AWS_SECRET_ACCESS_KEY
-                to:                    s3://dl.influxdata.com/platform/nightlies/<< pipeline.git.branch >>/CHANGELOG.md
-                from:                  /tmp/workspace/CHANGELOG.md
+            - run:
+                name: Upload CHANGELOG to R2
+                command: |
+                  export AWS_ACCESS_KEY_ID="${RELEASE_AWS_ACCESS_KEY_ID}"
+                  export AWS_SECRET_ACCESS_KEY="${RELEASE_AWS_SECRET_ACCESS_KEY}"
+                  aws s3 cp /tmp/workspace/CHANGELOG.md "s3://dl-influxdata-com/platform/nightlies/<< pipeline.git.branch >>/CHANGELOG.md" \
+                    --endpoint-url "${AWS_ENDPOINT_URL_S3}" \
+                    --region auto
 
   check_package_deb_amd64:
     machine:


### PR DESCRIPTION
### Description

Migrates 2.x release artifact publishing from AWS S3 to Cloudflare R2, following the org-wide convention (#27582 for 3.x, influxdata/chronograf#6241, influxdata/kapacitor#2905) and matching influxdata/influx-cli#581 and influxdata/dependabot-for-influxdb-2.x#1.

### Context

- Removed the `circleci/aws-s3@2.0.0` orb; uploads are now plain `run` steps using awscli with `--endpoint-url "${AWS_ENDPOINT_URL_S3}"` and `--region auto`.
- `publish-packages`: `aws-s3/sync` replaced with `aws s3 sync` to the `dl-influxdata-com` R2 bucket (path `influxdb/releases` unchanged). Dropped `--acl public-read` — R2 has no ACLs.
- `publish-changelog`: both `aws-s3/copy` steps (release and nightly) replaced with `aws s3 cp` to the same paths on `dl-influxdata-com`. Added an explicit awscli install step (previously provided by the orb).
- Added `AWS_REQUEST_CHECKSUM_CALCULATION: when_required` to both publish jobs. Newer awscli/boto3 send CRC32 checksum headers that R2 rejects unless checksum calculation is limited to when required.
- Credentials keep the `RELEASE_AWS_ACCESS_KEY_ID` / `RELEASE_AWS_SECRET_ACCESS_KEY` names (values are now R2 API tokens), re-exported as `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` in each step.

Out of scope: `TEST_AWS_*` EC2/terraform package validation and the perftest binary download — real AWS, not artifact publishing.

CircleCI project settings required before merge:
- `AWS_ENDPOINT_URL_S3` — R2 account endpoint
- `RELEASE_AWS_ACCESS_KEY_ID` / `RELEASE_AWS_SECRET_ACCESS_KEY` — replaced with Cloudflare R2 API token credentials
- `RELEASE_AWS_REGION` — no longer referenced; remove after verification

Verification after merge:
- [ ] Nightly workflow uploads packages and `platform/nightlies/<branch>/CHANGELOG.md`; artifacts served at `https://dl.influxdata.com/...`
- [ ] Next tagged release publishes packages to `influxdb/releases` and `CHANGELOG.<tag>.md`
- [ ] Then remove `RELEASE_AWS_REGION` and revoke old AWS IAM keys

### Note for reviewers:

CI-only change (`ci:` semantic commit type). No user-visible changes; download URLs on `https://dl.influxdata.com` are unchanged.
