### PR TITLE
fix: preserve multiline fields during import

### DIFF
--- a/importer/v8/importer.go
+++ b/importer/v8/importer.go
@@ -178,7 +178,7 @@ func (i *Importer) processDML(scanner *bufio.Reader) error {
 		line, err := scanner.ReadString(byte('\n'))
 		if err != nil && err != io.EOF {
 			return err
-		} else if err == io.EOF {
+		} else if err == io.EOF && len(line) == 0 {
 			// Call batchWrite one last time to flush anything out in the batch
 			i.batchWrite()
 			return nil
@@ -198,7 +198,58 @@ func (i *Importer) processDML(scanner *bufio.Reader) error {
 		if strings.TrimSpace(line) == "" {
 			continue
 		}
-		i.batchAccumulator(line)
+		record, err := readLineProtocolRecord(scanner, line)
+		if err != nil {
+			return err
+		}
+		i.batchAccumulator(record)
+	}
+}
+
+func readLineProtocolRecord(reader *bufio.Reader, line string) (string, error) {
+	var record strings.Builder
+	var fields, fieldValue, quoted bool
+
+	for {
+		record.WriteString(line)
+		for pos := 0; pos < len(line); pos++ {
+			if line[pos] == '\\' && pos+1 < len(line) {
+				pos++
+				continue
+			}
+			if line[pos] == ' ' {
+				fields = true
+			}
+			if fields {
+				if !quoted {
+					switch line[pos] {
+					case '=':
+						fieldValue = true
+					case ',':
+						fieldValue = false
+					}
+				}
+				if fieldValue && line[pos] == '"' {
+					quoted = !quoted
+				}
+			}
+			if line[pos] == '\n' && !quoted {
+				return record.String(), nil
+			}
+		}
+
+		if len(line) == 0 || line[len(line)-1] != '\n' {
+			if quoted {
+				return "", fmt.Errorf("unbalanced quotes")
+			}
+			return record.String(), nil
+		}
+
+		var err error
+		line, err = reader.ReadString(byte('\n'))
+		if err != nil && err != io.EOF {
+			return "", err
+		}
 	}
 }
 

--- a/importer/v8/importer.go
+++ b/importer/v8/importer.go
@@ -12,9 +12,13 @@ import (
 	"time"
 
 	"github.com/influxdata/influxdb/client"
+	"github.com/influxdata/influxdb/services/httpd"
 )
 
-const batchSize = 5000
+const (
+	batchSize                     = 5000
+	maxLineProtocolRecordSize int = httpd.DefaultMaxBodySize
+)
 
 // Config is the config used to initialize a Importer importer
 type Config struct {
@@ -206,36 +210,44 @@ func (i *Importer) processDML(scanner *bufio.Reader) error {
 	}
 }
 
+// Keep record framing aligned with models.scanLine.
 func readLineProtocolRecord(reader *bufio.Reader, line string) (string, error) {
 	var record strings.Builder
-	var fields, fieldValue, quoted bool
+	var fields, quoted bool
+	var equals, commas int
 
 	for {
+		if record.Len()+len(line) > maxLineProtocolRecordSize {
+			return "", fmt.Errorf("line protocol record exceeds %d byte limit", maxLineProtocolRecordSize)
+		}
 		record.WriteString(line)
-		for pos := 0; pos < len(line); pos++ {
-			if line[pos] == '\\' && pos+1 < len(line) {
-				pos++
+		for pos := 0; pos < len(line); {
+			if line[pos] == '\\' && pos+2 < len(line) {
+				pos += 2
 				continue
 			}
 			if line[pos] == ' ' {
 				fields = true
 			}
 			if fields {
-				if !quoted {
-					switch line[pos] {
-					case '=':
-						fieldValue = true
-					case ',':
-						fieldValue = false
-					}
-				}
-				if fieldValue && line[pos] == '"' {
+				if !quoted && line[pos] == '=' {
+					pos++
+					equals++
+					continue
+				} else if !quoted && line[pos] == ',' {
+					pos++
+					commas++
+					continue
+				} else if line[pos] == '"' && equals > commas {
+					pos++
 					quoted = !quoted
+					continue
 				}
 			}
 			if line[pos] == '\n' && !quoted {
 				return record.String(), nil
 			}
+			pos++
 		}
 
 		if len(line) == 0 || line[len(line)-1] != '\n' {

--- a/importer/v8/importer.go
+++ b/importer/v8/importer.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/influxdata/influxdb/client"
+	"github.com/influxdata/influxdb/models"
 	"github.com/influxdata/influxdb/services/httpd"
 )
 
@@ -176,17 +177,13 @@ func (i *Importer) processDDL(scanner *bufio.Reader) error {
 	}
 }
 
-func (i *Importer) processDML(scanner *bufio.Reader) error {
+func (i *Importer) processDML(reader *bufio.Reader) error {
 	i.startTime = time.Now()
-	for {
-		line, err := scanner.ReadString(byte('\n'))
-		if err != nil && err != io.EOF {
-			return err
-		} else if err == io.EOF && len(line) == 0 {
-			// Call batchWrite one last time to flush anything out in the batch
-			i.batchWrite()
-			return nil
-		}
+	scanner := bufio.NewScanner(reader)
+	scanner.Buffer(nil, maxLineProtocolRecordSize)
+	scanner.Split(models.ScanLine)
+	for scanner.Scan() {
+		line := scanner.Text()
 		if strings.HasPrefix(line, "# CONTEXT-DATABASE:") {
 			i.batchWrite()
 			i.database = strings.TrimSpace(strings.Split(line, ":")[1])
@@ -202,67 +199,13 @@ func (i *Importer) processDML(scanner *bufio.Reader) error {
 		if strings.TrimSpace(line) == "" {
 			continue
 		}
-		record, err := readLineProtocolRecord(scanner, line)
-		if err != nil {
-			return err
-		}
-		i.batchAccumulator(record)
+		i.batchAccumulator(line)
 	}
-}
-
-// Keep record framing aligned with models.scanLine.
-func readLineProtocolRecord(reader *bufio.Reader, line string) (string, error) {
-	var record strings.Builder
-	var fields, quoted bool
-	var equals, commas int
-
-	for {
-		if record.Len()+len(line) > maxLineProtocolRecordSize {
-			return "", fmt.Errorf("line protocol record exceeds %d byte limit", maxLineProtocolRecordSize)
-		}
-		record.WriteString(line)
-		for pos := 0; pos < len(line); {
-			if line[pos] == '\\' && pos+2 < len(line) {
-				pos += 2
-				continue
-			}
-			if line[pos] == ' ' {
-				fields = true
-			}
-			if fields {
-				if !quoted && line[pos] == '=' {
-					pos++
-					equals++
-					continue
-				} else if !quoted && line[pos] == ',' {
-					pos++
-					commas++
-					continue
-				} else if line[pos] == '"' && equals > commas {
-					pos++
-					quoted = !quoted
-					continue
-				}
-			}
-			if line[pos] == '\n' && !quoted {
-				return record.String(), nil
-			}
-			pos++
-		}
-
-		if len(line) == 0 || line[len(line)-1] != '\n' {
-			if quoted {
-				return "", fmt.Errorf("unbalanced quotes")
-			}
-			return record.String(), nil
-		}
-
-		var err error
-		line, err = reader.ReadString(byte('\n'))
-		if err != nil && err != io.EOF {
-			return "", err
-		}
+	if err := scanner.Err(); err != nil {
+		return err
 	}
+	i.batchWrite()
+	return nil
 }
 
 func (i *Importer) execute(command string) {

--- a/importer/v8/importer.go
+++ b/importer/v8/importer.go
@@ -179,6 +179,8 @@ func (i *Importer) processDDL(scanner *bufio.Reader) error {
 
 func (i *Importer) processDML(reader *bufio.Reader) error {
 	i.startTime = time.Now()
+	defer i.batchWrite()
+
 	scanner := bufio.NewScanner(reader)
 	scanner.Buffer(nil, maxLineProtocolRecordSize)
 	scanner.Split(models.ScanLine)
@@ -204,7 +206,6 @@ func (i *Importer) processDML(reader *bufio.Reader) error {
 	if err := scanner.Err(); err != nil {
 		return err
 	}
-	i.batchWrite()
 	return nil
 }
 

--- a/importer/v8/importer_test.go
+++ b/importer/v8/importer_test.go
@@ -1,6 +1,8 @@
 package v8
 
 import (
+	"bufio"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -10,7 +12,10 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"testing/iotest"
+	"time"
 
+	"github.com/influxdata/influxdb/client"
 	"github.com/influxdata/influxdb/models"
 	th "github.com/influxdata/influxdb/pkg/testing/helper"
 	"github.com/stretchr/testify/require"
@@ -39,6 +44,40 @@ lllll\slash`)
 
 func TestImporter_UnterminatedFinalPoint(t *testing.T) {
 	testImportRecords(t, []string{"test value=1i 1"}, false)
+}
+
+func TestImporter_FlushesBatchOnReadError(t *testing.T) {
+	var received string
+	var serverErr error
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			serverErr = err
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		received = string(body)
+		w.WriteHeader(http.StatusNoContent)
+	}))
+	t.Cleanup(server.Close)
+
+	serverURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+	config := NewConfig()
+	config.URL = *serverURL
+	importer := NewImporter(config)
+	importer.client, err = client.NewClient(config.Config)
+	require.NoError(t, err)
+	importer.lastWrite = time.Now()
+
+	readErr := errors.New("read failed")
+	reader := bufio.NewReader(io.MultiReader(
+		strings.NewReader("test value=1i 1\n"),
+		iotest.ErrReader(readErr),
+	))
+	require.ErrorIs(t, importer.processDML(reader), readErr)
+	require.NoError(t, serverErr)
+	require.Equal(t, "test value=1i 1", received)
 }
 
 func testImportRecords(t *testing.T, records []string, trailingNewline bool) {

--- a/importer/v8/importer_test.go
+++ b/importer/v8/importer_test.go
@@ -1,0 +1,118 @@
+package v8
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/influxdata/influxdb/models"
+)
+
+func TestImporter_MultilineFieldsAcrossBatchBoundary(t *testing.T) {
+	var (
+		mu             sync.Mutex
+		writeRequests  int
+		importedPoints int
+		parseErrors    []error
+	)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/ping":
+			w.WriteHeader(http.StatusNoContent)
+		case "/write":
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				t.Error(err)
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+
+			points, parseErr := models.ParsePoints(body)
+			mu.Lock()
+			writeRequests++
+			if parseErr != nil {
+				parseErrors = append(parseErrors, parseErr)
+			} else {
+				importedPoints += len(points)
+			}
+			mu.Unlock()
+
+			if parseErr != nil {
+				http.Error(w, "partial write: "+parseErr.Error(), http.StatusBadRequest)
+				return
+			}
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	input, err := os.CreateTemp(t.TempDir(), "multiline-import-*.lp")
+	if err != nil {
+		t.Fatal(err)
+	}
+	fmt.Fprintln(input, "# INFLUXDB EXPORT")
+	fmt.Fprintln(input, "# DDL")
+	fmt.Fprintln(input, "# DML")
+	fmt.Fprintln(input, "# CONTEXT-DATABASE:testdb")
+	fmt.Fprintln(input, "# CONTEXT-RETENTION-POLICY:default")
+	value := models.EscapeStringField(`aaaaaaaaaa
+bbbbbbbbbb
+cccccccccc
+dddddddddd
+eeeeeeeeee
+ffffffffff
+gggggggggg
+hhhhhhhhhh
+iiiiiiiiii
+jjjjjjjjjj
+kkkkk"quote
+lllll\slash`)
+	for n := range 501 {
+		fmt.Fprintf(input, "test,host=hosthost testvalue=\"%s\" %d\n", value, n)
+	}
+	if err := input.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	serverURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	config := NewConfig()
+	config.Path = input.Name()
+	config.URL = *serverURL
+
+	if err := NewImporter(config).Import(); err != nil {
+		mu.Lock()
+		defer mu.Unlock()
+		t.Fatalf("import failed: %v; write parse errors: %v", err, parseErrors)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if got, want := writeRequests, 1; got != want {
+		t.Fatalf("write request count: got %d, want %d", got, want)
+	}
+	if got, want := importedPoints, 501; got != want {
+		t.Fatalf("imported point count: got %d, want %d", got, want)
+	}
+}
+
+func TestReadLineProtocolRecord_UnbalancedQuote(t *testing.T) {
+	_, err := readLineProtocolRecord(
+		bufio.NewReader(strings.NewReader("continued")),
+		"test value=\"first line\n",
+	)
+	if err == nil || err.Error() != "unbalanced quotes" {
+		t.Fatalf("got %v, want unbalanced quotes", err)
+	}
+}

--- a/importer/v8/importer_test.go
+++ b/importer/v8/importer_test.go
@@ -116,3 +116,25 @@ func TestReadLineProtocolRecord_UnbalancedQuote(t *testing.T) {
 		t.Fatalf("got %v, want unbalanced quotes", err)
 	}
 }
+
+func TestReadLineProtocolRecord_TrailingBackslash(t *testing.T) {
+	reader := bufio.NewReader(strings.NewReader("next value=2\n"))
+	record, err := readLineProtocolRecord(reader, "test value=first\\\n")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := record, "test value=first\\\n"; got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestReadLineProtocolRecord_SizeLimit(t *testing.T) {
+	_, err := readLineProtocolRecord(
+		bufio.NewReader(strings.NewReader(strings.Repeat("x", maxLineProtocolRecordSize))),
+		"test value=\"first line\n",
+	)
+	want := fmt.Sprintf("line protocol record exceeds %d byte limit", maxLineProtocolRecordSize)
+	if err == nil || err.Error() != want {
+		t.Fatalf("got %v, want %s", err, want)
+	}
+}

--- a/importer/v8/importer_test.go
+++ b/importer/v8/importer_test.go
@@ -1,69 +1,22 @@
 package v8
 
 import (
-	"bufio"
 	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"os"
+	"path/filepath"
 	"strings"
-	"sync"
 	"testing"
 
 	"github.com/influxdata/influxdb/models"
+	th "github.com/influxdata/influxdb/pkg/testing/helper"
+	"github.com/stretchr/testify/require"
 )
 
 func TestImporter_MultilineFieldsAcrossBatchBoundary(t *testing.T) {
-	var (
-		mu             sync.Mutex
-		writeRequests  int
-		importedPoints int
-		parseErrors    []error
-	)
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		switch r.URL.Path {
-		case "/ping":
-			w.WriteHeader(http.StatusNoContent)
-		case "/write":
-			body, err := io.ReadAll(r.Body)
-			if err != nil {
-				t.Error(err)
-				w.WriteHeader(http.StatusInternalServerError)
-				return
-			}
-
-			points, parseErr := models.ParsePoints(body)
-			mu.Lock()
-			writeRequests++
-			if parseErr != nil {
-				parseErrors = append(parseErrors, parseErr)
-			} else {
-				importedPoints += len(points)
-			}
-			mu.Unlock()
-
-			if parseErr != nil {
-				http.Error(w, "partial write: "+parseErr.Error(), http.StatusBadRequest)
-				return
-			}
-			w.WriteHeader(http.StatusNoContent)
-		default:
-			http.NotFound(w, r)
-		}
-	}))
-	defer server.Close()
-
-	input, err := os.CreateTemp(t.TempDir(), "multiline-import-*.lp")
-	if err != nil {
-		t.Fatal(err)
-	}
-	fmt.Fprintln(input, "# INFLUXDB EXPORT")
-	fmt.Fprintln(input, "# DDL")
-	fmt.Fprintln(input, "# DML")
-	fmt.Fprintln(input, "# CONTEXT-DATABASE:testdb")
-	fmt.Fprintln(input, "# CONTEXT-RETENTION-POLICY:default")
 	value := models.EscapeStringField(`aaaaaaaaaa
 bbbbbbbbbb
 cccccccccc
@@ -76,65 +29,85 @@ iiiiiiiiii
 jjjjjjjjjj
 kkkkk"quote
 lllll\slash`)
-	for n := range 501 {
-		fmt.Fprintf(input, "test,host=hosthost testvalue=\"%s\" %d\n", value, n)
+	records := make([]string, 501)
+	for n := range records {
+		records[n] = fmt.Sprintf("test,host=hosthost testvalue=\"%s\" %d", value, n)
 	}
-	if err := input.Close(); err != nil {
-		t.Fatal(err)
+
+	testImportRecords(t, records, true)
+}
+
+func TestImporter_UnterminatedFinalPoint(t *testing.T) {
+	testImportRecords(t, []string{"test value=1i 1"}, false)
+}
+
+func testImportRecords(t *testing.T, records []string, trailingNewline bool) {
+	t.Helper()
+
+	var writeRequests int
+	var receivedPoints []string
+	var parseErrors, serverErrors []error
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/ping":
+			w.WriteHeader(http.StatusNoContent)
+		case "/write":
+			body, err := io.ReadAll(r.Body)
+			if err != nil {
+				serverErrors = append(serverErrors, err)
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+
+			points, parseErr := models.ParsePoints(body)
+			writeRequests++
+			if parseErr != nil {
+				parseErrors = append(parseErrors, parseErr)
+			} else {
+				for _, point := range points {
+					receivedPoints = append(receivedPoints, point.String())
+				}
+			}
+
+			if parseErr != nil {
+				http.Error(w, "partial write: "+parseErr.Error(), http.StatusBadRequest)
+				return
+			}
+			w.WriteHeader(http.StatusNoContent)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	var importContent strings.Builder
+	importContent.WriteString("# INFLUXDB EXPORT\n# DDL\n# DML\n")
+	importContent.WriteString("# CONTEXT-DATABASE:testdb\n")
+	importContent.WriteString("# CONTEXT-RETENTION-POLICY:default\n")
+	importContent.WriteString(strings.Join(records, "\n"))
+	if trailingNewline {
+		importContent.WriteByte('\n')
 	}
+
+	importPath := filepath.Join(t.TempDir(), "import.lp")
+	importFile, err := os.Create(importPath)
+	require.NoError(t, err)
+	closeImportFile := th.CheckedCloseOnce(t, importFile)
+	defer closeImportFile()
+	_, err = io.WriteString(importFile, importContent.String())
+	require.NoError(t, err)
+	closeImportFile()
 
 	serverURL, err := url.Parse(server.URL)
-	if err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, err)
 	config := NewConfig()
-	config.Path = input.Name()
+	config.Path = importPath
 	config.URL = *serverURL
 
-	if err := NewImporter(config).Import(); err != nil {
-		mu.Lock()
-		defer mu.Unlock()
-		t.Fatalf("import failed: %v; write parse errors: %v", err, parseErrors)
-	}
-
-	mu.Lock()
-	defer mu.Unlock()
-	if got, want := writeRequests, 1; got != want {
-		t.Fatalf("write request count: got %d, want %d", got, want)
-	}
-	if got, want := importedPoints, 501; got != want {
-		t.Fatalf("imported point count: got %d, want %d", got, want)
-	}
-}
-
-func TestReadLineProtocolRecord_UnbalancedQuote(t *testing.T) {
-	_, err := readLineProtocolRecord(
-		bufio.NewReader(strings.NewReader("continued")),
-		"test value=\"first line\n",
-	)
-	if err == nil || err.Error() != "unbalanced quotes" {
-		t.Fatalf("got %v, want unbalanced quotes", err)
-	}
-}
-
-func TestReadLineProtocolRecord_TrailingBackslash(t *testing.T) {
-	reader := bufio.NewReader(strings.NewReader("next value=2\n"))
-	record, err := readLineProtocolRecord(reader, "test value=first\\\n")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got, want := record, "test value=first\\\n"; got != want {
-		t.Fatalf("got %q, want %q", got, want)
-	}
-}
-
-func TestReadLineProtocolRecord_SizeLimit(t *testing.T) {
-	_, err := readLineProtocolRecord(
-		bufio.NewReader(strings.NewReader(strings.Repeat("x", maxLineProtocolRecordSize))),
-		"test value=\"first line\n",
-	)
-	want := fmt.Sprintf("line protocol record exceeds %d byte limit", maxLineProtocolRecordSize)
-	if err == nil || err.Error() != want {
-		t.Fatalf("got %v, want %s", err, want)
-	}
+	importErr := NewImporter(config).Import()
+	require.NoErrorf(t, importErr, "server errors: %v; write parse errors: %v", serverErrors, parseErrors)
+	require.Empty(t, serverErrors)
+	require.Empty(t, parseErrors)
+	require.Equal(t, 1, writeRequests)
+	require.Equal(t, records, receivedPoints)
 }

--- a/models/points.go
+++ b/models/points.go
@@ -1158,6 +1158,22 @@ func scanLine(buf []byte, i int) (int, []byte) {
 	return i, buf[start:i]
 }
 
+// ScanLine splits line protocol without breaking newlines inside quoted fields.
+func ScanLine(data []byte, atEOF bool) (advance int, token []byte, err error) {
+	if atEOF && len(data) == 0 {
+		return 0, nil, nil
+	}
+
+	end, line := scanLine(data, 0)
+	if end < len(data) {
+		return end + 1, line, nil
+	}
+	if atEOF {
+		return len(data), line, nil
+	}
+	return 0, nil, nil
+}
+
 // scanTo returns the end position in buf and the next consecutive block
 // of bytes, starting from i and ending with stop byte, where stop byte
 // has not been escaped.

--- a/models/points_test.go
+++ b/models/points_test.go
@@ -1,6 +1,7 @@
 package models_test
 
 import (
+	"bufio"
 	"bytes"
 	"errors"
 	"fmt"
@@ -1839,6 +1840,25 @@ func TestParsePointsWithPrecision(t *testing.T) {
 		if got != test.exp {
 			t.Errorf("%s: ParsePoint() to string mismatch:\n got %v\n exp %v", test.name, got, test.exp)
 		}
+	}
+}
+
+func TestScanLine(t *testing.T) {
+	input := "cpu value=\"first\nsecond\" 1\nmem value=2i 2"
+	scanner := bufio.NewScanner(strings.NewReader(input))
+	scanner.Split(models.ScanLine)
+
+	var got []string
+	for scanner.Scan() {
+		got = append(got, scanner.Text())
+	}
+	if err := scanner.Err(); err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{"cpu value=\"first\nsecond\" 1", "mem value=2i 2"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got %q, want %q", got, want)
 	}
 }
 

--- a/models/points_test.go
+++ b/models/points_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/influxdata/influxdb/models"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -1852,14 +1853,10 @@ func TestScanLine(t *testing.T) {
 	for scanner.Scan() {
 		got = append(got, scanner.Text())
 	}
-	if err := scanner.Err(); err != nil {
-		t.Fatal(err)
-	}
+	require.NoError(t, scanner.Err())
 
 	want := []string{"cpu value=\"first\nsecond\" 1", "mem value=2i 2"}
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("got %q, want %q", got, want)
-	}
+	require.Equal(t, want, got)
 }
 
 func TestParsePointsWithPrecisionNoTime(t *testing.T) {


### PR DESCRIPTION
`influx_inspect export` preserves literal newlines inside quoted string fields. `influx -import` counted those physical lines toward its 5,000-line batch, so a batch could end inside a field and fail to round trip with `unbalanced quotes`.

The importer now batches complete line-protocol records. Record framing uses `models.ScanLine` for quotes and escapes, rejects a single record above the server's default 25 MB request-body limit, and flushes valid records collected before a later read error.

Fixes https://github.com/influxdata/influxdb/issues/27589

## Testing

<details>
<summary>5,000-line red/green repro and package output</summary>

```console
Setup:
$ go build -o /tmp/influx-pkg-config github.com/influxdata/pkg-config

Before (afddccc2baec3ffc771cd1a120dbe8ace28f7bc2):
$ PKG_CONFIG=/tmp/influx-pkg-config go test ./importer/v8 -run '^TestImporter_MultilineFieldsAcrossBatchBoundary$' -count=1 -v
hhhhhhhhhh': unbalanced quotes
import failed: 6012 points were not inserted
--- FAIL: TestImporter_MultilineFieldsAcrossBatchBoundary (0.01s)
FAIL github.com/influxdata/influxdb/importer/v8 0.661s

After (2615fa1c145ed0affb433727b07ec82949e21d5a):
$ PKG_CONFIG=/tmp/influx-pkg-config go test ./importer/v8 -run '^TestImporter_(MultilineFieldsAcrossBatchBoundary|FlushesBatchOnReadError|UnterminatedFinalPoint)$' -count=1 -v
--- PASS: TestImporter_MultilineFieldsAcrossBatchBoundary (0.01s)
--- PASS: TestImporter_UnterminatedFinalPoint (0.00s)
--- PASS: TestImporter_FlushesBatchOnReadError (0.00s)
PASS
ok github.com/influxdata/influxdb/importer/v8 0.763s

$ PKG_CONFIG=/tmp/influx-pkg-config go test ./importer/v8 ./models -count=1
ok github.com/influxdata/influxdb/importer/v8 0.532s
ok github.com/influxdata/influxdb/models 2.293s

$ PKG_CONFIG=/tmp/influx-pkg-config go test -race ./importer/v8 -count=1
ok github.com/influxdata/influxdb/importer/v8 1.732s
```

</details>

###### Required for all non-trivial PRs
- [ ] Sign [CLA](https://influxdata.com/community/cla/) (if not already signed). The repository check reports this after PR creation.