### PR TITLE
chore(ci): add republish workflow for re-publishing a release tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,45 @@ parameters:
     type: string
     default: build
 
+  release-ref:
+    # Republish support. Set this to an existing release tag (e.g. "v1.13.0")
+    # together with 'workflow: republish' to rebuild and publish that tag using
+    # the CI configuration on the branch the pipeline is triggered from. Every
+    # job checks the tag out before building, so the artifacts are built from
+    # the tagged source even though the pipeline itself is branch triggered.
+    #
+    # Leave empty for normal tag, push and nightly builds.
+    type: string
+    default: ""
+
+commands:
+  checkout_source:
+    description: |
+      Check out the source to build: the ref that triggered the pipeline, or
+      the release-ref tag when one was supplied.
+    steps:
+      - checkout
+      - run:
+          name: Select source ref
+          command: |
+            REF='<< pipeline.parameters.release-ref >>'
+            if [ -z "${REF}" ] ; then
+              exit 0
+            fi
+            # This parameter names both the ref that gets built and the R2
+            # directory that gets published to, and it can be supplied straight
+            # from the CircleCI UI without going through releng/republish, so
+            # constrain it here too. Same expression as 'release_filter'.
+            if ! echo "${REF}" | grep -Eq '^v[0-9]+(\.[0-9]+)?(\.[0-9]+)?$' ; then
+              echo "release-ref '${REF}' is not a release tag" >&2
+              exit 1
+            fi
+            # CircleCI's checkout only fetches the triggering ref, so the tag
+            # is not guaranteed to be present in the clone.
+            git fetch --force --tags origin
+            git checkout --detach "refs/tags/${REF}"
+            git --no-pager log -1 --format='republishing %H (%s)'
+
 jobs:
   build_binaries:
     docker:
@@ -17,7 +56,7 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp/workspace
-      - checkout
+      - checkout_source
       - restore_cache:
           keys:
             # We save the cache from this one, so don't restore a cache with old junk and then save new stuff alongside.
@@ -26,7 +65,26 @@ jobs:
       - run:
           name: Get InfluxDB Version
           command: |
+            # After checkout_source, HEAD is the release tag, so get-version
+            # derives VERSION from it exactly as it does on a tag build.
             PREFIX=1.x .circleci/scripts/get-version
+
+            # A republish is triggered from a branch, so CIRCLE_SHA1 and
+            # CIRCLE_BRANCH describe that branch rather than the release. Stamp
+            # the binaries with the tagged commit and an empty branch, which is
+            # what a tag triggered pipeline produces.
+            #
+            # CIRCLE_TAG is exported for consistency, so that anything added to
+            # this job later sees the value a tag build would have set. BASH_ENV
+            # is per job, so it does not carry to build_packages, sign_packages
+            # or the publish jobs; those resolve it themselves.
+            if [ -n '<< pipeline.parameters.release-ref >>' ] ; then
+              {
+                printf 'export CIRCLE_SHA1=%s\n' "$(git rev-parse HEAD)"
+                printf 'export CIRCLE_TAG=%s\n'  '<< pipeline.parameters.release-ref >>'
+                printf 'export CIRCLE_BRANCH=\n'
+              } >>"${BASH_ENV}"
+            fi
       - run:
           name: Build source tarball
           command: |
@@ -194,10 +252,14 @@ jobs:
           username: _json_key
           password: $CISUPPORT_GCS_AUTHORIZATION
     steps:
-      - checkout
+      - checkout_source
       - attach_workspace:
           at: /tmp/workspace
       - run: |
