### PR TITLE
chore(install_influxdb): update to 3.11.1 for default version installed

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -92,6 +92,14 @@ ignore = [
     # upstream datafusion-udf-wasm bump.
     "RUSTSEC-2026-0188",
     #
+    # wasmtime 41.0.4 stores can mix up type indices between engines
+    # (https://rustsec.org/advisories/RUSTSEC-2026-0222). Same transitive path via
+    # datafusion-udf-wasm; only reachable if a Wasm UDF is loaded, and UDFs are
+    # disabled by default (udfs_enabled = false). The 41.x line has no patched
+    # release. The fix requires wasmtime >=46.0.2, which needs an upstream
+    # datafusion-udf-wasm bump to a DataFusion 52 rev.
+    "RUSTSEC-2026-0222",
+    #
     # TODO: update wasmtime-wasi via datafusion-udf-wasm to a patched version (>=45.0.3; >=46.0.1 is also fixed)
     #
     # pyo3 0.24-0.28 out-of-bounds read in Iterator::nth/nth_back on

--- a/install_influxdb.sh
+++ b/install_influxdb.sh
@@ -72,7 +72,7 @@
 # CONFIGURATION OPTIONS:
 #   Command Line Arguments:
 #     [enterprise]        Install Enterprise edition (default: Core)
-#     --version VERSION   Specify InfluxDB version (default: 3.11.0)
+#     --version VERSION   Specify InfluxDB version (default: 3.11.1)
 #
 #   Interactive Prompts (Binary Installation):
 #     Installation Type:  Docker Compose or Binary
@@ -167,8 +167,8 @@ PORT=8181
 # Set the default (latest) version here. Users may specify a version using the
 # --version arg (handled below)
 INFLUXDB_VERSION_FLAG_SET="0"
-INFLUXDB_OSS_VERSION="3.11.0"
-INFLUXDB_ENT_VERSION="3.11.0"
+INFLUXDB_OSS_VERSION="3.11.1"
+INFLUXDB_ENT_VERSION="3.11.1"
 
 EDITION="Core"
 EDITION_TAG="core"


### PR DESCRIPTION
follows
* #27572