### PR TITLE
chore: enhanced ownership semantics in flux storage layer

### DIFF
--- a/storage/flux/reader.go
+++ b/storage/flux/reader.go
@@ -916,6 +916,17 @@ func (ti *tagKeysIterator) Do(f func(flux.Table) error) error {
 	return ti.handleRead(f, rs)
 }
 
+// deliverTable hands a finished metadata table to f and settles ownership on
+// rejection: an erroring callback has not queued the table for a consumer, so
+// nobody else will release it.
+func deliverTable(f func(flux.Table) error, tbl flux.Table) error {
+	if err := f(tbl); err != nil {
+		tbl.Done()
+		return err
+	}
+	return nil
+}
+
 func (ti *tagKeysIterator) handleRead(f func(flux.Table) error, rs cursors.StringIterator) error {
 	key := execute.NewGroupKey(nil, nil)
 	builder := execute.NewColListTableBuilder(key, ti.alloc)
@@ -959,7 +970,8 @@ func (ti *tagKeysIterator) handleRead(f func(flux.Table) error, rs cursors.Strin
 
 	// Release the references to the arrays held by the builder.
 	builder.ClearData()
-	return f(tbl)
+
+	return deliverTable(f, tbl)
 }
 
 func (ti *tagKeysIterator) Statistics() cursors.CursorStats {
@@ -1036,7 +1048,8 @@ func (ti *tagValuesIterator) handleRead(f func(flux.Table) error, rs cursors.Str
 
 	// Release the references to the arrays held by the builder.
 	builder.ClearData()
-	return f(tbl)
+
+	return deliverTable(f, tbl)
 }
 
 func (ti *tagValuesIterator) Statistics() cursors.CursorStats {
@@ -1107,7 +1120,8 @@ func (si *seriesCardinalityIterator) handleRead(f func(flux.Table) error, rs cur
 
 	// Release the references to the arrays held by the builder.
 	builder.ClearData()
-	return f(tbl)
+
+	return deliverTable(f, tbl)
 }
 
 func (si *seriesCardinalityIterator) Statistics() cursors.CursorStats {

--- a/storage/flux/reader_metadata_release_test.go
+++ b/storage/flux/reader_metadata_release_test.go
@@ -1,0 +1,106 @@
+package storageflux
+
+import (
+	"fmt"
+	"testing"
+
+	arrowmem "github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/memory"
+	"github.com/influxdata/influxdb/v2/tsdb/cursors"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests cover the last f(table) hand-off class in this package: the
+// metadata iterators (tag keys, tag values, series cardinality) build a
+// ColListTable - whose columns are allocator-backed copies made by
+// ColListTableBuilder.Table() - and hand it to f. An erroring callback has not
+// queued the table for a consumer, so unless handleRead releases the table
+// itself, neither Do nor Done ever runs on it and the copies leak, exactly as
+// with the storage tables and splitWindows rows.
+
+type stringSliceIterator struct {
+	values []string
+	i      int
+}
+
+func (s *stringSliceIterator) Next() bool {
+	if s.i < len(s.values) {
+		s.i++
+		return true
+	}
+	return false
+}
+
+func (s *stringSliceIterator) Value() string              { return s.values[s.i-1] }
+func (s *stringSliceIterator) Stats() cursors.CursorStats { return cursors.CursorStats{} }
+
+type int64SliceIterator struct {
+	values []int64
+	i      int
+}
+
+func (s *int64SliceIterator) Next() bool {
+	if s.i < len(s.values) {
+		s.i++
+		return true
+	}
+	return false
+}
+
+func (s *int64SliceIterator) Value() int64               { return s.values[s.i-1] }
+func (s *int64SliceIterator) Stats() cursors.CursorStats { return cursors.CursorStats{} }
+
+// metadataReads drives each iterator's handleRead directly: it only touches
+// its allocator and the result-set iterator, so no store is needed.
+func metadataReads() map[string]func(alloc memory.Allocator, f func(flux.Table) error) error {
+	return map[string]func(alloc memory.Allocator, f func(flux.Table) error) error{
+		"tagKeys": func(alloc memory.Allocator, f func(flux.Table) error) error {
+			ti := &tagKeysIterator{alloc: alloc}
+			return ti.handleRead(f, &stringSliceIterator{values: []string{"t0", "t1"}})
+		},
+		"tagValues": func(alloc memory.Allocator, f func(flux.Table) error) error {
+			ti := &tagValuesIterator{alloc: alloc}
+			return ti.handleRead(f, &stringSliceIterator{values: []string{"a", "b"}})
+		},
+		"seriesCardinality": func(alloc memory.Allocator, f func(flux.Table) error) error {
+			si := &seriesCardinalityIterator{alloc: alloc}
+			return si.handleRead(f, &int64SliceIterator{values: []int64{42}})
+		},
+	}
+}
+
+// TestMetadataIterators_FErrorReleasesTable rejects the table from the Do
+// callback and requires that handleRead release it: nobody else will.
+func TestMetadataIterators_FErrorReleasesTable(t *testing.T) {
+	for name, read := range metadataReads() {
+		t.Run(name, func(t *testing.T) {
+			mem := arrowmem.NewCheckedAllocator(arrowmem.DefaultAllocator)
+			defer mem.AssertSize(t, 0)
+			alloc := &memory.ResourceAllocator{Allocator: mem}
+
+			rejected := fmt.Errorf("downstream rejected the table")
+			err := read(alloc, func(tbl flux.Table) error {
+				return rejected
+			})
+			require.ErrorIs(t, err, rejected)
+		})
+	}
+}
+
+// TestMetadataIterators_ConsumedReleasesTable is the control: a consumed table
+// releases itself through Do, so handleRead must not release it again.
+func TestMetadataIterators_ConsumedReleasesTable(t *testing.T) {
+	for name, read := range metadataReads() {
+		t.Run(name, func(t *testing.T) {
+			mem := arrowmem.NewCheckedAllocator(arrowmem.DefaultAllocator)
+			defer mem.AssertSize(t, 0)
+			alloc := &memory.ResourceAllocator{Allocator: mem}
+
+			err := read(alloc, func(tbl flux.Table) error {
+				return tbl.Do(func(flux.ColReader) error { return nil })
+			})
+			require.NoError(t, err)
+		})
+	}
+}

--- a/storage/flux/table.go
+++ b/storage/flux/table.go
@@ -93,8 +93,8 @@ func (t *table) init(advance func() bool) {
 // an unconditional wait can block forever.
 //
 // The used CAS already arbitrates ownership, so reuse it: whoever wins it owns
-// the table and is responsible for closing done. do() and Done() are the other
-// two claimants.
+// the table and is responsible for releasing its buffer and closing done. do()
+// and Done() are the other two claimants.
 func (t *table) awaitAbandoned(done <-chan struct{}) {
 	// Ask any running consumer to stop at its next iteration boundary, so the
 	// wait below is as short as possible.
@@ -103,7 +103,9 @@ func (t *table) awaitAbandoned(done <-chan struct{}) {
 	if t.used.CompareAndSwap(false, true) {
 		// We claimed the table first. do()'s opening act is this same CAS and it
 		// touches nothing beforehand, so no consumer can ever run against this
-		// table and there is nothing to wait for.
+		// table and there is nothing to wait for. The buffer is ours to release:
+		// nothing else will, since Done() only releases when it wins this CAS.
+		t.releaseColBufs()
 		t.closeDone()
 		return
 	}
@@ -138,6 +140,12 @@ func (t *table) do(f func(flux.ColReader) error, advance func() bool) error {
 		return errors.New("table already used")
 	}
 	defer t.closeDone()
+	// The loop below settles the buffer after every f call and nils colBufs, so
+	// this only fires on the exits that leave a live buffer behind: the early
+	// error return below, a panic unwinding out of f, and a panic out of
+	// advance after it installed a fresh buffer. It runs before closeDone
+	// (LIFO), so done never closes with the buffer still retained.
+	defer t.releaseColBufs()
 
 	// If an error occurred during initialization, that is
 	// returned here.
@@ -146,26 +154,40 @@ func (t *table) do(f func(flux.ColReader) error, advance func() bool) error {
 	}
 
 	if !t.Empty() {
+		// Settle each buffer through releaseColBufs rather than a bare Release:
+		// nil-ing colBufs per iteration means the deferred release above can
+		// never touch a buffer this loop already settled. advance() can panic
+		// on an allocator limit before installing a fresh buffer, and a stale
+		// colBufs there would release arrays a retaining consumer still holds.
+		// This forfeits allocateBuffer's colReader struct reuse, one small
+		// allocation per iteration.
 		t.err = f(t.colBufs)
-		t.colBufs.Release()
+		t.releaseColBufs()
 
 		for !t.isCancelled() && t.err == nil && advance() {
 			t.err = f(t.colBufs)
-			t.colBufs.Release()
+			t.releaseColBufs()
 		}
-		t.colBufs = nil
 	}
 
 	return t.err
 }
 
 func (t *table) Done() {
-	// Mark the table as having been used. If this has already
-	// been done, then nothing needs to be done.
+	// Mark the table as having been used. If this has already been done, then
+	// nothing needs to be done: the buffer belongs to whoever won the CAS, and
+	// releasing it here would race a concurrent awaitAbandoned or double-release
+	// behind a do() that covers its own exits.
 	if t.used.CompareAndSwap(false, true) {
-		defer t.closeDone()
+		t.releaseColBufs()
+		t.closeDone()
 	}
+}
 
+// releaseColBufs releases the table's current buffer, if any. Only the winner
+// of the used CAS may call it - do(), Done(), and awaitAbandoned each release
+// on the paths they own - so every buffer has exactly one releaser.
+func (t *table) releaseColBufs() {
 	if t.colBufs != nil {
 		t.colBufs.Release()
 		t.colBufs = nil
@@ -208,7 +230,16 @@ func (cr *colReader) Retain() {
 func (cr *colReader) Release() {
 	if atomic.AddInt64(&cr.refCount, -1) == 0 {
 		for _, col := range cr.cols {
-			col.Release()
+			// cols may hold nil entries when a panic interrupts advance()
+			// between allocateBuffer and the last column fill; the deferred
+			// releaseColBufs must not panic over them while unwinding. The
+			// cost is a weaker early warning: a construction bug that leaves
+			// a column nil now surfaces only when a consumer reads that
+			// column, where this loop previously panicked on the first
+			// release regardless of consumer behavior.
+			if col != nil {
+				col.Release()
+			}
 		}
 	}
 }

--- a/storage/flux/table_release_test.go
+++ b/storage/flux/table_release_test.go
@@ -1,0 +1,291 @@
+package storageflux
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	arrowmem "github.com/apache/arrow-go/v18/arrow/memory"
+	"github.com/influxdata/flux"
+	"github.com/influxdata/flux/arrow"
+	"github.com/influxdata/flux/codes"
+	"github.com/influxdata/flux/execute"
+	"github.com/influxdata/flux/memory"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests pin the buffer-ownership invariant on table: whoever wins the
+// used CAS - do(), Done(), or awaitAbandoned - owns colBufs and done, and is
+// the exactly-once releaser of both. The checked allocator makes a missed
+// release (a leak) observable, and a double release fails inside arrow.
+//
+// This mirrors what windowTableRow already guaranteed for its buffer: before
+// awaitAbandoned released the buffer, a table abandoned while unclaimed - a
+// cancelled query whose table was dropped from the transport queue without Do
+// or Done ever being called - kept its current buffer's arrays accounted
+// against the query's allocator forever.
+
+// newUnconsumedTable builds a bare *table holding one allocated buffer, in the
+// state handleRead hands tables to f: non-empty, unclaimed, buffer retained.
+func newUnconsumedTable(tb testing.TB, alloc memory.Allocator) (*table, chan struct{}) {
+	tb.Helper()
+	done := make(chan struct{})
+	cols := []flux.ColMeta{{Label: execute.DefaultValueColLabel, Type: flux.TFloat}}
+	tbl := newTable(done, execute.Bounds{}, nil, cols, make([][]byte, len(cols)), nil, alloc)
+	cr := tbl.allocateBuffer(3)
+	cr.cols[0] = arrow.NewFloat([]float64{1, 2, 3}, alloc)
+	tbl.empty = false
+	return &tbl, done
+}
+
+func requireDoneClosed(tb testing.TB, done <-chan struct{}) {
+	tb.Helper()
+	select {
+	case <-done:
+	default:
+		require.FailNow(tb, "done was not closed")
+	}
+}
+
+// TestTable_AbandonedUnclaimedReleasesBuffer is the leak this file exists for:
+// the producer abandons a table no consumer ever claimed, so awaitAbandoned
+// wins the CAS and must release the buffer itself - nothing else will, since
+// Done only releases when it wins the CAS.
+func TestTable_AbandonedUnclaimedReleasesBuffer(t *testing.T) {
+	mem := arrowmem.NewCheckedAllocator(arrowmem.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
+	alloc := &memory.ResourceAllocator{Allocator: mem}
+
+	tbl, done := newUnconsumedTable(t, alloc)
+	tbl.awaitAbandoned(done)
+	requireDoneClosed(t, done)
+}
+
+// TestTable_DoneUnclaimedReleasesBuffer covers flux discarding an unconsumed
+// table through Done (processMsg.Ack): Done wins the CAS and releases.
+func TestTable_DoneUnclaimedReleasesBuffer(t *testing.T) {
+	mem := arrowmem.NewCheckedAllocator(arrowmem.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
+	alloc := &memory.ResourceAllocator{Allocator: mem}
+
+	tbl, done := newUnconsumedTable(t, alloc)
+	tbl.Done()
+	requireDoneClosed(t, done)
+}
+
+// TestTable_ConsumedThenAbandonedReleasesOnce is the control against
+// over-releasing: once do() has consumed the table, a late awaitAbandoned and
+// a late Done both lose the CAS and must touch nothing.
+func TestTable_ConsumedThenAbandonedReleasesOnce(t *testing.T) {
+	mem := arrowmem.NewCheckedAllocator(arrowmem.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
+	alloc := &memory.ResourceAllocator{Allocator: mem}
+
+	tbl, done := newUnconsumedTable(t, alloc)
+	require.NoError(t, tbl.do(
+		func(flux.ColReader) error { return nil },
+		func() bool { return false },
+	))
+	requireDoneClosed(t, done)
+
+	tbl.awaitAbandoned(done)
+	tbl.Done()
+}
+
+// TestTable_DoWithInitErrorReleasesBuffer covers do()'s early error return, the
+// one exit of a claimed table that leaves the buffer set. do()'s deferred
+// release must cover it, because Done - the previous fallback for this case -
+// now loses the CAS and does nothing.
+func TestTable_DoWithInitErrorReleasesBuffer(t *testing.T) {
+	mem := arrowmem.NewCheckedAllocator(arrowmem.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
+	alloc := &memory.ResourceAllocator{Allocator: mem}
+
+	tbl, done := newUnconsumedTable(t, alloc)
+	tbl.err = fmt.Errorf("init failed")
+	require.Error(t, tbl.do(
+		func(flux.ColReader) error { return nil },
+		func() bool { return false },
+	))
+	requireDoneClosed(t, done)
+
+	tbl.Done()
+}
+
+// TestTable_PanicInFReleasesBuffer covers the panic half of do()'s deferred
+// release: f panics before the loop settles the buffer, so the defer is the
+// only releaser left for the claimed buffer. Deferred functions run LIFO, so
+// it must also fire before closeDone - done never closes with the buffer
+// still retained. PanicsWithValue pins that the original panic, not one
+// raised inside the defer, is what unwinds.
+func TestTable_PanicInFReleasesBuffer(t *testing.T) {
+	mem := arrowmem.NewCheckedAllocator(arrowmem.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
+	alloc := &memory.ResourceAllocator{Allocator: mem}
+
+	tbl, done := newUnconsumedTable(t, alloc)
+	require.PanicsWithValue(t, "consumer panicked", func() {
+		_ = tbl.do(
+			func(flux.ColReader) error { panic("consumer panicked") },
+			func() bool { return false },
+		)
+	})
+	requireDoneClosed(t, done)
+}
+
+// TestTable_PanicInAdvanceReleasesOnce is the panic exit before advance
+// installs a fresh buffer, the state an allocator-limit panic in a
+// windowTable's pre-allocateBuffer work leaves behind. The loop settles each
+// buffer through releaseColBufs and nils colBufs, so the deferred release
+// must find nothing to touch: a stale colBufs here would decrement a
+// colReader the loop already settled, releasing arrays a retaining consumer
+// still holds. The consumer's Retain across f is the anticipated state
+// allocateBuffer's own comment describes, and its reference surviving the
+// unwind is what makes that regression observable.
+func TestTable_PanicInAdvanceReleasesOnce(t *testing.T) {
+	mem := arrowmem.NewCheckedAllocator(arrowmem.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
+	alloc := &memory.ResourceAllocator{Allocator: mem}
+
+	tbl, done := newUnconsumedTable(t, alloc)
+	var retained flux.ColReader
+	require.PanicsWithValue(t, "advance panicked", func() {
+		_ = tbl.do(
+			func(cr flux.ColReader) error {
+				cr.Retain()
+				retained = cr
+				return nil
+			},
+			func() bool { panic("advance panicked") },
+		)
+	})
+	requireDoneClosed(t, done)
+
+	// The retained reference must be the only one left standing after the
+	// unwind; releasing it is what brings the allocator back to zero. NotNil
+	// keeps a failure where f never ran (retained never assigned) a clean
+	// assertion instead of a panic on the type assertion below.
+	require.NotNil(t, retained)
+	require.Equal(t, int64(1), atomic.LoadInt64(&retained.(*colReader).refCount))
+	retained.Release()
+}
+
+// TestTable_PanicMidFillReleasesFreshBuffer is the panic exit after advance
+// installs a fresh buffer but before every column is filled: filled and nil
+// cols entries coexist. The deferred release owns that buffer and must skip
+// the nil entries while still releasing the filled ones. The nil entry
+// deliberately precedes the filled column, so a guard that stops at the first
+// nil rather than skipping it leaks the filled column and fails the checked
+// allocator. PanicsWithValue pins that the original allocator panic, not a
+// nil dereference inside the defer, is what unwinds.
+func TestTable_PanicMidFillReleasesFreshBuffer(t *testing.T) {
+	mem := arrowmem.NewCheckedAllocator(arrowmem.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
+	alloc := &memory.ResourceAllocator{Allocator: mem}
+
+	done := make(chan struct{})
+	cols := []flux.ColMeta{
+		{Label: execute.DefaultTimeColLabel, Type: flux.TTime},
+		{Label: execute.DefaultValueColLabel, Type: flux.TFloat},
+	}
+	tbl := newTable(done, execute.Bounds{}, nil, cols, make([][]byte, len(cols)), nil, alloc)
+	cr := tbl.allocateBuffer(3)
+	cr.cols[0] = arrow.NewInt([]int64{1, 2, 3}, alloc)
+	cr.cols[1] = arrow.NewFloat([]float64{1, 2, 3}, alloc)
+	tbl.empty = false
+
+	require.PanicsWithValue(t, "allocator limit exceeded", func() {
+		_ = tbl.do(
+			func(flux.ColReader) error { return nil },
+			func() bool {
+				// Fill the value column but not the time column, modeling a
+				// limit panic partway through an advance() fill.
+				next := tbl.allocateBuffer(2)
+				next.cols[1] = arrow.NewFloat([]float64{10, 20}, alloc)
+				panic("allocator limit exceeded")
+			},
+		)
+	})
+	requireDoneClosed(t, done)
+}
+
+// TestTable_ConcurrentDoneAndAbandon races the two claimants that can both
+// find the table unclaimed. Exactly one may win the used CAS; the winner
+// releases the buffer and closes done, and the loser must touch nothing it
+// doesn't own. Run under -race this pins the arbitration itself, and the
+// checked allocator reports a missed release. (A double release is silent in
+// default builds - arrow's underflow check is a compiled-out debug assert -
+// so the race detector is the oracle for the loser touching shared state.)
+func TestTable_ConcurrentDoneAndAbandon(t *testing.T) {
+	mem := arrowmem.NewCheckedAllocator(arrowmem.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
+	alloc := &memory.ResourceAllocator{Allocator: mem}
+
+	for range 500 {
+		tbl, done := newUnconsumedTable(t, alloc)
+
+		start := make(chan struct{})
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			<-start
+			tbl.Done()
+		}()
+		go func() {
+			defer wg.Done()
+			<-start
+			tbl.awaitAbandoned(done)
+		}()
+		close(start)
+		wg.Wait()
+
+		requireDoneClosed(t, done)
+	}
+}
+
+// TestTable_ConcurrentDoAndAbandon races a consumer claiming the table against
+// the producer abandoning it, the arbitration awaitAbandoned exists for. On
+// top of the exactly-once release, this pins do()'s losing outcome: abandon
+// Cancels before taking the CAS, so a do that loses must report cancellation,
+// not "table already used".
+func TestTable_ConcurrentDoAndAbandon(t *testing.T) {
+	mem := arrowmem.NewCheckedAllocator(arrowmem.DefaultAllocator)
+	defer mem.AssertSize(t, 0)
+	alloc := &memory.ResourceAllocator{Allocator: mem}
+
+	for range 500 {
+		tbl, done := newUnconsumedTable(t, alloc)
+
+		start := make(chan struct{})
+		errCh := make(chan error, 1)
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			<-start
+			errCh <- tbl.do(
+				func(flux.ColReader) error { return nil },
+				func() bool { return false },
+			)
+		}()
+		go func() {
+			defer wg.Done()
+			<-start
+			tbl.awaitAbandoned(done)
+		}()
+		close(start)
+		wg.Wait()
+
+		requireDoneClosed(t, done)
+
+		// do either won the CAS and consumed the table, or lost it to the
+		// abandonment and reports cancellation.
+		if err := <-errCh; err != nil {
+			var ferr *flux.Error
+			require.ErrorAs(t, err, &ferr)
+			require.Equal(t, codes.Canceled, ferr.Code)
+		}
+	}
+}

--- a/storage/flux/window.go
+++ b/storage/flux/window.go
@@ -96,6 +96,10 @@ func (w *windowTableSplitter) Do(f func(flux.Table) error) error {
 				done:   done,
 			}
 			if err := f(table); err != nil {
+				// Same abandonment as the cancellation case below: an erroring
+				// callback has not queued the table for a consumer, so nobody
+				// else will release the buffer.
+				table.abandon(done)
 				return err
 			}
 
@@ -158,11 +162,14 @@ func (w *windowTableRow) Do(f func(flux.ColReader) error) error {
 			Msg:  "table already read",
 		}
 	}
+	// Release via defer so a panic in f - which flux's dispatcher recovers, so
+	// the process outlives it - cannot leak the buffer, matching (*table).do's
+	// deferred release. Defers run LIFO, so the buffer is released before done
+	// closes.
 	defer close(w.done)
+	defer w.buffer.Release()
 
-	err := f(&w.buffer)
-	w.buffer.Release()
-	return err
+	return f(&w.buffer)
 }
 
 func (w *windowTableRow) Done() {

--- a/storage/flux/window_cancel_test.go
+++ b/storage/flux/window_cancel_test.go
@@ -2,6 +2,7 @@ package storageflux
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	arrowmem "github.com/apache/arrow-go/v18/arrow/memory"
@@ -30,17 +31,25 @@ func (t *splitWindowsInput) Do(f func(flux.ColReader) error) error {
 }
 
 // newSplitWindowsInput builds an input table with the column layout
-// splitWindows requires: _start, _stop, _time, _value.
+// splitWindows requires: _start, _stop, _time, _value. Row 0's value is null,
+// so selector mode emits the first window as an empty table (window.go's
+// IsNull branch) where non-selector mode emits a buffer row - the divergence
+// that makes the selector subtest variants meaningful.
 func newSplitWindowsInput(alloc memory.Allocator, rows int) *splitWindowsInput {
 	starts := make([]int64, rows)
 	stops := make([]int64, rows)
 	times := make([]int64, rows)
-	vals := make([]float64, rows)
+	vb := arrow.NewFloatBuilder(alloc)
+	vb.Resize(rows)
 	for i := range rows {
 		starts[i] = int64(i * 10)
 		stops[i] = int64(i*10 + 10)
 		times[i] = int64(i * 10)
-		vals[i] = float64(i)
+		if i == 0 {
+			vb.AppendNull()
+		} else {
+			vb.Append(float64(i))
+		}
 	}
 
 	cols := []flux.ColMeta{
@@ -62,7 +71,7 @@ func newSplitWindowsInput(alloc memory.Allocator, rows int) *splitWindowsInput {
 				arrow.NewInt(starts, alloc),
 				arrow.NewInt(stops, alloc),
 				arrow.NewInt(times, alloc),
-				arrow.NewFloat(vals, alloc),
+				vb.NewFloatArray(),
 			},
 		},
 	}
@@ -85,42 +94,139 @@ func newSplitWindowsInput(alloc memory.Allocator, rows int) *splitWindowsInput {
 //
 // The checked allocator is what makes the leak observable: it reports any arrow
 // buffer still outstanding when the test ends.
+//
+// Every test here runs against both splitter modes. selector mode changes how
+// null values are emitted (an empty table instead of a buffer row), and the
+// input's null row 0 makes that branch real: selector variants walk the
+// empty-table emission - which settles nothing on rejection, because empty
+// tables hold no buffers - while non-selector variants walk a buffer row
+// through the same hand-off.
 func TestSplitWindows_CancelReleasesBuffer(t *testing.T) {
-	mem := arrowmem.NewCheckedAllocator(arrowmem.DefaultAllocator)
-	defer mem.AssertSize(t, 0)
+	for _, selector := range []bool{false, true} {
+		t.Run(fmt.Sprintf("selector=%v", selector), func(t *testing.T) {
+			mem := arrowmem.NewCheckedAllocator(arrowmem.DefaultAllocator)
+			defer mem.AssertSize(t, 0)
 
-	alloc := &memory.ResourceAllocator{Allocator: mem}
-	in := newSplitWindowsInput(alloc, 8)
+			alloc := &memory.ResourceAllocator{Allocator: mem}
+			in := newSplitWindowsInput(alloc, 8)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
 
-	// Model flux's handoff: the callback accepts the table and returns without
-	// consuming it, as consecutiveTransport does when it queues a table for a
-	// dispatcher goroutine. Cancelling then drives splitWindows down its
-	// abandonment path while that table is still unclaimed.
-	err := splitWindows(ctx, alloc, in, false, func(tbl flux.Table) error {
-		cancel()
-		return nil
-	})
-	require.ErrorIs(t, err, context.Canceled)
+			// Model flux's handoff: the callback accepts the table and returns without
+			// consuming it, as consecutiveTransport does when it queues a table for a
+			// dispatcher goroutine. Cancelling then drives splitWindows down its
+			// abandonment path while that table is still unclaimed.
+			err := splitWindows(ctx, alloc, in, selector, func(tbl flux.Table) error {
+				cancel()
+				return nil
+			})
+			require.ErrorIs(t, err, context.Canceled)
+		})
+	}
+}
+
+// TestSplitWindows_FErrorReleasesBuffer covers the other abandonment path: the
+// Do callback rejects the table with an error. An erroring callback has not
+// queued the table for a consumer (the same flux contract handleRead relies on),
+// so unless splitWindows settles ownership itself, neither Do nor Done ever runs
+// and the row's buffer leaks exactly as in the cancellation case. In selector
+// mode the rejected table is the null row's empty table, covering the error
+// return of the empty-table branch: it settles nothing today because empty
+// tables hold no buffers, and a future change that hands that branch a
+// buffer-backed table without settling it fails the allocator here.
+func TestSplitWindows_FErrorReleasesBuffer(t *testing.T) {
+	for _, selector := range []bool{false, true} {
+		t.Run(fmt.Sprintf("selector=%v", selector), func(t *testing.T) {
+			mem := arrowmem.NewCheckedAllocator(arrowmem.DefaultAllocator)
+			defer mem.AssertSize(t, 0)
+
+			alloc := &memory.ResourceAllocator{Allocator: mem}
+			in := newSplitWindowsInput(alloc, 8)
+
+			rejected := fmt.Errorf("downstream rejected the table")
+			err := splitWindows(context.Background(), alloc, in, selector, func(tbl flux.Table) error {
+				return rejected
+			})
+			require.ErrorIs(t, err, rejected)
+		})
+	}
+}
+
+// TestSplitWindows_FErrorOnLaterTableReleasesBuffer consumes the first table
+// normally and rejects the second. The consumed row released its own buffer
+// through Do, so the splitter must abandon only the rejected row: releasing
+// the consumed one again would double-release, and skipping the rejected one
+// would leak it. The windows after the rejection are never materialized, so
+// they have nothing to release.
+func TestSplitWindows_FErrorOnLaterTableReleasesBuffer(t *testing.T) {
+	for _, selector := range []bool{false, true} {
+		t.Run(fmt.Sprintf("selector=%v", selector), func(t *testing.T) {
+			mem := arrowmem.NewCheckedAllocator(arrowmem.DefaultAllocator)
+			defer mem.AssertSize(t, 0)
+
+			alloc := &memory.ResourceAllocator{Allocator: mem}
+			in := newSplitWindowsInput(alloc, 8)
+
+			rejected := fmt.Errorf("downstream rejected the table")
+			tables := 0
+			err := splitWindows(context.Background(), alloc, in, selector, func(tbl flux.Table) error {
+				tables++
+				if tables == 1 {
+					return tbl.Do(func(flux.ColReader) error { return nil })
+				}
+				return rejected
+			})
+			require.ErrorIs(t, err, rejected)
+			require.Equal(t, 2, tables)
+		})
+	}
+}
+
+// TestSplitWindows_PanicInConsumerReleasesBuffer covers the panic exit of
+// windowTableRow.Do: flux's dispatcher recovers consumer panics, so the
+// process outlives them and a buffer released only by a plain statement after
+// f would leak - and a leaked row pins the entire input table's arrays, not
+// just its own slice. The release must be deferred, mirroring (*table).do.
+// PanicsWithValue pins that the original panic, not one raised inside the
+// defer, is what unwinds.
+func TestSplitWindows_PanicInConsumerReleasesBuffer(t *testing.T) {
+	for _, selector := range []bool{false, true} {
+		t.Run(fmt.Sprintf("selector=%v", selector), func(t *testing.T) {
+			mem := arrowmem.NewCheckedAllocator(arrowmem.DefaultAllocator)
+			defer mem.AssertSize(t, 0)
+
+			alloc := &memory.ResourceAllocator{Allocator: mem}
+			in := newSplitWindowsInput(alloc, 8)
+
+			require.PanicsWithValue(t, "consumer panicked", func() {
+				_ = splitWindows(context.Background(), alloc, in, selector, func(tbl flux.Table) error {
+					return tbl.Do(func(flux.ColReader) error { panic("consumer panicked") })
+				})
+			})
+		})
+	}
 }
 
 // TestSplitWindows_ConsumedReleasesBuffer is the control: when every table is
 // consumed normally, nothing is outstanding. This must hold before and after the
 // fix, and guards against a fix that over-releases.
 func TestSplitWindows_ConsumedReleasesBuffer(t *testing.T) {
-	mem := arrowmem.NewCheckedAllocator(arrowmem.DefaultAllocator)
-	defer mem.AssertSize(t, 0)
+	for _, selector := range []bool{false, true} {
+		t.Run(fmt.Sprintf("selector=%v", selector), func(t *testing.T) {
+			mem := arrowmem.NewCheckedAllocator(arrowmem.DefaultAllocator)
+			defer mem.AssertSize(t, 0)
 
-	alloc := &memory.ResourceAllocator{Allocator: mem}
-	in := newSplitWindowsInput(alloc, 8)
+			alloc := &memory.ResourceAllocator{Allocator: mem}
+			in := newSplitWindowsInput(alloc, 8)
 
-	tables := 0
-	err := splitWindows(context.Background(), alloc, in, false, func(tbl flux.Table) error {
-		tables++
-		return tbl.Do(func(flux.ColReader) error { return nil })
-	})
-	require.NoError(t, err)
-	require.Equal(t, 8, tables)
+			tables := 0
+			err := splitWindows(context.Background(), alloc, in, selector, func(tbl flux.Table) error {
+				tables++
+				return tbl.Do(func(flux.ColReader) error { return nil })
+			})
+			require.NoError(t, err)
+			require.Equal(t, 8, tables)
+		})
+	}
 }


### PR DESCRIPTION
Continue the enhanced ownership semantics in the flux storage layer that were introduced with #27573. In contrast to those changes, these changes have no practical user-visible changes. Under rare circumstances the max query memory for failed flux queries may be slightly smaller than in previous versions.

The buffer-ownership model introduced in #27573 is now carried across all abandoment paths, including error rejection and panic. Every Arrow buffer now has exactly one releaser on every exit.

Closes: #27590