### PR TITLE
fix(query): preserve last-write-wins across query plans

### DIFF
--- a/core/iox_query/src/lib.rs
+++ b/core/iox_query/src/lib.rs
@@ -23,6 +23,7 @@ use schema::{Projection, Schema, sort::SortKey};
 use std::{
     any::Any,
     fmt::Debug,
+    ops::RangeInclusive,
     sync::{Arc, LazyLock},
 };
 use trace::{ctx::SpanContext, span::Span};
@@ -100,6 +101,13 @@ pub trait QueryChunk: Debug + Send + Sync + 'static {
 
     /// Order of this chunk relative to other overlapping chunks.
     fn order(&self) -> ChunkOrder;
+
+    /// Inclusive row-order values for data emitted oldest-to-newest.
+    ///
+    /// Ranges must not overlap between chunks that can contain the same primary key.
+    fn row_order_range(&self) -> Option<RangeInclusive<i64>> {
+        None
+    }
 
     /// Return backend as [`Any`] which can be used to downcast to a specific implementation.
     fn as_any(&self) -> &dyn Any;

--- a/core/iox_query/src/provider/adapter.rs
+++ b/core/iox_query/src/provider/adapter.rs
@@ -1,11 +1,11 @@
 //! Holds a stream that ensures chunks have the same (uniform) schema
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, ops::RangeInclusive, sync::Arc};
 
 use snafu::Snafu;
 use std::task::{Context, Poll};
 
 use arrow::{
-    array::new_null_array,
+    array::{Int64Array, new_null_array},
     datatypes::{DataType, SchemaRef},
     record_batch::RecordBatch,
 };
