### PR TITLE
fix: use nanoseconds for table index cache access times

### DIFF
--- a/influxdb3_write/src/table_index_cache.rs
+++ b/influxdb3_write/src/table_index_cache.rs
@@ -159,13 +159,13 @@ impl CachedTableIndex {
     async fn touch(&self) {
         let now = Instant::now();
         let last_accessed = now.duration_since(*TABLE_INDEX_CACHE_START_TIME);
-        let last_accessed = last_accessed.as_millis() as u64;
+        let last_accessed = last_accessed.as_nanos() as u64;
         self.inner
             .last_access_time_since_start_ns
             .store(last_accessed, Ordering::Relaxed);
     }
 
-    // Returns the length of time (ms) that this entry has been in the cache without being accessed.
+    // Returns the length of time (ns) that this entry has been in the cache without being accessed.
     //
     // We return this value to make code using this method less confusing when sorting.
     //
@@ -1073,7 +1073,10 @@ impl TableIndexCache {
         entries.sort_unstable_by_key(|(_, time)| *time);
 
         // Get the oldest entry's stale duration for logging
-        let oldest_stale_duration_ms = entries.last().map(|(_, duration)| *duration).unwrap_or(0);
+        let oldest_stale_duration_ms = entries
+            .last()
+            .map(|(_, duration)| duration / 1_000_000)
+            .unwrap_or(0);
 
         let to_remove: HashSet<_> = entries
             .into_iter()

--- a/influxdb3_write/src/table_index_cache/tests.rs
+++ b/influxdb3_write/src/table_index_cache/tests.rs
@@ -184,9 +184,9 @@ mod cache_operations {
             TestStep::ExpectCacheMiss { table_id: TableIndexId::new("node1", DbId::new(1), TableId::new(3)) },
             TestStep::CacheOpGet { table_id: TableIndexId::new("node1", DbId::new(1), TableId::new(3)) }, // Should evict table 2
             TestStep::ExpectCacheSize { count: 2 }, // Still 2, but table 2 was evicted
-            TestStep::ExpectCached { table_id: TableIndexId::new("node1", DbId::new(1), TableId::new(1)), expected: false }, // Table 1 should still be cached
+            TestStep::ExpectCached { table_id: TableIndexId::new("node1", DbId::new(1), TableId::new(1)), expected: true }, // Table 1 should still be cached
             TestStep::ExpectCached { table_id: TableIndexId::new("node1", DbId::new(1), TableId::new(3)), expected: true }, // Table 3 should be cached
-            TestStep::ExpectCached { table_id: TableIndexId::new("node1", DbId::new(1), TableId::new(2)), expected: true }, // Table 2 should be evicted
+            TestStep::ExpectCached { table_id: TableIndexId::new("node1", DbId::new(1), TableId::new(2)), expected: false }, // Table 2 should be evicted
         ],
     })]
     #[case::clear_operation(CacheTestCase {


### PR DESCRIPTION
Closes #

`CachedTableIndex::new()` initializes `last_access_time_since_start_ns` in nanoseconds, and `stale_duration_ns()` reads it as nanoseconds. However, `CachedTableIndex::touch()` stored the updated access time in milliseconds.

This caused recently accessed entries to appear significantly older than they were and could evict them before less recently used entries.



This change:

- stores touched access times in nanoseconds;
- updates the existing LRU eviction regression expectations so the recently accessed entry remains cached;
- converts the oldest stale duration to milliseconds before recording it in `oldest_evicted_stale_duration_ms`.




- [x] I've read the contributing section of the project [README](https://github.com/influxdata/influxdb/blob/main/README.md).
- [x] Signed [CLA](https://influxdata.com/community/cla/) (if not already signed).