+          # .circleci/packages/config.yaml derives the package version from
+          # CIRCLE_TAG, which is unset on a branch triggered republish.
+          export CIRCLE_TAG="${CIRCLE_TAG:-<< pipeline.parameters.release-ref >>}"
+
           ( cd man ; make build ; gzip -9 ./*.1 )
 
           packager .circleci/packages/config.yaml
@@ -222,6 +284,10 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
       - run: |
+          # Names the digests file below. Unset on a branch triggered republish,
+          # where it would silently produce "influxdb..digests".
+          export CIRCLE_TAG="${CIRCLE_TAG:-<< pipeline.parameters.release-ref >>}"
+
           for target in /tmp/workspace/packages/*
           do
             case "${target}"
@@ -260,7 +326,7 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp/workspace
-      - checkout
+      - checkout_source
       - run:
           name: Test 64 bit packages install
           command: |
@@ -281,7 +347,7 @@ jobs:
     steps:
       - attach_workspace:
           at: /tmp/workspace
-      - checkout
+      - checkout_source
       - run: ./checkfmt.sh
       - run: ./generate.sh
       - run: go vet ./...
@@ -301,7 +367,7 @@ jobs:
       INFLUXDB_DATA_INDEX_VERSION: << parameters.data >>
       GORACE: halt_on_error=1
     steps:
-      - checkout
+      - checkout_source
       - restore_cache:
           keys:
             - influxdb-cache-v2-{{ checksum "go.mod" }}
@@ -357,7 +423,7 @@ jobs:
     docker:
       - image: quay.io/influxdb/cross-builder:<< pipeline.parameters.cross-container-tag >>
     steps:
-      - checkout
+      - checkout_source
       - run:
           name: Execute test
           command: ./test-flux.sh || exit 1
@@ -367,7 +433,7 @@ jobs:
     docker:
       - image: quay.io/influxdb/changelogger:d7093c409adedd8837ef51fa84be0d0f8319177a
     steps:
-      - checkout
+      - checkout_source
       - run:
           name: Generate Changelog
           command: |
@@ -403,9 +469,14 @@ jobs:
             - run:
                 name: Upload CHANGELOG to R2
                 command: |
+                  TAG="${CIRCLE_TAG:-<< pipeline.parameters.release-ref >>}"
+                  if [ -z "${TAG}" ] ; then
+                    echo 'no release tag resolved; refusing to upload' >&2
+                    exit 1
+                  fi
                   export AWS_ACCESS_KEY_ID="${RELEASE_AWS_ACCESS_KEY_ID}"
                   export AWS_SECRET_ACCESS_KEY="${RELEASE_AWS_SECRET_ACCESS_KEY}"
-                  aws s3 cp /tmp/workspace/changelog_artifacts/CHANGELOG.md "s3://dl-influxdata-com/influxdb/releases/<< pipeline.git.tag >>/CHANGELOG.<< pipeline.git.tag >>.md" \
+                  aws s3 cp /tmp/workspace/changelog_artifacts/CHANGELOG.md "s3://dl-influxdata-com/influxdb/releases/${TAG}/CHANGELOG.${TAG}.md" \
                     --endpoint-url "${AWS_ENDPOINT_URL_S3}" \
                     --region auto
       - when:
@@ -438,9 +509,16 @@ jobs:
       - run:
           name: Upload packages to R2
           command: |
+            TAG="${CIRCLE_TAG:-<< pipeline.parameters.release-ref >>}"
+            # An empty tag would sync every package into the top of
+            # influxdb/releases/, so fail closed rather than make a mess.
+            if [ -z "${TAG}" ] ; then
+              echo 'no release tag resolved; refusing to sync' >&2
+              exit 1
+            fi
             export AWS_ACCESS_KEY_ID="${RELEASE_AWS_ACCESS_KEY_ID}"
             export AWS_SECRET_ACCESS_KEY="${RELEASE_AWS_SECRET_ACCESS_KEY}"
-            aws s3 sync /tmp/workspace/packages "s3://dl-influxdata-com/influxdb/releases/<< pipeline.git.tag >>" \
+            aws s3 sync /tmp/workspace/packages "s3://dl-influxdata-com/influxdb/releases/${TAG}" \
               --endpoint-url "${AWS_ENDPOINT_URL_S3}" \
               --region auto
   slack:
@@ -453,7 +531,9 @@ jobs:
       - attach_workspace:
           at: /tmp/workspace
       - run:
-          command: slack
+          command: |
+            export CIRCLE_TAG="${CIRCLE_TAG:-<< pipeline.parameters.release-ref >>}"
+            slack
           environment:
             SLACK_ARTIFACT_URL:         https://dl.influxdata.com/influxdb/releases
             SLACK_ARTIFACT_ROOT:        /tmp/workspace/packages
@@ -473,6 +553,8 @@ release_filter: &release_filter
 
 workflows:
   version: 2.1
+  # Mirrored by the 'republish' workflow below. A job added here, or a
+  # dependency changed here, needs the same change there.
   release:
     when:
       equal: [ << pipeline.parameters.workflow >>, build ]
@@ -522,6 +604,73 @@ workflows:
           <<: *release_filter
           name: unit_test_race
           race: true
+  # Rebuilds and publishes an already-cut release tag whose original release
+  # pipeline failed after build_packages. Trigger it against a branch that
+  # carries a working publish configuration:
+  #
+  #   curl -X POST \
+  #     https://circleci.com/api/v2/project/gh/influxdata/influxdb/pipeline \
+  #     -H "Circle-Token: ${CIRCLE_TOKEN}" \
+  #     -H 'Content-Type: application/json' \
+  #     -d '{"branch":"1.13","parameters":{"workflow":"republish","release-ref":"v1.13.0"}}'
+  #
+  # The source is built from release-ref, not from the branch, so the only
+  # difference from the original release build is the CI configuration.
+  #
+  # This workflow mirrors 'release' job for job, and the only intended
+  # difference is the hold_publish approval gate. Keep the two in step: the
+  # test jobs are leaf nodes here exactly as they are in 'release', and if
+  # publishing is ever gated on them it needs gating in both.
+  republish:
+    when:
+      equal: [ << pipeline.parameters.workflow >>, republish ]
+    jobs:
+      - build_binaries
+      - build_packages:
+          requires:
+            - build_binaries
+      - sign_packages:
+          requires:
+            - build_packages
+      - test_pkgs_64bit:
+          requires:
+            - build_packages
+      - changelog
+      # One gate covering both publish paths. A changelog is published
+      # whenever packages are, so neither should go out without the other and
+      # a single approval covers both.
+      #
+      # This couples publish_packages to changelog, which 'release' does not
+      # do: there, a failed changelog job still lets packages publish without
+      # one. That is a gap in 'release' rather than a deliberate difference
+      # here, and belongs in the same fix as the ungated test jobs.
+      - hold_publish:
+          type: approval
+          requires:
+            - sign_packages
+            - changelog
+      - publish_packages:
+          requires:
+            - hold_publish
+      - publish_changelog:
+          workflow: release
+          requires:
+            - hold_publish
+      - slack:
+          requires:
+            - publish_packages
+      - static_code_checks
+      - fluxtest
+      - unit_test:
+          name: unit_test_inmem
+          data: inmem
+      - unit_test:
+          name: unit_test_tsi1
+          data: tsi1
+      - unit_test:
+          name: unit_test_race
+          race: true
+
   on_push:
     when:
       equal: [ << pipeline.parameters.workflow >>, build ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,9 +13,18 @@ parameters:
   release-ref:
     # Republish support. Set this to an existing release tag (e.g. "v1.13.0")
     # together with 'workflow: republish' to rebuild and publish that tag using
-    # the CI configuration on the branch the pipeline is triggered from. Every
+    # this file as it stands on the branch the pipeline is triggered from. Every
     # job checks the tag out before building, so the artifacts are built from
     # the tagged source even though the pipeline itself is branch triggered.
+    #
+    # That cuts both ways, and only this file comes from the branch: CircleCI
+    # reads config.yml from the triggering ref, but checkout_source then
+    # detaches to the tag, so every file a job reads off disk is the tag's --
+    # .circleci/scripts/get-version, .circleci/packages/,
+    # releng/packages/spec/ and scripts/ci/CHANGELOG_frozen.md. Only the
+    # commands written inline here carry a branch fix. If a release failed
+    # because of a bug in one of those, republishing re-runs the broken tagged
+    # copy; that needs a new tag instead.
     #
     # Leave empty for normal tag, push and nightly builds.
     type: string
@@ -707,7 +716,9 @@ workflows:
   #     -d '{"branch":"1.13","parameters":{"workflow":"republish","release-ref":"v1.13.0"}}'
   #
   # The source is built from release-ref, not from the branch, so the only
-  # difference from the original release build is the CI configuration.
+  # difference from the original release build is this file. Every other file
+  # the jobs read comes from the tag, including the scripts this one invokes;
+  # see the release-ref parameter for what that rules out.
   #
   # This workflow mirrors 'release' job for job, with two intended
   # differences: the hold_publish approval gate, and check_release_tag, which

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,8 +40,10 @@ commands:
             # This parameter names both the ref that gets built and the R2
             # directory that gets published to, and it can be supplied straight
             # from the CircleCI UI without going through releng/republish, so
-            # constrain it here too. Same expression as 'release_filter'.
-            if ! echo "${REF}" | grep -Eq '^v[0-9]+(\.[0-9]+)?(\.[0-9]+)?$' ; then
+            # constrain it here too. Major, minor and patch are all required,
+            # matching .circleci/scripts/get-version: a tag it does not match
+            # produces a "1.x-<short sha>" version instead of a release one.
+            if ! echo "${REF}" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$' ; then
               echo "release-ref '${REF}' is not a release tag" >&2
               exit 1
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -85,10 +85,24 @@ jobs:
             # is per job, so it does not carry to build_packages, sign_packages
             # or the publish jobs; those resolve it themselves.
             if [ -n "${RELEASE_REF}" ] ; then
+              # VERSION is re-derived from the requested tag rather than left to
+              # get-version, which picks the *highest* release tag pointing at
+              # HEAD. That is right for a tag build but wrong here: republishing
+              # v1.9.0 from a commit also tagged v1.9.1 would stamp 1.9.1 into
+              # binaries that the packager names 1.9.0, because the packager
+              # reads CIRCLE_TAG. On a republish the requested tag is
+              # authoritative. check_release_tag reports the situation.
+              version="${RELEASE_REF#v}"
+              rest="${version#*.}"
               {
                 printf 'export CIRCLE_SHA1=%s\n' "$(git rev-parse HEAD)"
                 printf 'export CIRCLE_TAG=%s\n'  "${RELEASE_REF}"
                 printf 'export CIRCLE_BRANCH=\n'
+                printf 'export VERSION=%s\n'     "${version}"
+                printf 'export MAJOR=%s\n'       "${version%%.*}"
+                printf 'export MINOR=%s\n'       "${rest%%.*}"
+                printf 'export PATCH=%s\n'       "${rest#*.}"
+                printf 'export RELEASE=1\n'
               } >>"${BASH_ENV}"
             fi
       - run:
@@ -441,6 +455,49 @@ jobs:
           command: ./test-flux.sh || exit 1
           no_output_timeout: 1500s
 
+  check_release_tag:
+    docker:
+      - image: cimg/base:current
+    steps:
+      - checkout_source
+      - run:
+          name: Check for sibling release tags
+          environment:
+            RELEASE_REF: << pipeline.parameters.release-ref >>
+          command: |
+            if [ -z "${RELEASE_REF}" ] ; then
+              echo 'no release-ref; nothing to check'
+              exit 0
+            fi
+
+            # A commit carrying more than one release tag usually means the
+            # newer tag supersedes the older, so republishing the older one is
+            # rarely what was intended. build_binaries pins VERSION from
+            # release-ref so the artifacts are at least self consistent; this
+            # job exists to put the situation in front of whoever approves
+            # hold_publish. It is a leaf: nothing requires it, so a failure
+            # here reports without blocking.
+            siblings=''
+            for tag in $(git tag --points-at HEAD)
+            do
+              [ "${tag}" = "${RELEASE_REF}" ] && continue
+              echo "${tag}" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$' || continue
+              siblings="${siblings} ${tag}"
+            done
+
+            if [ -n "${siblings}" ] ; then
+              echo "The commit behind ${RELEASE_REF} also carries:${siblings}"
+              echo
+              echo "Republishing ${RELEASE_REF} will publish artifacts that a"
+              echo "newer tag on the same commit supersedes. If that is"
+              echo "intended, approve hold_publish as usual; this job does not"
+              echo "block it. If not, cancel the workflow and republish the"
+              echo "newer tag instead."
+              exit 1
+            fi
+
+            echo "${RELEASE_REF} is the only release tag on this commit"
+
   changelog:
     docker:
       - image: quay.io/influxdb/changelogger:d7093c409adedd8837ef51fa84be0d0f8319177a
@@ -634,8 +691,10 @@ workflows:
   # The source is built from release-ref, not from the branch, so the only
   # difference from the original release build is the CI configuration.
   #
-  # This workflow mirrors 'release' job for job, and the only intended
-  # difference is the hold_publish approval gate. Keep the two in step: the
+  # This workflow mirrors 'release' job for job, with two intended
+  # differences: the hold_publish approval gate, and check_release_tag, which
+  # only means anything when release-ref selects a tag and so has no place in
+  # 'release'. Keep the two in step: the
   # test jobs are leaf nodes here exactly as they are in 'release', and if
   # publishing is ever gated on them it needs gating in both.
   republish:
@@ -653,6 +712,7 @@ workflows:
           requires:
             - build_packages
       - changelog
+      - check_release_tag
       # One gate covering both publish paths. A changelog is published
       # whenever packages are, so neither should go out without the other and
       # a single approval covers both.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,8 +30,10 @@ commands:
       - checkout
       - run:
           name: Select source ref
+          environment:
+            RELEASE_REF: << pipeline.parameters.release-ref >>
           command: |
-            REF='<< pipeline.parameters.release-ref >>'
+            REF="${RELEASE_REF}"
             if [ -z "${REF}" ] ; then
               exit 0
             fi
@@ -64,6 +66,8 @@ jobs:
             - influxdb-cache-v2-{{ checksum "go.mod" }}
       - run:
           name: Get InfluxDB Version
+          environment:
+            RELEASE_REF: << pipeline.parameters.release-ref >>
           command: |
             # After checkout_source, HEAD is the release tag, so get-version
             # derives VERSION from it exactly as it does on a tag build.
@@ -78,10 +82,10 @@ jobs:
             # this job later sees the value a tag build would have set. BASH_ENV
             # is per job, so it does not carry to build_packages, sign_packages
             # or the publish jobs; those resolve it themselves.
-            if [ -n '<< pipeline.parameters.release-ref >>' ] ; then
+            if [ -n "${RELEASE_REF}" ] ; then
               {
                 printf 'export CIRCLE_SHA1=%s\n' "$(git rev-parse HEAD)"
-                printf 'export CIRCLE_TAG=%s\n'  '<< pipeline.parameters.release-ref >>'
+                printf 'export CIRCLE_TAG=%s\n'  "${RELEASE_REF}"
                 printf 'export CIRCLE_BRANCH=\n'
               } >>"${BASH_ENV}"
             fi
@@ -255,14 +259,17 @@ jobs:
       - checkout_source
       - attach_workspace:
           at: /tmp/workspace
-      - run: |
-          # .circleci/packages/config.yaml derives the package version from
-          # CIRCLE_TAG, which is unset on a branch triggered republish.
-          export CIRCLE_TAG="${CIRCLE_TAG:-<< pipeline.parameters.release-ref >>}"
+      - run:
+          environment:
+            RELEASE_REF: << pipeline.parameters.release-ref >>
+          command: |
+            # .circleci/packages/config.yaml derives the package version from
+            # CIRCLE_TAG, which is unset on a branch triggered republish.
+            export CIRCLE_TAG="${CIRCLE_TAG:-${RELEASE_REF}}"
 
-          ( cd man ; make build ; gzip -9 ./*.1 )
+            ( cd man ; make build ; gzip -9 ./*.1 )
 
-          packager .circleci/packages/config.yaml
+            packager .circleci/packages/config.yaml
       - persist_to_workspace:
           root: .
           paths:
@@ -283,34 +290,37 @@ jobs:
             - fc:7b:6e:a6:38:7c:63:5a:13:be:cb:bb:fa:33:b3:3c
       - attach_workspace:
           at: /tmp/workspace
-      - run: |
-          # Names the digests file below. Unset on a branch triggered republish,
-          # where it would silently produce "influxdb..digests".
-          export CIRCLE_TAG="${CIRCLE_TAG:-<< pipeline.parameters.release-ref >>}"
+      - run:
+          environment:
+            RELEASE_REF: << pipeline.parameters.release-ref >>
+          command: |
+            # Names the digests file below. Unset on a branch triggered republish,
+            # where it would silently produce "influxdb..digests".
+            export CIRCLE_TAG="${CIRCLE_TAG:-${RELEASE_REF}}"
 
-          for target in /tmp/workspace/packages/*
-          do
-            case "${target}"
-            in
-              # rsign is shipped on Alpine Linux which uses "busybox ash" instead
-              # of bash. ash is somewhat more posix compliant and is missing some
-              # extensions and niceties from bash.
-              *.deb|*.rpm|*.tar.gz|*.zip)
-                rsign "${target}"
-              ;;
-            esac
+            for target in /tmp/workspace/packages/*
+            do
+              case "${target}"
+              in
+                # rsign is shipped on Alpine Linux which uses "busybox ash" instead
+                # of bash. ash is somewhat more posix compliant and is missing some
+                # extensions and niceties from bash.
+                *.deb|*.rpm|*.tar.gz|*.zip)
+                  rsign "${target}"
+                ;;
+              esac
 
-            if [ -f "${target}" ]
-            then
-              # Since all artifacts are present, sign them here. This saves Circle
-              # credits over spinning up another instance just to separate out the
-              # checksum job.
-              sha256sum "${target}" >> "/tmp/workspace/packages/influxdb.${CIRCLE_TAG}.digests"
+              if [ -f "${target}" ]
+              then
+                # Since all artifacts are present, sign them here. This saves Circle
+                # credits over spinning up another instance just to separate out the
+                # checksum job.
+                sha256sum "${target}" >> "/tmp/workspace/packages/influxdb.${CIRCLE_TAG}.digests"
 
-              md5sum    "${target}" >"${target}.md5"
-              sha256sum "${target}" >"${target}.sha256"
-            fi
-          done
+                md5sum    "${target}" >"${target}.md5"
+                sha256sum "${target}" >"${target}.sha256"
+              fi
+            done
       - persist_to_workspace:
           root: /tmp/workspace
           paths:
@@ -468,8 +478,10 @@ jobs:
           steps:
             - run:
                 name: Upload CHANGELOG to R2
+                environment:
+                  RELEASE_REF: << pipeline.parameters.release-ref >>
                 command: |
-                  TAG="${CIRCLE_TAG:-<< pipeline.parameters.release-ref >>}"
+                  TAG="${CIRCLE_TAG:-${RELEASE_REF}}"
                   if [ -z "${TAG}" ] ; then
                     echo 'no release tag resolved; refusing to upload' >&2
                     exit 1
@@ -508,8 +520,10 @@ jobs:
             pip install awscli
       - run:
           name: Upload packages to R2
+          environment:
+            RELEASE_REF: << pipeline.parameters.release-ref >>
           command: |
-            TAG="${CIRCLE_TAG:-<< pipeline.parameters.release-ref >>}"
+            TAG="${CIRCLE_TAG:-${RELEASE_REF}}"
             # An empty tag would sync every package into the top of
             # influxdb/releases/, so fail closed rather than make a mess.
             if [ -z "${TAG}" ] ; then
@@ -532,9 +546,10 @@ jobs:
           at: /tmp/workspace
       - run:
           command: |
-            export CIRCLE_TAG="${CIRCLE_TAG:-<< pipeline.parameters.release-ref >>}"
+            export CIRCLE_TAG="${CIRCLE_TAG:-${RELEASE_REF}}"
             slack
           environment:
+            RELEASE_REF:                << pipeline.parameters.release-ref >>
             SLACK_ARTIFACT_URL:         https://dl.influxdata.com/influxdb/releases
             SLACK_ARTIFACT_ROOT:        /tmp/workspace/packages
             SLACK_ARTIFACT_EXCLUDE_DIR: race

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -505,7 +505,25 @@ jobs:
       - checkout_source
       - run:
           name: Generate Changelog
+          environment:
+            RELEASE_REF: << pipeline.parameters.release-ref >>
           command: |
+            # A republish is triggered from a branch, so CIRCLE_BRANCH and
+            # CIRCLE_SHA1 describe that branch rather than the release, and
+            # changelogger writes both into the CHANGELOG's first line. After
+            # checkout_source, HEAD is the release tag, so stamp the tagged
+            # commit and an empty branch, which is what a tag triggered
+            # pipeline produces. Everything below that line is generated from
+            # HEAD and so already matches.
+            #
+            # 'nightly' also runs this job, and leaves release-ref empty: its
+            # header names the nightly's branch, as it should.
+            if [ -n "${RELEASE_REF}" ] ; then
+              export CIRCLE_BRANCH=
+              CIRCLE_SHA1="$(git rev-parse HEAD)"
+              export CIRCLE_SHA1
+            fi
+
             PRODUCT=OSS changelogger
       - store_artifacts:
           path: changelog_artifacts/

--- a/releng/republish
+++ b/releng/republish
@@ -201,6 +201,27 @@ grep -Eq '^[[:space:]]*republish:' <<<"${branch_config}" ||
 grep -Eq '^[[:space:]]*release-ref:' <<<"${branch_config}" ||
   die "branch '${BRANCH}' has no 'release-ref' parameter in .circleci/config.yml"
 
+# A commit can carry more than one release tag; this repository has two such
+# commits. get-version selects the highest, so the pipeline pins VERSION from
+# the requested tag to keep the artifacts self consistent, and check_release_tag
+# reports the situation in the UI. Say so here too, because this is the point at
+# which it is cheapest to pick the other tag instead.
+siblings=''
+while IFS= read -r line
+do
+  [[ ${line} ]] || continue
+  [[ ${line%%$'\t'*} == "${COMMIT}" ]] || continue
+  ref="${line#*$'\t'}"
+  ref="${ref%^\{\}}"
+  sibling="${ref#refs/tags/}"
+  [[ ${sibling} == "${TAG}" ]] && continue
+  [[ ${sibling} =~ ${TAG_REGEX} ]] || continue
+  case " ${siblings} " in
+    *" ${sibling} "*) ;;
+    *) siblings="${siblings}${siblings:+ }${sibling}" ;;
+  esac
+done <<<"$(git ls-remote --tags "${REMOTE}")"
+
 ENDPOINT="https://circleci.com/api/v2/project/${PROJECT_SLUG}/pipeline"
 # cross-container-tag is omitted rather than sent empty, so that the branch's
 # own default applies. Sending "" would resolve to an image with an empty tag.
@@ -233,6 +254,17 @@ cat <<EOF
   publishes   s3://${R2_BUCKET}/influxdb/releases/${TAG}
 
 EOF
+
+if [[ ${siblings} ]]
+then
+  cat >&2 <<EOF
+  WARNING  this commit is also tagged: ${siblings}
+           ${TAG} is superseded by a newer tag on the same commit, so
+           republishing it will publish artifacts that tag replaced.
+           Republish the newer tag instead unless this is deliberate.
+
+EOF
+fi
 
 if (( DRY_RUN ))
 then

--- a/releng/republish
+++ b/releng/republish
@@ -1,0 +1,270 @@
+#!/bin/bash
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Republishing is only ever appropriate for a full release tag. Release
+# candidates are excluded by the release workflow's tag filter and are not
+# published under influxdb/releases, so they are rejected here too. This is
+# the same expression used by 'release_filter' in .circleci/config.yml.
+TAG_REGEX='^v[[:digit:]]+(\.[[:digit:]]+)?(\.[[:digit:]]+)?$'
+
+# The cross-container-tag parameter is interpolated into an "image:" line, not
+# into a shell command, so a bad value fails as an image pull rather than as
+# anything worse. Checked anyway, so that a typo is caught here instead of
+# several minutes into the pipeline. This is the OCI tag grammar.
+BUILDER_REGEX='^[A-Za-z0-9_][A-Za-z0-9._-]{0,127}$'
+
+PROJECT_VCS='github'
+PROJECT_ORG='influxdata'
+PROJECT_REPO='influxdb'
+PROJECT_SLUG="gh/${PROJECT_ORG}/${PROJECT_REPO}"
+R2_BUCKET='dl-influxdata-com'
+REMOTE='origin'
+
+# Branch supplying the CircleCI configuration. Derived from the tag unless -b
+# is given. The source that gets built comes from the tag, not from this
+# branch; only .circleci/config.yml is read from here.
+BRANCH=''
+
+# Cross builder image tag, overriding the branch's default. Empty means "use
+# whatever the branch config defaults to", which is the floating
+# 'go<version>-latest' tag. Republishing deliberately picks up a revised cross
+# builder: if a broken toolchain image is why the release needs republishing,
+# rebuilding against the image that produced the broken artifacts is the one
+# thing that cannot help. Set this when the opposite is wanted, to rebuild
+# against the same toolchain the original release used.
+CROSS_CONTAINER_TAG=''
+
+DRY_RUN=0
+ASSUME_YES=0
+
+usage()
+{
+cat <<'EOF'
+USAGE: republish -t TAG [OPTIONS]
+
+DESCRIPTION:
+  Triggers the "republish" CircleCI workflow, which rebuilds an existing
+  release tag from its own source and publishes the resulting packages to
+  Cloudflare R2.
+
+  Use this when a release pipeline built, signed and tested packages
+  successfully but failed before or during the publish step. It does not
+  move the tag and does not create a new version.
+
+  The pipeline pauses at a "hold_publish" approval gate covering both the
+  packages and the changelog. Nothing is written to R2 until someone approves
+  it in the CircleCI UI.
+
+OPTIONS:
+  -t TAG     Release tag to republish, e.g. "v1.13.0". Required.
+  -b BRANCH  Branch supplying .circleci/config.yml. This branch must already
+             contain the "republish" workflow. Defaults to the minor version
+             branch implied by the tag, e.g. "1.13" for v1.13.0. Releases are
+             only ever made from a minor version branch, never from
+             master-1.x, so the default is almost always correct.
+  -c TAG     Cross builder image tag, e.g. "go1.26.5-latest". Defaults to the
+             branch's own default, which floats: a republish picks up any
+             revision made to the toolchain image since the release was cut.
+             That is usually what is wanted, because a broken cross builder is
+             one of the reasons a release gets republished. Pass this to pin
+             the toolchain instead, either to rebuild against exactly what the
+             original release used or to avoid an image known to be bad.
+             Covers build_binaries, static_code_checks, fluxtest and the
+             unit_test jobs; the other job images are fixed in the config.
+  -y         Skip the interactive confirmation.
+  -n         Resolve and validate the tag and branch, print the request that
+             would be sent, and exit without contacting CircleCI. This still
+             reads from the git remote to resolve the tag and to check the
+             branch's configuration; it makes no other network access and
+             does not require CIRCLE_TOKEN.
+  -h         Displays this help text.
+
+ENVIRONMENT:
+  CIRCLE_TOKEN
+             CircleCI personal API token. Required unless -n is given.
+             Passed to curl over stdin so that it never appears in the
+             process table; do not pass it as a command line argument.
+EOF
+}
+
+die()
+{
+  printf 'republish: %s\n' "$1" >&2
+  exit 1
+}
+
+while getopts 't:b:c:ynh' opt
+do
+  case "${opt}"
+  in
+    t) TAG="${OPTARG}"                ;;
+    b) BRANCH="${OPTARG}"             ;;
+    c) CROSS_CONTAINER_TAG="${OPTARG}" ;;
+    y) ASSUME_YES=1                   ;;
+    n) DRY_RUN=1                      ;;
+    h) usage ; exit 0                 ;;
+    ?) usage ; exit 1                 ;;
+  esac
+done
+
+[[ ${TAG:-} ]] || { usage ; exit 1 ; }
+
+for tool in curl git jq
+do
+  command -v "${tool}" >/dev/null || die "${tool} is required but was not found"
+done
+
+[[ ${TAG} =~ ${TAG_REGEX} ]] ||
+  die "'${TAG}' is not a full release tag (expected something like v1.13.0)"
+
+[[ ! ${CROSS_CONTAINER_TAG} || ${CROSS_CONTAINER_TAG} =~ ${BUILDER_REGEX} ]] ||
+  die "'${CROSS_CONTAINER_TAG}' is not a valid image tag"
+
+# Releases are only ever made from a minor version branch, so the branch that
+# supplies the configuration is implied by the tag: v1.13.0 -> 1.13.
+if [[ ! ${BRANCH} ]]
+then
+  [[ ${TAG} =~ ^v([[:digit:]]+)\.([[:digit:]]+) ]] ||
+    die "cannot derive a release branch from '${TAG}'; pass -b"
+  BRANCH="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
+fi
+
+cd "$(git rev-parse --show-toplevel)"
+
+# Resolve the tag on the remote rather than locally, so that the operator is
+# shown the commit CI will actually build. For an annotated tag the peeled
+# entry ("^{}") is the commit; for a lightweight tag it is absent.
+#
+# ls-remote reports two different situations differently: a non-zero status
+# when it cannot reach the remote at all, and success with no output when the
+# connection worked and the tag simply is not there. Capture it into a
+# variable rather than piping it straight into the read loop, whose exit
+# status would be the loop's and not git's. Collapsing the two into "tag does
+# not exist" would send whoever is running a release after the wrong problem,
+# because the usual cause is an expired credential.
+if ! remote_refs="$(git ls-remote --tags "${REMOTE}" \
+                      "refs/tags/${TAG}" "refs/tags/${TAG}^{}")"
+then
+  # git has already written its own diagnosis to stderr.
+  die "could not read tags from ${REMOTE}; see the error above"
+fi
+
+[[ ${remote_refs} ]] || die "tag '${TAG}' does not exist on ${REMOTE}"
+
+# A read loop rather than mapfile, so that the script runs under the bash 3.2
+# that ships with macOS.
+refs=()
+while IFS= read -r line
+do
+  refs+=("${line}")
+done <<<"${remote_refs}"
+
+COMMIT=''
+for ref in "${refs[@]}"
+do
+  case "${ref}"
+  in
+    *"refs/tags/${TAG}^{}") COMMIT="${ref%%$'\t'*}" ; break ;;
+    *"refs/tags/${TAG}")    COMMIT="${ref%%$'\t'*}"        ;;
+  esac
+done
+[[ ${COMMIT} ]] || die "could not resolve '${TAG}' to a commit"
+
+# A pipeline triggered against a branch runs that branch's configuration. If
+# the branch predates the republish workflow the trigger is accepted and then
+# silently does nothing, so check before spending anyone's time.
+# Same failure classes as the ls-remote above, but fetch reports both with a
+# non-zero status, so they cannot be told apart here. Connectivity has already
+# been demonstrated by the ls-remote, which makes a missing branch the likely
+# cause; word it as the likely cause rather than asserting it.
+git fetch --quiet "${REMOTE}" "${BRANCH}" ||
+  die "could not fetch '${BRANCH}' from ${REMOTE}; does that branch exist?"
+
+git show FETCH_HEAD:.circleci/config.yml 2>/dev/null | grep -q '^  republish:' ||
+  die "branch '${BRANCH}' has no 'republish' workflow in .circleci/config.yml"
+
+ENDPOINT="https://circleci.com/api/v2/project/${PROJECT_SLUG}/pipeline"
+# cross-container-tag is omitted rather than sent empty, so that the branch's
+# own default applies. Sending "" would resolve to an image with an empty tag.
+BODY="$(jq --null-input \
+           --arg branch "${BRANCH}" \
+           --arg tag    "${TAG}" \
+           --arg cross  "${CROSS_CONTAINER_TAG}" \
+           '{branch: $branch,
+             parameters: {workflow: "republish", "release-ref": $tag}}
+            | if $cross == ""
+              then .
+              else .parameters["cross-container-tag"] = $cross
+              end')"
+
+# Reported either way. The floating default is the interesting case, and it is
+# invisible unless it is named here.
+if [[ ${CROSS_CONTAINER_TAG} ]]
+then
+  BUILDER="${CROSS_CONTAINER_TAG} (pinned)"
+else
+  BUILDER="${BRANCH} default, floats (pass -c to pin)"
+fi
+
+cat <<EOF
+
+  tag         ${TAG}
+  commit      ${COMMIT}
+  config from ${BRANCH}
+  builder     ${BUILDER}
+  publishes   s3://${R2_BUCKET}/influxdb/releases/${TAG}
+
+EOF
+
+if (( DRY_RUN ))
+then
+  printf 'POST %s\n%s\n' "${ENDPOINT}" "${BODY}"
+  exit 0
+fi
+
+[[ ${CIRCLE_TOKEN:-} ]] ||
+  die 'CIRCLE_TOKEN is not set; export a CircleCI personal API token'
+
+if (( ! ASSUME_YES ))
+then
+  read -r -p "Type the tag to confirm: " confirm
+  [[ ${confirm} == "${TAG}" ]] || die 'aborted'
+fi
+
+response="$(mktemp)"
+trap 'rm -f "${response}"' EXIT
+
+# The token is supplied through a curl config file on stdin. Passing it with
+# -H would expose it in the process table to every user on the host.
+status="$(curl --silent --show-error \
+               --request POST \
+               --header 'Content-Type: application/json' \
+               --data "${BODY}" \
+               --output "${response}" \
+               --write-out '%{http_code}' \
+               --config - \
+               "${ENDPOINT}" <<CURLRC
+header = "Circle-Token: ${CIRCLE_TOKEN}"
+CURLRC
+)"
+
+if [[ ${status} != 2?? ]]
+then
+  printf 'republish: CircleCI returned HTTP %s\n' "${status}" >&2
+  jq --raw-output '.message // .' <"${response}" >&2 || cat "${response}" >&2
+  exit 1
+fi
+
+number="$(jq --raw-output '.number' <"${response}")"
+
+cat <<EOF
+Triggered pipeline ${number}.
+
+  https://app.circleci.com/pipelines/${PROJECT_VCS}/${PROJECT_ORG}/${PROJECT_REPO}/${number}
+
+The workflow stops at hold_publish. Before approving, confirm that the
+build_packages artifacts are named influxdb-${TAG#v}-* and that the digests
+file is influxdb.${TAG}.digests. Nothing reaches R2 until you approve.
+EOF

--- a/releng/republish
+++ b/releng/republish
@@ -3,11 +3,11 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-# Republishing is only ever appropriate for a full release tag. Release
-# candidates are excluded by the release workflow's tag filter and are not
-# published under influxdb/releases, so they are rejected here too. This is
-# the same expression used by 'release_filter' in .circleci/config.yml.
-TAG_REGEX='^v[[:digit:]]+(\.[[:digit:]]+)?(\.[[:digit:]]+)?$'
+# Republishing is only ever appropriate for a full release tag: major, minor
+# and patch are all required. Release candidates are excluded by the release
+# workflow's tag filter and are not published under influxdb/releases, so they
+# are rejected here too.
+TAG_REGEX='^v[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+$'
 
 # The cross-container-tag parameter is interpolated into an "image:" line, not
 # into a shell command, so a bad value fails as an image pull rather than as

--- a/releng/republish
+++ b/releng/republish
@@ -182,8 +182,24 @@ done
 git fetch --quiet "${REMOTE}" "${BRANCH}" ||
   die "could not fetch '${BRANCH}' from ${REMOTE}; does that branch exist?"
 
-git show FETCH_HEAD:.circleci/config.yml 2>/dev/null | grep -q '^  republish:' ||
+# Read the branch's own configuration, not this checkout's: a pipeline
+# triggered against a branch runs that branch's config, and one that predates
+# republish support accepts the trigger and then silently runs no workflows.
+#
+# Matched without anchoring to a specific indent, so that reformatting the
+# config cannot turn a valid branch into a refusal. The parameter is checked
+# separately from the workflow because a branch could carry one without the
+# other, which would pass here and then fail during config processing.
+if ! branch_config="$(git show "FETCH_HEAD:.circleci/config.yml" 2>/dev/null)"
+then
+  die "branch '${BRANCH}' has no .circleci/config.yml"
+fi
+
+grep -Eq '^[[:space:]]*republish:' <<<"${branch_config}" ||
   die "branch '${BRANCH}' has no 'republish' workflow in .circleci/config.yml"
+
+grep -Eq '^[[:space:]]*release-ref:' <<<"${branch_config}" ||
+  die "branch '${BRANCH}' has no 'release-ref' parameter in .circleci/config.yml"
 
 ENDPOINT="https://circleci.com/api/v2/project/${PROJECT_SLUG}/pipeline"
 # cross-container-tag is omitted rather than sent empty, so that the branch's
@@ -258,13 +274,19 @@ then
 fi
 
 number="$(jq --raw-output '.number' <"${response}")"
+# The approval API is addressed by pipeline id, not by number, so print both
+# and save whoever approves a lookup.
+pipeline_id="$(jq --raw-output '.id' <"${response}")"
 
 cat <<EOF
 Triggered pipeline ${number}.
 
   https://app.circleci.com/pipelines/${PROJECT_VCS}/${PROJECT_ORG}/${PROJECT_REPO}/${number}
 
-The workflow stops at hold_publish. Before approving, confirm that the
-build_packages artifacts are named influxdb-${TAG#v}-* and that the digests
-file is influxdb.${TAG}.digests. Nothing reaches R2 until you approve.
+  pipeline id ${pipeline_id}
+
+The workflow stops at hold_publish. Before approving, confirm that every
+build_packages artifact carries the version ${TAG#v}, that none carries a
+"1.x-<short sha>" version, and that the digests file is
+influxdb.${TAG}.digests. Nothing reaches R2 until you approve.
 EOF


### PR DESCRIPTION
Add a republish workflow for rebuilding and republishing a release tag if the original source build succeeded, but other parts of the CI pipeline failed. This allows those parts that are not integral to building the binaries to be fixed and release performed without needing to move the tag or burn a release number.

The republish workflow takes its source from a release tag and its configuration from the branch it is triggered against. A new 'release-ref' parameter names the tag, and 'checkout_source' replaces plain 'checkout' throughout, detaching to that tag so get-version derives VERSION from it exactly as it does on a tag build.

releng/republish triggers the workflow through the CircleCI API. The workflow could also be triggered directly from the CircleCI UI.