@@ -123,10 +123,27 @@ impl SchemaAdapterStream {
     /// If the underlying stream produces columns that DO NOT appear
     /// in the output schema, or are different types than the output
     /// schema, an error will be produced.
+    #[cfg(test)]
     pub(crate) fn try_new(
         input: SendableRecordBatchStream,
         output_schema: SchemaRef,
         virtual_columns: &HashMap<&str, ScalarValue>,
+        baseline_metrics: BaselineMetrics,
+    ) -> Result<Self> {
+        Self::try_new_with_sequences(
+            input,
+            output_schema,
+            virtual_columns,
+            &Default::default(),
+            baseline_metrics,
+        )
+    }
+
+    pub(crate) fn try_new_with_sequences(
+        input: SendableRecordBatchStream,
+        output_schema: SchemaRef,
+        virtual_columns: &HashMap<&str, ScalarValue>,
+        virtual_sequences: &HashMap<&str, RangeInclusive<i64>>,
         baseline_metrics: BaselineMetrics,
     ) -> Result<Self> {
         // record this setup time
@@ -148,6 +165,11 @@ impl SchemaAdapterStream {
 
                 if let Some(input_field_index) = input_field_index {
                     ColumnMapping::FromInput(input_field_index)
+                } else if let Some(range) = virtual_sequences.get(output_field.name().as_str()) {
+                    ColumnMapping::Sequence {
+                        next: Some(*range.start()),
+                        end: *range.end(),
+                    }
                 } else if let Some(value) = virtual_columns.get(output_field.name().as_str()) {
                     ColumnMapping::Virtual(value.clone())
                 } else {
@@ -173,7 +195,9 @@ impl SchemaAdapterStream {
                         .fail();
                     }
 
-                    if virtual_columns.contains_key(input_field.name().as_str()) {
+                    if virtual_columns.contains_key(input_field.name().as_str())
+                        || virtual_sequences.contains_key(input_field.name().as_str())
+                    {
                         return InternalColumnBothInInputAndVirtualSnafu {
                             field_name: input_field.name().clone(),
                         }
@@ -200,6 +224,16 @@ impl SchemaAdapterStream {
                         .fail();
                     }
                 }
+                ColumnMapping::Sequence { .. } => {
+                    if output_field.data_type() != &DataType::Int64 {
+                        return InternalDataTypeMismatchForVirtualSnafu {
+                            field_type: DataType::Int64,
+                            output_field_name: output_field.name(),
+                            output_field_type: output_field.data_type().clone(),
+                        }
+                        .fail();
+                    }
+                }
             }
         }
 
@@ -213,16 +247,40 @@ impl SchemaAdapterStream {
     }
 
     /// Extends the record batch, if needed, so that it matches the schema
-    fn extend_batch(&self, batch: RecordBatch) -> Result<RecordBatch, DataFusionError> {
+    fn extend_batch(&mut self, batch: RecordBatch) -> Result<RecordBatch, DataFusionError> {
+        let row_count = i64::try_from(batch.num_rows()).map_err(|_| {
+            DataFusionError::Execution("record batch row count exceeds i64".to_string())
+        })?;
         let output_columns = self
             .mappings
-            .iter()
+            .iter_mut()
             .map(|mapping| match mapping {
                 ColumnMapping::FromInput(input_index) => Ok(Arc::clone(batch.column(*input_index))),
                 ColumnMapping::MakeNull(data_type) => {
                     Ok(new_null_array(data_type, batch.num_rows()))
                 }
                 ColumnMapping::Virtual(value) => value.to_array_of_size(batch.num_rows()),
+                ColumnMapping::Sequence { next, end } => {
+                    if row_count == 0 {
+                        return Ok(Arc::new(Int64Array::new_null(0)) as _);
+                    }
+                    let start = next.ok_or_else(|| {
+                        DataFusionError::Execution(
+                            "virtual sequence exceeds its declared range".to_string(),
+                        )
+                    })?;
+                    let batch_end = start.checked_add(row_count - 1).ok_or_else(|| {
+                        DataFusionError::Execution("virtual sequence exceeds i64".to_string())
+                    })?;
+                    if batch_end > *end {
+                        return Err(DataFusionError::Execution(
+                            "virtual sequence exceeds its declared range".to_string(),
+                        ));
+                    }
+                    let values = Int64Array::from_iter_values(start..=batch_end);
+                    *next = (batch_end < *end).then(|| batch_end + 1);
+                    Ok(Arc::new(values) as _)
+                }
             })
             .collect::<Result<Vec<_>, DataFusionError>>()?;
 
@@ -248,9 +306,12 @@ impl Stream for SchemaAdapterStream {
     ) -> Poll<Option<Self::Item>> {
         // the Poll result is an Opton<Result<Batch>> so we need a few
         // layers of maps to get at the actual batch, if any
-        let poll = self.input.as_mut().poll_next(ctx).map(|maybe_result| {
-            maybe_result.map(|batch| batch.and_then(|batch| self.extend_batch(batch)))
-        });
+        let poll = match self.input.as_mut().poll_next(ctx) {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(None) => Poll::Ready(None),
+            Poll::Ready(Some(Err(error))) => Poll::Ready(Some(Err(error))),
+            Poll::Ready(Some(Ok(batch))) => Poll::Ready(Some(self.extend_batch(batch))),
+        };
         self.baseline_metrics.record_poll(poll)
     }
 
@@ -268,6 +329,9 @@ enum ColumnMapping {
 
     /// Create virtual chunk column
     Virtual(ScalarValue),
+
+    /// Create a strictly increasing virtual column across input batches.
+    Sequence { next: Option<i64>, end: i64 },
 }
 
 #[cfg(test)]
@@ -282,7 +346,7 @@ mod tests {
     };
     use arrow_util::assert_batches_eq;
     use datafusion::physical_plan::{common::collect, metrics::ExecutionPlanMetricsSet};
-    use datafusion_util::stream_from_batch;
+    use datafusion_util::{stream_from_batch, stream_from_batches};
     use test_helpers::assert_contains;
 
     #[tokio::test]
@@ -310,6 +374,41 @@ mod tests {
             "| 2 | 5 | bar |",
             "| 3 | 6 | baz |",
             "+---+---+-----+",
+        ];
+        assert_batches_eq!(&expected, &output);
+    }
+
+    #[tokio::test]
+    async fn row_order_sequence_continues_across_batches() {
+        let batch = make_batch();
+        let input_stream =
+            stream_from_batches(batch.schema(), vec![batch.slice(0, 2), batch.slice(2, 1)]);
+        let output_schema = Arc::new(Schema::new(vec![
+            Field::new("a", DataType::Int32, false),
+            Field::new("b", DataType::Int32, false),
+            Field::new("c", DataType::Utf8, false),
+            Field::new("row_order", DataType::Int64, false),
+        ]));
+        let adapter_stream = SchemaAdapterStream::try_new_with_sequences(
+            input_stream,
+            output_schema,
+            &Default::default(),
+            &HashMap::from([("row_order", 10..=12)]),
+            BaselineMetrics::new(&ExecutionPlanMetricsSet::new(), 0),
+        )
+        .unwrap();
+
+        let output = collect(Box::pin(adapter_stream))
+            .await
+            .expect("Running plan");
+        let expected = vec![
+            "+---+---+-----+-----------+",
+            "| a | b | c   | row_order |",
+            "+---+---+-----+-----------+",
+            "| 1 | 4 | foo | 10        |",
+            "| 2 | 5 | bar | 11        |",
+            "| 3 | 6 | baz | 12        |",
+            "+---+---+-----+-----------+",
         ];
         assert_batches_eq!(&expected, &output);
     }

--- a/core/iox_query/src/provider/record_batch_exec.rs
+++ b/core/iox_query/src/provider/record_batch_exec.rs
@@ -210,10 +210,19 @@ impl ExecutionPlan for RecordBatchesExec {
                 )));
             }
         };
