### PR TITLE
chore(sync): influxdb_pro 2026-08-28 (3.11)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,7 +444,7 @@ dependencies = [
 
 [[package]]
 name = "arrow_util"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -541,7 +541,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "authz"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -655,7 +655,7 @@ dependencies = [
 
 [[package]]
 name = "backoff"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "rand 0.9.4",
  "snafu 0.9.0",
@@ -1087,7 +1087,7 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "catalog_cache"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "bytes",
  "criterion 0.8.2",
@@ -1231,14 +1231,14 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli_types"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "tokio",
 ]
 
 [[package]]
 name = "client_util"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "http 1.4.2",
  "iox_http_util",
@@ -1841,7 +1841,7 @@ dependencies = [
 
 [[package]]
 name = "data_types"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -2575,7 +2575,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion_util"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -2670,7 +2670,7 @@ dependencies = [
 
 [[package]]
 name = "dml"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "arrow_util",
  "data_types",
@@ -2782,7 +2782,7 @@ dependencies = [
 
 [[package]]
 name = "error_reporting"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "datafusion",
  "snafu 0.9.0",
@@ -2812,7 +2812,7 @@ dependencies = [
 
 [[package]]
 name = "executor"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "futures",
  "metric",
@@ -2893,7 +2893,7 @@ dependencies = [
 
 [[package]]
 name = "flightsql"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -3100,7 +3100,7 @@ dependencies = [
 
 [[package]]
 name = "futures_test_utils"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "clap",
  "futures",
@@ -3111,7 +3111,7 @@ dependencies = [
 
 [[package]]
 name = "generated_types"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "bytes",
  "pbjson",
@@ -3765,7 +3765,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb2_client"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "bytes",
  "futures",
@@ -3784,7 +3784,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3879,7 +3879,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_authz"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "async-trait",
  "authz",
@@ -3897,7 +3897,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_cache"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3932,7 +3932,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_catalog"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "ahash 0.8.12",
  "anyhow",
@@ -3989,7 +3989,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_clap_blocks"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4026,7 +4026,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_client"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "bytes",
  "flate2",
@@ -4047,7 +4047,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_commands"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4075,7 +4075,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_id"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "criterion 0.5.1",
  "indexmap 2.14.0",
@@ -4087,7 +4087,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_internal_api"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4108,7 +4108,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_process"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "iox_time",
  "uuid",
@@ -4116,7 +4116,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_processing_engine"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -4164,7 +4164,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_processing_engine_telemetry"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "hashbrown 0.14.5",
  "influxdb3_catalog",
@@ -4174,7 +4174,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_py_api"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -4198,7 +4198,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_query_executor"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4249,7 +4249,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_server"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4336,7 +4336,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_shutdown"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "futures",
  "futures-util",
@@ -4351,14 +4351,14 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_startup"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "chrono",
 ]
 
 [[package]]
 name = "influxdb3_sys_events"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4377,7 +4377,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_system_tables"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4409,7 +4409,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_telemetry"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "futures",
  "futures-util",
@@ -4430,7 +4430,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_test_helpers"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4443,7 +4443,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_types"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4463,7 +4463,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_wal"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "async-trait",
  "bitcode",
@@ -4494,7 +4494,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_write"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4564,7 +4564,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb_influxql_parser"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "assert_matches",
  "chrono",
@@ -4581,7 +4581,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb_iox_client"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -4610,7 +4610,7 @@ dependencies = [
 
 [[package]]
 name = "ingester_query_grpc"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "base64 0.22.1",
  "data_types",
@@ -4676,7 +4676,7 @@ checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
 
 [[package]]
 name = "iox_http"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -4696,7 +4696,7 @@ dependencies = [
 
 [[package]]
 name = "iox_http_util"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "futures",
  "http 1.4.2",
@@ -4707,7 +4707,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "arrow",
  "arrow_util",
@@ -4756,7 +4756,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query_influxql"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "arrow",
  "assert_matches",
@@ -4783,7 +4783,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query_influxql_rewrite"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "influxdb_influxql_parser",
  "thiserror 2.0.18",
@@ -4791,7 +4791,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query_params"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "arrow",
  "assert_matches",
@@ -4805,7 +4805,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query_udf"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "datafusion-udf-wasm-host",
  "datafusion-udf-wasm-query",
@@ -4816,7 +4816,7 @@ dependencies = [
 
 [[package]]
 name = "iox_system_tables"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4826,7 +4826,7 @@ dependencies = [
 
 [[package]]
 name = "iox_time"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "chrono",
  "parking_lot",
@@ -4835,7 +4835,7 @@ dependencies = [
 
 [[package]]
 name = "iox_v1_query_api"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4949,7 +4949,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jemalloc_pprof_http"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "http-body-util",
  "hyper 1.11.0",
@@ -4962,7 +4962,7 @@ dependencies = [
 
 [[package]]
 name = "jemalloc_stats"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "futures",
  "snafu 0.9.0",
@@ -5155,7 +5155,7 @@ dependencies = [
 
 [[package]]
 name = "linear_buffer"
-version = "3.11.2"
+version = "3.11.3"
 
 [[package]]
 name = "linux-raw-sys"
@@ -5199,7 +5199,7 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "logfmt"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "humantime",
  "parking_lot",
@@ -5298,14 +5298,14 @@ dependencies = [
 
 [[package]]
 name = "metric"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "parking_lot",
 ]
 
 [[package]]
 name = "metric_exporters"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "metric",
  "mockito",
@@ -5430,7 +5430,7 @@ checksum = "9252111cf132ba0929b6f8e030cac2a24b507f3a4d6db6fb2896f27b354c714b"
 
 [[package]]
 name = "mutable_batch"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "arrow",
  "arrow_util",
@@ -5448,7 +5448,7 @@ dependencies = [
 
 [[package]]
 name = "mutable_batch_lp"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "arrow_util",
  "assert_matches",
@@ -5464,7 +5464,7 @@ dependencies = [
 
 [[package]]
 name = "mutable_batch_pb"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "arrow_util",
  "criterion 0.8.2",
@@ -5702,7 +5702,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_limit"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5714,7 +5714,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_mem_cache"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5742,7 +5742,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_metrics"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "async-trait",
  "bloom2",
@@ -5767,7 +5767,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_mock"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5781,7 +5781,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_size_hinting"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "chrono",
  "http 1.4.2",
@@ -5791,7 +5791,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_utils"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "async-trait",
  "backon",
@@ -5807,7 +5807,7 @@ dependencies = [
 
 [[package]]
 name = "observability_deps"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "tracing",
 ]
@@ -5881,7 +5881,7 @@ dependencies = [
 
 [[package]]
 name = "panic_logging"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "metric",
  "test_helpers",
@@ -5956,7 +5956,7 @@ dependencies = [
 
 [[package]]
 name = "parquet_file"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "arrow",
  "arrow_util",
@@ -5987,7 +5987,7 @@ dependencies = [
 
 [[package]]
 name = "partition"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "arrow",
  "assert_matches",
@@ -6284,7 +6284,7 @@ dependencies = [
 
 [[package]]
 name = "predicate"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6627,7 +6627,7 @@ dependencies = [
 
 [[package]]
 name = "query_functions"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "arrow",
  "chrono",
@@ -7337,7 +7337,7 @@ dependencies = [
 
 [[package]]
 name = "schema"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "arrow",
  "base64 0.22.1",
@@ -7521,7 +7521,7 @@ dependencies = [
 
 [[package]]
 name = "service_common"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -7535,7 +7535,7 @@ dependencies = [
 
 [[package]]
 name = "service_grpc_flight"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -7611,7 +7611,7 @@ dependencies = [
 
 [[package]]
 name = "sharder"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "criterion 0.8.2",
  "data_types",
@@ -8133,7 +8133,7 @@ dependencies = [
 
 [[package]]
 name = "table_batch"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "arrow_util",
  "bitvec",
@@ -8229,7 +8229,7 @@ dependencies = [
 
 [[package]]
 name = "test_helpers"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "async-trait",
  "dotenvy",
@@ -8248,7 +8248,7 @@ dependencies = [
 
 [[package]]
 name = "test_helpers_authz"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "futures",
  "generated_types",
@@ -8533,7 +8533,7 @@ dependencies = [
 
 [[package]]
 name = "tokio_metrics_bridge"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "metric",
  "parking_lot",
@@ -8542,7 +8542,7 @@ dependencies = [
 
 [[package]]
 name = "tokio_watchdog"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "metric",
  "test_helpers",
@@ -8765,7 +8765,7 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tower_trailer"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "futures",
  "http 1.4.2",
@@ -8777,7 +8777,7 @@ dependencies = [
 
 [[package]]
 name = "trace"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "chrono",
  "parking_lot",
@@ -8787,7 +8787,7 @@ dependencies = [
 
 [[package]]
 name = "trace_exporters"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8804,7 +8804,7 @@ dependencies = [
 
 [[package]]
 name = "trace_http"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "bytes",
  "futures",
@@ -8899,7 +8899,7 @@ dependencies = [
 
 [[package]]
 name = "tracker"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "futures",
  "hashbrown 0.14.5",
@@ -8919,7 +8919,7 @@ dependencies = [
 
 [[package]]
 name = "trogging"
-version = "3.11.2"
+version = "3.11.3"
 dependencies = [
  "clap",
  "logfmt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,7 +127,7 @@ exclude = [
 #
 # For porting to the actual OSS repo (influxdb), this would need to change to `-nightly`, i.e., by
 # stripping the `-oss`.
-version = "3.11.2"
+version = "3.11.3"
 authors = ["InfluxData OSS Developers"]
 edition = "2024"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Source: 0ecc60e2e5031d769650b7277b585a7324f91f9c

Commits:
- `0ecc60e2e5` chore: bump version to 3.11.3 (influxdata/influxdb_pro#5503)

Co-authored-by: Joe-Blount <73478756+Joe-Blount@users.noreply.github.com>