### PR TITLE
ci: push release artifacts to Cloudflare R2 instead of AWS S3 (1.x)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,4 @@
 version: 2.1
-orbs:
-  aws-cli: circleci/aws-cli@4.1.2
-  aws-s3: circleci/aws-s3@2.0.0
 parameters:
   cross-container-tag:
     # when updating the go version, should also update the go version in go.mod
@@ -388,43 +385,64 @@ jobs:
         type: string
     docker:
       - image: cimg/python:3.6
+    environment:
+      # Newer awscli/boto3 send CRC32 checksum headers that Cloudflare R2
+      # rejects unless checksum calculation is limited to when required.
+      AWS_REQUEST_CHECKSUM_CALCULATION: when_required
     steps:
       - attach_workspace:
           at: /tmp/workspace
+      - run:
+          name: Install AWS CLI
+          command: |
+            pip install awscli
       - when:
           condition:
             equal: [ << parameters.workflow >>, release ]
           steps:
-            - aws-s3/copy:
-                aws-region:            RELEASE_AWS_REGION
-                aws-access-key-id:     RELEASE_AWS_ACCESS_KEY_ID
-                aws-secret-access-key: RELEASE_AWS_SECRET_ACCESS_KEY
-                from:                  /tmp/workspace/changelog_artifacts/CHANGELOG.md
-                to:                    s3://dl.influxdata.com/influxdb/releases/<< pipeline.git.tag >>/CHANGELOG.<< pipeline.git.tag >>.md
+            - run:
+                name: Upload CHANGELOG to R2
+                command: |
+                  export AWS_ACCESS_KEY_ID="${RELEASE_AWS_ACCESS_KEY_ID}"
+                  export AWS_SECRET_ACCESS_KEY="${RELEASE_AWS_SECRET_ACCESS_KEY}"
+                  aws s3 cp /tmp/workspace/changelog_artifacts/CHANGELOG.md "s3://dl-influxdata-com/influxdb/releases/<< pipeline.git.tag >>/CHANGELOG.<< pipeline.git.tag >>.md" \
+                    --endpoint-url "${AWS_ENDPOINT_URL_S3}" \
+                    --region auto
       - when:
           condition:
             equal: [ << parameters.workflow >>, nightly ]
           steps:
-            - aws-s3/copy:
-                aws-region:            RELEASE_AWS_REGION
-                aws-access-key-id:     RELEASE_AWS_ACCESS_KEY_ID
-                aws-secret-access-key: RELEASE_AWS_SECRET_ACCESS_KEY
-                from:                  /tmp/workspace/changelog_artifacts/CHANGELOG.md
-                to:                    s3://dl.influxdata.com/influxdb/nightlies/<< pipeline.git.branch >>/CHANGELOG.md
+            - run:
+                name: Upload CHANGELOG to R2
+                command: |
+                  export AWS_ACCESS_KEY_ID="${RELEASE_AWS_ACCESS_KEY_ID}"
+                  export AWS_SECRET_ACCESS_KEY="${RELEASE_AWS_SECRET_ACCESS_KEY}"
+                  aws s3 cp /tmp/workspace/changelog_artifacts/CHANGELOG.md "s3://dl-influxdata-com/influxdb/nightlies/<< pipeline.git.branch >>/CHANGELOG.md" \
+                    --endpoint-url "${AWS_ENDPOINT_URL_S3}" \
+                    --region auto
 
   publish_packages:
     docker:
       - image: cimg/python:3.6
+    environment:
+      # Newer awscli/boto3 send CRC32 checksum headers that Cloudflare R2
+      # rejects unless checksum calculation is limited to when required.
+      AWS_REQUEST_CHECKSUM_CALCULATION: when_required
     steps:
       - attach_workspace:
           at: /tmp/workspace
-      - aws-s3/sync:
-          arguments:             --acl public-read
-          aws-region:            RELEASE_AWS_REGION
-          aws-access-key-id:     RELEASE_AWS_ACCESS_KEY_ID
-          aws-secret-access-key: RELEASE_AWS_SECRET_ACCESS_KEY
-          from:                  /tmp/workspace/packages
-          to:                    s3://dl.influxdata.com/influxdb/releases/<< pipeline.git.tag >>
+      - run:
+          name: Install AWS CLI
+          command: |
+            pip install awscli
+      - run:
+          name: Upload packages to R2
+          command: |
+            export AWS_ACCESS_KEY_ID="${RELEASE_AWS_ACCESS_KEY_ID}"
+            export AWS_SECRET_ACCESS_KEY="${RELEASE_AWS_SECRET_ACCESS_KEY}"
+            aws s3 sync /tmp/workspace/packages "s3://dl-influxdata-com/influxdb/releases/<< pipeline.git.tag >>" \
+              --endpoint-url "${AWS_ENDPOINT_URL_S3}" \
+              --region auto
   slack:
     docker:
       - image: us-east1-docker.pkg.dev/influxdata-team-edge/ci-support/ci-slack:latest


### PR DESCRIPTION
### Description

Migrates 1.x release artifact publishing from AWS S3 to Cloudflare R2, replicating #27583 (2.x) for the `1.13` branch, following the org-wide convention (#27582 for 3.x, influxdata/chronograf#6241, influxdata/kapacitor#2905) and matching influxdata/influx-cli#581.

### Context

- Removed the `circleci/aws-s3@2.0.0` orb; uploads are now plain `run` steps using awscli with `--endpoint-url "${AWS_ENDPOINT_URL_S3}"` and `--region auto`.
- Also removed the `circleci/aws-cli@4.1.2` orb: never used on this branch.
- `publish_packages`: `aws-s3/sync` replaced with `aws s3 sync` to the `dl-influxdata-com` R2 bucket (path `influxdb/releases/<tag>` unchanged). Dropped `--acl public-read` — R2 has no ACLs.
- `publish_changelog`: both `aws-s3/copy` steps (release and nightly) replaced with `aws s3 cp` to the same paths on `dl-influxdata-com` (`influxdb/releases/<tag>/CHANGELOG.<tag>.md` and `influxdb/nightlies/<branch>/CHANGELOG.md`).
- Added an explicit `pip install awscli` step to both publish jobs (previously provided by the orb).
- Added `AWS_REQUEST_CHECKSUM_CALCULATION: when_required` to both publish jobs. Newer awscli/boto3 send CRC32 checksum headers that R2 rejects unless checksum calculation is limited to when required.
- Credentials keep the `RELEASE_AWS_ACCESS_KEY_ID` / `RELEASE_AWS_SECRET_ACCESS_KEY` names (values are now R2 API tokens), re-exported as `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` in each step.

Differences from the 2.x change (#27583): 1.x publishes packages and the release changelog under a `<tag>` subdirectory, and nightly changelogs live under `influxdb/nightlies/<branch>` rather than `platform/nightlies/<branch>`.