-        let virtual_columns = HashMap::from([(
-            CHUNK_ORDER_COLUMN_NAME,
-            ScalarValue::from(chunk.order().get()),
-        )]);
+        let row_order_range = chunk.row_order_range();
+        let virtual_columns = if row_order_range.is_none() {
+            HashMap::from([(
+                CHUNK_ORDER_COLUMN_NAME,
+                ScalarValue::from(chunk.order().get()),
+            )])
+        } else {
+            HashMap::new()
+        };
+        let virtual_sequences = row_order_range
+            .into_iter()
+            .map(|range| (CHUNK_ORDER_COLUMN_NAME, range))
+            .collect();
 
         // If these are ingester chunks, we want to decorate with the MetricDecorator
         // so we can accumulate ingester <=> querier metrics in the query log/system tables/etc.
@@ -229,8 +238,14 @@ impl ExecutionPlan for RecordBatchesExec {
         };
 
         let adapter = Box::pin(
-            SchemaAdapterStream::try_new(stream, schema, &virtual_columns, baseline_metrics)
-                .map_err(|e| DataFusionError::External(Box::new(e)))?,
+            SchemaAdapterStream::try_new_with_sequences(
+                stream,
+                schema,
+                &virtual_columns,
+                &virtual_sequences,
+                baseline_metrics,
+            )
+            .map_err(|e| DataFusionError::External(Box::new(e)))?,
         );
 
         trace!(partition, "End RecordBatchesExec::execute");

