### PR TITLE
chore(sync): influxdb_pro 2026-08-20 (3.11)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,7 +444,7 @@ dependencies = [
 
 [[package]]
 name = "arrow_util"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -541,7 +541,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "authz"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -655,7 +655,7 @@ dependencies = [
 
 [[package]]
 name = "backoff"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "rand 0.9.4",
  "snafu 0.9.0",
@@ -1087,7 +1087,7 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "catalog_cache"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "bytes",
  "criterion 0.8.2",
@@ -1231,14 +1231,14 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli_types"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "tokio",
 ]
 
 [[package]]
 name = "client_util"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "http 1.4.2",
  "iox_http_util",
@@ -1841,7 +1841,7 @@ dependencies = [
 
 [[package]]
 name = "data_types"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -2575,7 +2575,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion_util"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -2670,7 +2670,7 @@ dependencies = [
 
 [[package]]
 name = "dml"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "arrow_util",
  "data_types",
@@ -2777,12 +2777,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "error_reporting"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "datafusion",
  "snafu 0.9.0",
@@ -2812,7 +2812,7 @@ dependencies = [
 
 [[package]]
 name = "executor"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "futures",
  "metric",
@@ -2893,7 +2893,7 @@ dependencies = [
 
 [[package]]
 name = "flightsql"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -3100,7 +3100,7 @@ dependencies = [
 
 [[package]]
 name = "futures_test_utils"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "clap",
  "futures",
@@ -3111,7 +3111,7 @@ dependencies = [
 
 [[package]]
 name = "generated_types"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "bytes",
  "pbjson",
@@ -3233,9 +3233,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.14"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3510,7 +3510,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.14",
+ "h2 0.4.16",
  "http 1.4.2",
  "http-body 1.1.0",
  "httparse",
@@ -3581,7 +3581,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -3765,7 +3765,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb2_client"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "bytes",
  "futures",
@@ -3784,7 +3784,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3838,6 +3838,7 @@ dependencies = [
  "num_cpus",
  "object_store",
  "object_store_metrics",
+ "object_store_utils",
  "observability_deps",
  "owo-colors",
  "panic_logging",
@@ -3878,7 +3879,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_authz"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "async-trait",
  "authz",
@@ -3896,7 +3897,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_cache"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3931,7 +3932,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_catalog"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "ahash 0.8.12",
  "anyhow",
@@ -3988,7 +3989,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_clap_blocks"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4025,7 +4026,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_client"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "bytes",
  "flate2",
@@ -4046,7 +4047,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_commands"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4074,7 +4075,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_id"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "criterion 0.5.1",
  "indexmap 2.14.0",
@@ -4086,7 +4087,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_internal_api"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4107,7 +4108,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_process"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "iox_time",
  "uuid",
@@ -4115,7 +4116,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_processing_engine"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -4163,7 +4164,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_processing_engine_telemetry"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "hashbrown 0.14.5",
  "influxdb3_catalog",
@@ -4173,7 +4174,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_py_api"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -4197,7 +4198,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_query_executor"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4248,7 +4249,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_server"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4335,7 +4336,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_shutdown"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "futures",
  "futures-util",
@@ -4350,14 +4351,14 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_startup"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "chrono",
 ]
 
 [[package]]
 name = "influxdb3_sys_events"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4376,7 +4377,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_system_tables"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4408,7 +4409,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_telemetry"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "futures",
  "futures-util",
@@ -4429,7 +4430,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_test_helpers"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4442,7 +4443,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_types"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4462,7 +4463,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_wal"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "async-trait",
  "bitcode",
@@ -4477,7 +4478,9 @@ dependencies = [
  "influxdb3_id",
  "influxdb3_shutdown",
  "iox_time",
+ "metric",
  "object_store",
+ "object_store_utils",
  "observability_deps",
  "parking_lot",
  "rustc-hash",
@@ -4491,7 +4494,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_write"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4561,7 +4564,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb_influxql_parser"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "assert_matches",
  "chrono",
@@ -4578,7 +4581,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb_iox_client"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -4607,7 +4610,7 @@ dependencies = [
 
 [[package]]
 name = "ingester_query_grpc"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "base64 0.22.1",
  "data_types",
@@ -4673,7 +4676,7 @@ checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
 
 [[package]]
 name = "iox_http"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -4693,7 +4696,7 @@ dependencies = [
 
 [[package]]
 name = "iox_http_util"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "futures",
  "http 1.4.2",
@@ -4704,7 +4707,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "arrow",
  "arrow_util",
@@ -4753,7 +4756,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query_influxql"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "arrow",
  "assert_matches",
@@ -4780,7 +4783,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query_influxql_rewrite"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "influxdb_influxql_parser",
  "thiserror 2.0.18",
@@ -4788,7 +4791,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query_params"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "arrow",
  "assert_matches",
@@ -4802,7 +4805,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query_udf"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "datafusion-udf-wasm-host",
  "datafusion-udf-wasm-query",
@@ -4813,7 +4816,7 @@ dependencies = [
 
 [[package]]
 name = "iox_system_tables"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4823,7 +4826,7 @@ dependencies = [
 
 [[package]]
 name = "iox_time"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "chrono",
  "parking_lot",
@@ -4832,7 +4835,7 @@ dependencies = [
 
 [[package]]
 name = "iox_v1_query_api"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4893,7 +4896,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4946,7 +4949,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jemalloc_pprof_http"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "http-body-util",
  "hyper 1.11.0",
@@ -4959,7 +4962,7 @@ dependencies = [
 
 [[package]]
 name = "jemalloc_stats"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "futures",
  "snafu 0.9.0",
@@ -5152,7 +5155,7 @@ dependencies = [
 
 [[package]]
 name = "linear_buffer"
-version = "3.11.1"
+version = "3.11.2"
 
 [[package]]
 name = "linux-raw-sys"
@@ -5196,7 +5199,7 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "logfmt"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "humantime",
  "parking_lot",
@@ -5295,14 +5298,14 @@ dependencies = [
 
 [[package]]
 name = "metric"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "parking_lot",
 ]
 
 [[package]]
 name = "metric_exporters"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "metric",
  "mockito",
@@ -5427,7 +5430,7 @@ checksum = "9252111cf132ba0929b6f8e030cac2a24b507f3a4d6db6fb2896f27b354c714b"
 
 [[package]]
 name = "mutable_batch"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "arrow",
  "arrow_util",
@@ -5445,7 +5448,7 @@ dependencies = [
 
 [[package]]
 name = "mutable_batch_lp"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "arrow_util",
  "assert_matches",
@@ -5461,7 +5464,7 @@ dependencies = [
 
 [[package]]
 name = "mutable_batch_pb"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "arrow_util",
  "criterion 0.8.2",
@@ -5699,7 +5702,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_limit"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5711,7 +5714,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_mem_cache"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5739,7 +5742,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_metrics"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "async-trait",
  "bloom2",
@@ -5764,7 +5767,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_mock"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5778,7 +5781,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_size_hinting"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "chrono",
  "http 1.4.2",
@@ -5788,21 +5791,23 @@ dependencies = [
 
 [[package]]
 name = "object_store_utils"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "async-trait",
  "backon",
  "bytes",
  "futures",
  "iox_time",
+ "metric",
  "object_store",
  "observability_deps",
  "tokio",
+ "uuid",
 ]
 
 [[package]]
 name = "observability_deps"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "tracing",
 ]
@@ -5876,7 +5881,7 @@ dependencies = [
 
 [[package]]
 name = "panic_logging"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "metric",
  "test_helpers",
@@ -5951,7 +5956,7 @@ dependencies = [
 
 [[package]]
 name = "parquet_file"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "arrow",
  "arrow_util",
@@ -5982,7 +5987,7 @@ dependencies = [
 
 [[package]]
 name = "partition"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "arrow",
  "assert_matches",
@@ -6279,7 +6284,7 @@ dependencies = [
 
 [[package]]
 name = "predicate"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6622,7 +6627,7 @@ dependencies = [
 
 [[package]]
 name = "query_functions"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "arrow",
  "chrono",
@@ -6665,7 +6670,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.42",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -6702,7 +6707,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.5",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.52.0",
 ]
@@ -6961,7 +6966,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "h2 0.4.14",
+ "h2 0.4.16",
  "http 1.4.2",
  "http-body 1.1.0",
  "http-body-util",
@@ -7166,7 +7171,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7257,7 +7262,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7332,7 +7337,7 @@ dependencies = [
 
 [[package]]
 name = "schema"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "arrow",
  "base64 0.22.1",
@@ -7516,7 +7521,7 @@ dependencies = [
 
 [[package]]
 name = "service_common"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -7530,7 +7535,7 @@ dependencies = [
 
 [[package]]
 name = "service_grpc_flight"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -7606,7 +7611,7 @@ dependencies = [
 
 [[package]]
 name = "sharder"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "criterion 0.8.2",
  "data_types",
@@ -8128,7 +8133,7 @@ dependencies = [
 
 [[package]]
 name = "table_batch"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "arrow_util",
  "bitvec",
@@ -8172,7 +8177,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -8224,7 +8229,7 @@ dependencies = [
 
 [[package]]
 name = "test_helpers"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "async-trait",
  "dotenvy",
@@ -8243,7 +8248,7 @@ dependencies = [
 
 [[package]]
 name = "test_helpers_authz"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "futures",
  "generated_types",
@@ -8528,7 +8533,7 @@ dependencies = [
 
 [[package]]
 name = "tokio_metrics_bridge"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "metric",
  "parking_lot",
@@ -8537,7 +8542,7 @@ dependencies = [
 
 [[package]]
 name = "tokio_watchdog"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "metric",
  "test_helpers",
@@ -8614,7 +8619,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "flate2",
- "h2 0.4.14",
+ "h2 0.4.16",
  "http 1.4.2",
  "http-body 1.1.0",
  "http-body-util",
@@ -8760,7 +8765,7 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tower_trailer"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "futures",
  "http 1.4.2",
@@ -8772,7 +8777,7 @@ dependencies = [
 
 [[package]]
 name = "trace"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "chrono",
  "parking_lot",
@@ -8782,7 +8787,7 @@ dependencies = [
 
 [[package]]
 name = "trace_exporters"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8799,7 +8804,7 @@ dependencies = [
 
 [[package]]
 name = "trace_http"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "bytes",
  "futures",
@@ -8894,7 +8899,7 @@ dependencies = [
 
 [[package]]
 name = "tracker"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "futures",
  "hashbrown 0.14.5",
@@ -8914,7 +8919,7 @@ dependencies = [
 
 [[package]]
 name = "trogging"
-version = "3.11.1"
+version = "3.11.2"
 dependencies = [
  "clap",
  "logfmt",
@@ -9687,7 +9692,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,7 +127,7 @@ exclude = [
 #
 # For porting to the actual OSS repo (influxdb), this would need to change to `-nightly`, i.e., by
 # stripping the `-oss`.
-version = "3.11.1"
+version = "3.11.2"
 authors = ["InfluxData OSS Developers"]
 edition = "2024"
 license = "MIT OR Apache-2.0"

--- a/deny.toml
+++ b/deny.toml
@@ -101,18 +101,6 @@ ignore = [
     "RUSTSEC-2026-0222",
     #
     # TODO: update wasmtime-wasi via datafusion-udf-wasm to a patched version (>=45.0.3; >=46.0.1 is also fixed)
-    #
-    # pyo3 0.24-0.28 out-of-bounds read in Iterator::nth/nth_back on
-    # PyList/PyTuple iterators; fix is only in pyo3 0.29 (API-breaking bump,
-    # tracked in influxdb_pro#4072). Not reachable here: no nth/nth_back calls
-    # in our pyo3-consuming crates, and the overflow needs a Rust-side n near
-    # usize::MAX, which our embedding never produces.
-    "RUSTSEC-2026-0176",
-    #
-    # pyo3 0.15-0.29 unsoundness bug. Possible data race in functions supplied
-    # to PyCFunction::new_closure, or PyCFunction::new_closure_bound.
-    # Neither of these methods are used in this code.
-    "RUSTSEC-2026-0177",
 ]
 git-fetch-with-cli = true
 
@@ -130,16 +118,8 @@ allow = [
     "CDLA-Permissive-2.0",
     "ISC",
     "MIT",
-    "NCSA",
-    "Unicode-DFS-2016",
     "Unicode-3.0",
     "Zlib",
-]
-exceptions = [
-    # We should probably NOT bundle CA certs but use the OS ones.
-    { name = "webpki-roots", allow = ["MPL-2.0"] },
-    # aws sdk-s3 uses aws-lc-sys for rustls
-    { name = "aws-lc-sys", allow = ["OpenSSL"] },
 ]
 
 [[licenses.clarify]]

--- a/influxdb3/Cargo.toml
+++ b/influxdb3/Cargo.toml
@@ -54,6 +54,7 @@ influxdb3_telemetry = { path = "../influxdb3_telemetry" }
 influxdb3_types = { path = "../influxdb3_types" }
 influxdb3_wal = { path = "../influxdb3_wal" }
 influxdb3_write = { path = "../influxdb3_write" }
+object_store_utils = { path = "../object_store_utils" }
 
 # Crates.io dependencies
 anyhow.workspace = true

--- a/influxdb3/src/commands/serve.rs
+++ b/influxdb3/src/commands/serve.rs
@@ -66,6 +66,7 @@ use iox_time::{SystemProvider, TimeProvider};
 use metric::U64Gauge;
 use object_store::ObjectStore;
 use object_store_metrics::ObjectStoreMetrics;
+use object_store_utils::SelfVerifyingCreateStore;
 use observability_deps::tracing::*;
 use panic_logging::SendPanicsToTracing;
 use parquet_file::storage::{ParquetStorage, StorageId};
@@ -1010,6 +1011,21 @@ pub async fn command(mut config: Config, user_params: HashMap<String, String>) -
         .object_store_config
         .make_object_store_with_metrics(&metrics)
         .map_err(Error::ObjectStoreParsing)?;
+
+    // The WAL tags its conditional creates so it can recognise its own object
+    // when a retried PUT collides with its own hidden success. This layer sits
+    // innermost so the read-back reaches the real store, not the cache. A
+    // backend that discards object metadata has nowhere to carry the tag, so it
+    // is left unwrapped and keeps the un-verified behaviour.
+    let object_store: Arc<dyn ObjectStore> = if config
+        .object_store_config
+        .object_store
+        .supports_object_metadata()
+    {
+        Arc::new(SelfVerifyingCreateStore::new(object_store, &metrics))
+    } else {
+        object_store
+    };
 
     // setup metrics'd object store:
     let object_store: Arc<dyn ObjectStore> = Arc::new(ObjectStoreMetrics::new(

--- a/influxdb3/tests/server/system_tables.rs
+++ b/influxdb3/tests/server/system_tables.rs
@@ -93,6 +93,37 @@ async fn queries_table() {
     }
 }
 
+// Regression test for https://github.com/influxdata/influxdb/issues/27593: a `table_name` filter
+// naming a table that does not exist must return zero rows, not panic the request thread.
+#[tokio::test]
+async fn parquet_files_table_name_filter_unknown_table_is_empty() {
+    let server = TestServer::spawn().await;
+
+    server
+        .write_lp_to_db("foo", "cpu,host=s1 usage=0.9 2998574931", Precision::Second)
+        .await
+        .expect("write some lp");
+
+    let mut client = server.flight_sql_client("foo").await;
+
+    let response = client
+        .query("SELECT COUNT(*) FROM system.parquet_files WHERE table_name = 'no_such_table_xyz'")
+        .await
+        .expect("query should succeed, not panic");
+
+    let batches = collect_stream(response).await;
+    assert_batches_sorted_eq!(
+        [
+            "+----------+",
+            "| count(*) |",
+            "+----------+",
+            "| 0        |",
+            "+----------+",
+        ],
+        &batches
+    );
+}
+
 #[test_log::test(tokio::test)]
 async fn last_caches_table() {
     let server = TestServer::spawn().await;

--- a/influxdb3_catalog/src/catalog/versions/v3/catalog/tests.rs
+++ b/influxdb3_catalog/src/catalog/versions/v3/catalog/tests.rs
@@ -2112,6 +2112,66 @@ mod limits {
         txn.check_write_column_limits("cpu", &incoming_tags, &incoming_fields)
             .expect("duplicate keys within a line should count once toward the limit");
     }
+
+    #[tokio::test]
+    async fn check_write_column_limits_projects_for_nonexistent_table() {
+        let catalog = catalog_with_limits(CatalogLimits::new(10, 100, 5));
+        let mut txn = catalog.begin_database_transaction("db1").unwrap();
+        // No table created: every unique incoming column is new.
+        let incoming_tags = ["tag1", "tag2"];
+        let incoming_fields = ["field1", "field2", "field3", "field4"];
+        let err = txn
+            .check_write_column_limits("cpu", &incoming_tags, &incoming_fields)
+            .unwrap_err();
+        assert!(
+            matches!(
+                err,
+                CatalogError::TooManyColumns {
+                    ref table_name,
+                    attempted: 6,
+                    limit: 5,
+                } if table_name.inner() == "cpu"
+            ),
+            "expected projected TooManyColumns for a table that doesn't exist yet, got {err:?}",
+        );
+    }
+
+    #[tokio::test]
+    async fn check_projected_column_counts() {
+        let catalog = catalog_with_limits(CatalogLimits::new(10, 100, 5));
+        let mut txn = catalog.begin_database_transaction("db1").unwrap();
+        // Nonexistent table: every counted column is new.
+        txn.check_new_table_column_counts("cpu", 1, 4).unwrap();
+        let err = txn.check_new_table_column_counts("cpu", 1, 5).unwrap_err();
+        assert!(
+            matches!(
+                err,
+                CatalogError::TooManyColumns {
+                    attempted: 6,
+                    limit: 5,
+                    ..
+                }
+            ),
+            "expected projected TooManyColumns, got {err:?}",
+        );
+        // Existing columns count toward the projection.
+        let tx = txn.table_tx_or_create("cpu").unwrap();
+        tx.tag_or_create("t0").unwrap();
+        tx.tag_or_create("t1").unwrap();
+        tx.check_projected_column_counts(1, 2).unwrap();
+        let err = tx.check_projected_column_counts(1, 3).unwrap_err();
+        assert!(
+            matches!(
+                err,
+                CatalogError::TooManyColumns {
+                    attempted: 6,
+                    limit: 5,
+                    ..
+                }
+            ),
+            "expected projected TooManyColumns, got {err:?}",
+        );
+    }
 }
 // ---------------------------------------------------------------------------
 // Write-path feature-level gate

--- a/influxdb3_catalog/src/catalog/versions/v3/schema/database.rs
+++ b/influxdb3_catalog/src/catalog/versions/v3/schema/database.rs
@@ -177,12 +177,18 @@ impl DatabaseSchema {
         now: Time,
         table_id: &TableId,
     ) -> Option<Time> {
-        let table_value =
-            self.table_definition_by_id(table_id)
-                .and_then(|def| match def.retention_period {
-                    RetentionPeriod::Duration(d) => Some(d),
-                    RetentionPeriod::Indefinite => None,
-                });
+        self.retention_period_cutoff(now, Some(table_id))
+    }
+
+    /// Like [`get_retention_period_cutoff_ts_nanos`][Self::get_retention_period_cutoff_ts_nanos],
+    /// but for a table that may not exist yet (`None` → db-level retention).
+    pub fn retention_period_cutoff(&self, now: Time, table_id: Option<&TableId>) -> Option<Time> {
+        let table_value = table_id
+            .and_then(|table_id| self.table_definition_by_id(table_id))
+            .and_then(|def| match def.retention_period {
+                RetentionPeriod::Duration(d) => Some(d),
+                RetentionPeriod::Indefinite => None,
+            });
         let db_value = match self.retention_period {
             RetentionPeriod::Duration(d) => Some(d),
             RetentionPeriod::Indefinite => None,

--- a/influxdb3_catalog/src/catalog/versions/v3/transaction.rs
+++ b/influxdb3_catalog/src/catalog/versions/v3/transaction.rs
@@ -256,6 +256,17 @@ impl DatabaseCatalogTransaction {
             .expect("table transaction should exist after table_or_create"))
     }
 
+    /// Table transaction handle for a table that already exists in this
+    /// transaction or the schema snapshot; `None` otherwise. Never creates
+    /// the table.
+    pub fn existing_table_tx(&mut self, table_name: &str) -> Option<&TableTransaction> {
+        self.table_id_by_name(table_name).map(|table_id| {
+            self.tables
+                .get(&table_id)
+                .expect("table transaction should exist after table_id_by_name")
+        })
+    }
+
     /// Get-or-create a column on a named table. Errors if the column exists
     /// with a different type.
     pub fn column_or_create(
@@ -270,14 +281,7 @@ impl DatabaseCatalogTransaction {
             .get_mut(&table_id)
             .expect("table should exist after table_or_create");
 
-        if let Some(existing) = tx.table.column_definition(column_name) {
-            if existing.column_type() != column_type {
-                return Err(CatalogError::InvalidColumnType {
-                    column_name: Arc::from(column_name),
-                    expected: existing.column_type(),
-                    got: column_type,
-                });
-            }
+        if let Some(existing) = tx.resolve_column(column_name, column_type)? {
             return Ok(existing);
         }
 
@@ -348,63 +352,55 @@ impl DatabaseCatalogTransaction {
         self.inner
     }
 
-    /// Check that adding the incoming write columns won't exceed column limits.
-    ///
-    /// Computes projected counts for the full write by counting only columns
-    /// that do not already exist in the table schema. Write validation calls
-    /// this after a per-column limit breach to rewrite the error with the
-    /// final projected count instead of "current + 1"; enforcement itself
-    /// stays with the per-column checks so the success path pays nothing.
+    /// Check that adding the incoming write columns won't exceed column
+    /// limits, projecting the final counts for the whole write (only columns
+    /// that don't already exist count). Name-based variant for callers that
+    /// haven't resolved the columns; write validation counts new columns
+    /// while resolving a line and uses
+    /// [`TableTransaction::check_projected_column_counts`] /
+    /// [`check_new_table_column_counts`][Self::check_new_table_column_counts]
+    /// instead.
     pub fn check_write_column_limits(
         &mut self,
         table_name: &str,
         incoming_tags: &[&str],
         incoming_fields: &[&str],
     ) -> Result<()> {
-        let column_limit = self.columns_per_table_limit;
-        let tag_column_limit = self.tag_columns_per_table_limit;
-        let Some(table_id) = self.table_id_by_name(table_name) else {
-            return Ok(());
-        };
-        let table_tx = self
-            .tables
-            .get(&table_id)
-            .expect("table transaction should exist after table_id_by_name");
-
-        // Collect into sets so duplicate keys within a single line count once.
-        let new_tags = incoming_tags
-            .iter()
-            .filter(|t| table_tx.table.column_definition(t).is_none())
-            .collect::<std::collections::HashSet<_>>()
-            .len();
-        let new_fields = incoming_fields
-            .iter()
-            .filter(|f| table_tx.table.column_definition(f).is_none())
-            .collect::<std::collections::HashSet<_>>()
-            .len();
-
-        let projected_tag_count = table_tx.table.num_tag_columns() + new_tags;
-        let projected_total = table_tx.table.num_tag_columns()
-            + table_tx.table.num_field_columns()
-            + new_tags
-            + new_fields;
-
-        if projected_tag_count > tag_column_limit {
-            return Err(CatalogError::TooManyTagColumns {
-                table_name: TruncatedTableName::new(Arc::clone(&table_tx.table.table_name)),
-                attempted: projected_tag_count,
-                limit: tag_column_limit,
-            });
+        match self.table_id_by_name(table_name) {
+            Some(table_id) => self
+                .tables
+                .get(&table_id)
+                .expect("table transaction should exist after table_id_by_name")
+                .check_write_column_limits(incoming_tags, incoming_fields),
+            // Table doesn't exist yet: every unique incoming column is new.
+            None => check_projected_column_limits(
+                Arc::from(table_name),
+                None,
+                incoming_tags,
+                incoming_fields,
+                self.tag_columns_per_table_limit,
+                self.columns_per_table_limit,
+            ),
         }
-        if projected_total > column_limit {
-            return Err(CatalogError::TooManyColumns {
-                table_name: TruncatedTableName::new(Arc::clone(&table_tx.table.table_name)),
-                attempted: projected_total,
-                limit: column_limit,
-            });
-        }
+    }
 
-        Ok(())
+    /// Projected-count limit check for a table that doesn't exist yet: every
+    /// column the line adds is new. Counterpart of
+    /// [`TableTransaction::check_projected_column_counts`] for the fresh-table
+    /// case.
+    pub fn check_new_table_column_counts(
+        &self,
+        table_name: &str,
+        new_tag_count: usize,
+        new_field_count: usize,
+    ) -> Result<()> {
+        check_projected_totals(
+            Arc::from(table_name),
+            (0, 0),
+            (new_tag_count, new_field_count),
+            self.tag_columns_per_table_limit,
+            self.columns_per_table_limit,
+        )
     }
 
     fn table_id_by_name(&mut self, table_name: &str) -> Option<TableId> {
@@ -429,6 +425,70 @@ impl DatabaseCatalogTransaction {
 
         None
     }
+}
+
+/// Count incoming columns that don't already exist (duplicate keys count
+/// once) and compare the projected totals against the limits. `table` is
+/// `None` when it hasn't been created yet.
+fn check_projected_column_limits(
+    table_name: Arc<str>,
+    table: Option<&TableDefinition>,
+    incoming_tags: &[&str],
+    incoming_fields: &[&str],
+    tag_column_limit: usize,
+    column_limit: usize,
+) -> Result<()> {
+    let column_exists = |name: &&&str| table.is_some_and(|t| t.column_definition(name).is_some());
+    let new_tags = incoming_tags
+        .iter()
+        .filter(|t| !column_exists(t))
+        .collect::<std::collections::HashSet<_>>()
+        .len();
+    let new_fields = incoming_fields
+        .iter()
+        .filter(|f| !column_exists(f))
+        .collect::<std::collections::HashSet<_>>()
+        .len();
+    let current = table.map_or((0, 0), |t| (t.num_tag_columns(), t.num_field_columns()));
+
+    check_projected_totals(
+        table_name,
+        current,
+        (new_tags, new_fields),
+        tag_column_limit,
+        column_limit,
+    )
+}
+
+/// Compare projected column totals — `(current tags, current fields)` plus
+/// `(new tags, new fields)`, both counting unique columns only — against the
+/// limits.
+fn check_projected_totals(
+    table_name: Arc<str>,
+    (current_tags, current_fields): (usize, usize),
+    (new_tags, new_fields): (usize, usize),
+    tag_column_limit: usize,
+    column_limit: usize,
+) -> Result<()> {
+    let projected_tag_count = current_tags + new_tags;
+    let projected_total = current_tags + current_fields + new_tags + new_fields;
+
+    if projected_tag_count > tag_column_limit {
+        return Err(CatalogError::TooManyTagColumns {
+            table_name: TruncatedTableName::new(table_name),
+            attempted: projected_tag_count,
+            limit: tag_column_limit,
+        });
+    }
+    if projected_total > column_limit {
+        return Err(CatalogError::TooManyColumns {
+            table_name: TruncatedTableName::new(table_name),
+            attempted: projected_total,
+            limit: column_limit,
+        });
+    }
+
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -516,6 +576,39 @@ impl TableTransaction {
         }
     }
 
+    /// See [`DatabaseCatalogTransaction::check_write_column_limits`].
+    pub fn check_write_column_limits(
+        &self,
+        incoming_tags: &[&str],
+        incoming_fields: &[&str],
+    ) -> Result<()> {
+        check_projected_column_limits(
+            Arc::clone(&self.table.table_name),
+            Some(&self.table),
+            incoming_tags,
+            incoming_fields,
+            self.tag_column_limit,
+            self.column_limit,
+        )
+    }
+
+    /// Compare projected column counts against the limits, where `new_*` are
+    /// the unique columns a write adds (e.g. counted while resolving a line's
+    /// columns against the schema). No lookups, no mutation.
+    pub fn check_projected_column_counts(
+        &self,
+        new_tag_count: usize,
+        new_field_count: usize,
+    ) -> Result<()> {
+        check_projected_totals(
+            Arc::clone(&self.table.table_name),
+            (self.table.num_tag_columns(), self.table.num_field_columns()),
+            (new_tag_count, new_field_count),
+            self.tag_column_limit,
+            self.column_limit,
+        )
+    }
+
     pub fn time_or_create(&mut self) -> Result<Arc<TimestampColumn>> {
         if let Some(existing) = self.table.column_definition("time")
             && let ColumnDefinition::Timestamp(ts) = existing
@@ -532,18 +625,33 @@ impl TableTransaction {
         }
     }
 
+    /// Look up `name` without mutating: `Ok(Some)` to reuse, `Ok(None)` if
+    /// absent, `Err` if it exists with a different type. Lets write
+    /// validation type-check a whole line before creating any column.
+    pub fn resolve_column(
+        &self,
+        name: &str,
+        incoming: InfluxColumnType,
+    ) -> Result<Option<ColumnDefinition>> {
+        let Some(existing) = self.table.column_definition(name) else {
+            return Ok(None);
+        };
+        if existing.column_type() == incoming {
+            Ok(Some(existing))
+        } else {
+            Err(CatalogError::InvalidColumnType {
+                column_name: Arc::from(name),
+                expected: existing.column_type(),
+                got: incoming,
+            })
+        }
+    }
+
     pub fn tag_or_create(&mut self, name: &str) -> Result<Arc<TagColumn>> {
-        if let Some(existing) = self.table.column_definition(name) {
-            match existing {
-                ColumnDefinition::Tag(tag) => return Ok(tag),
-                other => {
-                    return Err(CatalogError::InvalidColumnType {
-                        column_name: Arc::from(name),
-                        expected: InfluxColumnType::Tag,
-                        got: other.column_type(),
-                    });
-                }
-            }
+        if let Some(ColumnDefinition::Tag(tag)) =
+            self.resolve_column(name, InfluxColumnType::Tag)?
+        {
+            return Ok(tag);
         }
         let col_def = self.add_tag(name)?;
         match col_def {
@@ -564,17 +672,10 @@ impl TableTransaction {
         name: &str,
         field_type: InfluxFieldType,
     ) -> Result<Arc<FieldColumn>> {
-        if let Some(existing) = self.table.column_definition(name) {
-            match existing {
-                ColumnDefinition::Field(f) if f.data_type == field_type => return Ok(f),
-                other => {
-                    return Err(CatalogError::InvalidColumnType {
-                        column_name: Arc::from(name),
-                        expected: InfluxColumnType::Field(field_type),
-                        got: other.column_type(),
-                    });
-                }
-            }
+        if let Some(ColumnDefinition::Field(f)) =
+            self.resolve_column(name, InfluxColumnType::Field(field_type))?
+        {
+            return Ok(f);
         }
         let col_def = self.add_field(name, field_type)?;
         match col_def {

--- a/influxdb3_clap_blocks/src/object_store.rs
+++ b/influxdb3_clap_blocks/src/object_store.rs
@@ -1135,6 +1135,20 @@ impl ObjectStoreType {
             Self::Azure => "azure",
         }
     }
+
+    /// Whether the backend retains user-defined object metadata, which gates
+    /// nonce-tagged conditional creates.
+    pub fn supports_object_metadata(&self) -> bool {
+        match self {
+            // `InMemory` keeps the attributes it was given, and
+            // `ThrottledStore` passes them through to it.
+            Self::Memory | Self::MemoryThrottled => true,
+            // `LocalFileSystem` rejects a put carrying any attributes.
+            Self::File => false,
+            // User-defined metadata headers on the object.
+            Self::S3 | Self::Google | Self::Azure => true,
+        }
+    }
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/influxdb3_internal_api/src/sll.rs
+++ b/influxdb3_internal_api/src/sll.rs
@@ -169,6 +169,34 @@ pub enum SystemEvent {
         duration_ms: u64,
     },
 
+    // ── upgrade_retry ─────────────────────────────────────────────────
+    /// An operator reset of a failed Parquet → PachaTree upgrade rewrote the
+    /// durable migration state so the upgrade resumes on the next compactor
+    /// start. Cluster-wide: whichever node served the request emits it.
+    UpgradeRetrySuccess {
+        /// Terminal failures re-probed against the catalog and object store.
+        entries_inspected: u64,
+        /// Entries recorded as skips because their table or every one of
+        /// their sources is gone.
+        entries_skipped: u64,
+        /// Entries returned to the queue because a source is still readable.
+        entries_requeued: u64,
+        /// Entries whose sequence already held converted data, settled as
+        /// imported.
+        entries_already_converted: u64,
+        /// Entries left untouched because the object holding their sequence
+        /// could not be read; a re-run re-attempts them.
+        entries_unresolved: u64,
+        duration_ms: u64,
+    },
+    /// An operator reset was refused or could not be carried out. Nothing
+    /// durable changed except idempotent skip markers; `error_code` is a
+    /// static category and never includes a path or message.
+    UpgradeRetryError {
+        error_code: &'static str,
+        duration_ms: u64,
+    },
+
     // ── compaction_planned ────────────────────────────────────────────
     /// The compactor produced one or more plans for a database in this
     /// planning cycle. One emission per (cycle, database).

--- a/influxdb3_system_tables/src/parquet_files.rs
+++ b/influxdb3_system_tables/src/parquet_files.rs
@@ -57,18 +57,24 @@ impl IoxSystemTable for ParquetFilesTable {
         let table_name = find_table_name_in_filter(filters);
 
         let parquet_files = if let Some(table_name) = table_name {
+            // `table_name` is an untrusted value from the query's WHERE clause, and the database can
+            // be dropped between this table's construction and the scan. Either miss resolves to
+            // `None` and must yield zero rows, not a panic.
             let table_id = self
                 .buffer
                 .catalog()
                 .db_schema_by_id(&self.db_id)
-                .expect("db exists")
-                .table_name_to_id(Arc::clone(&table_name))
-                .expect("table exists");
-            self.buffer
-                .parquet_files(self.db_id, table_id)
-                .into_iter()
-                .map(|file| (Arc::clone(&table_name), file))
-                .collect()
+                .and_then(|db| db.table_name_to_id(Arc::clone(&table_name)));
+            match table_id {
+                Some(table_id) => self
+                    .buffer
+                    .parquet_files(self.db_id, table_id)
+                    .into_iter()
+                    .map(|file| (Arc::clone(&table_name), file))
+                    .take(limit)
+                    .collect(),
+                None => vec![],
+            }
         } else {
             self.buffer
                 .catalog()

--- a/influxdb3_wal/Cargo.toml
+++ b/influxdb3_wal/Cargo.toml
@@ -16,6 +16,7 @@ schema = { path = "../core/schema" }
 # Local Crates
 influxdb3_id = { path = "../influxdb3_id" }
 influxdb3_shutdown = { path = "../influxdb3_shutdown" }
+object_store_utils = { path = "../object_store_utils" }
 
 # crates.io dependencies
 async-trait.workspace = true
@@ -41,4 +42,6 @@ large-strings = ["influxdb-line-protocol/large-strings"]
 workspace = true
 
 [dev-dependencies]
+metric = { path = "../core/metric" }
+object_store_utils = { path = "../object_store_utils", features = ["test-helpers"] }
 test-log.workspace = true

--- a/influxdb3_wal/src/object_store.rs
+++ b/influxdb3_wal/src/object_store.rs
@@ -11,7 +11,8 @@ use hashbrown::HashMap;
 use influxdb3_shutdown::{CancellationToken, ShutdownToken};
 use iox_time::TimeProvider;
 use object_store::path::{Path, PathPart};
-use object_store::{ObjectStore, PutMode, PutOptions, PutPayload};
+use object_store::{ObjectStore, PutPayload};
+use object_store_utils::{PutNonce, SelfVerifyingCreate};
 use observability_deps::tracing::{debug, error, info, trace, warn};
 use std::time::{Duration, Instant};
 use std::{str::FromStr, sync::Arc};
@@ -335,6 +336,9 @@ impl WalObjectStore {
         let data = crate::serialize::serialize_to_file_bytes(&wal_contents)
             .expect("unable to serialize wal contents into bytes for file");
         let data = Bytes::from(data);
+        // One nonce per WAL file, minted outside the retry loop below so that
+        // every attempt at this file carries the same one.
+        let nonce = PutNonce::generate();
 
         let mut retry_count = 0;
 
@@ -345,27 +349,26 @@ impl WalObjectStore {
                 .put_opts(
                     &wal_path,
                     PutPayload::from_bytes(data.clone()),
-                    PutOptions {
-                        mode: PutMode::Create,
-                        ..Default::default()
-                    },
+                    SelfVerifyingCreate::with_nonce(nonce.clone()).put_options(),
                 )
                 .await
             {
                 Ok(_) => {
                     break;
                 }
-                // In the event that the WAL file has already been written, we want to stop the
-                // process. This would be due to someone running multiple processes with the same
-                // `--node-id` simultaneously. Whether that is intentional or not, we have to stop
-                // the process so that either the other running process can take over, or so that
-                // the operator can intervene and correct the state of their object store.
+                // A WAL file already exists at this path and is not one of this writer's own
+                // retries. The likeliest cause is a second process running with the same
+                // `--node-id`. Whatever the cause we stop, so that the other process can take
+                // over or the operator can correct the state of the object store.
                 Err(object_store::Error::AlreadyExists { path, source }) => {
                     error!(
                         path,
                         ?source,
-                        "invoking shutdown after attempt to persist a WAL file \
-                        that already exists on the object store"
+                        "invoking shutdown: a WAL file this process was writing already exists \
+                        on the object store; check for another process running with the same \
+                        --node-id. Where write verification is active, a store that discards \
+                        object metadata or a WAL file left by an older build can produce the \
+                        same result"
                     );
                     // update the state on the wal buffer so that new writes are not
                     // accepted:

--- a/influxdb3_wal/src/object_store/tests.rs
+++ b/influxdb3_wal/src/object_store/tests.rs
@@ -7,6 +7,7 @@ use indexmap::IndexMap;
 use influxdb3_id::{ColumnId, DbId, TableId};
 use iox_time::{MockProvider, Time};
 use object_store::memory::InMemory;
+use object_store_utils::{LostResponseError, LostResponseStore, SelfVerifyingCreateStore};
 use rustc_hash::FxHasher;
 use std::any::Any;
 use std::hash::BuildHasherDefault;
@@ -903,4 +904,133 @@ impl WalFileNotifier for TestNotifier {
     fn as_any(&self) -> &dyn Any {
         self
     }
+}
+
+/// Build a WAL over `inner` wrapped in the verifying layer.
+fn verifying_wal_over(inner: Arc<dyn ObjectStore>) -> (WalObjectStore, CancellationToken) {
+    let registry = metric::Registry::new();
+    wal_over(Arc::new(SelfVerifyingCreateStore::new(inner, &registry)))
+}
+
+/// Build a WAL over `object_store`, returning the WAL and the shutdown token it
+/// will cancel if it decides a foreign writer holds the path.
+fn wal_over(object_store: Arc<dyn ObjectStore>) -> (WalObjectStore, CancellationToken) {
+    let time_provider: Arc<dyn TimeProvider> =
+        Arc::new(MockProvider::new(Time::from_timestamp_nanos(0)));
+    let notifier: Arc<dyn WalFileNotifier> = Arc::new(TestNotifier::default());
+    let shutdown = CancellationToken::new();
+    let wal = WalObjectStore::new_without_replay(
+        time_provider,
+        object_store,
+        "my_host",
+        notifier,
+        WalConfig {
+            max_write_buffer_size: 100,
+            flush_interval: Duration::from_secs(1),
+            snapshot_size: 2,
+            gen1_duration: Gen1Duration::new_1m(),
+            ..Default::default()
+        },
+        None,
+        None,
+        &[],
+        1,
+        shutdown.clone(),
+    );
+    (wal, shutdown)
+}
+
+/// A single write op, enough to fill the WAL buffer so a flush persists a file.
+fn op() -> WalOp {
+    WalOp::Write(WriteBatch {
+        catalog_sequence: 0,
+        database_id: DbId::from(0),
+        database_name: "db1".into(),
+        table_chunks: fx_index_map([(
+            TableId::from(0),
+            TableChunks {
+                min_time: 1,
+                max_time: 1,
+                chunk_time_to_chunk: HashMap::from([(
+                    0,
+                    TableChunk {
+                        rows: vec![Row {
+                            time: 1,
+                            fields: vec![
+                                Field {
+                                    id: ColumnId::from(0),
+                                    value: FieldData::Integer(1),
+                                },
+                                Field {
+                                    id: ColumnId::from(1),
+                                    value: FieldData::Timestamp(1),
+                                },
+                            ],
+                        }],
+                    },
+                )]),
+            },
+        )])
+        .into(),
+        min_time_ns: 1,
+        max_time_ns: 1,
+    })
+}
+
+/// The bug from EAR 7005: the PUT is applied, the response is lost, the
+/// client's own retry gets 412. The node must not shut down.
+#[tokio::test]
+async fn own_lost_put_response_is_not_a_duplicate_writer() {
+    let inner = Arc::new(LostResponseStore::new(Arc::new(InMemory::new())));
+    let (wal, shutdown) = verifying_wal_over(Arc::clone(&inner) as _);
+
+    wal.write_ops_unconfirmed(vec![op()]).await.unwrap();
+    inner.lose_next_put_response_with(LostResponseError::AlreadyExists);
+
+    let flushed = wal.flush_buffer(true).await;
+
+    assert!(!shutdown.is_cancelled(), "node shut down on its own write");
+    assert!(
+        flushed.is_some(),
+        "flush reported failure for a durable write"
+    );
+}
+
+/// Control: without the verifying layer, the same scenario still shuts the node
+/// down. This proves the test above detects the bug, and that a store left
+/// unwrapped is unchanged.
+#[tokio::test]
+async fn an_unwrapped_store_still_shuts_down_on_a_lost_put_response() {
+    let inner = Arc::new(LostResponseStore::new(Arc::new(InMemory::new())));
+    let (wal, shutdown) = wal_over(Arc::clone(&inner) as _);
+
+    wal.write_ops_unconfirmed(vec![op()]).await.unwrap();
+    inner.lose_next_put_response_with(LostResponseError::AlreadyExists);
+
+    let flushed = wal.flush_buffer(true).await;
+
+    assert!(shutdown.is_cancelled());
+    assert!(flushed.is_none());
+}
+
+/// The WAL's own 100x retry loop re-issues the create. A nonce minted per
+/// `put_opts` call would be fresh on the second attempt and read the first
+/// attempt's nonce as foreign; a nonce minted per WAL file covers it.
+#[tokio::test]
+async fn outer_retry_loop_is_covered_by_the_per_file_nonce() {
+    let inner = Arc::new(LostResponseStore::new(Arc::new(InMemory::new())));
+    let (wal, shutdown) = verifying_wal_over(Arc::clone(&inner) as _);
+
+    wal.write_ops_unconfirmed(vec![op()]).await.unwrap();
+    // First attempt lands but returns a retryable error, so the WAL's own loop
+    // re-enters put_opts; the second attempt collides with attempt one.
+    inner.lose_next_put_response_with(LostResponseError::Generic);
+
+    let flushed = wal.flush_buffer(true).await;
+
+    assert!(
+        !shutdown.is_cancelled(),
+        "outer-loop retry shut the node down"
+    );
+    assert!(flushed.is_some());
 }

--- a/influxdb3_write/Cargo.toml
+++ b/influxdb3_write/Cargo.toml
@@ -77,6 +77,7 @@ regex.workspace = true
 [dev-dependencies]
 # Core Crates
 arrow_util = { path = "../core/arrow_util" }
+object_store_utils = { path = "../object_store_utils", features = ["test-helpers"] }
 query_functions = { path = "../core/query_functions" }
 test_helpers = { path = "../core/test_helpers" }
 influxdb3_catalog = { path = "../influxdb3_catalog", features = [ "test_helpers" ] }

--- a/influxdb3_write/benches/persisted_files_bench.rs
+++ b/influxdb3_write/benches/persisted_files_bench.rs
@@ -31,7 +31,7 @@ fn create_parquet_file(idx: usize, prefix: &str) -> ParquetFile {
     let min_time = idx as i64 * 1000;
     ParquetFile {
         id: ParquetFileId::new(),
-        path: format!("/db/table/{prefix}_{idx:08}.parquet"),
+        path: format!("/db/table/{prefix}_{idx:08}.parquet").into(),
         size_bytes: 1024,
         row_count: 100,
         chunk_time: min_time,

--- a/influxdb3_write/src/lib.rs
+++ b/influxdb3_write/src/lib.rs
@@ -350,7 +350,7 @@ pub struct DatabaseTables {
 #[derive(Debug, Serialize, Deserialize, Eq, PartialEq, Clone)]
 pub struct ParquetFile {
     pub id: ParquetFileId,
-    pub path: String,
+    pub path: Arc<str>,
     pub size_bytes: u64,
     pub row_count: u64,
     /// chunk time nanos
@@ -397,7 +397,7 @@ impl AsRef<ParquetFile> for ParquetFile {
 
 #[cfg(test)]
 impl ParquetFile {
-    pub(crate) fn create_for_test(path: impl Into<String>) -> Self {
+    pub(crate) fn create_for_test(path: impl Into<Arc<str>>) -> Self {
         Self {
             id: ParquetFileId::new(),
             path: path.into(),

--- a/influxdb3_write/src/persister.rs
+++ b/influxdb3_write/src/persister.rs
@@ -34,9 +34,9 @@ use futures_util::stream::{FuturesOrdered, StreamExt};
 use influxdb3_cache::parquet_cache::ParquetFileDataToCache;
 use influxdb3_wal::SnapshotSequenceNumber;
 use iox_time::TimeProvider;
-use object_store::ObjectStore;
 use object_store::path::Path as ObjPath;
-use object_store_utils::AdaptivePutExt;
+use object_store::{ObjectMeta, ObjectStore};
+use object_store_utils::{AdaptiveGetExt, AdaptivePutExt};
 use observability_deps::tracing::{debug, error, info, trace, warn};
 use parking_lot::RwLock;
 use parquet::arrow::ArrowWriter;
@@ -98,6 +98,16 @@ pub const DEFAULT_OBJECT_STORE_URL: &str = "iox://influxdb3/";
 const MAX_CONCURRENT_CHECKPOINT_LOADS: usize = 10;
 /// Number of checkpoints to retain per month when cleaning up (latest + previous for safety)
 const CHECKPOINTS_TO_RETAIN_PER_MONTH: usize = 2;
+/// Default number of snapshot manifests fetched concurrently during startup
+/// restore. Matches the default object-store connection limit so small
+/// manifests keep loading at full concurrency (no startup regression); large
+/// manifests fan out into ranged GETs that share that same connection-limit
+/// semaphore, so peak in-flight requests are bounded regardless. Clusters with
+/// large manifests can dial this down via
+/// [`Persister::with_snapshot_load_concurrency`] to cap reassembly-buffer
+/// memory (enterprise exposes it as
+/// `--replica-snapshot-manifest-load-concurrency`).
+pub const DEFAULT_MAX_CONCURRENT_SNAPSHOT_LOADS: usize = 64;
 
 /// Cached checkpoint with its file index for efficient incremental updates.
 ///
@@ -130,6 +140,8 @@ pub struct Persister {
     last_checkpoint_time: RwLock<Option<Instant>>,
     /// Cached checkpoint for the current month to avoid reloading from object store.
     cached_checkpoint: RwLock<Option<CachedCheckpoint>>,
+    /// Max snapshot manifests fetched concurrently during startup restore.
+    snapshot_load_concurrency: usize,
 }
 
 impl Persister {
@@ -157,7 +169,15 @@ impl Persister {
             checkpoint_interval,
             last_checkpoint_time: RwLock::new(None),
             cached_checkpoint: RwLock::new(None),
+            snapshot_load_concurrency: DEFAULT_MAX_CONCURRENT_SNAPSHOT_LOADS,
         }
+    }
+
+    /// Override the number of snapshot manifests fetched concurrently during
+    /// startup restore. Defaults to [`DEFAULT_MAX_CONCURRENT_SNAPSHOT_LOADS`].
+    pub fn with_snapshot_load_concurrency(mut self, concurrency: usize) -> Self {
+        self.snapshot_load_concurrency = concurrency.max(1);
+        self
     }
 
     /// Get the Object Store URL
@@ -200,7 +220,7 @@ impl Persister {
             node_identifier_prefix = %self.node_identifier_prefix,
             "load_snapshots: starting"
         );
-        let mut futures = FuturesOrdered::new();
+        let mut fetches = Vec::new();
         let mut offset: Option<ObjPath> = None;
 
         while most_recent_n > 0 {
@@ -245,9 +265,15 @@ impl Persister {
             async fn get_snapshot(
                 location: ObjPath,
                 last_modified: DateTime<Utc>,
+                object_size: u64,
                 object_store: Arc<dyn ObjectStore>,
             ) -> Result<(usize, PersistedSnapshotVersion)> {
-                let bytes = object_store.get(&location).await?.bytes().await?;
+                // Manifests can be multi-GiB; get_adaptive chunks large
+                // reads. Size is known from list(), so pass it to skip a
+                // HEAD.
+                let bytes = object_store
+                    .get_adaptive(&location, Some(object_size))
+                    .await?;
                 let size = bytes.len();
                 let mut snapshot: PersistedSnapshotVersion = serde_json::from_slice(&bytes)?;
                 match &mut snapshot {
@@ -261,9 +287,10 @@ impl Persister {
 
             trace!(count = end, "load_snapshots: queueing snapshot fetches");
             for item in &list[0..end] {
-                futures.push_back(get_snapshot(
+                fetches.push(get_snapshot(
                     item.location.clone(),
                     item.last_modified,
+                    item.size,
                     Arc::clone(&self.object_store),
                 ));
             }
@@ -278,14 +305,24 @@ impl Persister {
             offset = Some(list[end - 1].location.clone());
         }
 
+        // Fetch with bounded concurrency: each in-flight manifest holds a
+        // reassembly buffer, so an unbounded fan-out over many (potentially
+        // multi-GiB) manifests can exhaust memory at startup. buffered() keeps
+        // at most snapshot_load_concurrency requests in flight while preserving
+        // input order.
         trace!(
-            pending_fetches = futures.len(),
+            pending_fetches = fetches.len(),
+            snapshot_load_concurrency = self.snapshot_load_concurrency,
             "load_snapshots: fetching snapshot contents"
         );
-        let mut results = Vec::new();
+        let results_with_size: Vec<(usize, PersistedSnapshotVersion)> =
+            futures_util::stream::iter(fetches)
+                .buffered(self.snapshot_load_concurrency)
+                .try_collect()
+                .await?;
+        let mut results = Vec::with_capacity(results_with_size.len());
         let mut total_bytes = 0usize;
-        while let Some(result) = futures.next().await {
-            let (size, snapshot) = result?;
+        for (size, snapshot) in results_with_size {
             total_bytes += size;
             results.push(snapshot);
         }
@@ -554,7 +591,7 @@ impl Persister {
     pub async fn list_latest_checkpoints_per_month(
         &self,
         min_sequence: Option<SnapshotSequenceNumber>,
-    ) -> Result<Vec<ObjPath>> {
+    ) -> Result<Vec<ObjectMeta>> {
         debug!(
             node_identifier_prefix = %self.node_identifier_prefix,
             ?min_sequence,
@@ -564,18 +601,16 @@ impl Persister {
         let checkpoint_dir = SnapshotCheckpointPath::dir(&self.node_identifier_prefix);
         let mut checkpoint_list = self.object_store.list(Some(&checkpoint_dir));
 
-        // Collect all checkpoint paths
-        let mut paths_by_month: HashMap<YearMonth, Vec<ObjPath>> = HashMap::new();
+        // Collect all checkpoint metas (kept whole so the size from the LIST is
+        // threaded to the loader, letting it size the read without a HEAD).
+        let mut metas_by_month: HashMap<YearMonth, Vec<ObjectMeta>> = HashMap::new();
 
         while let Some(item) = checkpoint_list.next().await {
             match item {
                 Ok(meta) => {
                     let path_str = meta.location.as_ref();
                     if let Some(year_month) = SnapshotCheckpointPath::parse_year_month(path_str) {
-                        paths_by_month
-                            .entry(year_month)
-                            .or_default()
-                            .push(meta.location);
+                        metas_by_month.entry(year_month).or_default().push(meta);
                     }
                 }
                 Err(e) => {
@@ -589,12 +624,12 @@ impl Persister {
         }
 
         // For each month, select only the latest checkpoint
-        let mut result: Vec<(YearMonth, ObjPath)> = paths_by_month
+        let mut result: Vec<(YearMonth, ObjectMeta)> = metas_by_month
             .into_iter()
-            .map(|(month, mut paths)| {
-                paths.sort();
+            .map(|(month, mut metas)| {
+                metas.sort_by(|a, b| a.location.cmp(&b.location));
                 // First path after sorting is the latest due to inverted sequence numbers
-                (month, paths.into_iter().next().unwrap())
+                (month, metas.into_iter().next().unwrap())
             })
             .collect();
 
@@ -605,9 +640,9 @@ impl Persister {
             let min_seq_u64 = min_seq.as_u64();
             let with_seqs: Vec<_> = result
                 .iter()
-                .filter_map(|(month, path)| {
-                    SnapshotCheckpointPath::parse_sequence_number(path.as_ref())
-                        .map(|seq| (*month, path.clone(), seq.as_u64()))
+                .filter_map(|(month, meta)| {
+                    SnapshotCheckpointPath::parse_sequence_number(meta.location.as_ref())
+                        .map(|seq| (*month, meta.clone(), seq.as_u64()))
                 })
                 .collect();
 
@@ -626,7 +661,7 @@ impl Persister {
                         .map(|(_, _, next_seq)| *next_seq >= min_seq_u64)
                         .unwrap_or(false)
                 })
-                .map(|(_, (month, path, _))| (*month, path.clone()))
+                .map(|(_, (month, meta, _))| (*month, meta.clone()))
                 .collect();
 
             debug!(
@@ -636,37 +671,41 @@ impl Persister {
             );
         }
 
-        let paths: Vec<ObjPath> = result.into_iter().map(|(_, path)| path).collect();
+        let metas: Vec<ObjectMeta> = result.into_iter().map(|(_, meta)| meta).collect();
 
         debug!(
-            count = paths.len(),
+            count = metas.len(),
             "list_latest_checkpoints_per_month: completed"
         );
-        Ok(paths)
+        Ok(metas)
     }
 
-    /// Loads checkpoints from the given paths.
+    /// Loads checkpoints from the given object metas.
     ///
-    /// Use with paths returned from `list_latest_checkpoints_per_month()`.
+    /// Use with the metas returned from `list_latest_checkpoints_per_month()`.
     /// Limits concurrency to avoid overwhelming the object store.
     pub async fn load_checkpoints(
         &self,
-        paths: Vec<ObjPath>,
+        metas: Vec<ObjectMeta>,
     ) -> Result<Vec<PersistedSnapshotCheckpointVersion>> {
-        debug!(count = paths.len(), "load_checkpoints: starting");
+        debug!(count = metas.len(), "load_checkpoints: starting");
 
         let semaphore = Arc::new(Semaphore::new(MAX_CONCURRENT_CHECKPOINT_LOADS));
         let mut futures = FuturesOrdered::new();
 
-        for path in paths {
+        for meta in metas {
             let object_store = Arc::clone(&self.object_store);
             let semaphore = Arc::clone(&semaphore);
-            let path_clone = path.clone();
 
             futures.push_back(async move {
                 let _permit = semaphore.acquire().await.expect("semaphore not closed");
-                trace!(path = %path_clone, "loading checkpoint");
-                let bytes = object_store.get(&path_clone).await?.bytes().await?;
+                trace!(path = %meta.location, "loading checkpoint");
+                // Checkpoints merge a month of snapshots and are the most likely
+                // to be multi-GiB; get_adaptive chunks large reads. The size is
+                // known from the prior list(), so pass it to skip size discovery.
+                let bytes = object_store
+                    .get_adaptive(&meta.location, Some(meta.size))
+                    .await?;
                 let checkpoint: PersistedSnapshotCheckpointVersion =
                     serde_json::from_slice(&bytes)?;
                 Result::<_, PersisterError>::Ok(checkpoint)

--- a/influxdb3_write/src/persister/tests.rs
+++ b/influxdb3_write/src/persister/tests.rs
@@ -496,7 +496,7 @@ async fn test_persist_and_load_checkpoint_roundtrip() {
         .await
         .unwrap();
     assert_eq!(paths.len(), 1);
-    assert!(paths[0].as_ref().contains("2025-01"));
+    assert!(paths[0].location.as_ref().contains("2025-01"));
 
     // Load it back
     let loaded = persister.load_checkpoints(paths).await.unwrap();
@@ -743,7 +743,7 @@ fn create_snapshot_with_files(
 fn create_test_parquet_file(size_bytes: u64, row_count: u64) -> ParquetFile {
     ParquetFile {
         id: ParquetFileId::new(),
-        path: "test/file.parquet".to_string(),
+        path: "test/file.parquet".into(),
         size_bytes,
         row_count,
         chunk_time: 0,
@@ -1231,4 +1231,45 @@ async fn test_checkpoint_cleanup_only_affects_specified_month() {
 
     // Now both should have 2
     assert_eq!(count_checkpoints_for_month(&persister, &feb_2025).await, 2);
+}
+
+#[tokio::test]
+async fn load_snapshots_bounds_fetch_concurrency() {
+    use object_store_utils::TestObjectStore;
+    use std::sync::Arc as StdArc;
+
+    // Persist more snapshots than the concurrency bound onto an InMemory store.
+    let inner = StdArc::new(InMemory::new());
+    let seed = Persister::new(
+        StdArc::clone(&inner) as _,
+        "test_host",
+        StdArc::new(MockProvider::new(Time::from_timestamp_nanos(0))) as _,
+        None,
+    );
+    let n = 24usize;
+    for seq in 1..=n as u64 {
+        seed.persist_snapshot(&PersistedSnapshotVersion::V1(create_test_snapshot(seq)))
+            .await
+            .unwrap();
+    }
+
+    // Wrap the store so each get() is tracked and delayed enough to overlap,
+    // making the peak concurrency observable.
+    let tracking = StdArc::new(TestObjectStore::new(inner).with_latency_ms(Some(20), None));
+    let k = 4usize;
+    let persister = Persister::new(
+        StdArc::clone(&tracking) as _,
+        "test_host",
+        StdArc::new(MockProvider::new(Time::from_timestamp_nanos(0))) as _,
+        None,
+    )
+    .with_snapshot_load_concurrency(k);
+
+    let loaded = persister.load_snapshots(n).await.unwrap();
+    assert_eq!(loaded.len(), n, "all snapshots should load");
+    assert!(
+        tracking.max_in_flight_gets() <= k,
+        "peak concurrent gets {} exceeded the bound {k}",
+        tracking.max_in_flight_gets()
+    );
 }

--- a/influxdb3_write/src/table_index/test_persisted_snapshot_conversion.rs
+++ b/influxdb3_write/src/table_index/test_persisted_snapshot_conversion.rs
@@ -12,7 +12,7 @@ struct CreateTestParquetFileArgs {
     /// Optional file ID; if None, a new ID will be generated
     file_id: Option<ParquetFileId>,
     /// The path for the parquet file
-    path: Option<String>,
+    path: Option<Arc<str>>,
     /// Size in bytes (default: 100)
     size_bytes: Option<u64>,
     /// Number of rows (default: 10,000)
@@ -27,7 +27,7 @@ fn create_test_parquet_file(args: CreateTestParquetFileArgs) -> ParquetFile {
     let time_offset = args.time_offset_minutes;
     ParquetFile {
         id: args.file_id.unwrap_or_default(),
-        path: args.path.unwrap_or_else(|| "whatever".to_string()),
+        path: args.path.unwrap_or_else(|| "whatever".into()),
         size_bytes: args.size_bytes.unwrap_or(100),
         row_count: args.row_count.unwrap_or(10_000),
         chunk_time: time_offset * MINUTE_NS,

--- a/influxdb3_write/src/table_index/test_table_index_operations.rs
+++ b/influxdb3_write/src/table_index/test_table_index_operations.rs
@@ -83,7 +83,7 @@ impl TableIndexSnapshotBuilder {
                     };
                     let file = ParquetFile {
                         id: file_id,
-                        path: format!("test_file_{i}"),
+                        path: format!("test_file_{i}").into(),
                         size_bytes: 100 * (i as u64 + 1),
                         row_count: 1000 * (i as u64 + 1),
                         chunk_time: 0,
@@ -115,7 +115,7 @@ impl TableIndexSnapshotBuilder {
                     };
                     let file = ParquetFile {
                         id: file_id,
-                        path: format!("test_file_{i}"),
+                        path: format!("test_file_{i}").into(),
                         size_bytes: 100 * (i as u64 + 1),
                         row_count: 1000 * (i as u64 + 1),
                         chunk_time: 0,
@@ -227,7 +227,7 @@ struct LoadFromObjectStoreTestCase {
             // Files from first snapshot (seq 10) - 2 files
             files.insert(ParquetFile {
                 id: ParquetFileId::from(100),
-                path: "test_file_0".to_string(),
+                path: "test_file_0".into(),
                 size_bytes: 100,
                 row_count: 1000,
                 chunk_time: 0,
@@ -236,7 +236,7 @@ struct LoadFromObjectStoreTestCase {
             });
             files.insert(ParquetFile {
                 id: ParquetFileId::from(101),
-                path: "test_file_1".to_string(),
+                path: "test_file_1".into(),
                 size_bytes: 200,
                 row_count: 2000,
                 chunk_time: 0,
@@ -246,7 +246,7 @@ struct LoadFromObjectStoreTestCase {
             // File from second snapshot (seq 20) - 1 file
             files.insert(ParquetFile {
                 id: ParquetFileId::from(102),
-                path: "test_file_0".to_string(),
+                path: "test_file_0".into(),
                 size_bytes: 100,
                 row_count: 1000,
                 chunk_time: 0,
@@ -269,7 +269,7 @@ struct LoadFromObjectStoreTestCase {
             let mut files = BTreeSet::new();
             files.insert(ParquetFile {
                 id: ParquetFileId::from(200),
-                path: "existing_file".to_string(),
+                path: "existing_file".into(),
                 size_bytes: 500,
                 row_count: 5000,
                 chunk_time: 0,
@@ -288,7 +288,7 @@ struct LoadFromObjectStoreTestCase {
             let mut files = BTreeSet::new();
             files.insert(ParquetFile {
                 id: ParquetFileId::from(200),
-                path: "existing_file".to_string(),
+                path: "existing_file".into(),
                 size_bytes: 500,
                 row_count: 5000,
                 chunk_time: 0,
@@ -311,7 +311,7 @@ struct LoadFromObjectStoreTestCase {
             let mut files = BTreeSet::new();
             files.insert(ParquetFile {
                 id: ParquetFileId::from(200),
-                path: "existing_file".to_string(),
+                path: "existing_file".into(),
                 size_bytes: 500,
                 row_count: 5000,
                 chunk_time: 0,
@@ -336,7 +336,7 @@ struct LoadFromObjectStoreTestCase {
             let mut files = BTreeSet::new();
             files.insert(ParquetFile {
                 id: ParquetFileId::from(200),
-                path: "existing_file".to_string(),
+                path: "existing_file".into(),
                 size_bytes: 500,
                 row_count: 5000,
                 chunk_time: 0,
@@ -345,7 +345,7 @@ struct LoadFromObjectStoreTestCase {
             });
             files.insert(ParquetFile {
                 id: ParquetFileId::from(201),
-                path: "test_file_0".to_string(),
+                path: "test_file_0".into(),
                 size_bytes: 100,
                 row_count: 1000,
                 chunk_time: 0,
@@ -368,7 +368,7 @@ struct LoadFromObjectStoreTestCase {
             let mut files = BTreeSet::new();
             files.insert(ParquetFile {
                 id: ParquetFileId::from(200),
-                path: "existing_file".to_string(),
+                path: "existing_file".into(),
                 size_bytes: 500,
                 row_count: 5000,
                 chunk_time: 0,
@@ -401,7 +401,7 @@ struct LoadFromObjectStoreTestCase {
             let mut files = BTreeSet::new();
             files.insert(ParquetFile {
                 id: ParquetFileId::from(200),
-                path: "existing_file".to_string(),
+                path: "existing_file".into(),
                 size_bytes: 500,
                 row_count: 5000,
                 chunk_time: 0,
@@ -410,7 +410,7 @@ struct LoadFromObjectStoreTestCase {
             });
             files.insert(ParquetFile {
                 id: ParquetFileId::from(301),
-                path: "test_file_0".to_string(),
+                path: "test_file_0".into(),
                 size_bytes: 100,
                 row_count: 1000,
                 chunk_time: 0,
@@ -433,7 +433,7 @@ struct LoadFromObjectStoreTestCase {
             let mut files = BTreeSet::new();
             files.insert(ParquetFile {
                 id: ParquetFileId::from(100),
-                path: "file_to_keep".to_string(),
+                path: "file_to_keep".into(),
                 size_bytes: 1000,
                 row_count: 10000,
                 chunk_time: 0,
@@ -442,7 +442,7 @@ struct LoadFromObjectStoreTestCase {
             });
             files.insert(ParquetFile {
                 id: ParquetFileId::from(101),
-                path: "file_to_remove".to_string(),
+                path: "file_to_remove".into(),
                 size_bytes: 2000,
                 row_count: 20000,
                 chunk_time: 0,
@@ -472,7 +472,7 @@ struct LoadFromObjectStoreTestCase {
             // File 100 remains
             files.insert(ParquetFile {
                 id: ParquetFileId::from(100),
-                path: "file_to_keep".to_string(),
+                path: "file_to_keep".into(),
                 size_bytes: 1000,
                 row_count: 10000,
                 chunk_time: 0,
@@ -483,7 +483,7 @@ struct LoadFromObjectStoreTestCase {
             // File 102 was added
             files.insert(ParquetFile {
                 id: ParquetFileId::from(102),
-                path: "test_file_0".to_string(),
+                path: "test_file_0".into(),
                 size_bytes: 100,
                 row_count: 1000,
                 chunk_time: 0,
@@ -621,7 +621,7 @@ fn test_merge_validation(
             let mut files = BTreeSet::new();
             files.insert(ParquetFile {
                 id: ParquetFileId::from(1),
-                path: "file1".to_string(),
+                path: "file1".into(),
                 size_bytes: 100,
                 row_count: 1000,
                 chunk_time: 0,
@@ -647,7 +647,7 @@ fn test_merge_validation(
             let mut files = BTreeSet::new();
             files.insert(ParquetFile {
                 id: ParquetFileId::from(2),
-                path: "file2".to_string(),
+                path: "file2".into(),
                 size_bytes: 200,
                 row_count: 2000,
                 chunk_time: 0,

--- a/influxdb3_write/src/table_index_cache.rs
+++ b/influxdb3_write/src/table_index_cache.rs
@@ -696,7 +696,7 @@ impl TableIndexCache {
 
             // Delete each parquet file
             for parquet_file in index.parquet_files().await {
-                let path = ObjPath::from(parquet_file.path.as_str());
+                let path = ObjPath::from(parquet_file.path.as_ref());
                 debug!(
                     path = %path,
                     "Deleting parquet file"
@@ -897,7 +897,7 @@ impl TableIndexCache {
 
         // Delete expired parquet files from object store
         for file in &expired_files {
-            let path = ObjPath::from(file.path.as_str());
+            let path = ObjPath::from(file.path.as_ref());
             debug!(
                 path = %path,
                 max_time = file.max_time,

--- a/influxdb3_write/src/table_index_cache/tests.rs
+++ b/influxdb3_write/src/table_index_cache/tests.rs
@@ -14,7 +14,7 @@ use crate::table_index::{CoreTableIndex, IndexMetadata, TableIndexSnapshot};
 fn create_test_parquet_file(file_id: ParquetFileId, size: u64, row_count: u64) -> ParquetFile {
     ParquetFile {
         id: file_id,
-        path: format!("fake/test/file_{}.parquet", file_id.as_u64()),
+        path: format!("fake/test/file_{}.parquet", file_id.as_u64()).into(),
         size_bytes: size,
         row_count,
         chunk_time: 1000,
@@ -1300,7 +1300,7 @@ mod split_and_update_indices {
                 for i in 0..file_count {
                     let file = ParquetFile {
                         id: ParquetFileId::from(next_file_id),
-                        path: format!("test_file_{next_file_id}.parquet"),
+                        path: format!("test_file_{next_file_id}.parquet").into(),
                         size_bytes: 1000 * (i as u64 + 1),
                         row_count: 100 * (i as u64 + 1),
                         chunk_time: 0,
@@ -1344,7 +1344,7 @@ mod split_and_update_indices {
         for i in 0..file_count {
             files.insert(ParquetFile {
                 id: ParquetFileId::from(i as u64),
-                path: format!("test_file_{i}.parquet"),
+                path: format!("test_file_{i}.parquet").into(),
                 size_bytes: 100 * (i as u64 + 1),
                 row_count: 1000 * (i as u64 + 1),
                 chunk_time: 0,
@@ -2323,7 +2323,7 @@ mod purge {
     struct PurgeTestRunner {
         object_store: Arc<dyn ObjectStore>,
         cache: TableIndexCache,
-        loaded_file_paths: HashMap<TableIndexId, Vec<String>>,
+        loaded_file_paths: HashMap<TableIndexId, Vec<Arc<str>>>,
         // Track file info for purge_expired tests
         file_time_info: HashMap<TableIndexId, FileInfo>,
     }
@@ -2354,10 +2354,10 @@ mod purge {
                             .expect("failed to load table index into cache");
 
                         // Collect file paths from the loaded index
-                        let file_paths: Vec<String> = index
+                        let file_paths: Vec<Arc<str>> = index
                             .parquet_files()
                             .await
-                            .map(|file| file.path.clone())
+                            .map(|file| Arc::clone(&file.path))
                             .collect();
                         self.loaded_file_paths.insert(table_id.clone(), file_paths);
                     }
@@ -2441,7 +2441,7 @@ mod purge {
                                 for (_table_id, index) in tables.iter() {
                                     let tx_clone = tx.clone();
                                     for file in index.parquet_files().await {
-                                        let path = ObjPath::from(file.path.clone());
+                                        let path = ObjPath::from(file.path.as_ref());
                                         let _ = tx_clone.send(path);
                                     }
                                 }
@@ -2473,7 +2473,7 @@ mod purge {
                                 for path in file_paths {
                                     let exists = self
                                         .object_store
-                                        .head(&object_store::path::Path::from(path.clone()))
+                                        .head(&object_store::path::Path::from(path.as_ref()))
                                         .await
                                         .is_ok();
                                     assert!(
@@ -2696,7 +2696,7 @@ mod purge {
 
             let parquet_file = ParquetFile {
                 id: file_id,
-                path: file_path,
+                path: file_path.into(),
                 size_bytes: 1000,
                 row_count: 100,
                 chunk_time: 1234567890,
@@ -2764,7 +2764,7 @@ mod purge {
 
             let parquet_file = ParquetFile {
                 id: file_id,
-                path: file_path.clone(),
+                path: file_path.clone().into(),
                 size_bytes: 1000 + i as u64 * 100, // Vary size for testing
                 row_count: 100 + i as u64 * 10,
                 chunk_time: min_time,
@@ -2818,7 +2818,7 @@ mod purge {
             let file_id = ParquetFileId::new();
             let parquet_file = ParquetFile {
                 id: file_id,
-                path: format!("test_file_{i}.parquet"),
+                path: format!("test_file_{i}.parquet").into(),
                 size_bytes: 1000,
                 row_count: 100,
                 chunk_time: 1234567890,
@@ -2833,7 +2833,7 @@ mod purge {
             let content = b"fake parquet data";
             object_store
                 .put(
-                    &object_store::path::Path::from(file.path.clone()),
+                    &object_store::path::Path::from(file.path.as_ref()),
                     content.to_vec().into(),
                 )
                 .await
@@ -2888,7 +2888,7 @@ mod purge {
             let file_id = ParquetFileId::new();
             let parquet_file = ParquetFile {
                 id: file_id,
-                path: format!("test_file_{i}.parquet"),
+                path: format!("test_file_{i}.parquet").into(),
                 size_bytes: 1000,
                 row_count: 100,
                 chunk_time: 1234567890,
@@ -3088,7 +3088,7 @@ mod purge {
         );
 
         // Track loaded file paths for verification
-        let loaded_file_paths: HashMap<TableIndexId, Vec<String>> = HashMap::new();
+        let loaded_file_paths: HashMap<TableIndexId, Vec<Arc<str>>> = HashMap::new();
         let mut runner = PurgeTestRunner {
             object_store,
             cache,

--- a/influxdb3_write/src/tests.rs
+++ b/influxdb3_write/src/tests.rs
@@ -29,7 +29,7 @@ fn test_overall_counts() {
     let parquet_files_1 = vec![
         ParquetFile {
             id: ParquetFileId::from(1),
-            path: "some_path".to_string(),
+            path: "some_path".into(),
             size_bytes: 100_000,
             row_count: 200,
             chunk_time: 1123456789,
@@ -38,7 +38,7 @@ fn test_overall_counts() {
         },
         ParquetFile {
             id: ParquetFileId::from(2),
-            path: "some_path".to_string(),
+            path: "some_path".into(),
             size_bytes: 100_000,
             row_count: 200,
             chunk_time: 1123456789,
@@ -73,7 +73,7 @@ fn test_overall_counts() {
     let parquet_files_2 = vec![
         ParquetFile {
             id: ParquetFileId::from(4),
-            path: "some_path".to_string(),
+            path: "some_path".into(),
             size_bytes: 100_000,
             row_count: 200,
             chunk_time: 1123456789,
@@ -82,7 +82,7 @@ fn test_overall_counts() {
         },
         ParquetFile {
             id: ParquetFileId::from(5),
-            path: "some_path".to_string(),
+            path: "some_path".into(),
             size_bytes: 100_000,
             row_count: 200,
             chunk_time: 1123456789,
@@ -126,7 +126,7 @@ fn test_overall_counts_zero() {
     let parquet_files_1 = vec![
         ParquetFile {
             id: ParquetFileId::from(1),
-            path: "some_path".to_string(),
+            path: "some_path".into(),
             size_bytes: 100_000,
             row_count: 200,
             chunk_time: 1123456789,
@@ -135,7 +135,7 @@ fn test_overall_counts_zero() {
         },
         ParquetFile {
             id: ParquetFileId::from(2),
-            path: "some_path".to_string(),
+            path: "some_path".into(),
             size_bytes: 100_000,
             row_count: 200,
             chunk_time: 1123456789,
@@ -154,7 +154,7 @@ fn test_overall_counts_zero() {
     let parquet_files_2 = vec![
         ParquetFile {
             id: ParquetFileId::from(4),
-            path: "some_path".to_string(),
+            path: "some_path".into(),
             size_bytes: 100_000,
             row_count: 200,
             chunk_time: 1123456789,
@@ -163,7 +163,7 @@ fn test_overall_counts_zero() {
         },
         ParquetFile {
             id: ParquetFileId::from(5),
-            path: "some_path".to_string(),
+            path: "some_path".into(),
             size_bytes: 100_000,
             row_count: 200,
             chunk_time: 1123456789,

--- a/influxdb3_write/src/write_buffer/checkpoint/tests.rs
+++ b/influxdb3_write/src/write_buffer/checkpoint/tests.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 fn create_test_file(id: ParquetFileId, size_bytes: u64, row_count: u64) -> ParquetFile {
     ParquetFile {
         id,
-        path: format!("test/{:?}.parquet", id),
+        path: format!("test/{:?}.parquet", id).into(),
         size_bytes,
         row_count,
         chunk_time: 0,

--- a/influxdb3_write/src/write_buffer/mod.rs
+++ b/influxdb3_write/src/write_buffer/mod.rs
@@ -582,7 +582,7 @@ impl WriteBufferImpl {
         let span_ctx = ctx.span_ctx().map(|span| span.child("table_chunks"));
         let mut recorder = SpanRecorder::new(span_ctx);
 
-        let mut chunks = self.buffer.get_table_chunks(
+        let (mut chunks, parquet_files) = self.buffer.get_table_chunks_and_parquet_files(
             Arc::clone(&db_schema),
             Arc::clone(&table_def),
             filter,
@@ -595,9 +595,6 @@ impl WriteBufferImpl {
             MetaValue::Int(num_chunks_from_buffer as i64),
         );
 
-        let parquet_files =
-            self.persisted_files
-                .get_files_filtered(db_schema.id, table_def.table_id, filter);
         let num_parquet_files_needed = parquet_files.len();
         recorder.set_metadata(
             "parquet_files",
@@ -696,7 +693,7 @@ pub fn cache_parquet_files<T: AsRef<ParquetFile>>(
                 // cache might be handy for this case.
                 let f: &ParquetFile = file.borrow().as_ref();
                 let (cache_req, receiver) = CacheRequest::create_eventual_mode_cache_request(
-                    ObjPath::from(f.path.as_str()),
+                    ObjPath::from(f.path.as_ref()),
                     Some(f.timestamp_min_max()),
                 );
                 parquet_cache.register(cache_req);

--- a/influxdb3_write/src/write_buffer/persisted_files.rs
+++ b/influxdb3_write/src/write_buffer/persisted_files.rs
@@ -19,6 +19,11 @@ use parking_lot::RwLock;
 type DatabaseToTables = HashMap<DbId, TableToFiles>;
 type TableToFiles = HashMap<TableId, Vec<ParquetFile>>;
 
+/// Put parquet files in the descending min_time order the query path expects.
+pub fn sort_by_min_time_desc(files: &mut [ParquetFile]) {
+    files.sort_by_key(|f| std::cmp::Reverse(f.min_time));
+}
+
 #[derive(Debug, Default)]
 pub struct PersistedFiles {
     inner: RwLock<Inner>,
@@ -168,20 +173,32 @@ impl PersistedFiles {
         table_id: TableId,
         filter: &ChunkFilter<'_>,
     ) -> Vec<ParquetFile> {
+        let mut files = self.get_files_filtered_unsorted(db_id, table_id, filter);
+        sort_by_min_time_desc(&mut files);
+        files
+    }
+
+    /// Get the list of files for a given database and table, using the provided filter to filter
+    /// results, in whatever order the index holds them.
+    pub fn get_files_filtered_unsorted(
+        &self,
+        db_id: DbId,
+        table_id: TableId,
+        filter: &ChunkFilter<'_>,
+    ) -> Vec<ParquetFile> {
         let inner = self.inner.read();
-        let mut files = inner
+        inner
             .files
             .get(&db_id)
             .and_then(|tables| tables.get(&table_id))
-            .cloned()
+            .map(|files| {
+                files
+                    .iter()
+                    .filter(|file| filter.test_time_stamp_min_max(file.min_time, file.max_time))
+                    .cloned()
+                    .collect()
+            })
             .unwrap_or_default()
-            .into_iter()
-            .filter(|file| filter.test_time_stamp_min_max(file.min_time, file.max_time))
-            .collect::<Vec<_>>();
-
-        files.sort_by_key(|f| std::cmp::Reverse(f.min_time));
-
-        files
     }
 
     /// Remove files that are marked for deletion or that violate their retention period.
@@ -190,7 +207,7 @@ impl PersistedFiles {
         catalog: Arc<Catalog>,
     ) -> SerdeVecMap<DbId, DatabaseTables> {
         let mut removed: SerdeVecMap<DbId, DatabaseTables> = SerdeVecMap::new();
-        let mut removed_paths: HashSet<String> = HashSet::new();
+        let mut removed_paths: HashSet<Arc<str>> = HashSet::new();
         let mut size = 0;
         let mut row_count = 0;
 
@@ -211,7 +228,7 @@ impl PersistedFiles {
                     .entry(table_id)
                     .or_default()
                     .push(file.clone());
-                removed_paths.insert(file.path.clone());
+                removed_paths.insert(Arc::clone(&file.path));
             };
 
             let guard = self.inner.read();

--- a/influxdb3_write/src/write_buffer/persisted_files/tests.rs
+++ b/influxdb3_write/src/write_buffer/persisted_files/tests.rs
@@ -89,7 +89,7 @@ fn test_get_files_with_filters() {
             let chunk_time = i;
             ParquetFile {
                 id: ParquetFileId::new(),
-                path: format!("/path/{i:03}.parquet"),
+                path: format!("/path/{i:03}.parquet").into(),
                 size_bytes: 1,
                 row_count: 1,
                 chunk_time,
@@ -231,7 +231,7 @@ fn build_parquet_files(prefix: &str, num_files: u32) -> Vec<ParquetFile> {
     let parquet_files: Vec<ParquetFile> = (0..num_files)
         .map(|i| ParquetFile {
             id: ParquetFileId::new(),
-            path: format!("/random/path/{prefix}_{i}.parquet"),
+            path: format!("/random/path/{prefix}_{i}.parquet").into(),
             size_bytes: 50_000,
             row_count: 10,
             chunk_time: 10,
@@ -439,7 +439,7 @@ fn test_new_from_checkpoints_with_pending_removed() {
     // Create a file that exists in January
     let jan_file = ParquetFile {
         id: ParquetFileId::new(),
-        path: "/jan/file.parquet".to_string(),
+        path: "/jan/file.parquet".into(),
         size_bytes: 50_000,
         row_count: 10,
         chunk_time: 10,
@@ -502,7 +502,7 @@ fn test_new_from_checkpoints_pending_removed_missing_db() {
     // Create a pending_removed that references a non-existent database
     let missing_file = ParquetFile {
         id: ParquetFileId::new(),
-        path: "/missing/file.parquet".to_string(),
+        path: "/missing/file.parquet".into(),
         size_bytes: 50_000,
         row_count: 10,
         chunk_time: 10,

--- a/influxdb3_write/src/write_buffer/queryable_buffer.rs
+++ b/influxdb3_write/src/write_buffer/queryable_buffer.rs
@@ -1,7 +1,7 @@
 use crate::chunk::BufferChunk;
 use crate::paths::ParquetFilePath;
 use crate::persister::Persister;
-use crate::write_buffer::persisted_files::PersistedFiles;
+use crate::write_buffer::persisted_files::{PersistedFiles, sort_by_min_time_desc};
 use crate::write_buffer::table_buffer::TableBuffer;
 use crate::{ChunkFilter, ParquetFile, ParquetFileId, PersistedSnapshot, PersistedSnapshotVersion};
 use anyhow::Context;
@@ -36,6 +36,9 @@ use std::time::Duration;
 use tokio::sync::Semaphore;
 use tokio::sync::oneshot::{self, Receiver};
 use tokio::task::JoinSet;
+
+/// The buffer chunks and persisted parquet files for a single table.
+pub type TableChunksAndFiles = (Vec<Arc<dyn QueryChunk>>, Vec<ParquetFile>);
 
 #[derive(Debug)]
 pub struct QueryableBuffer {
@@ -96,7 +99,10 @@ impl QueryableBuffer {
         }
     }
 
-    pub fn get_table_chunks(
+    /// The buffer chunks for a table. Callers that also need the persisted files must use
+    /// [`Self::get_table_chunks_and_parquet_files`], which reads both under one lock.
+    #[cfg(test)]
+    pub(crate) fn get_table_chunks(
         &self,
         db_schema: Arc<DatabaseSchema>,
         table_def: Arc<TableDefinition>,
@@ -104,9 +110,46 @@ impl QueryableBuffer {
         _projection: Option<&Vec<usize>>,
         _ctx: &dyn Session,
     ) -> Result<Vec<Arc<dyn QueryChunk>>, DataFusionError> {
-        let influx_schema = table_def.influx_schema();
-
         let buffer = self.buffer.read();
+        Self::table_chunks_locked(&buffer, &db_schema, table_def, buffer_filter)
+    }
+
+    /// The buffer chunks and the persisted parquet files for a table, read under one
+    /// acquisition of the buffer lock.
+    ///
+    /// A persist job swaps the two under a single buffer write guard. Reading them separately
+    /// can return the snapshotted rows twice.
+    pub fn get_table_chunks_and_parquet_files(
+        &self,
+        db_schema: Arc<DatabaseSchema>,
+        table_def: Arc<TableDefinition>,
+        buffer_filter: &ChunkFilter<'_>,
+        _projection: Option<&Vec<usize>>,
+        _ctx: &dyn Session,
+    ) -> Result<TableChunksAndFiles, DataFusionError> {
+        let table_id = table_def.table_id;
+        let (chunks, mut parquet_files) = {
+            let buffer = self.buffer.read();
+            let chunks = Self::table_chunks_locked(&buffer, &db_schema, table_def, buffer_filter)?;
+            let parquet_files = self.persisted_files.get_files_filtered_unsorted(
+                db_schema.id,
+                table_id,
+                buffer_filter,
+            );
+            (chunks, parquet_files)
+        };
+        sort_by_min_time_desc(&mut parquet_files);
+
+        Ok((chunks, parquet_files))
+    }
+
+    fn table_chunks_locked(
+        buffer: &BufferState,
+        db_schema: &DatabaseSchema,
+        table_def: Arc<TableDefinition>,
+        buffer_filter: &ChunkFilter<'_>,
+    ) -> Result<Vec<Arc<dyn QueryChunk>>, DataFusionError> {
+        let influx_schema = table_def.influx_schema();
 
         let Some(db_buffer) = buffer.db_to_table.get(&db_schema.id) else {
             return Ok(vec![]);
@@ -205,12 +248,11 @@ impl QueryableBuffer {
                     // (table_buffer::buffer_chunk). Each chunk needs a distinct path:
                     // with a shared path the persist jobs race, the last PUT wins the
                     // object, and every job's size is recorded — stale records that
-                    // fail reads with "Corrupt footer".
-                    let mut chunk_ordinals: HashMap<i64, u32> = HashMap::new();
+                    // fail reads with "Corrupt footer". `snapshot` assigns the
+                    // ordinal, so one value both names the path and identifies the
+                    // chunk when the finished job hands it over to that file.
                     for chunk in snapshot_chunks {
-                        let ordinal_ref = chunk_ordinals.entry(chunk.chunk_time).or_insert(0);
-                        let chunk_ordinal = *ordinal_ref;
-                        *ordinal_ref += 1;
+                        let chunk_ordinal = chunk.chunk_ordinal;
                         let table_name =
                             db_schema.table_id_to_name(table_id).expect("table exists");
                         let persist_job = PersistJob {
@@ -218,6 +260,7 @@ impl QueryableBuffer {
                             table_id: *table_id,
                             table_name: Arc::clone(&table_name),
                             chunk_time: chunk.chunk_time,
+                            chunk_ordinal,
                             path: ParquetFilePath::new_with_chunk_ordinal(
                                 self.persister.node_identifier_prefix(),
                                 database_id.get(),
@@ -247,7 +290,7 @@ impl QueryableBuffer {
         for (_, tables) in &removed_files {
             for (_, files) in &tables.tables {
                 for file in files {
-                    let path = file.path.clone();
+                    let path = Arc::clone(&file.path);
                     let object_store = Arc::clone(&self.persister.object_store());
                     // We've removed the file from the PersistedFiles field.
                     // We'll store them as part of the snapshot so that other parts
@@ -257,7 +300,7 @@ impl QueryableBuffer {
                     // referenced anymore.
                     tokio::spawn(async move {
                         let mut retry_count = 0;
-                        let path = path.into();
+                        let path = Path::from(path.as_ref());
                         while retry_count <= 10 {
                             match object_store.delete(&path).await {
                                 Ok(()) => break,
@@ -325,10 +368,11 @@ impl QueryableBuffer {
 
                 set.spawn(async move {
                     let _permit = permit;
-                    let path = persist_job.path.to_string();
+                    let path: Arc<str> = persist_job.path.to_string().into();
                     let database_id = persist_job.database_id;
                     let table_id = persist_job.table_id;
                     let chunk_time = persist_job.chunk_time;
+                    let chunk_ordinal = persist_job.chunk_ordinal;
                     let min_time = persist_job.timestamp_min_max.min;
                     let max_time = persist_job.timestamp_min_max.max;
 
@@ -364,16 +408,22 @@ impl QueryableBuffer {
                     };
 
                     {
-                        // we can clear the buffer as we move on
+                        // Hand this chunk over from the buffer to its parquet file
+                        // under one lock, so it is queryable from one of the two at
+                        // every instant.
                         let mut buffer = buffer.write();
 
                         // add file first
                         persisted_files.add_persisted_file(&database_id, &table_id, &parquet_file);
-                        // then clear the buffer
+                        // then drop only the chunk that file covers. The sibling
+                        // chunks of this snapshot are still being written by the
+                        // other jobs in this set; a table-wide clear here would
+                        // evict them before their own parquet files exist and make
+                        // whole chunk_times briefly vanish from query results.
                         if let Some(db) = buffer.db_to_table.get_mut(&database_id)
                             && let Some(table) = db.get_mut(&table_id)
                         {
-                            table.clear_snapshots();
+                            table.remove_snapshotting_chunk(chunk_time, chunk_ordinal);
                         }
                     }
 
@@ -555,6 +605,9 @@ struct PersistJob {
     table_id: TableId,
     table_name: Arc<str>,
     chunk_time: i64,
+    /// Position among the chunks sharing `chunk_time`; assigned by
+    /// `TableBuffer::snapshot` and stored on its `SnapshotChunk`.
+    chunk_ordinal: u32,
     path: ParquetFilePath,
     batch: RecordBatch,
     schema: Schema,

--- a/influxdb3_write/src/write_buffer/queryable_buffer/tests.rs
+++ b/influxdb3_write/src/write_buffer/queryable_buffer/tests.rs
@@ -478,7 +478,7 @@ async fn split_chunks_persist_to_distinct_paths() {
     // the shared path violated).
     for f in &files {
         let head = object_store
-            .head(&object_store::path::Path::from(f.path.as_str()))
+            .head(&object_store::path::Path::from(f.path.as_ref()))
             .await
             .expect("persisted object exists");
         assert_eq!(
@@ -487,4 +487,261 @@ async fn split_chunks_persist_to_distinct_paths() {
             f.path
         );
     }
+}
+
+/// An object store that blocks one parquet path until the test opens its gate.
+#[derive(Debug)]
+struct GatedParquetPutStore {
+    inner: Arc<dyn ObjectStore>,
+    gated_path_substr: &'static str,
+    gate_open: tokio::sync::watch::Receiver<bool>,
+    gated_put_started: tokio::sync::watch::Sender<bool>,
+}
+
+impl GatedParquetPutStore {
+    fn new(
+        inner: Arc<dyn ObjectStore>,
+        gated_path_substr: &'static str,
+    ) -> (
+        Arc<Self>,
+        tokio::sync::watch::Sender<bool>,
+        tokio::sync::watch::Receiver<bool>,
+    ) {
+        let (gate_open_tx, gate_open_rx) = tokio::sync::watch::channel(false);
+        let (gated_put_started_tx, gated_put_started_rx) = tokio::sync::watch::channel(false);
+        (
+            Arc::new(Self {
+                inner,
+                gated_path_substr,
+                gate_open: gate_open_rx,
+                gated_put_started: gated_put_started_tx,
+            }),
+            gate_open_tx,
+            gated_put_started_rx,
+        )
+    }
+}
+
+impl std::fmt::Display for GatedParquetPutStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "GatedParquetPutStore({})", self.gated_path_substr)
+    }
+}
+
+#[async_trait]
+impl ObjectStore for GatedParquetPutStore {
+    async fn put_opts(
+        &self,
+        location: &object_store::path::Path,
+        payload: object_store::PutPayload,
+        opts: object_store::PutOptions,
+    ) -> object_store::Result<object_store::PutResult> {
+        if location.as_ref().contains(self.gated_path_substr) {
+            let _ = self.gated_put_started.send(true);
+            let _ = self.gate_open.clone().wait_for(|open| *open).await;
+        }
+        self.inner.put_opts(location, payload, opts).await
+    }
+
+    async fn put_multipart_opts(
+        &self,
+        location: &object_store::path::Path,
+        opts: object_store::PutMultipartOptions,
+    ) -> object_store::Result<Box<dyn object_store::MultipartUpload>> {
+        self.inner.put_multipart_opts(location, opts).await
+    }
+
+    async fn get_opts(
+        &self,
+        location: &object_store::path::Path,
+        options: object_store::GetOptions,
+    ) -> object_store::Result<object_store::GetResult> {
+        self.inner.get_opts(location, options).await
+    }
+
+    async fn delete(&self, location: &object_store::path::Path) -> object_store::Result<()> {
+        self.inner.delete(location).await
+    }
+
+    fn list(
+        &self,
+        prefix: Option<&object_store::path::Path>,
+    ) -> futures_util::stream::BoxStream<'static, object_store::Result<object_store::ObjectMeta>>
+    {
+        self.inner.list(prefix)
+    }
+
+    async fn list_with_delimiter(
+        &self,
+        prefix: Option<&object_store::path::Path>,
+    ) -> object_store::Result<object_store::ListResult> {
+        self.inner.list_with_delimiter(prefix).await
+    }
+
+    async fn copy(
+        &self,
+        from: &object_store::path::Path,
+        to: &object_store::path::Path,
+    ) -> object_store::Result<()> {
+        self.inner.copy(from, to).await
+    }
+
+    async fn copy_if_not_exists(
+        &self,
+        from: &object_store::path::Path,
+        to: &object_store::path::Path,
+    ) -> object_store::Result<()> {
+        self.inner.copy_if_not_exists(from, to).await
+    }
+}
+
+/// Pin the snapshot handoff invariant at the production call site: when one
+/// parquet job finishes while its sibling is still blocked, every row must be
+/// queryable from either the newly registered file or the snapshotting buffer.
+#[tokio::test]
+async fn snapshot_handoff_keeps_sibling_chunks_queryable() {
+    let inner: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    // The second row is in the 00:01 Gen1 chunk; hold that parquet PUT while
+    // the 00:00 chunk finishes its handoff.
+    let (gated_store, gate_open, mut gated_put_started) =
+        GatedParquetPutStore::new(Arc::clone(&inner), "/1970-01-01/00-01/");
+    let object_store: Arc<dyn ObjectStore> = gated_store;
+    let metrics = Arc::new(metric::Registry::default());
+    let parquet_store =
+        ParquetStorage::new(Arc::clone(&object_store), StorageId::from("influxdb3"));
+    let exec = Arc::new(Executor::new_with_config_and_executor(
+        ExecutorConfig {
+            target_query_partitions: NonZeroUsize::new(1).unwrap(),
+            object_stores: [&parquet_store]
+                .into_iter()
+                .map(|store| (store.id(), Arc::clone(store.object_store())))
+                .collect(),
+            metric_registry: Arc::clone(&metrics),
+            mem_pool_size: 1024 * 1024 * 1024,
+            per_query_mem_pool_config: PerQueryMemoryPoolConfig::Disabled,
+            heap_memory_limit: None,
+        },
+        DedicatedExecutor::new_testing(),
+    ));
+    let runtime_env = exec.new_context().inner().runtime_env();
+    register_iox_object_store(runtime_env, parquet_store.id(), Arc::clone(&object_store));
+    register_current_runtime_for_io();
+
+    let time_provider = Arc::new(MockProvider::new(Time::from_timestamp_nanos(0)));
+    let catalog = Arc::new(
+        Catalog::new(
+            "hosta",
+            Arc::clone(&inner),
+            Arc::clone(&time_provider) as _,
+            Default::default(),
+        )
+        .await
+        .unwrap(),
+    );
+    let persister = Arc::new(Persister::new(
+        Arc::clone(&object_store),
+        "hosta",
+        Arc::clone(&time_provider) as _,
+        None,
+    ));
+    let time_provider: Arc<dyn TimeProvider> = time_provider;
+    let queryable_buffer = QueryableBuffer::new(QueryableBufferArgs {
+        executor: Arc::clone(&exec),
+        catalog: Arc::clone(&catalog),
+        persister,
+        last_cache_provider: LastCacheProvider::new_from_catalog(Arc::clone(&catalog))
+            .await
+            .unwrap(),
+        distinct_cache_provider: DistinctCacheProvider::new_from_catalog(
+            Arc::clone(&time_provider),
+            Arc::clone(&catalog),
+        )
+        .await
+        .unwrap(),
+        persisted_files: Arc::new(PersistedFiles::new(None)),
+        parquet_cache: None,
+        parquet_snapshot_concurrency_limit: NonZeroUsize::new(2).unwrap(),
+    });
+
+    let writer = TestWriter::new_with_catalog(Arc::clone(&catalog));
+    let write_batch = writer
+        .write_lp_to_write_batch("foo,tag=a value=1i 1\nfoo,tag=b value=2i 60000000001", 0)
+        .await;
+    let db_schema = catalog.db_schema(TestWriter::DB_NAME).unwrap();
+    let table_def = db_schema.table_definition("foo").unwrap();
+    let snapshot_details = SnapshotDetails {
+        snapshot_sequence_number: SnapshotSequenceNumber::new(1),
+        end_time_marker: 120_000_000_000,
+        first_wal_sequence_number: WalFileSequenceNumber::new(1),
+        last_wal_sequence_number: WalFileSequenceNumber::new(1),
+        forced: false,
+    };
+    let wal_contents = influxdb3_wal::create::wal_contents_with_snapshot(
+        (1, 60_000_000_001, 1),
+        [influxdb3_wal::create::write_batch_op(write_batch)],
+        snapshot_details,
+    );
+    let snapshot_done = queryable_buffer
+        .notify_and_snapshot(Arc::new(wal_contents), snapshot_details)
+        .await;
+
+    tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        gated_put_started
+            .wait_for(|started| *started)
+            .await
+            .unwrap();
+        loop {
+            if queryable_buffer
+                .persisted_files
+                .get_files(db_schema.id, table_def.table_id)
+                .len()
+                == 1
+            {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("one parquet job should finish while its sibling is gated");
+
+    let ctx = exec.new_context();
+    let chunks = queryable_buffer
+        .get_table_chunks(
+            Arc::clone(&db_schema),
+            Arc::clone(&table_def),
+            &ChunkFilter::default(),
+            None,
+            &ctx.inner().state(),
+        )
+        .unwrap();
+    let files = queryable_buffer
+        .persisted_files
+        .get_files(db_schema.id, table_def.table_id);
+    let buffered_rows: usize = chunks
+        .iter()
+        .map(|chunk| {
+            chunk
+                .as_any()
+                .downcast_ref::<BufferChunk>()
+                .expect("snapshotting chunk should be in memory")
+                .batches
+                .iter()
+                .map(|batch| batch.num_rows())
+                .sum::<usize>()
+        })
+        .sum();
+    let persisted_rows = files
+        .iter()
+        .map(|file| file.row_count as usize)
+        .sum::<usize>();
+    assert_eq!(1, buffered_rows, "the gated sibling must remain buffered");
+    assert_eq!(1, persisted_rows, "the completed chunk must be registered");
+    assert_eq!(2, buffered_rows + persisted_rows, "no rows may disappear");
+
+    gate_open.send(true).unwrap();
+    tokio::time::timeout(std::time::Duration::from_secs(5), snapshot_done)
+        .await
+        .expect("snapshot should finish after the gate opens")
+        .unwrap();
 }

--- a/influxdb3_write/src/write_buffer/table_buffer.rs
+++ b/influxdb3_write/src/write_buffer/table_buffer.rs
@@ -175,12 +175,17 @@ impl TableBuffer {
         let mut snapshot_chunks = Vec::new();
         for chunk_time in keys_to_remove {
             let chunks = self.chunk_time_to_chunks.remove(&chunk_time).unwrap();
-            for chunk in chunks {
+            // A chunk_time can yield several chunks (a string/tag column crossing
+            // the Arrow varchar limit splits one). The ordinal makes each chunk
+            // individually addressable, both for its parquet path and for
+            // `remove_snapshotting_chunk` once that parquet file exists.
+            for (chunk_ordinal, chunk) in chunks.into_iter().enumerate() {
                 let timestamp_min_max = chunk.timestamp_min_max();
                 let (schema, record_batch) = chunk.into_schema_record_batch(Arc::clone(&table_def));
 
                 snapshot_chunks.push(SnapshotChunk {
                     chunk_time,
+                    chunk_ordinal: chunk_ordinal as u32,
                     timestamp_min_max,
                     record_batch,
                     schema,
@@ -192,6 +197,28 @@ impl TableBuffer {
         self.snapshotting_chunks.clone()
     }
 
+    /// Drop a single snapshotting chunk, identified by the `chunk_time` /
+    /// `chunk_ordinal` pair [`TableBuffer::snapshot`] assigned it.
+    ///
+    /// Callers persist the chunks of one snapshot concurrently and must drop
+    /// each chunk only once its own parquet file is queryable — a chunk is
+    /// served from `snapshotting_chunks` until then, and from the parquet file
+    /// after, so dropping it early makes those rows briefly invisible to
+    /// queries.
+    pub fn remove_snapshotting_chunk(&mut self, chunk_time: i64, chunk_ordinal: u32) {
+        if let Some(index) = self.snapshotting_chunks.iter().position(|chunk| {
+            chunk.chunk_time == chunk_time && chunk.chunk_ordinal == chunk_ordinal
+        }) {
+            self.snapshotting_chunks.swap_remove(index);
+        }
+    }
+
+    /// Drop every snapshotting chunk at once.
+    ///
+    /// Only correct for a caller that has already made the whole table's
+    /// snapshot queryable elsewhere — one that registers every parquet file of
+    /// the snapshot before clearing. A caller that persists chunk by chunk
+    /// wants [`TableBuffer::remove_snapshotting_chunk`].
     pub fn clear_snapshots(&mut self) {
         self.snapshotting_chunks.clear();
     }
@@ -200,6 +227,10 @@ impl TableBuffer {
 #[derive(Debug, Clone)]
 pub struct SnapshotChunk {
     pub(crate) chunk_time: i64,
+    /// Position of this chunk among the chunks sharing its `chunk_time`,
+    /// assigned by [`TableBuffer::snapshot`]. Identifies the chunk for its
+    /// parquet path and for [`TableBuffer::remove_snapshotting_chunk`].
+    pub(crate) chunk_ordinal: u32,
     pub(crate) timestamp_min_max: TimestampMinMax,
     pub(crate) record_batch: RecordBatch,
     pub(crate) schema: Schema,

--- a/influxdb3_write/src/write_buffer/table_buffer/tests.rs
+++ b/influxdb3_write/src/write_buffer/table_buffer/tests.rs
@@ -412,3 +412,89 @@ async fn test_chunk_splits_on_large_tag_payload() {
     let total_rows: usize = record_batches.iter().map(|rb| rb.num_rows()).sum();
     assert_eq!(total_rows, 3);
 }
+
+/// A snapshot's chunks are persisted concurrently, and each job hands its own
+/// chunk over to its parquet file. Dropping a chunk is therefore per chunk, not
+/// per table: a chunk is served from `snapshotting_chunks` until its own file
+/// exists and from that file afterwards, so evicting the whole table when the
+/// first job finishes makes every sibling chunk — whole gen1 chunk_times —
+/// briefly invisible to queries.
+#[tokio::test]
+async fn test_remove_snapshotting_chunk_leaves_the_other_chunks_queryable() {
+    // 30-byte strings against a 100-byte cap, so chunk_time 0 splits in two and
+    // the ordinal has to distinguish them.
+    let _guard = VarColMaxGuard::new(100);
+
+    let writer = TestWriter::new().await;
+    let rows1 = writer
+        .write_to_rows("tbl,tag=a val=\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\" 1", 0)
+        .await;
+    let rows2 = writer
+        .write_to_rows("tbl,tag=b val=\"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\" 2", 0)
+        .await;
+    let rows3 = writer
+        .write_to_rows("tbl,tag=c val=\"cccccccccccccccccccccccccccccc\" 3", 0)
+        .await;
+    let rows4 = writer
+        .write_to_rows("tbl,tag=d val=\"dddddddddddddddddddddddddddddd\" 4", 0)
+        .await;
+    let table_def = writer.db_schema().table_definition("tbl").unwrap();
+
+    let mut table_buffer = TableBuffer::new();
+    // chunk_time 0: rows1-3 fill the first chunk, rows4 opens a second one.
+    table_buffer.buffer_chunk(0, &rows1);
+    table_buffer.buffer_chunk(0, &rows2);
+    table_buffer.buffer_chunk(0, &rows3);
+    table_buffer.buffer_chunk(0, &rows4);
+    assert_eq!(table_buffer.chunk_time_to_chunks.get(&0).unwrap().len(), 2);
+    // chunk_time 10: one chunk, the sibling gen1 block.
+    table_buffer.buffer_chunk(10, &rows1);
+
+    let snapshot_chunks = table_buffer.snapshot(Arc::clone(&table_def), i64::MAX);
+    assert_eq!(
+        vec![(0, 0), (0, 1), (10, 0)],
+        snapshot_chunks
+            .iter()
+            .map(|c| (c.chunk_time, c.chunk_ordinal))
+            .collect::<Vec<_>>(),
+        "snapshot assigns each chunk an ordinal within its chunk_time"
+    );
+
+    let queryable_rows = |buffer: &TableBuffer| -> Vec<(i64, usize)> {
+        let batches = buffer
+            .partitioned_record_batches(Arc::clone(&table_def), &ChunkFilter::default())
+            .unwrap();
+        let mut counts: Vec<(i64, usize)> = batches
+            .into_iter()
+            .map(|(chunk_time, (_, rbs))| {
+                (
+                    chunk_time,
+                    rbs.iter().map(|rb| rb.num_rows()).sum::<usize>(),
+                )
+            })
+            .collect();
+        counts.sort();
+        counts
+    };
+
+    assert_eq!(vec![(0, 4), (10, 1)], queryable_rows(&table_buffer));
+
+    // The first job finishes: only its chunk goes, the rest stay queryable.
+    table_buffer.remove_snapshotting_chunk(0, 0);
+    assert_eq!(
+        vec![(0, 1), (10, 1)],
+        queryable_rows(&table_buffer),
+        "the split sibling at chunk_time 0 and the chunk at chunk_time 10 are \
+         still being persisted and must remain queryable"
+    );
+
+    table_buffer.remove_snapshotting_chunk(10, 0);
+    assert_eq!(vec![(0, 1)], queryable_rows(&table_buffer));
+
+    // An ordinal that no longer matches anything is a no-op, not a table wipe.
+    table_buffer.remove_snapshotting_chunk(0, 7);
+    assert_eq!(vec![(0, 1)], queryable_rows(&table_buffer));
+
+    table_buffer.remove_snapshotting_chunk(0, 1);
+    assert!(queryable_rows(&table_buffer).is_empty());
+}

--- a/influxdb3_write/src/write_buffer/tests.rs
+++ b/influxdb3_write/src/write_buffer/tests.rs
@@ -1482,7 +1482,7 @@ async fn test_parquet_cache() {
     // get the path for the created parquet file:
     let persisted_files = wbuf.persisted_files().get_files(db_id, tbl_id);
     assert_eq!(1, persisted_files.len());
-    let path = ObjPath::from(persisted_files[0].path.as_str());
+    let path = ObjPath::from(persisted_files[0].path.as_ref());
 
     // check the number of requests to that path before making a query:
     // there should be no get request, made by the cache oracle:
@@ -1591,7 +1591,7 @@ async fn test_no_parquet_cache() {
     // get the path for the created parquet file:
     let persisted_files = wbuf.persisted_files().get_files(db_id, tbl_id);
     assert_eq!(1, persisted_files.len());
-    let path = ObjPath::from(persisted_files[0].path.as_str());
+    let path = ObjPath::from(persisted_files[0].path.as_ref());
 
     // check the number of requests to that path before making a query:
     // there should be no get or get_range requests since nothing has asked for this file yet:
@@ -2315,7 +2315,7 @@ async fn test_query_path_parquet_cache() {
         .persisted_files()
         .get_files(DbId::from(1), TableId::from(0));
     assert_eq!(1, persisted_files.len());
-    let path = ObjPath::from(persisted_files[0].path.as_str());
+    let path = ObjPath::from(persisted_files[0].path.as_ref());
 
     let batches = write_buffer
         .get_record_batches_unchecked(db_name, "temp", &ctx)

--- a/influxdb3_write/src/write_buffer/validator.rs
+++ b/influxdb3_write/src/write_buffer/validator.rs
@@ -4,7 +4,6 @@ use crate::{Precision, WriteLineError, write_buffer::Result};
 use data_types::Timestamp;
 use hashbrown::HashSet;
 use indexmap::IndexMap;
-use influxdb3_catalog::CatalogError;
 use influxdb3_catalog::catalog::{
     Catalog, CatalogSequenceNumber, DatabaseCatalogTransaction, Prompt,
 };
@@ -132,7 +131,6 @@ impl WriteValidator<Initialized> {
         let mut lp_lines = lp.lines();
         let mut lines = vec![];
         let mut bytes = 0;
-        let mut column_ids: HashSet<ColumnId> = HashSet::new();
 
         for (line_idx, maybe_line) in parse_lines(lp).enumerate() {
             let qualified_line = match maybe_line
@@ -151,7 +149,6 @@ impl WriteValidator<Initialized> {
                         l,
                         ingest_time,
                         precision,
-                        &mut column_ids,
                     )
                     .inspect(|_| bytes += raw_line.len() as u64)
                 }) {
@@ -184,93 +181,149 @@ impl WriteValidator<Initialized> {
 
 /// Validate a line of line protocol against the given schema definition
 ///
-/// This is for scenarios where a write comes in for a table that exists, but may have
-/// invalid field types, based on the pre-existing schema.
-///
-/// An error will also be produced if the write, which is for the v1 data model, is targetting
-/// a v3 table.
+/// The whole line is validated before the catalog is mutated, so a rejected
+/// line contributes nothing to it and column-limit errors report the
+/// projected count for the whole line.
 fn validate_and_qualify_v1_line(
     txn: &mut DatabaseCatalogTransaction,
     line_number: usize,
     line: ParsedLine<'_>,
     ingest_time: Time,
     precision: Precision,
-    column_ids: &mut HashSet<ColumnId>,
 ) -> Result<QualifiedLine, WriteLineError> {
-    column_ids.clear();
-
     let table_name = line.series.measurement.as_str();
+    let line_error = |error_message: String| WriteLineError {
+        original_line: line.to_string(),
+        line_number: line_number + 1,
+        error_message,
+    };
+    let lp_field_type = |field_val: &FieldValue<'_>| match field_val {
+        FieldValue::I64(_) => InfluxFieldType::Integer,
+        FieldValue::U64(_) => InfluxFieldType::UInteger,
+        FieldValue::F64(_) => InfluxFieldType::Float,
+        FieldValue::String(_) => InfluxFieldType::String,
+        FieldValue::Boolean(_) => InfluxFieldType::Boolean,
+    };
+
+    let incoming_tag_count = line.series.tag_set.as_ref().map_or(0, |ts| ts.len());
+
+    let timestamp_ns = precision
+        .to_nanos(line.timestamp, ingest_time.timestamp_nanos())
+        .map_err(|error| line_error(error.to_string()))?;
+
+    let existing = txn.existing_table_tx(table_name);
+    let table_is_new = existing.is_none();
+    let (mut new_tag_count, mut new_field_count) = (0usize, 0usize);
+    // Reject a point that repeats a tag key. Without this a duplicate tag
+    // produces two columns with the same id, which desyncs the table buffer
+    // and later panics when building the record batch (all columns must have
+    // the same length). Mirrors the duplicate-field check below.
+    let mut tag_names = HashSet::with_capacity(incoming_tag_count);
+    let mut resolved_tags: Vec<Option<ColumnId>> = Vec::with_capacity(incoming_tag_count);
+    if let Some(tag_set) = &line.series.tag_set {
+        for (tag_key, _) in tag_set {
+            if !tag_names.insert(tag_key.as_str()) {
+                return Err(line_error(format!(
+                    "invalid line protocol - multiple instances of '{}' tag found",
+                    tag_key.as_str()
+                )));
+            }
+            let resolved = match existing {
+                Some(table_tx) => table_tx
+                    .resolve_column(tag_key.as_str(), InfluxColumnType::Tag)
+                    .map_err(|error| line_error(error.to_string()))?
+                    .map(|def| {
+                        def.ord_id()
+                            .expect("parquet write paths require legacy column ids")
+                    }),
+                None => None,
+            };
+            if resolved.is_none() {
+                new_tag_count += 1;
+            }
+            resolved_tags.push(resolved);
+        }
+    }
+
+    let mut field_names = HashSet::with_capacity(line.field_set.len());
+    let mut resolved_fields: Vec<Option<ColumnId>> = Vec::with_capacity(line.field_set.len());
+    for (field_name, field_val) in line.field_set.iter() {
+        if !field_names.insert(field_name.as_str()) {
+            return Err(line_error(format!(
+                "invalid line protocol - multiple instances of '{field_name}' field found"
+            )));
+        }
+        if tag_names.contains(field_name.as_str()) {
+            return Err(line_error(format!(
+                "invalid line protocol - '{field_name}' is used as both a tag and a field"
+            )));
+        }
+        let resolved = match existing {
+            Some(table_tx) => table_tx
+                .resolve_column(
+                    field_name,
+                    InfluxColumnType::Field(lp_field_type(field_val)),
+                )
+                .map_err(|error| line_error(error.to_string()))?
+                .map(|def| {
+                    def.ord_id()
+                        .expect("parquet write paths require legacy column ids")
+                }),
+            None => None,
+        };
+        if resolved.is_none() {
+            new_field_count += 1;
+        }
+        resolved_fields.push(resolved);
+    }
+
+    // Projected column-limit check from the resolution results: unresolved
+    // entries are the line's new columns.
+    if let Some(table_tx) = existing {
+        table_tx
+            .check_projected_column_counts(new_tag_count, new_field_count)
+            .map_err(|error| line_error(error.to_string()))?;
+    }
+    if table_is_new {
+        txn.check_new_table_column_counts(table_name, new_tag_count, new_field_count)
+            .map_err(|error| line_error(error.to_string()))?;
+    }
+
+    // The line is valid; apply it to the catalog.
     let mut fields = Vec::with_capacity(line.column_count());
     let mut index_count = 0;
     let mut field_count = 0;
     let table_id = txn
         .table_or_create(table_name)
-        .map_err(|error| WriteLineError {
-            original_line: line.to_string(),
-            line_number: line_number + 1,
-            error_message: error.to_string(),
-        })?;
+        .map_err(|error| line_error(error.to_string()))?;
 
     if let Some(tag_set) = &line.series.tag_set {
-        for (tag_key, tag_val) in tag_set {
-            let col_id = txn
-                .column_or_create(table_name, tag_key.as_str(), InfluxColumnType::Tag)
-                .map_err(|error| WriteLineError {
-                    original_line: line.to_string(),
-                    line_number: line_number + 1,
-                    error_message: project_column_limit_error(txn, table_name, &line, error)
-                        .to_string(),
-                })?
-                .ord_id()
-                .expect("parquet write paths require legacy column ids");
-            // Reject a point that repeats a tag key. Without this a duplicate tag
-            // produces two columns with the same id, which desyncs the table buffer
-            // and later panics when building the record batch (all columns must have
-            // the same length). Mirrors the duplicate-field check below.
-            if !column_ids.insert(col_id) {
-                return Err(WriteLineError {
-                    original_line: line.to_string(),
-                    line_number: line_number + 1,
-                    error_message: format!(
-                        "invalid line protocol - multiple instances of '{}' tag found",
-                        tag_key.as_str()
-                    ),
-                });
-            }
+        for ((tag_key, tag_val), resolved) in tag_set.iter().zip(resolved_tags) {
+            let col_id = match resolved {
+                Some(id) => id,
+                None => txn
+                    .column_or_create(table_name, tag_key.as_str(), InfluxColumnType::Tag)
+                    .map_err(|error| line_error(error.to_string()))?
+                    .ord_id()
+                    .expect("parquet write paths require legacy column ids"),
+            };
             fields.push(Field::new(col_id, FieldData::Tag(tag_val.to_string())));
             index_count += 1;
         }
     }
 
-    for (field_name, field_val) in line.field_set.iter() {
-        let col_id = txn
-            .column_or_create(
-                table_name,
-                field_name,
-                InfluxColumnType::Field(match field_val {
-                    FieldValue::I64(_) => InfluxFieldType::Integer,
-                    FieldValue::U64(_) => InfluxFieldType::UInteger,
-                    FieldValue::F64(_) => InfluxFieldType::Float,
-                    FieldValue::String(_) => InfluxFieldType::String,
-                    FieldValue::Boolean(_) => InfluxFieldType::Boolean,
-                }),
-            )
-            .map_err(|error| WriteLineError {
-                original_line: line.to_string(),
-                line_number: line_number + 1,
-                error_message: project_column_limit_error(txn, table_name, &line, error)
-                    .to_string(),
-            })?
-            .ord_id()
-            .expect("parquet write paths require legacy column ids");
-        if !column_ids.insert(col_id) {
-            return Err(WriteLineError {
-                original_line: line.to_string(),
-                line_number: line_number + 1,
-                error_message: format!(
-                    "invalid line protocol - multiple instances of '{field_name}' field found"
-                ),
-            });
+    for ((field_name, field_val), resolved) in line.field_set.iter().zip(resolved_fields) {
+        let col_id = match resolved {
+            Some(id) => id,
+            None => txn
+                .column_or_create(
+                    table_name,
+                    field_name,
+                    InfluxColumnType::Field(lp_field_type(field_val)),
+                )
+                .map_err(|error| line_error(error.to_string()))?
+                .ord_id()
+                .expect("parquet write paths require legacy column ids"),
         };
         fields.push(Field::new(col_id, field_val));
         field_count += 1;
@@ -278,21 +331,9 @@ fn validate_and_qualify_v1_line(
 
     let time_col_id = txn
         .column_or_create(table_name, TIME_COLUMN_NAME, InfluxColumnType::Timestamp)
-        .map_err(|error| WriteLineError {
-            original_line: line.to_string(),
-            line_number: line_number + 1,
-            error_message: project_column_limit_error(txn, table_name, &line, error).to_string(),
-        })?
+        .map_err(|error| line_error(error.to_string()))?
         .ord_id()
         .expect("parquet write paths require legacy column ids");
-    let timestamp_ns = precision
-        .to_nanos(line.timestamp, ingest_time.timestamp_nanos())
-        .map_err(|error| WriteLineError {
-            original_line: line.to_string(),
-            line_number: line_number + 1,
-            error_message: error.to_string(),
-        })?;
-
     fields.push(Field::new(time_col_id, FieldData::Timestamp(timestamp_ns)));
 
     Ok(QualifiedLine {
@@ -304,35 +345,6 @@ fn validate_and_qualify_v1_line(
         index_count,
         field_count,
     })
-}
-
-/// If `error` is a column or tag column limit breach, recompute it against the
-/// full set of columns in the line so it reports the projected total for the
-/// whole write rather than "current + 1". Runs only on the error path, so
-/// successful writes pay nothing for the richer message. Falls back to the
-/// original error if the recomputation does not reproduce a breach.
-fn project_column_limit_error(
-    txn: &mut DatabaseCatalogTransaction,
-    table_name: &str,
-    line: &ParsedLine<'_>,
-    error: CatalogError,
-) -> CatalogError {
-    if !matches!(
-        error,
-        CatalogError::TooManyColumns { .. } | CatalogError::TooManyTagColumns { .. }
-    ) {
-        return error;
-    }
-    let incoming_tags: Vec<&str> = line
-        .series
-        .tag_set
-        .as_ref()
-        .map(|ts| ts.iter().map(|(k, _)| k.as_str()).collect())
-        .unwrap_or_default();
-    let incoming_fields: Vec<&str> = line.field_set.iter().map(|(k, _)| k.as_str()).collect();
-    txn.check_write_column_limits(table_name, &incoming_tags, &incoming_fields)
-        .err()
-        .unwrap_or(error)
 }
 
 impl WriteValidator<LinesParsed> {

--- a/influxdb3_write/src/write_buffer/validator/tests.rs
+++ b/influxdb3_write/src/write_buffer/validator/tests.rs
@@ -11,6 +11,171 @@ use iox_time::{MockProvider, Time};
 use object_store::memory::InMemory;
 
 #[tokio::test]
+async fn rejected_over_limit_line_creates_no_schema() {
+    let catalog = Catalog::new_in_memory_with_limits(
+        "test",
+        influxdb3_catalog::catalog::CatalogLimits::new(10, 100, 5),
+    )
+    .await
+    .unwrap();
+    let database_name = DatabaseName::new("test").unwrap();
+    // 1 tag + 8 fields projects to 9 columns against a limit of 5.
+    let lp = "cpu,host=a f1=1,f2=1,f3=1,f4=1,f5=1,f6=1,f7=1,f8=1 1000";
+    let result = WriteValidator::initialize(database_name.clone(), Arc::clone(&catalog))
+        .unwrap()
+        .v1_parse_lines_and_catalog_updates(
+            lp,
+            true,
+            Time::from_timestamp_nanos(0),
+            Precision::Auto,
+        )
+        .unwrap()
+        .commit_catalog_changes()
+        .await
+        .unwrap()
+        .unwrap_success()
+        .convert_lines_to_buffer(Gen1Duration::new_5m());
+    assert_eq!(result.errors.len(), 1);
+    assert!(
+        result.errors[0].error_message.contains("9 columns"),
+        "error should report the projected column count, got: {}",
+        result.errors[0].error_message
+    );
+    // The rejected line must not have created the table or any columns.
+    assert!(
+        catalog
+            .db_schema("test")
+            .unwrap()
+            .table_definition("cpu")
+            .is_none()
+    );
+
+    // An existing table's schema stays unchanged when an over-limit line is
+    // rejected.
+    let result = WriteValidator::initialize(database_name.clone(), Arc::clone(&catalog))
+        .unwrap()
+        .v1_parse_lines_and_catalog_updates(
+            "cpu,host=a f1=1 1000",
+            true,
+            Time::from_timestamp_nanos(0),
+            Precision::Auto,
+        )
+        .unwrap()
+        .commit_catalog_changes()
+        .await
+        .unwrap()
+        .unwrap_success()
+        .convert_lines_to_buffer(Gen1Duration::new_5m());
+    assert!(result.errors.is_empty());
+    let columns_before = catalog
+        .db_schema("test")
+        .unwrap()
+        .table_definition("cpu")
+        .unwrap()
+        .num_columns();
+    let result = WriteValidator::initialize(database_name, Arc::clone(&catalog))
+        .unwrap()
+        .v1_parse_lines_and_catalog_updates(
+            lp,
+            true,
+            Time::from_timestamp_nanos(0),
+            Precision::Auto,
+        )
+        .unwrap()
+        .commit_catalog_changes()
+        .await
+        .unwrap()
+        .unwrap_success()
+        .convert_lines_to_buffer(Gen1Duration::new_5m());
+    assert_eq!(result.errors.len(), 1);
+    let columns_after = catalog
+        .db_schema("test")
+        .unwrap()
+        .table_definition("cpu")
+        .unwrap()
+        .num_columns();
+    assert_eq!(columns_before, columns_after);
+}
+
+#[tokio::test]
+async fn rejected_type_conflict_line_creates_no_schema() {
+    let catalog = Catalog::new_in_memory("test").await.unwrap();
+    let database_name = DatabaseName::new("test").unwrap();
+    let result = WriteValidator::initialize(database_name.clone(), Arc::clone(&catalog))
+        .unwrap()
+        .v1_parse_lines_and_catalog_updates(
+            "cpu f1=1.0 1000",
+            true,
+            Time::from_timestamp_nanos(0),
+            Precision::Second,
+        )
+        .unwrap()
+        .commit_catalog_changes()
+        .await
+        .unwrap()
+        .unwrap_success()
+        .convert_lines_to_buffer(Gen1Duration::new_5m());
+    assert!(result.errors.is_empty());
+
+    // f1 exists as a float; the string value rejects the line, and the line's
+    // other new columns must not be created.
+    let result = WriteValidator::initialize(database_name, Arc::clone(&catalog))
+        .unwrap()
+        .v1_parse_lines_and_catalog_updates(
+            "cpu,newtag=x f9=9,f1=\"s\" 1000",
+            true,
+            Time::from_timestamp_nanos(0),
+            Precision::Second,
+        )
+        .unwrap()
+        .commit_catalog_changes()
+        .await
+        .unwrap()
+        .unwrap_success()
+        .convert_lines_to_buffer(Gen1Duration::new_5m());
+    assert_eq!(result.errors.len(), 1);
+    let table = catalog
+        .db_schema("test")
+        .unwrap()
+        .table_definition("cpu")
+        .unwrap();
+    assert!(
+        !table.column_exists("newtag") && !table.column_exists("f9"),
+        "rejected line must not create columns"
+    );
+}
+
+#[tokio::test]
+async fn rejected_bad_timestamp_line_creates_no_schema() {
+    let catalog = Catalog::new_in_memory("test").await.unwrap();
+    let database_name = DatabaseName::new("test").unwrap();
+    // Seconds precision overflows to_nanos for this timestamp.
+    let result = WriteValidator::initialize(database_name, Arc::clone(&catalog))
+        .unwrap()
+        .v1_parse_lines_and_catalog_updates(
+            "cpu,t1=a f1=1 100000000000000",
+            true,
+            Time::from_timestamp_nanos(0),
+            Precision::Second,
+        )
+        .unwrap()
+        .commit_catalog_changes()
+        .await
+        .unwrap()
+        .unwrap_success()
+        .convert_lines_to_buffer(Gen1Duration::new_5m());
+    assert_eq!(result.errors.len(), 1);
+    assert!(
+        catalog
+            .db_schema("test")
+            .unwrap()
+            .table_definition("cpu")
+            .is_none(),
+        "rejected line must not create the table"
+    );
+}
+
+#[tokio::test]
 async fn write_validator_v1() -> Result<(), Error> {
     let node_id = Arc::from("sample-host-id");
     let obj_store = Arc::new(InMemory::new());

--- a/object_store_limit/src/lib.rs
+++ b/object_store_limit/src/lib.rs
@@ -23,6 +23,18 @@ use tracker::{
     AsyncSemaphoreMetrics, InstrumentedAsyncOwnedSemaphorePermit, InstrumentedAsyncSemaphore,
 };
 
+/// Marker extension that exempts one operation from the concurrency limit.
+///
+/// Insert into [`GetOptions::extensions`] / [`PutOptions::extensions`] and
+/// [`LimitObjectStore`] executes that call without acquiring a permit. For
+/// small, deadline-bearing control-plane operations (e.g. the compactor's
+/// primary-lease renewal): permits are FIFO and a `get`'s permit is held for
+/// the whole life of the returned stream, so a data-plane backlog can starve
+/// such an operation past its deadline. Ops carrying this marker must stay
+/// rare and tiny; they are invisible to the semaphore's utilisation metrics.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct BypassLimit;
+
 /// Store wrapper that limits the maximum number of concurrent object store
 /// operations via an [`InstrumentedAsyncSemaphore`], and reports utilisation
 /// through the [`AsyncSemaphoreMetrics`] registered with the metric registry.
@@ -32,6 +44,9 @@ use tracker::{
 ///
 /// For streaming responses (`get`, `list`), the permit is held for the entire
 /// lifetime of the returned stream.
+///
+/// Operations whose options carry the [`BypassLimit`] extension skip the
+/// semaphore entirely (see its docs for when that is appropriate).
 #[derive(Debug)]
 pub struct LimitObjectStore {
     inner: Arc<dyn ObjectStore>,
@@ -100,6 +115,9 @@ impl ObjectStore for LimitObjectStore {
         payload: PutPayload,
         opts: PutOptions,
     ) -> Result<PutResult> {
+        if opts.extensions.get::<BypassLimit>().is_some() {
+            return self.inner.put_opts(location, payload, opts).await;
+        }
         let _permit = self.acquire().await;
         self.inner.put_opts(location, payload, opts).await
     }
@@ -134,6 +152,9 @@ impl ObjectStore for LimitObjectStore {
     }
 
     async fn get_opts(&self, location: &Path, options: GetOptions) -> Result<GetResult> {
+        if options.extensions.get::<BypassLimit>().is_some() {
+            return self.inner.get_opts(location, options).await;
+        }
         let permit = self.acquire().await;
         let r = self.inner.get_opts(location, options).await?;
         Ok(permit_get_result(r, permit))

--- a/object_store_limit/src/tests.rs
+++ b/object_store_limit/src/tests.rs
@@ -98,3 +98,43 @@ fn display() {
     let store = LimitObjectStore::new(Arc::new(InMemory::new()), 42, &unregistered_metrics());
     assert_eq!(store.to_string(), "LimitObjectStore(42, InMemory)");
 }
+
+#[tokio::test]
+async fn bypass_limit_ops_skip_the_semaphore() {
+    let inner = Arc::new(InMemory::new());
+    let store = LimitObjectStore::new(Arc::clone(&inner) as _, 1, &unregistered_metrics());
+    let path = Path::from("test");
+    store.put(&path, PutPayload::from("data")).await.unwrap();
+
+    // Pin the only permit by holding a list stream open.
+    let mut stream = store.list(None).peekable();
+    Pin::new(&mut stream).peek().await;
+    assert_eq!(store.permits_in_use(), 1);
+
+    // A normal op queues behind the held permit...
+    let fut = store.get_opts(&path, GetOptions::default());
+    assert!(timeout(Duration::from_millis(20), fut).await.is_err());
+
+    // ...while ops carrying BypassLimit proceed without a permit.
+    let mut get_options = GetOptions::default();
+    get_options.extensions.insert(BypassLimit);
+    let got = timeout(Duration::from_secs(5), store.get_opts(&path, get_options))
+        .await
+        .expect("bypass get must not queue")
+        .unwrap();
+    assert_eq!(got.bytes().await.unwrap().as_ref(), b"data");
+
+    let mut put_options = PutOptions::default();
+    put_options.extensions.insert(BypassLimit);
+    timeout(
+        Duration::from_secs(5),
+        store.put_opts(&path, PutPayload::from("data2"), put_options),
+    )
+    .await
+    .expect("bypass put must not queue")
+    .unwrap();
+
+    // The permit accounting never saw the bypass ops.
+    assert_eq!(store.permits_in_use(), 1);
+    drop(stream);
+}

--- a/object_store_utils/Cargo.toml
+++ b/object_store_utils/Cargo.toml
@@ -11,6 +11,7 @@ test-helpers = ["tokio"]
 [dependencies]
 # core deps
 iox_time = { path = "../core/iox_time" }
+metric = { path = "../core/metric" }
 observability_deps = { path = "../core/observability_deps" }
 
 # crates.io deps
@@ -20,6 +21,7 @@ bytes.workspace = true
 futures.workspace = true
 object_store.workspace = true
 tokio = { workspace = true, optional = true }
+uuid.workspace = true
 
 [dev-dependencies]
 tokio.workspace = true

--- a/object_store_utils/src/adaptive_get.rs
+++ b/object_store_utils/src/adaptive_get.rs
@@ -1,0 +1,406 @@
+//! Adaptive GET for object store: ranged/chunked reads for large objects,
+//! single-part GET for small ones.
+
+use bytes::{Bytes, BytesMut};
+use object_store::{ObjectStore, path::Path};
+use std::num::{NonZeroU64, NonZeroUsize};
+
+/// Object size at or below which [`AdaptiveGetExt::get_adaptive`] issues a
+/// single [`ObjectStore::get`]; strictly above, it chunks into
+/// [`DEFAULT_GET_CHUNK_SIZE`] ranged reads.
+///
+/// Set higher than the chunk size: a single GET has no protocol overhead, so
+/// chunking only pays off once one GET risks exceeding the per-request HTTP
+/// timeout (`--object-store-request-timeout`, default 30s) and would restart
+/// the whole download from byte 0 — the multi-GiB case.
+pub const SINGLE_GET_THRESHOLD: NonZeroU64 =
+    const { NonZeroU64::new(128 * 1024 * 1024).expect("single-GET threshold must be non-zero") };
+
+/// Range size for the chunked branch (16 MiB), matching
+/// `object_store_utils::DEFAULT_MULTIPART_CHUNK_SIZE`. Sized to sit well under
+/// the 30s per-request HTTP timeout so each ranged GET has ample budget.
+pub const DEFAULT_GET_CHUNK_SIZE: NonZeroU64 =
+    const { NonZeroU64::new(16 * 1024 * 1024).expect("default get chunk size must be non-zero") };
+
+/// Number of [`DEFAULT_GET_CHUNK_SIZE`] ranged GETs the chunked branch issues
+/// concurrently per batch. Bounds both in-flight requests and the transient
+/// memory held on top of the reassembly buffer to
+/// `MAX_CHUNKS_PER_BATCH * DEFAULT_GET_CHUNK_SIZE` (here 8 * 16 MiB = 128 MiB)
+/// instead of buffering every chunk of a multi-GiB object at once, which would
+/// roughly double peak RSS.
+pub const MAX_CHUNKS_PER_BATCH: NonZeroUsize =
+    const { NonZeroUsize::new(8).expect("max chunks per batch must be non-zero") };
+
+/// Extension trait that adds a size-gated `get_adaptive` method to any
+/// [`ObjectStore`] implementation.
+///
+/// At or below [`SINGLE_GET_THRESHOLD`] it does a single [`ObjectStore::get`]
+/// (unchanged behavior); above, it fetches [`DEFAULT_GET_CHUNK_SIZE`] chunks via
+/// per-chunk [`ObjectStore::get_range`] ([`MAX_CHUNKS_PER_BATCH`] at a time) and
+/// concatenates them. This is the read-side counterpart to `put_adaptive`: each
+/// chunk gets its own request-timeout and retry budget, so a transient failure
+/// retries one range rather than restarting a whole-object GET from byte 0.
+/// (`get_range`, not `get_ranges`, which would coalesce the contiguous ranges
+/// back into one request.)
+///
+/// `size` is the object's byte length. Pass `Some` when the caller already
+/// knows it (e.g. from a prior `list()` / `ObjectMeta`) to skip size discovery;
+/// pass `None` to have the method discover it with a ranged GET of the first
+/// chunk (which also returns the whole object in one request when it is small).
+///
+/// # Correctness
+///
+/// The chunked branch reads the object across multiple requests, so it assumes
+/// the object is immutable for the duration of the read. Snapshot manifests and
+/// checkpoints are write-once (a new sequence number is a new path), so this
+/// holds for their load paths.
+#[async_trait::async_trait]
+pub trait AdaptiveGetExt: ObjectStore {
+    /// Size-gated GET using [`SINGLE_GET_THRESHOLD`] / [`DEFAULT_GET_CHUNK_SIZE`].
+    async fn get_adaptive(
+        &self,
+        path: &Path,
+        size: Option<u64>,
+    ) -> Result<Bytes, object_store::Error> {
+        get_adaptive_impl(
+            self,
+            path,
+            size,
+            SINGLE_GET_THRESHOLD,
+            DEFAULT_GET_CHUNK_SIZE,
+            MAX_CHUNKS_PER_BATCH,
+        )
+        .await
+    }
+}
+
+impl<T: ObjectStore + ?Sized> AdaptiveGetExt for T {}
+
+/// The underlying implementation, taking explicit `threshold` / `chunk_size`
+/// for test coverage at small sizes. Production callers should use
+/// [`AdaptiveGetExt::get_adaptive`], which bakes in the defaults.
+pub(crate) async fn get_adaptive_impl<S: ObjectStore + ?Sized>(
+    store: &S,
+    path: &Path,
+    size: Option<u64>,
+    threshold: NonZeroU64,
+    chunk_size: NonZeroU64,
+    max_chunks_per_batch: NonZeroUsize,
+) -> Result<Bytes, object_store::Error> {
+    let chunk = chunk_size.get();
+
+    // `first_chunk` holds the leading chunk when size discovery fetched it (the
+    // size=None path), so the range walk can reuse it instead of re-fetching.
+    let (size, first_chunk): (u64, Option<Bytes>) = match size {
+        Some(size) => (size, None),
+        None => {
+            // Discover the size with a ranged get_opts rather than a HEAD:
+            // GetResult.meta.size is the object's *total* size, so one request
+            // yields both the size and the first chunk's bytes. Avoids HEAD,
+            // which on S3 has no error response body and is opaque on failure
+            // (influxdata/influxdb_pro#4423). Range one chunk (not the whole
+            // threshold) so this request stays within the per-request timeout.
+            let options = object_store::GetOptions {
+                range: Some((0..chunk).into()),
+                ..Default::default()
+            };
+            let result = store.get_opts(path, options).await?;
+            let size = result.meta.size;
+            let bytes = result.bytes().await?;
+            if size <= chunk {
+                // The object fits in the first chunk — return it, one request.
+                return Ok(bytes);
+            }
+            (size, Some(bytes))
+        }
+    };
+
+    // Up to the threshold a single GET fits the timeout budget and is cheaper
+    // than several — but only if discovery didn't already fetch the first chunk.
+    // If it did, fall through to the range walk, which reuses that chunk and
+    // fetches only the remainder rather than re-downloading the whole object.
+    if size <= threshold.get() && first_chunk.is_none() {
+        return store.get(path).await?.bytes().await;
+    }
+
+    // Reassembly buffer is contiguous (callers use serde_json::from_slice); a
+    // checked cast surfaces objects larger than usize on 32-bit rather than
+    // truncating the capacity.
+    let capacity = usize::try_from(size).map_err(|_| object_store::Error::Generic {
+        store: "adaptive_get",
+        source: format!("object size {size} exceeds addressable memory on this platform").into(),
+    })?;
+
+    // If size discovery already fetched range 0, seed the buffer with it and
+    // start the range walk at the second chunk to avoid re-fetching.
+    let first_offset = if first_chunk.is_some() { chunk } else { 0 };
+    let ranges: Vec<std::ops::Range<u64>> = (first_offset..size)
+        .step_by(chunk as usize)
+        .map(|offset| offset..(offset + chunk).min(size))
+        .collect();
+
+    // Per-chunk get_range, NOT get_ranges: get_ranges coalesces ranges within
+    // OBJECT_STORE_COALESCE_DEFAULT (1 MiB), so our contiguous ranges would
+    // merge back into one whole-object GET, re-exposing the timeout cliff this
+    // path avoids. Guarded by the test
+    // `chunked_branch_issues_one_get_range_per_chunk_not_coalesced`. Batching
+    // bounds concurrency and holds at most one batch on top of the buffer.
+    let mut buf = BytesMut::with_capacity(capacity);
+    if let Some(first) = first_chunk {
+        buf.extend_from_slice(&first);
+    }
+    for batch in ranges.chunks(max_chunks_per_batch.get()) {
+        let parts = futures::future::try_join_all(
+            batch
+                .iter()
+                .map(|range| store.get_range(path, range.clone())),
+        )
+        .await?;
+        for part in parts {
+            buf.extend_from_slice(&part);
+        }
+    }
+    Ok(buf.freeze())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_object_store::{ErrorConfig, OperationKind, TestObjectStore};
+    use object_store::memory::InMemory;
+    use std::sync::Arc;
+
+    #[derive(Copy, Clone, Debug)]
+    enum Branch {
+        SingleGet,
+        Chunked,
+    }
+
+    fn nz(n: u64) -> NonZeroU64 {
+        NonZeroU64::new(n).unwrap()
+    }
+
+    fn nzu(n: usize) -> NonZeroUsize {
+        NonZeroUsize::new(n).unwrap()
+    }
+
+    /// Assert that `get_adaptive_impl` routes a `payload`-sized object through
+    /// `expected` AND returns the bytes intact.
+    ///
+    /// Wraps `InMemory` in a `TestObjectStore` that fails on the *opposite*
+    /// branch's operation, mirroring `adaptive_put`'s `assert_branch`: if the
+    /// code under test takes the expected branch the failure predicate never
+    /// fires; if it takes the wrong branch the failure surfaces as an error and
+    /// the test fails. Guards against a silent flip of the `<=` comparison that
+    /// a round-trip-only test (indifferent `InMemory`) would not catch.
+    async fn assert_branch(
+        label: &str,
+        payload: Bytes,
+        threshold: NonZeroU64,
+        chunk_size: NonZeroU64,
+        expected: Branch,
+    ) {
+        let inner: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let path = Path::from(label);
+        inner.put(&path, payload.clone().into()).await.unwrap();
+
+        let fail_kind = match expected {
+            // Single-GET branch must not touch the ranged path.
+            Branch::SingleGet => OperationKind::GetRange,
+            // Chunked branch must not issue a whole-object GET.
+            Branch::Chunked => OperationKind::Get,
+        };
+        let test_store = TestObjectStore::new(inner)
+            .with_error_config(ErrorConfig::PercentageError(100.0))
+            .with_failure_predicate(move |ctx| ctx.kind == fail_kind);
+
+        let size = Some(payload.len() as u64);
+        // Large batch: branch-routing tests don't care about batching.
+        let got = get_adaptive_impl(&test_store, &path, size, threshold, chunk_size, nzu(1024))
+            .await
+            .unwrap_or_else(|e| {
+                panic!("{label}: get_adaptive took the wrong branch (expected {expected:?}): {e}")
+            });
+
+        assert_eq!(
+            test_store.get_injected_failure_count(),
+            0,
+            "{label}: get_adaptive touched the {fail_kind:?} path (expected {expected:?})",
+        );
+        assert_eq!(got, payload, "{label}: round-trip mismatch");
+    }
+
+    #[tokio::test]
+    async fn small_object_takes_single_get_branch() {
+        assert_branch(
+            "small",
+            Bytes::from(vec![1u8; 100]),
+            nz(1024),
+            nz(256),
+            Branch::SingleGet,
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn exact_threshold_takes_single_get_branch() {
+        // An object of exactly the threshold stays on the single-GET fast path.
+        assert_branch(
+            "exact",
+            Bytes::from(vec![2u8; 1024]),
+            nz(1024),
+            nz(256),
+            Branch::SingleGet,
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn above_threshold_takes_chunked_branch() {
+        // threshold+1 crosses into the ranged path.
+        assert_branch(
+            "above",
+            Bytes::from(vec![3u8; 1025]),
+            nz(1024),
+            nz(256),
+            Branch::Chunked,
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn chunked_branch_reassembles_multiple_chunks_intact() {
+        // 1000 bytes / 256-byte chunks -> 4 ranges (256,256,256,232); the
+        // reassembled bytes must equal the original exactly.
+        let payload: Bytes = (0..1000u32).map(|i| i as u8).collect::<Vec<u8>>().into();
+        assert_branch("multi", payload, nz(512), nz(256), Branch::Chunked).await;
+    }
+
+    #[tokio::test]
+    async fn size_none_small_object_served_by_ranged_get_no_head() {
+        // Size unknown + object smaller than one chunk: a single get_range of
+        // the first chunk returns the whole object (short read), so no HEAD is
+        // issued. A store that fails HEAD must still succeed.
+        let inner: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let path = Path::from("small-none");
+        let payload = Bytes::from(vec![7u8; 50]);
+        inner.put(&path, payload.clone().into()).await.unwrap();
+
+        let head_fails = TestObjectStore::new(inner)
+            .with_error_config(ErrorConfig::PercentageError(100.0))
+            .with_failure_predicate(|ctx| ctx.kind == OperationKind::Head);
+        // chunk=256 > payload=50, so the ranged GET short-reads the whole object.
+        let got = get_adaptive_impl(&head_fails, &path, None, nz(1024), nz(256), nzu(4))
+            .await
+            .expect("small object with size=None must not require a HEAD");
+        assert_eq!(got, payload);
+        assert_eq!(
+            head_fails.get_injected_failure_count(),
+            0,
+            "size=None small-object path must not issue a HEAD"
+        );
+    }
+
+    #[tokio::test]
+    async fn size_none_large_object_discovers_size_without_head() {
+        // Size unknown + object larger than one chunk: the first ranged GET
+        // (get_opts) yields the object's true size via GetResult.meta, so the
+        // impl learns the size AND the first chunk in one request and never
+        // issues a HEAD (a foot-gun on S3, see #4423). Result byte-identical.
+        let payload: Bytes = (0..1000u32).map(|i| i as u8).collect::<Vec<u8>>().into();
+        let inner: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let path = Path::from("large-none");
+        inner.put(&path, payload.clone().into()).await.unwrap();
+        // Fail any HEAD so the test proves the discovery path avoids it.
+        let store = TestObjectStore::new(inner)
+            .with_error_config(ErrorConfig::PercentageError(100.0))
+            .with_failure_predicate(|ctx| ctx.kind == OperationKind::Head);
+
+        // threshold=500 < size(1000) -> chunked; chunk=100 -> first get_opts
+        // returns a full 100-byte chunk plus meta.size=1000.
+        let got = get_adaptive_impl(&store, &path, None, nz(500), nz(100), nzu(4))
+            .await
+            .expect("size discovery for a large object must not require a HEAD");
+        assert_eq!(got, payload);
+        assert_eq!(
+            store.get_injected_failure_count(),
+            0,
+            "size=None large-object path must not issue a HEAD"
+        );
+    }
+
+    #[tokio::test]
+    async fn size_none_midsize_object_reuses_first_chunk_no_full_get() {
+        // Size unknown + object between one chunk and the threshold (chunk <
+        // size <= threshold): discovery already fetched the first chunk via
+        // get_opts, so the impl must fetch only the remainder and concat, NOT
+        // re-download the whole object with a plain get() (which would waste the
+        // prefetched chunk). Fail whole-object Get to prove it is not used.
+        let payload: Bytes = (0..300u32).map(|i| i as u8).collect::<Vec<u8>>().into();
+        let inner: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let path = Path::from("midsize-none");
+        inner.put(&path, payload.clone().into()).await.unwrap();
+        let store = TestObjectStore::new(inner)
+            .with_error_config(ErrorConfig::PercentageError(100.0))
+            .with_failure_predicate(|ctx| {
+                matches!(ctx.kind, OperationKind::Get | OperationKind::Head)
+            });
+
+        // chunk=100, threshold=500 -> size(300) is in (100, 500]: threshold
+        // branch, but discovery already holds bytes 0..100.
+        let got = get_adaptive_impl(&store, &path, None, nz(500), nz(100), nzu(4))
+            .await
+            .expect("mid-size size=None path must not issue a whole-object get or HEAD");
+        assert_eq!(got, payload);
+        assert_eq!(
+            store.get_injected_failure_count(),
+            0,
+            "mid-size size=None path must reuse the prefetched chunk, not re-get the whole object"
+        );
+    }
+
+    #[tokio::test]
+    async fn chunked_branch_issues_one_get_range_per_chunk_not_coalesced() {
+        // 1000 bytes / 100-byte chunks -> 10 contiguous ranges. The impl must
+        // issue 10 separate get_range requests (one per chunk), NOT a single
+        // get_ranges: object_store's get_ranges coalesces adjacent ranges (gap
+        // <= 1 MiB) and would merge all 10 back into one whole-object GET,
+        // defeating chunking and re-exposing the request-timeout cliff.
+        //
+        // Fail on GetRanges so any coalescing path surfaces as an error, and
+        // count the per-chunk get_range calls (the only op in this branch).
+        let payload: Bytes = (0..1000u32).map(|i| i as u8).collect::<Vec<u8>>().into();
+        let inner: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let path = Path::from("perchunk");
+        inner.put(&path, payload.clone().into()).await.unwrap();
+        let store = TestObjectStore::new(inner)
+            .with_error_config(ErrorConfig::PercentageError(100.0))
+            .with_failure_predicate(|ctx| ctx.kind == OperationKind::GetRanges);
+
+        let got = get_adaptive_impl(
+            &store,
+            &path,
+            Some(payload.len() as u64),
+            nz(500), // threshold < size -> chunked
+            nz(100), // chunk size -> 10 ranges
+            nzu(4),  // batches of 4 (concurrency/memory bound), still 10 get_range total
+        )
+        .await
+        .unwrap_or_else(|e| {
+            panic!("chunked read must not use the coalescing get_ranges path: {e}")
+        });
+
+        assert_eq!(got, payload, "reassembly across batches must be intact");
+        assert_eq!(
+            store.get_injected_failure_count(),
+            0,
+            "chunked read touched the coalescing get_ranges path",
+        );
+        assert_eq!(
+            store.get_call_count(),
+            10,
+            "expected 10 per-chunk get_range calls, got {}",
+            store.get_call_count()
+        );
+    }
+}

--- a/object_store_utils/src/cas_test_stores.rs
+++ b/object_store_utils/src/cas_test_stores.rs
@@ -5,27 +5,82 @@ use std::sync::Arc;
 
 use object_store::ObjectStore;
 
+/// Which error a lost response surfaces as. A `PutMode::Create` collision
+/// reaches the caller as `AlreadyExists`; `PutMode::Update` as `Precondition`;
+/// a dropped connection on a committed write as `Generic`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LostResponseError {
+    Precondition,
+    AlreadyExists,
+    Generic,
+}
+
 /// Store wrapper simulating an ambiguous conditional-put success: the write
-/// lands on the inner store, but the caller receives `Precondition` — as
-/// happens when the client's internal retry layer re-sends a PUT whose
-/// response was lost and collides with its own earlier success.
+/// lands on the inner store, but the caller receives a failure — as happens
+/// when the client's internal retry layer re-sends a PUT whose response was
+/// lost and collides with its own earlier success.
 #[derive(Debug)]
 pub struct LostResponseStore {
     inner: Arc<dyn ObjectStore>,
-    lose_next_put_response: std::sync::atomic::AtomicBool,
+    lose_next_put_response: std::sync::Mutex<Option<LostResponseError>>,
+    collision_shape: std::sync::Mutex<Option<LostResponseError>>,
+    last_get: std::sync::Mutex<Option<(Option<object_store::GetRange>, bool)>>,
+}
+
+/// The error a lost response, or a reshaped collision, surfaces as.
+fn lost_response_error(
+    error: LostResponseError,
+    location: &object_store::path::Path,
+) -> object_store::Error {
+    match error {
+        LostResponseError::Precondition => object_store::Error::Precondition {
+            path: location.to_string(),
+            source: "simulated lost response + retry collision".into(),
+        },
+        LostResponseError::AlreadyExists => object_store::Error::AlreadyExists {
+            path: location.to_string(),
+            source: "simulated lost response + retry collision".into(),
+        },
+        LostResponseError::Generic => object_store::Error::Generic {
+            store: "LostResponseStore",
+            source: "simulated lost response on a committed write".into(),
+        },
+    }
 }
 
 impl LostResponseStore {
     pub fn new(inner: Arc<dyn ObjectStore>) -> Self {
         Self {
             inner,
-            lose_next_put_response: std::sync::atomic::AtomicBool::new(false),
+            lose_next_put_response: std::sync::Mutex::new(None),
+            collision_shape: std::sync::Mutex::new(None),
+            last_get: std::sync::Mutex::new(None),
         }
     }
 
+    /// Report every `PutMode::Create` collision as `error`, as Azure does when
+    /// an `If-None-Match: *` put comes back 412 rather than 409.
+    pub fn report_collisions_as(&self, error: LostResponseError) {
+        *self.collision_shape.lock().expect("lock not poisoned") = Some(error);
+    }
+
+    /// The `range` and `head` of the most recent `get_opts`, for pinning the
+    /// shape of a read-back.
+    pub fn last_get(&self) -> Option<(Option<object_store::GetRange>, bool)> {
+        self.last_get.lock().expect("lock not poisoned").clone()
+    }
+
+    /// Lose the next put response as a `Precondition`, the shape a
+    /// `PutMode::Update` collision takes.
     pub fn lose_next_put_response(&self) {
-        self.lose_next_put_response
-            .store(true, std::sync::atomic::Ordering::SeqCst);
+        self.lose_next_put_response_with(LostResponseError::Precondition);
+    }
+
+    pub fn lose_next_put_response_with(&self, error: LostResponseError) {
+        *self
+            .lose_next_put_response
+            .lock()
+            .expect("lock not poisoned") = Some(error);
     }
 }
 
@@ -43,18 +98,24 @@ impl ObjectStore for LostResponseStore {
         payload: object_store::PutPayload,
         opts: object_store::PutOptions,
     ) -> object_store::Result<object_store::PutResult> {
-        let result = self.inner.put_opts(location, payload, opts).await?;
-        if self
+        let result = match self.inner.put_opts(location, payload, opts).await {
+            Ok(result) => result,
+            Err(e @ object_store::Error::AlreadyExists { .. }) => {
+                let shape = *self.collision_shape.lock().expect("lock not poisoned");
+                return Err(shape.map_or(e, |shape| lost_response_error(shape, location)));
+            }
+            Err(e) => return Err(e),
+        };
+        // The write landed, but the caller sees the failure its own retry got.
+        let taken = self
             .lose_next_put_response
-            .swap(false, std::sync::atomic::Ordering::SeqCst)
-        {
-            // The write landed, but the caller sees the 412 its own retry got.
-            return Err(object_store::Error::Precondition {
-                path: location.to_string(),
-                source: "simulated lost response + retry collision".into(),
-            });
+            .lock()
+            .expect("lock not poisoned")
+            .take();
+        match taken {
+            Some(error) => Err(lost_response_error(error, location)),
+            None => Ok(result),
         }
-        Ok(result)
     }
 
     async fn put_multipart_opts(
@@ -70,6 +131,8 @@ impl ObjectStore for LostResponseStore {
         location: &object_store::path::Path,
         options: object_store::GetOptions,
     ) -> object_store::Result<object_store::GetResult> {
+        *self.last_get.lock().expect("lock not poisoned") =
+            Some((options.range.clone(), options.head));
         self.inner.get_opts(location, options).await
     }
 

--- a/object_store_utils/src/lib.rs
+++ b/object_store_utils/src/lib.rs
@@ -7,11 +7,23 @@ pub use retryable_object_store::set_default_retry_params;
 mod adaptive_put;
 pub use adaptive_put::{AdaptivePutExt, DEFAULT_MULTIPART_CHUNK_SIZE};
 
+mod adaptive_get;
+pub use adaptive_get::{
+    AdaptiveGetExt, DEFAULT_GET_CHUNK_SIZE, MAX_CHUNKS_PER_BATCH, SINGLE_GET_THRESHOLD,
+};
+
 mod object_store_health;
 pub use object_store_health::{ErrorCategory, ObjectStoreHealth};
 
 mod observed_object_store;
 pub use observed_object_store::ObservedObjectStore;
+
+mod self_verifying_create;
+pub use self_verifying_create::{
+    CONFLICT_METRIC_NAME, NonceCheck, PUT_NONCE_METADATA_KEY, PutNonce, SELF_WRITE_METRIC_NAME,
+    SelfVerifyingCreate, SelfVerifyingCreateStore, UNTAGGED_CONFLICT_METRIC_NAME,
+    UNVERIFIED_CONFLICT_METRIC_NAME, nonce_check,
+};
 
 #[cfg(any(feature = "test-helpers", test))]
 mod test_object_store;
@@ -23,4 +35,4 @@ pub use test_object_store::{
 #[cfg(any(feature = "test-helpers", test))]
 mod cas_test_stores;
 #[cfg(any(feature = "test-helpers", test))]
-pub use cas_test_stores::{LostResponseStore, VersionKeyedStore};
+pub use cas_test_stores::{LostResponseError, LostResponseStore, VersionKeyedStore};

--- a/object_store_utils/src/retryable_object_store.rs
+++ b/object_store_utils/src/retryable_object_store.rs
@@ -246,6 +246,12 @@ pub trait RetryableObjectStore: ObjectStore {
         .await
     }
 
+    /// Put with retries, skipping the errors a retry cannot change.
+    ///
+    /// `NotFound`, `Precondition`, and `AlreadyExists` are returned on the first
+    /// attempt: a conditional put that lost the race loses it identically on
+    /// every retry, so retrying only delays the caller. Setting
+    /// [`RetryParams::when`] replaces this predicate rather than adding to it.
     async fn put_opts_with_retries(
         &self,
         path: &Path,
@@ -264,7 +270,9 @@ pub trait RetryableObjectStore: ObjectStore {
             Some(|err| {
                 !matches!(
                     err,
-                    ObjectStoreError::NotFound { .. } | ObjectStoreError::Precondition { .. }
+                    ObjectStoreError::NotFound { .. }
+                        | ObjectStoreError::Precondition { .. }
+                        | ObjectStoreError::AlreadyExists { .. }
                 )
             }),
             || async { store.put_opts(path, payload.clone(), options.clone()).await },

--- a/object_store_utils/src/retryable_object_store/tests.rs
+++ b/object_store_utils/src/retryable_object_store/tests.rs
@@ -253,6 +253,44 @@ async fn put_opts_precondition_not_retried() {
     );
 }
 
+// Ensures put_opts surfaces AlreadyExists errors without retrying.
+#[tokio::test]
+async fn put_opts_already_exists_not_retried() {
+    let inner: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let path = Path::from("catalog/0001.json");
+    inner
+        .put(&path, PutPayload::from("theirs"))
+        .await
+        .expect("setup: direct put to InMemory should succeed");
+
+    let concrete_store = Arc::new(TestObjectStore::new(Arc::clone(&inner)));
+    let test_store: Arc<dyn ObjectStore> = Arc::clone(&concrete_store) as _;
+
+    concrete_store.reset_call_count();
+
+    let result = test_store
+        .put_opts_with_retries(
+            &path,
+            PutPayload::from("ours"),
+            PutOptions::from(PutMode::Create),
+            "already exists put_opts".to_string(),
+            test_retry_params(4),
+        )
+        .await;
+
+    assert!(matches!(
+        result,
+        Err(ObjectStoreError::AlreadyExists { .. })
+    ));
+    // A conditional create that lost the race loses it identically on every
+    // attempt. Callers passing max_retries: usize::MAX spin forever.
+    assert_eq!(
+        concrete_store.get_call_count(),
+        1,
+        "AlreadyExists failures should not be retried"
+    );
+}
+
 #[tokio::test]
 async fn list_with_retries() {
     let inner: Arc<dyn ObjectStore> = Arc::new(InMemory::new());

--- a/object_store_utils/src/self_verifying_create.rs
+++ b/object_store_utils/src/self_verifying_create.rs
@@ -1,0 +1,417 @@
+//! Nonce-tagged conditional creates, so a writer can recognise its own object
+//! when a retried `PutMode::Create` collides with its own hidden success.
+//!
+//! Background and the reasoning behind each choice: influxdata/influxdb_pro#4776.
+
+use std::ops::Range;
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use futures::stream::BoxStream;
+use metric::{Registry, U64Counter};
+use object_store::{
+    Attribute, Attributes, GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta,
+    ObjectStore, PutMode, PutMultipartOptions, PutOptions, PutPayload, PutResult, Result,
+    path::Path,
+};
+use observability_deps::tracing::{debug, warn};
+
+use crate::{RetryParams, RetryableObjectStore};
+
+/// Object metadata key carrying the writer's nonce.
+///
+/// Lowercase and underscore-separated: Azure requires metadata names to be
+/// valid C# identifiers, and S3 and GCS store keys lowercased.
+pub const PUT_NONCE_METADATA_KEY: &str = "influxdb3_put_nonce";
+
+/// Identifies one logical write. Stable across a caller's own retries when the
+/// caller mints it outside its retry loop.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PutNonce(String);
+
+impl PutNonce {
+    pub fn generate() -> Self {
+        Self(uuid::Uuid::new_v4().to_string())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// Marks a `PutMode::Create` as verifiable against whatever object is already
+/// at the path. Placed in `PutOptions::extensions`, so a store built without
+/// the verifying layer drops it and behaves as it always has.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct SelfVerifyingCreate {
+    nonce: Option<PutNonce>,
+}
+
+impl SelfVerifyingCreate {
+    /// Verify against a caller-owned nonce. Minting it outside the caller's
+    /// retry loop is what extends coverage to that loop.
+    pub fn with_nonce(nonce: PutNonce) -> Self {
+        Self { nonce: Some(nonce) }
+    }
+
+    /// Verify against a nonce minted per call, covering only the object store
+    /// client's internal retries.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn put_options(self) -> PutOptions {
+        let mut opts = PutOptions::from(PutMode::Create);
+        opts.extensions.insert(self);
+        opts
+    }
+
+    pub(crate) fn into_nonce(self) -> PutNonce {
+        self.nonce.unwrap_or_else(PutNonce::generate)
+    }
+}
+
+/// Verdict on the nonce stored against an existing object.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NonceCheck {
+    /// The stored nonce is ours: this is our own write.
+    Ours,
+    /// A different nonce: another writer holds the path.
+    Foreign,
+    /// No nonce at all. Cannot be distinguished from a foreign writer that
+    /// does not tag, an older build, or a store that discards metadata.
+    Absent,
+}
+
+pub fn nonce_check(attributes: &Attributes, nonce: &PutNonce) -> NonceCheck {
+    match attributes.get(&Attribute::Metadata(PUT_NONCE_METADATA_KEY.into())) {
+        None => NonceCheck::Absent,
+        Some(stored) if stored.as_ref() == nonce.as_str() => NonceCheck::Ours,
+        Some(_) => NonceCheck::Foreign,
+    }
+}
+
+pub const SELF_WRITE_METRIC_NAME: &str = "influxdb3_conditional_create_self_write_verified";
+pub const CONFLICT_METRIC_NAME: &str = "influxdb3_conditional_create_conflict_confirmed";
+pub const UNTAGGED_CONFLICT_METRIC_NAME: &str = "influxdb3_conditional_create_conflict_untagged";
+pub const UNVERIFIED_CONFLICT_METRIC_NAME: &str =
+    "influxdb3_conditional_create_conflict_unverified";
+
+/// Recorders are taken at construction so every series exists from startup,
+/// reading as zero until something is recorded to it.
+#[derive(Debug)]
+struct SelfVerifyMetrics {
+    self_writes: U64Counter,
+    conflicts: U64Counter,
+    untagged_conflicts: U64Counter,
+    unverified_conflicts: U64Counter,
+}
+
+impl SelfVerifyMetrics {
+    fn new(registry: &Registry) -> Self {
+        Self {
+            self_writes: registry
+                .register_metric::<U64Counter>(
+                    SELF_WRITE_METRIC_NAME,
+                    "conditional creates that failed but were confirmed to be this writer's own object",
+                )
+                .recorder(&[]),
+            conflicts: registry
+                .register_metric::<U64Counter>(
+                    CONFLICT_METRIC_NAME,
+                    "conditional creates that failed against an object carrying another writer's nonce",
+                )
+                .recorder(&[]),
+            untagged_conflicts: registry
+                .register_metric::<U64Counter>(
+                    UNTAGGED_CONFLICT_METRIC_NAME,
+                    "conditional creates that failed against an object carrying no nonce",
+                )
+                .recorder(&[]),
+            unverified_conflicts: registry
+                .register_metric::<U64Counter>(
+                    UNVERIFIED_CONFLICT_METRIC_NAME,
+                    "conditional creates that failed and could not be read back to check the nonce",
+                )
+                .recorder(&[]),
+        }
+    }
+}
+
+/// Read-back attempts inside one verification, covering a transient failure on
+/// the GET without waiting out a lasting one.
+const READ_BACK_ATTEMPTS: usize = 3;
+
+fn read_back_retry_params() -> RetryParams {
+    RetryParams {
+        max_retries: READ_BACK_ATTEMPTS - 1,
+        min_delay: Duration::from_millis(50),
+        max_delay: Duration::from_millis(500),
+        ..Default::default()
+    }
+}
+
+/// Report a collision as `AlreadyExists` whatever shape the backend gave it,
+/// so a caller that keys on that variant sees it on every backend.
+fn conflict(location: &Path, source: object_store::Error) -> object_store::Error {
+    object_store::Error::AlreadyExists {
+        path: location.to_string(),
+        source: Box::new(source),
+    }
+}
+
+#[derive(Debug)]
+pub struct SelfVerifyingCreateStore {
+    inner: Arc<dyn ObjectStore>,
+    metrics: SelfVerifyMetrics,
+}
+
+impl SelfVerifyingCreateStore {
+    pub fn new(inner: Arc<dyn ObjectStore>, registry: &Registry) -> Self {
+        Self {
+            inner,
+            metrics: SelfVerifyMetrics::new(registry),
+        }
+    }
+
+    /// Decide whether the object already at `location` is our own write.
+    async fn verify(
+        &self,
+        location: &Path,
+        nonce: &PutNonce,
+        collision: object_store::Error,
+    ) -> Result<PutResult> {
+        // Metadata only: the nonce rides in the object's attributes, and a
+        // ranged read is rejected outright against a zero-length object.
+        let opts = GetOptions {
+            head: true,
+            ..Default::default()
+        };
+
+        let existing = match self
+            .inner
+            .get_opts_with_retries(
+                location,
+                opts,
+                format!("verifying conditional create for {location}"),
+                read_back_retry_params(),
+            )
+            .await
+        {
+            Ok(existing) => existing,
+            Err(source) => {
+                // There is some special handling of NotFound here; if we are doing verification in
+                // this method, it is because we encoutered a 412/409 error when doing a PUT, i.e.,
+                // the object we tried to create reported as already exists.
+                //
+                // How would a NotFound arise when doing this GET request? Perhaps:
+                // - the object was persisted, then deleted due to a snapshot; that is not likely,
+                //   since the snapshot-triggered deletion gives some grace period before deleting,
+                //   but it is one conceivable way in which a NotFound could be encountered here.
+                // - a NotFound is improperly reported by the store due to cosmic anomoly or act of
+                //   God.
+                //
+                // The special handling is a difference in warning message to distinguish the
+                // underlying error when viewing the logs. For *all* errors in this scenario, we
+                // return AlreadyExists. The effect of this would be that the verification fails.
+                //
+                // For example, in the Parquet WAL, this would be treated as another process having
+                // persisted a WAL file in place of the current process, and the current process
+                // would exit. That outcome is appropriate (terminating the process) as allowing it
+                // to continue (and continue ingesting/persisting WAL) could lead to undefined
+                // behaviour or data corruption/loss; in which case, having the control plane
+                // restart the node (or if there _actually is_ another process running in place of
+                // this one, just letting the node shutdown) is better.
+                self.metrics.unverified_conflicts.inc(1);
+                if matches!(source, object_store::Error::NotFound { .. }) {
+                    warn!(
+                        %location,
+                        %source,
+                        "attempt to verify object after write conflict failed: the object was \
+                         gone before it could be checked; another process may have already \
+                         written and removed it"
+                    );
+                } else {
+                    warn!(
+                        %location,
+                        %source,
+                        "attempt to verify object after write conflict failed: the object \
+                         could not be fetched"
+                    );
+                }
+                return Err(object_store::Error::AlreadyExists {
+                    path: location.to_string(),
+                    source: format!(
+                        "write conflict ({collision}), and the attempt to verify the object \
+                         failed: {source}"
+                    )
+                    .into(),
+                });
+            }
+        };
+
+        match nonce_check(&existing.attributes, nonce) {
+            NonceCheck::Ours => {
+                self.metrics.self_writes.inc(1);
+                debug!(
+                    %location,
+                    "conditional create reported a conflict against this writer's own object; \
+                     the write is durable, treating as success"
+                );
+                Ok(PutResult {
+                    e_tag: existing.meta.e_tag.clone(),
+                    version: existing.meta.version.clone(),
+                })
+            }
+            NonceCheck::Foreign => {
+                self.metrics.conflicts.inc(1);
+                warn!(
+                    %location,
+                    "conditional create reported a conflict against an object carrying another \
+                     writer's nonce"
+                );
+                Err(conflict(location, collision))
+            }
+            NonceCheck::Absent => {
+                self.metrics.untagged_conflicts.inc(1);
+                warn!(
+                    %location,
+                    "conditional create reported a conflict against an object carrying no nonce; \
+                     the store may not retain object metadata, or the object predates tagging"
+                );
+                Err(conflict(location, collision))
+            }
+        }
+    }
+}
+
+impl std::fmt::Display for SelfVerifyingCreateStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "SelfVerifyingCreateStore({})", self.inner)
+    }
+}
+
+#[async_trait]
+impl ObjectStore for SelfVerifyingCreateStore {
+    async fn put(&self, location: &Path, payload: PutPayload) -> Result<PutResult> {
+        self.inner.put(location, payload).await
+    }
+
+    async fn put_opts(
+        &self,
+        location: &Path,
+        payload: PutPayload,
+        mut opts: PutOptions,
+    ) -> Result<PutResult> {
+        let Some(marker) = opts.extensions.remove::<SelfVerifyingCreate>() else {
+            return self.inner.put_opts(location, payload, opts).await;
+        };
+
+        // The marker only means anything on a create. Any other mode may be
+        // writing over an object this writer created earlier, so its nonce
+        // would still be at the path and a lost race would read back as ours.
+        if !matches!(opts.mode, PutMode::Create) {
+            return self.inner.put_opts(location, payload, opts).await;
+        }
+
+        let nonce = marker.into_nonce();
+        opts.attributes.insert(
+            Attribute::Metadata(PUT_NONCE_METADATA_KEY.into()),
+            nonce.as_str().to_string().into(),
+        );
+
+        match self.inner.put_opts(location, payload, opts).await {
+            // A conditional create that collided. Backends disagree on the
+            // shape: S3 and GCS translate the 412 into `AlreadyExists`, Azure
+            // passes the status through, so an `If-None-Match: *` collision
+            // there arrives as `Precondition` (412) or `AlreadyExists` (409).
+            // Within a marked create all three mean the same thing.
+            Err(
+                e @ (object_store::Error::AlreadyExists { .. }
+                | object_store::Error::Precondition { .. }
+                | object_store::Error::NotModified { .. }),
+            ) => self.verify(location, &nonce, e).await,
+            other => other,
+        }
+    }
+
+    async fn put_multipart(&self, location: &Path) -> Result<Box<dyn MultipartUpload>> {
+        self.inner.put_multipart(location).await
+    }
+
+    async fn put_multipart_opts(
+        &self,
+        location: &Path,
+        opts: PutMultipartOptions,
+    ) -> Result<Box<dyn MultipartUpload>> {
+        self.inner.put_multipart_opts(location, opts).await
+    }
+
+    async fn get(&self, location: &Path) -> Result<GetResult> {
+        self.inner.get(location).await
+    }
+
+    async fn get_opts(&self, location: &Path, options: GetOptions) -> Result<GetResult> {
+        self.inner.get_opts(location, options).await
+    }
+
+    async fn get_range(&self, location: &Path, range: Range<u64>) -> Result<Bytes> {
+        self.inner.get_range(location, range).await
+    }
+
+    async fn get_ranges(&self, location: &Path, ranges: &[Range<u64>]) -> Result<Vec<Bytes>> {
+        self.inner.get_ranges(location, ranges).await
+    }
+
+    async fn head(&self, location: &Path) -> Result<ObjectMeta> {
+        self.inner.head(location).await
+    }
+
+    async fn delete(&self, location: &Path) -> Result<()> {
+        self.inner.delete(location).await
+    }
+
+    fn delete_stream<'a>(
+        &'a self,
+        locations: BoxStream<'a, Result<Path>>,
+    ) -> BoxStream<'a, Result<Path>> {
+        self.inner.delete_stream(locations)
+    }
+
+    fn list(&self, prefix: Option<&Path>) -> BoxStream<'static, Result<ObjectMeta>> {
+        self.inner.list(prefix)
+    }
+
+    fn list_with_offset(
+        &self,
+        prefix: Option<&Path>,
+        offset: &Path,
+    ) -> BoxStream<'static, Result<ObjectMeta>> {
+        self.inner.list_with_offset(prefix, offset)
+    }
+
+    async fn list_with_delimiter(&self, prefix: Option<&Path>) -> Result<ListResult> {
+        self.inner.list_with_delimiter(prefix).await
+    }
+
+    async fn copy(&self, from: &Path, to: &Path) -> Result<()> {
+        self.inner.copy(from, to).await
+    }
+
+    async fn rename(&self, from: &Path, to: &Path) -> Result<()> {
+        self.inner.rename(from, to).await
+    }
+
+    async fn copy_if_not_exists(&self, from: &Path, to: &Path) -> Result<()> {
+        self.inner.copy_if_not_exists(from, to).await
+    }
+
+    async fn rename_if_not_exists(&self, from: &Path, to: &Path) -> Result<()> {
+        self.inner.rename_if_not_exists(from, to).await
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/object_store_utils/src/self_verifying_create/tests.rs
+++ b/object_store_utils/src/self_verifying_create/tests.rs
@@ -1,0 +1,492 @@
+use super::*;
+use crate::cas_test_stores::{LostResponseError, LostResponseStore};
+use crate::test_object_store::{ErrorConfig, OperationKind, TestObjectStore};
+use metric::Metric;
+use object_store::UpdateVersion;
+use object_store::memory::InMemory;
+
+#[test]
+fn metadata_key_is_portable_across_providers() {
+    // Azure metadata names must be valid C# identifiers.
+    assert!(!PUT_NONCE_METADATA_KEY.contains('-'));
+    assert_eq!(
+        PUT_NONCE_METADATA_KEY,
+        PUT_NONCE_METADATA_KEY.to_lowercase()
+    );
+    assert!(PUT_NONCE_METADATA_KEY.starts_with(|c: char| c.is_ascii_alphabetic()));
+    assert!(
+        PUT_NONCE_METADATA_KEY
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_')
+    );
+}
+
+#[test]
+fn generated_nonces_differ() {
+    assert_ne!(PutNonce::generate(), PutNonce::generate());
+}
+
+#[test]
+fn put_options_carry_the_marker_and_create_mode() {
+    let nonce = PutNonce::generate();
+    let opts = SelfVerifyingCreate::with_nonce(nonce.clone()).put_options();
+
+    assert!(matches!(opts.mode, PutMode::Create));
+    assert!(
+        opts.attributes.is_empty(),
+        "the layer adds attributes, not the caller"
+    );
+
+    let marker = opts
+        .extensions
+        .get::<SelfVerifyingCreate>()
+        .expect("marker present");
+    assert_eq!(marker.clone().into_nonce(), nonce);
+}
+
+#[test]
+fn marker_without_a_nonce_mints_one() {
+    let a = SelfVerifyingCreate::new().into_nonce();
+    let b = SelfVerifyingCreate::new().into_nonce();
+    assert_ne!(a, b);
+}
+
+#[test]
+fn nonce_check_classifies_all_three_cases() {
+    let ours = PutNonce::generate();
+    let theirs = PutNonce::generate();
+
+    let mut attrs = Attributes::new();
+    assert_eq!(nonce_check(&attrs, &ours), NonceCheck::Absent);
+
+    attrs.insert(
+        Attribute::Metadata(PUT_NONCE_METADATA_KEY.into()),
+        theirs.as_str().to_string().into(),
+    );
+    assert_eq!(nonce_check(&attrs, &ours), NonceCheck::Foreign);
+
+    attrs.insert(
+        Attribute::Metadata(PUT_NONCE_METADATA_KEY.into()),
+        ours.as_str().to_string().into(),
+    );
+    assert_eq!(nonce_check(&attrs, &ours), NonceCheck::Ours);
+}
+
+fn store() -> (Arc<LostResponseStore>, SelfVerifyingCreateStore, Registry) {
+    let inner = Arc::new(LostResponseStore::new(Arc::new(InMemory::new())));
+    let registry = Registry::new();
+    let layer = SelfVerifyingCreateStore::new(Arc::clone(&inner) as _, &registry);
+    (inner, layer, registry)
+}
+
+fn count(registry: &Registry, name: &'static str) -> u64 {
+    registry
+        .get_instrument::<Metric<U64Counter>>(name)
+        .expect("counter registered")
+        .get_observer(&metric::Attributes::from(&[]))
+        .expect("series registered at construction")
+        .fetch()
+}
+
+#[tokio::test]
+async fn lost_response_on_a_marked_create_reports_success() {
+    let (inner, layer, _registry) = store();
+    let path = Path::from("wal/0001.wal");
+    inner.lose_next_put_response_with(LostResponseError::AlreadyExists);
+
+    let result = layer
+        .put_opts(
+            &path,
+            PutPayload::from_static(b"wal bytes"),
+            SelfVerifyingCreate::with_nonce(PutNonce::generate()).put_options(),
+        )
+        .await;
+
+    assert!(
+        result.is_ok(),
+        "own write reported as a conflict: {result:?}"
+    );
+}
+
+/// S3 and GCS translate a conditional-create 412 into `AlreadyExists`;
+/// Azure passes the status through, so the same collision arrives as
+/// `Precondition`. Both must be verified, or the fix is S3/GCS-only.
+#[tokio::test]
+async fn precondition_on_a_marked_create_is_also_verified() {
+    for shape in [
+        LostResponseError::Precondition,
+        LostResponseError::AlreadyExists,
+    ] {
+        let (inner, layer, _registry) = store();
+        inner.lose_next_put_response_with(shape);
+
+        let result = layer
+            .put_opts(
+                &Path::from("wal/0001.wal"),
+                PutPayload::from_static(b"wal bytes"),
+                SelfVerifyingCreate::with_nonce(PutNonce::generate()).put_options(),
+            )
+            .await;
+
+        assert!(
+            result.is_ok(),
+            "own write reported as a conflict for {shape:?}: {result:?}"
+        );
+    }
+}
+
+/// Pins the read-back shape: the nonce lives in the object's metadata, and
+/// asking for a range of an object of unknown length can fail on its own.
+#[tokio::test]
+async fn read_back_is_metadata_only() {
+    let (inner, layer, _registry) = store();
+    inner.lose_next_put_response_with(LostResponseError::AlreadyExists);
+
+    layer
+        .put_opts(
+            &Path::from("wal/0001.wal"),
+            PutPayload::from_static(b"wal bytes"),
+            SelfVerifyingCreate::with_nonce(PutNonce::generate()).put_options(),
+        )
+        .await
+        .unwrap();
+
+    let (range, head) = inner.last_get().expect("the layer read the object back");
+    assert!(head, "read-back requested the object body");
+    assert_eq!(range, None);
+}
+
+/// A ranged read-back is rejected against a zero-length object, so an empty
+/// object at the path would leave every collision unverifiable.
+#[tokio::test]
+async fn a_zero_length_object_is_verified() {
+    let (inner, layer, _registry) = store();
+    inner.lose_next_put_response_with(LostResponseError::AlreadyExists);
+
+    let result = layer
+        .put_opts(
+            &Path::from("wal/0001.wal"),
+            PutPayload::new(),
+            SelfVerifyingCreate::with_nonce(PutNonce::generate()).put_options(),
+        )
+        .await;
+
+    assert!(
+        result.is_ok(),
+        "own zero-length write reported as a conflict: {result:?}"
+    );
+}
+
+/// Azure surfaces an `If-None-Match: *` collision as `Precondition`, which
+/// a caller keying its fail-stop on `AlreadyExists` would never see.
+#[tokio::test]
+async fn a_confirmed_conflict_is_reported_as_already_exists_on_every_backend() {
+    for shape in [
+        LostResponseError::Precondition,
+        LostResponseError::AlreadyExists,
+    ] {
+        let (inner, layer, registry) = store();
+        inner.report_collisions_as(shape);
+        let path = Path::from("wal/0001.wal");
+
+        // A different writer gets there first, tagging with its own nonce.
+        layer
+            .put_opts(
+                &path,
+                PutPayload::from_static(b"theirs"),
+                SelfVerifyingCreate::with_nonce(PutNonce::generate()).put_options(),
+            )
+            .await
+            .unwrap();
+
+        let result = layer
+            .put_opts(
+                &path,
+                PutPayload::from_static(b"ours"),
+                SelfVerifyingCreate::with_nonce(PutNonce::generate()).put_options(),
+            )
+            .await;
+
+        assert!(
+            matches!(result, Err(object_store::Error::AlreadyExists { .. })),
+            "collision shaped as {shape:?} was not normalised: {result:?}"
+        );
+        assert_eq!(count(&registry, CONFLICT_METRIC_NAME), 1);
+    }
+}
+
+#[tokio::test]
+async fn counters_separate_self_writes_from_conflicts() {
+    let (inner, layer, registry) = store();
+
+    // Every series exists from construction, so a healthy node exports
+    // zeroes rather than nothing at all.
+    assert_eq!(count(&registry, SELF_WRITE_METRIC_NAME), 0);
+    assert_eq!(count(&registry, CONFLICT_METRIC_NAME), 0);
+    assert_eq!(count(&registry, UNTAGGED_CONFLICT_METRIC_NAME), 0);
+    assert_eq!(count(&registry, UNVERIFIED_CONFLICT_METRIC_NAME), 0);
+
+    // Our own write, seen as a collision.
+    let ours = Path::from("wal/0001.wal");
+    inner.lose_next_put_response_with(LostResponseError::AlreadyExists);
+    layer
+        .put_opts(
+            &ours,
+            PutPayload::from_static(b"ours"),
+            SelfVerifyingCreate::with_nonce(PutNonce::generate()).put_options(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(count(&registry, SELF_WRITE_METRIC_NAME), 1);
+    assert_eq!(count(&registry, CONFLICT_METRIC_NAME), 0);
+
+    // Someone else's object at a second path.
+    let theirs = Path::from("wal/0002.wal");
+    layer
+        .put_opts(
+            &theirs,
+            PutPayload::from_static(b"theirs"),
+            SelfVerifyingCreate::with_nonce(PutNonce::generate()).put_options(),
+        )
+        .await
+        .unwrap();
+    layer
+        .put_opts(
+            &theirs,
+            PutPayload::from_static(b"ours"),
+            SelfVerifyingCreate::with_nonce(PutNonce::generate()).put_options(),
+        )
+        .await
+        .unwrap_err();
+
+    assert_eq!(count(&registry, SELF_WRITE_METRIC_NAME), 1);
+    assert_eq!(count(&registry, CONFLICT_METRIC_NAME), 1);
+
+    // An object nobody tagged, at a third path.
+    let untagged = Path::from("wal/0003.wal");
+    inner
+        .put(&untagged, PutPayload::from_static(b"pre-upgrade"))
+        .await
+        .unwrap();
+    layer
+        .put_opts(
+            &untagged,
+            PutPayload::from_static(b"ours"),
+            SelfVerifyingCreate::with_nonce(PutNonce::generate()).put_options(),
+        )
+        .await
+        .unwrap_err();
+
+    assert_eq!(count(&registry, CONFLICT_METRIC_NAME), 1);
+    assert_eq!(count(&registry, UNTAGGED_CONFLICT_METRIC_NAME), 1);
+    assert_eq!(count(&registry, UNVERIFIED_CONFLICT_METRIC_NAME), 0);
+}
+
+#[tokio::test]
+async fn a_genuine_conflict_still_reports_already_exists() {
+    let (_inner, layer, _registry) = store();
+    let path = Path::from("wal/0001.wal");
+
+    // A different writer gets there first, tagging with its own nonce.
+    layer
+        .put_opts(
+            &path,
+            PutPayload::from_static(b"theirs"),
+            SelfVerifyingCreate::with_nonce(PutNonce::generate()).put_options(),
+        )
+        .await
+        .unwrap();
+
+    let result = layer
+        .put_opts(
+            &path,
+            PutPayload::from_static(b"ours"),
+            SelfVerifyingCreate::with_nonce(PutNonce::generate()).put_options(),
+        )
+        .await;
+
+    assert!(matches!(
+        result,
+        Err(object_store::Error::AlreadyExists { .. })
+    ));
+}
+
+#[tokio::test]
+async fn an_untagged_object_reports_already_exists() {
+    let (inner, layer, _registry) = store();
+    let path = Path::from("wal/0001.wal");
+    inner
+        .put(&path, PutPayload::from_static(b"pre-upgrade"))
+        .await
+        .unwrap();
+
+    let result = layer
+        .put_opts(
+            &path,
+            PutPayload::from_static(b"ours"),
+            SelfVerifyingCreate::with_nonce(PutNonce::generate()).put_options(),
+        )
+        .await;
+
+    assert!(matches!(
+        result,
+        Err(object_store::Error::AlreadyExists { .. })
+    ));
+}
+
+/// A store built without the layer drops the marker: it writes no
+/// attributes, so a `LocalFileSystem` would still accept the put, and a
+/// collision reaches the caller as the backend shaped it.
+#[tokio::test]
+async fn an_unwrapped_store_ignores_the_marker() {
+    let inner = LostResponseStore::new(Arc::new(InMemory::new()));
+    let path = Path::from("wal/0001.wal");
+    inner.lose_next_put_response_with(LostResponseError::AlreadyExists);
+
+    let result = inner
+        .put_opts(
+            &path,
+            PutPayload::from_static(b"wal bytes"),
+            SelfVerifyingCreate::with_nonce(PutNonce::generate()).put_options(),
+        )
+        .await;
+
+    assert!(matches!(
+        result,
+        Err(object_store::Error::AlreadyExists { .. })
+    ));
+
+    let stored = inner.get(&path).await.unwrap();
+    assert!(stored.attributes.is_empty());
+}
+
+#[tokio::test]
+async fn an_unmarked_create_is_forwarded_untouched() {
+    let (inner, layer, _registry) = store();
+    let path = Path::from("wal/0001.wal");
+
+    layer
+        .put_opts(
+            &path,
+            PutPayload::from_static(b"plain"),
+            PutOptions::from(PutMode::Create),
+        )
+        .await
+        .unwrap();
+
+    let stored = inner.get(&path).await.unwrap();
+    assert!(stored.attributes.is_empty());
+}
+
+/// Read-backs the layer cannot perform must not soften a collision: a
+/// caller that fail-stops on a duplicate writer would otherwise retry
+/// forever while a second writer holds the path.
+#[tokio::test]
+async fn a_failed_read_back_reports_already_exists() {
+    let lost = Arc::new(LostResponseStore::new(Arc::new(InMemory::new())));
+    let unreadable = Arc::new(
+        TestObjectStore::new(Arc::clone(&lost) as _)
+            .with_error_config(ErrorConfig::PercentageError(100.0))
+            .with_failure_predicate(|ctx| matches!(ctx.kind, OperationKind::GetOpts)),
+    );
+    let registry = Registry::new();
+    let layer = SelfVerifyingCreateStore::new(unreadable as _, &registry);
+
+    lost.lose_next_put_response_with(LostResponseError::AlreadyExists);
+
+    let result = layer
+        .put_opts(
+            &Path::from("wal/0001.wal"),
+            PutPayload::from_static(b"wal bytes"),
+            SelfVerifyingCreate::with_nonce(PutNonce::generate()).put_options(),
+        )
+        .await;
+
+    assert!(
+        matches!(result, Err(object_store::Error::AlreadyExists { .. })),
+        "unverifiable conflict was softened: {result:?}"
+    );
+    assert_eq!(count(&registry, UNVERIFIED_CONFLICT_METRIC_NAME), 1);
+    assert_eq!(count(&registry, CONFLICT_METRIC_NAME), 0);
+}
+
+#[tokio::test]
+async fn a_read_back_that_fails_once_is_retried() {
+    let lost = Arc::new(LostResponseStore::new(Arc::new(InMemory::new())));
+    let flaky = Arc::new(
+        TestObjectStore::new(Arc::clone(&lost) as _)
+            .with_error_config(ErrorConfig::FirstCallFails)
+            .with_failure_predicate(|ctx| matches!(ctx.kind, OperationKind::GetOpts)),
+    );
+    let registry = Registry::new();
+    let layer = SelfVerifyingCreateStore::new(flaky as _, &registry);
+
+    lost.lose_next_put_response_with(LostResponseError::AlreadyExists);
+
+    let result = layer
+        .put_opts(
+            &Path::from("wal/0001.wal"),
+            PutPayload::from_static(b"wal bytes"),
+            SelfVerifyingCreate::with_nonce(PutNonce::generate()).put_options(),
+        )
+        .await;
+
+    assert!(
+        result.is_ok(),
+        "a transient read-back failure was not retried: {result:?}"
+    );
+    assert_eq!(count(&registry, SELF_WRITE_METRIC_NAME), 1);
+    assert_eq!(count(&registry, UNVERIFIED_CONFLICT_METRIC_NAME), 0);
+}
+
+#[tokio::test]
+async fn a_marked_overwrite_is_forwarded_untouched() {
+    let (inner, layer, _registry) = store();
+    let path = Path::from("wal/0001.wal");
+
+    let mut opts = PutOptions::from(PutMode::Overwrite);
+    opts.extensions
+        .insert(SelfVerifyingCreate::with_nonce(PutNonce::generate()));
+    layer
+        .put_opts(&path, PutPayload::from_static(b"plain"), opts)
+        .await
+        .unwrap();
+
+    let stored = inner.get(&path).await.unwrap();
+    assert!(stored.attributes.is_empty());
+}
+
+/// A conditional update that loses its race is a lost race, even where the
+/// object at the path carries this writer's nonce from an earlier create.
+#[tokio::test]
+async fn a_marked_update_that_loses_is_not_verified() {
+    let (_inner, layer, registry) = store();
+    let path = Path::from("wal/0001.wal");
+    let nonce = PutNonce::generate();
+
+    layer
+        .put_opts(
+            &path,
+            PutPayload::from_static(b"ours"),
+            SelfVerifyingCreate::with_nonce(nonce.clone()).put_options(),
+        )
+        .await
+        .unwrap();
+
+    let mut opts = PutOptions::from(PutMode::Update(UpdateVersion {
+        e_tag: Some("stale".to_string()),
+        version: None,
+    }));
+    opts.extensions
+        .insert(SelfVerifyingCreate::with_nonce(nonce));
+    let result = layer
+        .put_opts(&path, PutPayload::from_static(b"newer"), opts)
+        .await;
+
+    assert!(
+        matches!(result, Err(object_store::Error::Precondition { .. })),
+        "a lost update was verified as this writer's own object: {result:?}"
+    );
+    assert_eq!(count(&registry, SELF_WRITE_METRIC_NAME), 0);
+}


### PR DESCRIPTION

Source: 9f763b7fe93da443e911bd9fd12820e8f1b8ee90

Commits:
- `9f763b7fe9` chore: update versions to 3.11.2 (influxdata/influxdb_pro#5355)
- `6101e62859` fix: backport per-line column-limit atomicity to 3.11 (influxdata/influxdb_pro#5252, influxdata/influxdb_pro#5276) (influxdata/influxdb_pro#5335)
- `db56c29705` fix(write_buffer): drop snapshotting chunks per chunk, not per table (influxdata/influxdb_pro#5319) (influxdata/influxdb_pro#5328)
- `62b76fe304` fix(enterprise): read each buffer's chunks and parquet files under one lock (influxdata/influxdb_pro#4932)
- `b7f22fb60b` fix(write_buffer): read buffer chunks and parquet files under one lock (influxdata/influxdb_pro#4928)
- `521aaaed7b` feat: operator retry for a failed Parquet to PachaTree upgrade (influxdata/influxdb_pro#5211)
- `9d71ea2e35` fix(system.parquet_files): return no rows for an unknown table_name filter (influxdata/influxdb_pro#5323)
- `eef4bcc261` fix(wal): stop shutting down when a conditional PUT retry hits its own write (influxdata/influxdb_pro#5127)
- `fa2f767b6f` perf(write_buffer): store ParquetFile path as Arc<str> (influxdata/influxdb_pro#4933)
- `d6ae507220` fix(pacha-compactor): exempt primary-lease IO from the object-store concurrency limit (influxdata/influxdb_pro#5309) (influxdata/influxdb_pro#5314)
- `2a0f4ba171` fix(pacha-compactor): scale snapshot backlog compaction (influxdata/influxdb_pro#5216) (3.11 backport) (influxdata/influxdb_pro#5301)
- `a9a73cf310` fix: backport EAR 7027 fixes to 3.11 (influxdata/influxdb_pro#4972, influxdata/influxdb_pro#4983, influxdata/influxdb_pro#5011) (influxdata/influxdb_pro#5106)
- `cabfeeefb6` chore(ci): push release artifacts to Cloudflare R2 instead of AWS S3 (influxdata/influxdb_pro#5045)
- `6a0a1e941a` chore: bump versions to 3.11.1 (influxdata/influxdb_pro#5097)

Co-authored-by: Paul Dix <paul@pauldix.net>
Co-authored-by: Phil Bracikowski <13472206+philjb@users.noreply.github.com>
Co-authored-by: praveen-influx <pkumar@influxdata.com>
Co-authored-by: Reid Kaufmann <73494261+reidkaufmann@users.noreply.github.com>
Co-authored-by: Timothy Maloney <tmaloney@influxdata.com>
Co-authored-by: Tim Yocum <tim@yocum.org>
Co-authored-by: Trevor Hilton <thilton@influxdata.com>