--- a/core/iox_query/src/statistics/aggregate_per_chunk.rs
+++ b/core/iox_query/src/statistics/aggregate_per_chunk.rs
@@ -202,8 +202,17 @@ pub fn build_statistics_for_chunks(
             agg.update(&chunk.stats(), chunk.schema().as_arrow().as_ref());
 
             if let Some(schema) = chunk_order_only_schema.as_ref() {
-                let order = chunk.order().get();
-                let order = ScalarValue::from(order);
+                let (min_order, max_order, distinct_count) =
+                    if let Some(range) = chunk.row_order_range() {
+                        (
+                            ScalarValue::from(*range.start()),
+                            ScalarValue::from(*range.end()),
+                            Precision::Absent,
+                        )
+                    } else {
+                        let order = ScalarValue::from(chunk.order().get());
+                        (order.clone(), order, Precision::Exact(1))
+                    };
 
                 agg.update(
                     &DFStatistics {
@@ -211,9 +220,9 @@ pub fn build_statistics_for_chunks(
                         total_byte_size: Precision::Exact(0),
                         column_statistics: vec![ColumnStatistics {
                             null_count: Precision::Exact(0),
-                            max_value: Precision::Exact(order.clone()),
-                            min_value: Precision::Exact(order),
-                            distinct_count: Precision::Exact(1),
+                            max_value: Precision::Exact(max_order),
+                            min_value: Precision::Exact(min_order),
+                            distinct_count,
                             sum_value: Precision::Absent,
                         }],
                     },
@@ -710,6 +719,35 @@ mod test {
 
         let parquet_stats = build_statistics_for_chunks(&[parquet_chunk], &schema);
         assert_eq!(parquet_stats.column_statistics, expected_stats);
+    }
+
+    #[test]
+    fn test_row_order_range_stats() {
+        let schema: SchemaRef = SchemaBuilder::new()
+            .timestamp()
+            .influx_field(CHUNK_ORDER_COLUMN_NAME, InfluxFieldType::Integer)
+            .build()
+            .unwrap()
+            .into();
+        let chunk = Arc::new(
+            TestChunk::new("t")
+                .with_time_column_with_stats(Some(10), Some(20))
+                .with_row_count(5)
+                .with_order(9)
+                .with_row_order_range(5, 9),
+        );
+
+        let stats = build_statistics_for_chunks(&[chunk], &schema);
+        assert_eq!(
+            stats.column_statistics[1],
+            ColumnStatistics {
+                null_count: Precision::Absent,
+                max_value: Precision::Exact(ScalarValue::Int64(Some(9))),
+                min_value: Precision::Exact(ScalarValue::Int64(Some(5))),
+                distinct_count: Precision::Absent,
+                sum_value: Precision::Absent,
+            }
+        );
     }
 
     #[test]

--- a/core/iox_query/src/test.rs
+++ b/core/iox_query/src/test.rs
@@ -51,6 +51,7 @@ use std::{
     collections::{BTreeMap, BTreeSet, HashMap},
     fmt::{self},
     num::NonZeroU64,
+    ops::RangeInclusive,
     sync::Arc,
 };
 use trace::{ctx::SpanContext, span::Span};
@@ -431,6 +432,8 @@ pub struct TestChunk {
     /// Order of this chunk relative to other overlapping chunks.
     order: ChunkOrder,
 
+    row_order_range: Option<RangeInclusive<i64>>,
+
     /// The sort key of this chunk
     sort_key: Option<SortKey>,
 
@@ -497,6 +500,7 @@ impl TestChunk {
             table_data: TestChunkData::RecordBatches(vec![]),
             saved_error: Default::default(),
             order: ChunkOrder::MIN,
+            row_order_range: None,
             sort_key: None,
             partition_id: PartitionHashId::arbitrary_for_testing(),
             quiet: false,
@@ -515,6 +519,13 @@ impl TestChunk {
     pub fn with_order(self, order: i64) -> Self {
         Self {
             order: ChunkOrder::new(order),
+            ..self
+        }
+    }
+
+    pub fn with_row_order_range(self, start: i64, end: i64) -> Self {
+        Self {
+            row_order_range: Some(start..=end),
             ..self
         }
     }
@@ -1228,6 +1239,10 @@ impl QueryChunk for TestChunk {
 
     fn order(&self) -> ChunkOrder {
         self.order
+    }
+
+    fn row_order_range(&self) -> Option<RangeInclusive<i64>> {
+        self.row_order_range.clone()
     }
 
     fn as_any(&self) -> &dyn Any {

--- a/influxdb3_query_executor/src/tests.rs
+++ b/influxdb3_query_executor/src/tests.rs
@@ -1,6 +1,6 @@
 use super::CreateQueryExecutorArgs;
 use crate::QueryExecutorImpl;
-use arrow::array::RecordBatch;
+use arrow::array::{Int64Array, RecordBatch};
 use datafusion::assert_batches_sorted_eq;
 use futures::TryStreamExt;
 use influxdb3_cache::{
@@ -29,6 +29,7 @@ use object_store::{ObjectStore, local::LocalFileSystem};
 use parquet_file::storage::{ParquetStorage, StorageId};
 use pretty_assertions::assert_eq;
 use std::collections::HashMap;
+use std::fmt::Write as _;
 use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::time::Duration;
@@ -63,6 +64,30 @@ pub(crate) fn make_exec(object_store: Arc<dyn ObjectStore>) -> Arc<Executor> {
 pub(crate) async fn setup(
     query_file_limit: Option<usize>,
     started_with_auth: bool,
+) -> (
+    Arc<dyn WriteBuffer>,
+    QueryExecutorImpl,
+    Arc<MockProvider>,
+    Arc<SysEventStore>,
+) {
+    setup_with_wal_config(
+        query_file_limit,
+        started_with_auth,
+        WalConfig {
+            gen1_duration: Gen1Duration::new_1m(),
+            max_write_buffer_size: 100,
+            flush_interval: Duration::from_millis(10),
+            snapshot_size: 1,
+            ..Default::default()
+        },
+    )
+    .await
+}
+
+async fn setup_with_wal_config(
+    query_file_limit: Option<usize>,
+    started_with_auth: bool,
+    wal_config: WalConfig,
 ) -> (
     Arc<dyn WriteBuffer>,
     QueryExecutorImpl,
@@ -111,13 +136,7 @@ pub(crate) async fn setup(
         .unwrap(),
         time_provider: Arc::<MockProvider>::clone(&time_provider),
         executor: Arc::clone(&exec),
-        wal_config: WalConfig {
-            gen1_duration: Gen1Duration::new_1m(),
-            max_write_buffer_size: 100,
-            flush_interval: Duration::from_millis(10),
-            snapshot_size: 1,
-            ..Default::default()
-        },
+        wal_config,
         parquet_cache: Some(parquet_cache),
         metric_registry: Default::default(),
         snapshotted_wal_files_to_keep: 1,
@@ -170,6 +189,225 @@ pub(crate) async fn setup(
         time_provider,
         sys_events_store,
     )
+}
+
+async fn query_count(query_executor: &QueryExecutorImpl, database: &str, query: &str) -> i64 {
+    let batches: Vec<RecordBatch> = query_executor
+        .query_sql(database, query, None, None, None)
+        .await
+        .unwrap()
+        .try_collect()
+        .await
+        .unwrap();
+    batches[0]
+        .column(0)
+        .as_any()
+        .downcast_ref::<Int64Array>()
+        .unwrap()
+        .value(0)
+}
+
+async fn assert_latest_counts(
+    query_executor: &QueryExecutorImpl,
+    database: &str,
+    component_a: i64,
+    component_b: i64,
+    run_id: &str,
+) {
+    let single_a = format!(
+        "SELECT count(*) FROM repro WHERE plant_id = 'REPRO01' \
+         AND component_id = 'RINV{component_a:02}' AND run_id = '{run_id}'"
+    );
+    let single_b = format!(
+        "SELECT count(*) FROM repro WHERE plant_id = 'REPRO01' \
+         AND component_id = 'RINV{component_b:02}' AND run_id = '{run_id}'"
+    );
+    let in_list = format!(
+        "SELECT count(*) FROM repro WHERE plant_id = 'REPRO01' \
+         AND component_id IN ('RINV{component_a:02}', 'RINV{component_b:02}') \
+         AND run_id = '{run_id}'"
+    );
+    let wide =
+        format!("SELECT count(*) FROM repro WHERE plant_id = 'REPRO01' AND run_id = '{run_id}'");
+    assert_eq!(query_count(query_executor, database, &single_a).await, 6);
+    assert_eq!(query_count(query_executor, database, &single_b).await, 6);
+    assert_eq!(query_count(query_executor, database, &in_list).await, 12);
+    assert_eq!(query_count(query_executor, database, &wide).await, 12);
+}
+
+#[test_log::test(tokio::test)]
+async fn overwrite_returns_latest_values_for_all_query_shapes() {
+    let wal_config = WalConfig {
+        gen1_duration: Gen1Duration::new_1m(),
+        max_write_buffer_size: 100,
+        flush_interval: Duration::from_millis(10),
+        snapshot_size: 6,
+        ..Default::default()
+    };
+    let (write_buffer, query_executor, _, _) = setup_with_wal_config(None, true, wal_config).await;
+    let database = "dedup";
+    let database_name = DatabaseName::new(database).unwrap();
+    let start = 1_677_628_800_i64;
+
+    let mut baseline = String::new();
+    for component in 1..=20 {
+        for point in 0..144 {
+            let timestamp = start + point * 600;
+            writeln!(
+                baseline,
+                "repro,plant_id=REPRO01,component_id=RINV{component:02} \
+                 value={},run_id=\"seed\" {timestamp}",
+                1_000.0 + ((component - 1) * 144 + point) as f64 * 0.001
+            )
+            .unwrap();
+        }
+    }
+
+    for generation in 0..4 {
+        let lines = baseline.replace("run_id=\"seed\"", &format!("run_id=\"seed-{generation}\""));
+        write_buffer
+            .write_lp(
+                database_name.clone(),
+                &lines,
+                Time::from_timestamp_nanos(0),
+                false,
+                influxdb3_write::Precision::Second,
+                false,
+            )
+            .await
+            .unwrap();
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+
+    let mut overwritten = Vec::new();
+    for trial in 0..4 {
+        let component_a = trial + 1;
+        let component_b = trial + 11;
+        let hour_start = start + (1 + 2 * trial) * 3_600;
+        let run_id = format!("overwrite-{trial}");
+        let mut lines = String::new();
+        for component in [component_a, component_b] {
+            for point in 0..6 {
+                let timestamp = hour_start + point * 600;
+                writeln!(
+                    lines,
+                    "repro,plant_id=REPRO01,component_id=RINV{component:02} \
+                     value={},run_id=\"{run_id}\" {timestamp}",
+                    2_000.0 + (component * 144 + point) as f64 * 0.001
+                )
+                .unwrap();
+            }
+        }
+        write_buffer
+            .write_lp(
+                database_name.clone(),
+                &lines,
+                Time::from_timestamp_nanos(0),
+                false,
+                influxdb3_write::Precision::Second,
+                false,
+            )
+            .await
+            .unwrap();
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        overwritten.push((component_a, component_b, run_id));
+    }
+
+    assert_eq!(
+        query_count(
+            &query_executor,
+            database,
+            "SELECT count(*) FROM system.parquet_files WHERE table_name = 'repro'",
+        )
+        .await,
+        0
+    );
+
+    for (component_a, component_b, run_id) in &overwritten {
+        assert_latest_counts(
+            &query_executor,
+            database,
+            *component_a,
+            *component_b,
+            run_id,
+        )
+        .await;
+    }
+
+    for filler in 0..4 {
+        write_buffer
+            .write_lp(
+                database_name.clone(),
+                &format!(
+                    "filler,id={filler} value={filler}i {}",
+                    start + 86_400 + filler
+                ),
+                Time::from_timestamp_nanos(0),
+                false,
+                influxdb3_write::Precision::Second,
+                false,
+            )
+            .await
+            .unwrap();
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+
+    let mut parquet_files = 0;
+    for _ in 0..500 {
+        parquet_files = query_count(
+            &query_executor,
+            database,
+            "SELECT count(*) FROM system.parquet_files WHERE table_name = 'repro'",
+        )
+        .await;
+        if parquet_files == 144 {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    assert_eq!(
+        parquet_files, 144,
+        "snapshot did not persist all repro data"
+    );
+
+    for (component_a, component_b, run_id) in &overwritten {
+        assert_latest_counts(
+            &query_executor,
+            database,
+            *component_a,
+            *component_b,
+            run_id,
+        )
+        .await;
+    }
+
+    let post_snapshot_run = "post-snapshot-overwrite";
+    let mut post_snapshot_lines = String::new();
+    for component in [1, 11] {
+        for point in 0..6 {
+            writeln!(
+                post_snapshot_lines,
+                "repro,plant_id=REPRO01,component_id=RINV{component:02} \
+                 value={},run_id=\"{post_snapshot_run}\" {}",
+                3_000.0 + (component * 144 + point) as f64 * 0.001,
+                start + 3_600 + point * 600
+            )
+            .unwrap();
+        }
+    }
+    write_buffer
+        .write_lp(
+            database_name,
+            &post_snapshot_lines,
+            Time::from_timestamp_nanos(0),
+            false,
+            influxdb3_write::Precision::Second,
+            false,
+        )
+        .await
+        .unwrap();
+    tokio::time::sleep(Duration::from_millis(20)).await;
+    assert_latest_counts(&query_executor, database, 1, 11, post_snapshot_run).await;
 }
 
 #[test_log::test(tokio::test)]

--- a/influxdb3_write/src/chunk.rs
+++ b/influxdb3_write/src/chunk.rs
@@ -57,6 +57,23 @@ impl QueryChunk for BufferChunk {
         self.chunk_order
     }
 
+    fn row_order_range(&self) -> Option<std::ops::RangeInclusive<i64>> {
+        let row_count = self
+            .batches
+            .iter()
+            .map(RecordBatch::num_rows)
+            .sum::<usize>();
+        if row_count == 0 {
+            return None;
+        }
+        let offset = i64::try_from(row_count - 1).expect("buffer row count must fit in i64");
+        let end = self.chunk_order.get();
+        let start = end
+            .checked_sub(offset)
+            .expect("buffer row-order range must fit in i64");
+        Some(start..=end)
+    }
+
     fn as_any(&self) -> &dyn Any {
         self
     }


### PR DESCRIPTION
Closes https://github.com/influxdata/influxdb/issues/27548

After a point was overwritten, equivalent SQL queries could disagree about which generation was current. In the reported workload, component-tag and `IN` reads returned all 12 corrected rows while a plant-wide read returned 6. A snapshot could then persist the stale half.

Buffered generations shared one `__chunk_order`, leaving equal sort keys with no recency tie-breaker. Buffer chunks now expose their append order as a row range. Deduplication sees a total order, so the latest fields win across query plans, WAL replay, snapshots, and mixed buffered/parquet reads.

## Testing

`cargo test --locked -p influxdb3_query_executor overwrite_returns_latest_values_for_all_query_shapes -- --nocapture`

<details>
<summary>Regression output</summary>

```text
Before (693b1fd1b96cdcb980cf76a1004c0b3f1b46db48):
Diff < left / right > :
<6
>12
test tests::overwrite_returns_latest_values_for_all_query_shapes ... FAILED

After:
test tests::overwrite_returns_latest_values_for_all_query_shapes ... ok
test result: ok. 1 passed; 0 failed
```

</details>

## Checks

- `cargo test --locked -p iox_query`
- `cargo test --locked -p influxdb3_write`
- `cargo clippy --locked --all-targets -p iox_query -p influxdb3_write -p influxdb3_query_executor -- -D warnings`
- `cargo fmt --all --check`

- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
