### PR TITLE
chore(sync): influxdb_pro 2026-09-04 (3.11)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -145,10 +145,10 @@ parameters:
   # Consistent environment setup for Python Build Standalone
   PBS_DATE:
     type: string
-    default: "20260610"
+    default: "20260901"
   PBS_VERSION:
     type: string
-    default: "3.13.14"
+    default: "3.13.15"
 
 # Consistent Cargo environment configuration
 cargo_env: &cargo_env

--- a/.circleci/packages/influxdb3/fs/lib/systemd/system/influxdb3-core.service
+++ b/.circleci/packages/influxdb3/fs/lib/systemd/system/influxdb3-core.service
@@ -14,7 +14,7 @@ ExecReload=
 WorkingDirectory=/var/lib/influxdb3
 StateDirectory=influxdb3
 # Logs default to journald (StandardOutput/Error); you may optionally set
-# LOG_DESTINATION=file:/var/log/influxdb3/influxdb3.log to use LogsDirectory.
+# INFLUXDB3_LOG_DESTINATION=file:/var/log/influxdb3/influxdb3.log to use LogsDirectory.
 LogsDirectory=influxdb3
 StandardOutput=journal
 StandardError=journal

--- a/.circleci/packages/influxdb3/fs/usr/lib/influxdb3/influxdb3-launcher
+++ b/.circleci/packages/influxdb3/fs/usr/lib/influxdb3/influxdb3-launcher
@@ -40,18 +40,12 @@ TOML_KEY_ENVVAR: Dict[str, Dict[str, str]] = {
     "common": {  # core and enterprise
         # Node configuration
         "http-bind": "INFLUXDB3_HTTP_BIND_ADDR",
-        "node-id": "INFLUXDB3_NODE_IDENTIFIER_PREFIX",
-        "node-id-from-env": "INFLUXDB3_NODE_IDENTIFIER_FROM_ENV",
         # Admin token recovery
         "admin-token-recovery-http-bind": "INFLUXDB3_ADMIN_TOKEN_RECOVERY_HTTP_BIND_ADDR",
-        # Authorization
-        "without-auth": "INFLUXDB3_START_WITHOUT_AUTH",
-        # Datafusion
-        "num-datafusion-threads": "INFLUXDB3_DATAFUSION_NUM_THREADS",
-        # IO
+        # Runtime threads
         "num-io-threads": "INFLUXDB3_NUM_IO_THREADS",
-        # Object storage
-        "data-dir": "INFLUXDB3_DB_DIR",
+        # Deprecated alias of num-datafusion-threads; exports that flag's env
+        "datafusion-num-threads": "INFLUXDB3_NUM_DATAFUSION_THREADS",
         # AWS (AWS_ prefix, not INFLUXDB3_)
         "aws-access-key-id": "AWS_ACCESS_KEY_ID",
         "aws-allow-http": "AWS_ALLOW_HTTP",
@@ -69,63 +63,23 @@ TOML_KEY_ENVVAR: Dict[str, Dict[str, str]] = {
         "azure-storage-account": "AZURE_STORAGE_ACCOUNT",
         # Google Cloud (GOOGLE_ prefix, not INFLUXDB3_)
         "google-service-account": "GOOGLE_SERVICE_ACCOUNT",
-        # Object store
-        "object-store-connection-limit": "INFLUXDB3_OBJECT_STORE_CONNECTION_LIMIT",
-        "object-store-http2-only": "INFLUXDB3_OBJECT_STORE_HTTP2_ONLY",
-        "object-store-http2-max-frame-size": "INFLUXDB3_OBJECT_STORE_HTTP2_MAX_FRAME_SIZE",
-        "object-store-max-retries": "INFLUXDB3_OBJECT_STORE_MAX_RETRIES",
-        "object-store-request-timeout": "INFLUXDB3_OBJECT_STORE_REQUEST_TIMEOUT",
-        "object-store-retry-timeout": "INFLUXDB3_OBJECT_STORE_RETRY_TIMEOUT",
-        "object-store-tls-allow-insecure": "INFLUXDB3_OBJECT_STORE_TLS_ALLOW_INSECURE",
-        "object-store-tls-ca": "INFLUXDB3_OBJECT_STORE_TLS_CA",
         # Processing engine
         "virtual-env-location": "VIRTUAL_ENV",
-        # WAL
-        "snapshotted-wal-files-to-keep": "INFLUXDB3_NUM_WAL_FILES_TO_KEEP",
         # Tokio console
         "tokio-console-enabled": "INFLUXDB3_TOKIO_CONSOLE_ENABLED",
         "tokio-console-client-buffer-capacity": "INFLUXDB3_TOKIO_CONSOLE_CLIENT_BUFFER_CAPACITY",
         "tokio-console-event-buffer-capacity": "INFLUXDB3_TOKIO_CONSOLE_EVENT_BUFFER_CAPACITY",
-        # Tracing
-        "traces-exporter": "INFLUXDB3_TRACES_EXPORTER",
-        "traces-exporter-jaeger-agent-host": "INFLUXDB3_TRACES_EXPORTER_JAEGER_AGENT_HOST",
-        "traces-exporter-jaeger-agent-port": "INFLUXDB3_TRACES_EXPORTER_JAEGER_AGENT_PORT",
-        "traces-exporter-jaeger-debug-name": "INFLUXDB3_TRACES_EXPORTER_JAEGER_DEBUG_NAME",
-        "traces-exporter-jaeger-service-name": "INFLUXDB3_TRACES_EXPORTER_JAEGER_SERVICE_NAME",
-        "traces-exporter-jaeger-trace-context-header-name": "INFLUXDB3_TRACES_EXPORTER_JAEGER_TRACE_CONTEXT_HEADER_NAME",
         "traces-jaeger-debug-name": "INFLUXDB3_TRACES_EXPORTER_JAEGER_DEBUG_NAME",
-        "traces-jaeger-max-msgs-per-second": "INFLUXDB3_TRACES_JAEGER_MAX_MSGS_PER_SECOND",
         "traces-jaeger-tags": "INFLUXDB3_TRACES_EXPORTER_JAEGER_TAGS",
     },
     "core": {
         # Core-specific mappings (currently none - all are in common)
     },
     "enterprise": {
-        # Enterprise cluster configuration
-        "cluster-id": "INFLUXDB3_ENTERPRISE_CLUSTER_ID",
-        "conn-info": "INFLUXDB3_ENTERPRISE_CONN_INFO",
-        "mode": "INFLUXDB3_ENTERPRISE_MODE",
-        "num-cores": "INFLUXDB3_ENTERPRISE_NUM_CORES",
-        # Compaction
-        "compaction-check-interval": "INFLUXDB3_ENTERPRISE_COMPACTION_CHECK_INTERVAL",
-        "compaction-cleanup-wait": "INFLUXDB3_ENTERPRISE_COMPACTION_CLEANUP_WAIT",
-        "compaction-gen2-duration": "INFLUXDB3_ENTERPRISE_COMPACTION_GEN2_DURATION",
-        "compaction-max-num-files-per-plan": "INFLUXDB3_ENTERPRISE_COMPACTION_MAX_NUM_FILES_PER_PLAN",
-        "compaction-multipliers": "INFLUXDB3_ENTERPRISE_COMPACTION_MULTIPLIERS",
-        "compaction-row-limit": "INFLUXDB3_ENTERPRISE_COMPACTION_ROW_LIMIT",
         # Last Value & Distinct Value Caches
         "preemptive-cache-age": "INFLUXDB3_PREEMPTIVE_CACHE_AGE",
-        # Licensing
-        "license-email": "INFLUXDB3_ENTERPRISE_LICENSE_EMAIL",
-        "license-file": "INFLUXDB3_ENTERPRISE_LICENSE_FILE",
-        "license-type": "INFLUXDB3_ENTERPRISE_LICENSE_TYPE",
         # Resource limits
-        "catalog-sync-interval": "INFLUXDB3_ENTERPRISE_CATALOG_SYNC_INTERVAL",
         "max-columns": "INFLUXDB3_MAX_TOTAL_COLUMNS",
-        "num-database-limit": "INFLUXDB3_ENTERPRISE_NUM_DATABASE_LIMIT",
-        "num-table-limit": "INFLUXDB3_ENTERPRISE_NUM_TABLE_LIMIT",
-        "num-total-columns-per-table-limit": "INFLUXDB3_ENTERPRISE_NUM_TOTAL_COLUMNS_PER_TABLE_LIMIT",
-        "replication-interval": "INFLUXDB3_ENTERPRISE_REPLICATION_INTERVAL",
     },
 }
 

--- a/.circleci/packages/influxdb3/fs/usr/share/influxdb3/influxdb3-core.conf
+++ b/.circleci/packages/influxdb3/fs/usr/share/influxdb3/influxdb3-core.conf
@@ -16,11 +16,11 @@
 
 # Node identifier used as prefix in object store file paths
 # Default (quick-start mode): {hostname}-node or primary-node if hostname
-# unavailable (env: INFLUXDB3_NODE_IDENTIFIER_PREFIX)
+# unavailable (env: INFLUXDB3_NODE_ID)
 #node-id="<NODE_ID>"
 
 # Obtain the node id from the specified environment variable; conflicts with
-# --node-id flag (env: INFLUXDB3_NODE_IDENTIFIER_FROM_ENV)
+# --node-id flag (env: INFLUXDB3_NODE_ID_FROM_ENV)
 #node-id-from-env="<VARNAME>"
 
 # Object storage to use (Required)
@@ -44,7 +44,7 @@
 
 # Logs: filter directive
 # Default: info,iox_query::query_log=warn,influxdb3_query_executor::core=warn
-# (env: LOG_FILTER)
+# (env: INFLUXDB3_LOG_FILTER)
 #log-filter="info,iox_query::query_log=warn,influxdb3_query_executor::core=warn"
 
 # Disable automatic noise-reduction expansion of debug/trace log filters
@@ -78,7 +78,7 @@
 
 # Disables authentication for all server actions (CLI commands and API
 # requests). The server processes all requests without requiring tokens or
-# authentication. (env: INFLUXDB3_START_WITHOUT_AUTH)
+# authentication. (env: INFLUXDB3_WITHOUT_AUTH)
 #without-auth="<BOOL>"
 
 # Optionally disable authz by passing in a comma separated list of resources.
@@ -106,7 +106,7 @@
 
 # Location to store files locally. Required when using the file object store
 # (default object store type)
-# Default (quick-start mode; env: INFLUXDB3_DB_DIR)
+# Default (quick-start mode; env: INFLUXDB3_DATA_DIR)
 #data-dir="<DIR>"
 
 # Bucket name for cloud object storage
@@ -181,33 +181,33 @@
 # -----------------------------------------------------------------------------
 
 # Connection limit for network object stores
-# Default: 16 (env: OBJECT_STORE_CONNECTION_LIMIT)
+# Default: 16 (env: INFLUXDB3_OBJECT_STORE_CONNECTION_LIMIT)
 #object-store-connection-limit="16"
 
 # HTTP request timeout for object store operations
-# Default: 30s (env: OBJECT_STORE_REQUEST_TIMEOUT)
+# Default: 30s (env: INFLUXDB3_OBJECT_STORE_REQUEST_TIMEOUT)
 #object-store-request-timeout="30s"
 
-# Force HTTP/2 for object stores (env: OBJECT_STORE_HTTP2_ONLY)
+# Force HTTP/2 for object stores (env: INFLUXDB3_OBJECT_STORE_HTTP2_ONLY)
 #object-store-http2-only="false"
 
-# HTTP/2 max frame size (env: OBJECT_STORE_HTTP2_MAX_FRAME_SIZE)
+# HTTP/2 max frame size (env: INFLUXDB3_OBJECT_STORE_HTTP2_MAX_FRAME_SIZE)
 #object-store-http2-max-frame-size="<SIZE>"
 
 # Max request retry attempts
-# Default: 10 (env: OBJECT_STORE_MAX_RETRIES)
+# Default: 10 (env: INFLUXDB3_OBJECT_STORE_MAX_RETRIES)
 #object-store-max-retries="<N>"
 
 # Max retry timeout
-# Default: 180s (env: OBJECT_STORE_RETRY_TIMEOUT)
+# Default: 180s (env: INFLUXDB3_OBJECT_STORE_RETRY_TIMEOUT)
 #object-store-retry-timeout="<TIMEOUT>"
 
-# Skip TLS certificate verification for object storage (env: OBJECT_STORE_TLS_ALLOW_INSECURE)
+# Skip TLS certificate verification for object storage (env: INFLUXDB3_OBJECT_STORE_TLS_ALLOW_INSECURE)
 #object-store-tls-allow-insecure="false"
 
 # Path to custom CA certificate file (PEM format) for object storage
 # Use when your object store uses a certificate signed by a private CA
-# (env: OBJECT_STORE_TLS_CA)
+# (env: INFLUXDB3_OBJECT_STORE_TLS_CA)
 #object-store-tls-ca="<PATH>"
 
 # =============================================================================
@@ -302,7 +302,7 @@
 #wal-replay-fail-on-error="false"
 
 # Number of snapshotted WAL files to retain
-# Default: 300 (env: INFLUXDB3_NUM_WAL_FILES_TO_KEEP)
+# Default: 300 (env: INFLUXDB3_SNAPSHOTTED_WAL_FILES_TO_KEEP)
 #snapshotted-wal-files-to-keep="300"
 
 # Interval for persisting snapshot checkpoints to object storage
@@ -379,11 +379,11 @@
 
 # Number of DataFusion runtime threads
 # Default: Auto-determined based on available cores minus IO threads
-# (env: INFLUXDB3_DATAFUSION_NUM_THREADS)
+# (env: INFLUXDB3_NUM_DATAFUSION_THREADS)
 #num-datafusion-threads="<N>"
 
 # Legacy alias for num-datafusion-threads (deprecated)
-# (env: INFLUXDB3_DATAFUSION_NUM_THREADS)
+# (env: INFLUXDB3_NUM_DATAFUSION_THREADS)
 #datafusion-num-threads="<N>"
 
 # DataFusion runtime type. Possible values: current-thread, multi-thread,
@@ -462,42 +462,42 @@
 # =============================================================================
 
 # Logs: destination
-# Default: stdout (env: LOG_DESTINATION)
+# Default: stdout (env: INFLUXDB3_LOG_DESTINATION)
 #log-destination="stdout"
 
 # Logs: message format
-# Default: full (env: LOG_FORMAT)
+# Default: full (env: INFLUXDB3_LOG_FORMAT)
 #log-format="full"
 
 # Tracing: exporter type
-# Default: none (env: TRACES_EXPORTER)
+# Default: none (env: INFLUXDB3_TRACES_EXPORTER)
 #traces-exporter="none"
 
 # Jaeger agent hostname
-# Default: 0.0.0.0 (env: TRACES_EXPORTER_JAEGER_AGENT_HOST)
+# Default: 0.0.0.0 (env: INFLUXDB3_TRACES_EXPORTER_JAEGER_AGENT_HOST)
 #traces-exporter-jaeger-agent-host="0.0.0.0"
 
 # Jaeger agent port
-# Default: 6831 (env: TRACES_EXPORTER_JAEGER_AGENT_PORT)
+# Default: 6831 (env: INFLUXDB3_TRACES_EXPORTER_JAEGER_AGENT_PORT)
 #traces-exporter-jaeger-agent-port="6831"
 
 # Jaeger service name
-# Default: iox-conductor (env: TRACES_EXPORTER_JAEGER_SERVICE_NAME)
+# Default: iox-conductor (env: INFLUXDB3_TRACES_EXPORTER_JAEGER_SERVICE_NAME)
 #traces-exporter-jaeger-service-name="iox-conductor"
 
 # Header for trace context
-# Default: uber-trace-id (env: TRACES_EXPORTER_JAEGER_TRACE_CONTEXT_HEADER_NAME)
+# Default: uber-trace-id (env: INFLUXDB3_TRACES_EXPORTER_JAEGER_TRACE_CONTEXT_HEADER_NAME)
 #traces-exporter-jaeger-trace-context-header-name="uber-trace-id"
 
 # Header for force sampling
-# Default: jaeger-debug-id (env: TRACES_EXPORTER_JAEGER_DEBUG_NAME)
+# Default: jaeger-debug-id (env: INFLUXDB3_TRACES_EXPORTER_JAEGER_DEBUG_NAME)
 #traces-jaeger-debug-name="jaeger-debug-id"
 
-# Key-value pairs for tracing spans (env: TRACES_EXPORTER_JAEGER_TAGS)
+# Key-value pairs for tracing spans (env: INFLUXDB3_TRACES_EXPORTER_JAEGER_TAGS)
 #traces-jaeger-tags="<TAGS>"
 
 # Max messages per second
-# Default: 1000 (env: TRACES_JAEGER_MAX_MSGS_PER_SECOND)
+# Default: 1000 (env: INFLUXDB3_TRACES_JAEGER_MAX_MSGS_PER_SECOND)
 #traces-jaeger-max-msgs-per-second="1000"
 
 # -----------------------------------------------------------------------------

--- a/.circleci/packages/test_influxdb3-launcher.py
+++ b/.circleci/packages/test_influxdb3-launcher.py
@@ -174,7 +174,7 @@ class TestReadConfigTOML(unittest.TestCase):
             env_vars,
             {
                 "INFLUXDB3_OBJECT_STORE": "file",
-                "INFLUXDB3_NODE_IDENTIFIER_PREFIX": "test-node",
+                "INFLUXDB3_NODE_ID": "test-node",
             },
         )
 
@@ -190,7 +190,7 @@ class TestReadConfigTOML(unittest.TestCase):
             env_vars,
             {
                 "INFLUXDB3_OBJECT_STORE": "file",
-                "INFLUXDB3_DB_DIR": "/var/lib/influxdb3/data",
+                "INFLUXDB3_DATA_DIR": "/var/lib/influxdb3/data",
                 "INFLUXDB3_PLUGIN_DIR": "/var/lib/influxdb3/plugins",
             },
         )
@@ -247,7 +247,7 @@ class TestReadConfigTOML(unittest.TestCase):
             env_vars,
             {
                 "INFLUXDB3_OBJECT_STORE": "file",
-                "INFLUXDB3_NODE_IDENTIFIER_PREFIX": "test",
+                "INFLUXDB3_NODE_ID": "test",
             },
         )
 
@@ -333,9 +333,9 @@ class TestReadConfigTOML(unittest.TestCase):
             env_vars,
             {
                 "INFLUXDB3_OBJECT_STORE": "file",
-                "INFLUXDB3_ENTERPRISE_CLUSTER_ID": "my-cluster",
-                "INFLUXDB3_ENTERPRISE_MODE": "all",
-                "INFLUXDB3_ENTERPRISE_LICENSE_FILE": "/path/to/license.jwt",
+                "INFLUXDB3_CLUSTER_ID": "my-cluster",
+                "INFLUXDB3_MODE": "all",
+                "INFLUXDB3_LICENSE_FILE": "/path/to/license.jwt",
             },
         )
 
@@ -353,7 +353,7 @@ class TestReadConfigTOML(unittest.TestCase):
             env_vars,
             {
                 "INFLUXDB3_OBJECT_STORE": "file",
-                "INFLUXDB3_ENTERPRISE_LICENSE_FILE": "/path/to/license.jwt",
+                "INFLUXDB3_LICENSE_FILE": "/path/to/license.jwt",
                 # --max-total-columns; historic TOML key kept for compatibility
                 "INFLUXDB3_MAX_TOTAL_COLUMNS": "1000000",
                 # --preemptive-cache-age was never ENTERPRISE_-prefixed
@@ -391,7 +391,7 @@ class TestReadConfigTOML(unittest.TestCase):
             env_vars,
             {
                 "INFLUXDB3_OBJECT_STORE": "file",
-                "INFLUXDB3_NODE_IDENTIFIER_PREFIX": "test-node",
+                "INFLUXDB3_NODE_ID": "test-node",
                 "INFLUXDB3_RAM_CACHE_SIZE_MB": "2048",
                 "INFLUXDB3_FORCE_SNAPSHOT_MEM_THRESHOLD": "true",
             },
@@ -550,7 +550,7 @@ class TestReadConfigTOMLValidation(unittest.TestCase):
             result,
             {
                 "INFLUXDB3_OBJECT_STORE": "file",
-                "INFLUXDB3_ENTERPRISE_LICENSE_FILE": "/path/to/license.jwt",
+                "INFLUXDB3_LICENSE_FILE": "/path/to/license.jwt",
             },
         )
 
@@ -566,8 +566,8 @@ class TestReadConfigTOMLValidation(unittest.TestCase):
             result,
             {
                 "INFLUXDB3_OBJECT_STORE": "file",
-                "INFLUXDB3_ENTERPRISE_LICENSE_EMAIL": "test@example.com",
-                "INFLUXDB3_ENTERPRISE_LICENSE_TYPE": "trial",
+                "INFLUXDB3_LICENSE_EMAIL": "test@example.com",
+                "INFLUXDB3_LICENSE_TYPE": "trial",
             },
         )
 
@@ -1946,7 +1946,7 @@ class TestLauncherIntegration(unittest.TestCase):
         # Create a mock executable that prints an env var
         mock_exec = self._create_mock_executable(
             "import os\n"
-            'print(f\'NODE_ID={os.environ.get("INFLUXDB3_NODE_IDENTIFIER_PREFIX", "NOT_SET")}\')\n'
+            'print(f\'NODE_ID={os.environ.get("INFLUXDB3_NODE_ID", "NOT_SET")}\')\n'
         )
 
         result = subprocess.run(

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -444,7 +444,7 @@ dependencies = [
 
 [[package]]
 name = "arrow_util"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -541,7 +541,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "authz"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -655,7 +655,7 @@ dependencies = [
 
 [[package]]
 name = "backoff"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "rand 0.9.4",
  "snafu 0.9.0",
@@ -1087,7 +1087,7 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "catalog_cache"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "bytes",
  "criterion 0.8.2",
@@ -1231,14 +1231,14 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cli_types"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "tokio",
 ]
 
 [[package]]
 name = "client_util"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "http 1.4.2",
  "iox_http_util",
@@ -1841,7 +1841,7 @@ dependencies = [
 
 [[package]]
 name = "data_types"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -2575,7 +2575,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion_util"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -2670,7 +2670,7 @@ dependencies = [
 
 [[package]]
 name = "dml"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "arrow_util",
  "data_types",
@@ -2782,7 +2782,7 @@ dependencies = [
 
 [[package]]
 name = "error_reporting"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "datafusion",
  "snafu 0.9.0",
@@ -2812,7 +2812,7 @@ dependencies = [
 
 [[package]]
 name = "executor"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "futures",
  "metric",
@@ -2893,7 +2893,7 @@ dependencies = [
 
 [[package]]
 name = "flightsql"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -3100,7 +3100,7 @@ dependencies = [
 
 [[package]]
 name = "futures_test_utils"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "clap",
  "futures",
@@ -3111,7 +3111,7 @@ dependencies = [
 
 [[package]]
 name = "generated_types"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "bytes",
  "pbjson",
@@ -3765,7 +3765,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb2_client"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "bytes",
  "futures",
@@ -3784,7 +3784,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3879,7 +3879,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_authz"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "async-trait",
  "authz",
@@ -3897,7 +3897,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_cache"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3932,7 +3932,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_catalog"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "ahash 0.8.12",
  "anyhow",
@@ -3989,7 +3989,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_clap_blocks"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4026,7 +4026,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_client"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "bytes",
  "flate2",
@@ -4047,7 +4047,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_commands"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4075,7 +4075,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_id"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "criterion 0.5.1",
  "indexmap 2.14.0",
@@ -4087,7 +4087,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_internal_api"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4108,7 +4108,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_process"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "iox_time",
  "uuid",
@@ -4116,7 +4116,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_processing_engine"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -4145,6 +4145,7 @@ dependencies = [
  "iox_query_params",
  "iox_time",
  "metric",
+ "mockito",
  "object_store",
  "observability_deps",
  "parking_lot",
@@ -4164,7 +4165,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_processing_engine_telemetry"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "hashbrown 0.14.5",
  "influxdb3_catalog",
@@ -4174,7 +4175,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_py_api"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -4198,7 +4199,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_query_executor"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4249,7 +4250,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_server"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4336,7 +4337,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_shutdown"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "futures",
  "futures-util",
@@ -4351,14 +4352,17 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_startup"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "chrono",
+ "observability_deps",
+ "test_helpers",
+ "tokio",
 ]
 
 [[package]]
 name = "influxdb3_sys_events"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4377,7 +4381,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_system_tables"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4409,7 +4413,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_telemetry"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "futures",
  "futures-util",
@@ -4430,7 +4434,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_test_helpers"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4443,7 +4447,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_types"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4463,7 +4467,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_wal"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "async-trait",
  "bitcode",
@@ -4494,7 +4498,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_write"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4552,6 +4556,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "sha2 0.10.9",
+ "siphasher",
  "snap",
  "test-log",
  "test_helpers",
@@ -4564,7 +4569,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb_influxql_parser"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "assert_matches",
  "chrono",
@@ -4581,7 +4586,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb_iox_client"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -4610,7 +4615,7 @@ dependencies = [
 
 [[package]]
 name = "ingester_query_grpc"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "base64 0.22.1",
  "data_types",
@@ -4676,7 +4681,7 @@ checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
 
 [[package]]
 name = "iox_http"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -4696,7 +4701,7 @@ dependencies = [
 
 [[package]]
 name = "iox_http_util"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "futures",
  "http 1.4.2",
@@ -4707,7 +4712,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "arrow",
  "arrow_util",
@@ -4756,7 +4761,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query_influxql"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "arrow",
  "assert_matches",
@@ -4783,7 +4788,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query_influxql_rewrite"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "influxdb_influxql_parser",
  "thiserror 2.0.18",
@@ -4791,7 +4796,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query_params"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "arrow",
  "assert_matches",
@@ -4805,7 +4810,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query_udf"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "datafusion-udf-wasm-host",
  "datafusion-udf-wasm-query",
@@ -4816,7 +4821,7 @@ dependencies = [
 
 [[package]]
 name = "iox_system_tables"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4826,7 +4831,7 @@ dependencies = [
 
 [[package]]
 name = "iox_time"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "chrono",
  "parking_lot",
@@ -4835,7 +4840,7 @@ dependencies = [
 
 [[package]]
 name = "iox_v1_query_api"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4949,7 +4954,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jemalloc_pprof_http"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "http-body-util",
  "hyper 1.11.0",
@@ -4962,7 +4967,7 @@ dependencies = [
 
 [[package]]
 name = "jemalloc_stats"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "futures",
  "snafu 0.9.0",
@@ -5155,7 +5160,7 @@ dependencies = [
 
 [[package]]
 name = "linear_buffer"
-version = "3.11.3"
+version = "3.11.4"
 
 [[package]]
 name = "linux-raw-sys"
@@ -5199,7 +5204,7 @@ checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "logfmt"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "humantime",
  "parking_lot",
@@ -5298,14 +5303,14 @@ dependencies = [
 
 [[package]]
 name = "metric"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "parking_lot",
 ]
 
 [[package]]
 name = "metric_exporters"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "metric",
  "mockito",
@@ -5430,7 +5435,7 @@ checksum = "9252111cf132ba0929b6f8e030cac2a24b507f3a4d6db6fb2896f27b354c714b"
 
 [[package]]
 name = "mutable_batch"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "arrow",
  "arrow_util",
@@ -5448,7 +5453,7 @@ dependencies = [
 
 [[package]]
 name = "mutable_batch_lp"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "arrow_util",
  "assert_matches",
@@ -5464,7 +5469,7 @@ dependencies = [
 
 [[package]]
 name = "mutable_batch_pb"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "arrow_util",
  "criterion 0.8.2",
@@ -5702,7 +5707,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_limit"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5714,7 +5719,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_mem_cache"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5742,7 +5747,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_metrics"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "async-trait",
  "bloom2",
@@ -5767,7 +5772,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_mock"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5781,7 +5786,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_size_hinting"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "chrono",
  "http 1.4.2",
@@ -5791,7 +5796,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_utils"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "async-trait",
  "backon",
@@ -5807,7 +5812,7 @@ dependencies = [
 
 [[package]]
 name = "observability_deps"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "tracing",
 ]
@@ -5881,7 +5886,7 @@ dependencies = [
 
 [[package]]
 name = "panic_logging"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "metric",
  "test_helpers",
@@ -5956,7 +5961,7 @@ dependencies = [
 
 [[package]]
 name = "parquet_file"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "arrow",
  "arrow_util",
@@ -5987,7 +5992,7 @@ dependencies = [
 
 [[package]]
 name = "partition"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "arrow",
  "assert_matches",
@@ -6284,7 +6289,7 @@ dependencies = [
 
 [[package]]
 name = "predicate"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6627,7 +6632,7 @@ dependencies = [
 
 [[package]]
 name = "query_functions"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "arrow",
  "chrono",
@@ -7337,7 +7342,7 @@ dependencies = [
 
 [[package]]
 name = "schema"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "arrow",
  "base64 0.22.1",
@@ -7521,7 +7526,7 @@ dependencies = [
 
 [[package]]
 name = "service_common"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -7535,7 +7540,7 @@ dependencies = [
 
 [[package]]
 name = "service_grpc_flight"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -7611,7 +7616,7 @@ dependencies = [
 
 [[package]]
 name = "sharder"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "criterion 0.8.2",
  "data_types",
@@ -8133,7 +8138,7 @@ dependencies = [
 
 [[package]]
 name = "table_batch"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "arrow_util",
  "bitvec",
@@ -8229,7 +8234,7 @@ dependencies = [
 
 [[package]]
 name = "test_helpers"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "async-trait",
  "dotenvy",
@@ -8248,7 +8253,7 @@ dependencies = [
 
 [[package]]
 name = "test_helpers_authz"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "futures",
  "generated_types",
@@ -8533,7 +8538,7 @@ dependencies = [
 
 [[package]]
 name = "tokio_metrics_bridge"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "metric",
  "parking_lot",
@@ -8542,7 +8547,7 @@ dependencies = [
 
 [[package]]
 name = "tokio_watchdog"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "metric",
  "test_helpers",
@@ -8765,7 +8770,7 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tower_trailer"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "futures",
  "http 1.4.2",
@@ -8777,7 +8782,7 @@ dependencies = [
 
 [[package]]
 name = "trace"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "chrono",
  "parking_lot",
@@ -8787,7 +8792,7 @@ dependencies = [
 
 [[package]]
 name = "trace_exporters"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8804,7 +8809,7 @@ dependencies = [
 
 [[package]]
 name = "trace_http"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "bytes",
  "futures",
@@ -8899,7 +8904,7 @@ dependencies = [
 
 [[package]]
 name = "tracker"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "futures",
  "hashbrown 0.14.5",
@@ -8919,7 +8924,7 @@ dependencies = [
 
 [[package]]
 name = "trogging"
-version = "3.11.3"
+version = "3.11.4"
 dependencies = [
  "clap",
  "logfmt",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,7 +127,7 @@ exclude = [
 #
 # For porting to the actual OSS repo (influxdb), this would need to change to `-nightly`, i.e., by
 # stripping the `-oss`.
-version = "3.11.3"
+version = "3.11.4"
 authors = ["InfluxData OSS Developers"]
 edition = "2024"
 license = "MIT OR Apache-2.0"
@@ -225,6 +225,7 @@ serde_json = "1.0.127"
 serde_urlencoded = "0.7.0"
 serde_with = "3.8.1"
 sha2 = "0.10.8"
+siphasher = "1.0"
 snafu = "0.8"
 snap = "1.0.0"
 sqlparser = "0.48.0"

--- a/deny.toml
+++ b/deny.toml
@@ -100,6 +100,15 @@ ignore = [
     # datafusion-udf-wasm bump to a DataFusion 52 rev.
     "RUSTSEC-2026-0222",
     #
+    # wasmtime 41.0.4 filesystem sandbox escape when paths or symlinks contain
+    # trailing slashes (https://rustsec.org/advisories/RUSTSEC-2026-0269). Same
+    # transitive path via datafusion-udf-wasm; only reachable if a Wasm UDF is
+    # loaded with WASI filesystem preopens granted, and UDFs are disabled by
+    # default (udfs_enabled = false). The 41.x line has no patched release. The
+    # fix requires wasmtime >=46.0.3, which needs an upstream datafusion-udf-wasm
+    # bump.
+    "RUSTSEC-2026-0269",
+    #
     # TODO: update wasmtime-wasi via datafusion-udf-wasm to a patched version (>=45.0.3; >=46.0.1 is also fixed)
 ]
 git-fetch-with-cli = true

--- a/influxdb3/src/commands/serve/cli_params/tests.rs
+++ b/influxdb3/src/commands/serve/cli_params/tests.rs
@@ -296,3 +296,170 @@ fn test_config_file_cli_option_drift() {
         panic!("Config file and CLI options are out of sync!{}", error_msg);
     }
 }
+
+/// Parse the launcher's `TOML_KEY_ENVVAR` table: `section -> (toml key -> env name)`.
+///
+/// The table is a Python dict literal with one `"key": "ENV",` entry per
+/// line, grouped under `"common"`, `"core"` and `"enterprise"` sections.
+fn parse_launcher_env_table(launcher: &str) -> HashMap<String, HashMap<String, String>> {
+    let mut table: HashMap<String, HashMap<String, String>> = HashMap::new();
+    let mut section: Option<String> = None;
+    let mut in_table = false;
+    for line in launcher.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("TOML_KEY_ENVVAR") {
+            in_table = true;
+            continue;
+        }
+        if !in_table {
+            continue;
+        }
+        // The table ends at the first unindented closing brace.
+        if line == "}" {
+            break;
+        }
+        if trimmed.starts_with('#') {
+            continue;
+        }
+        let Some((key, rest)) = trimmed.split_once(':') else {
+            continue;
+        };
+        let key = key.trim().trim_matches('"');
+        let rest = rest.trim();
+        if rest.starts_with('{') {
+            section = Some(key.to_string());
+            continue;
+        }
+        let env = rest.trim_end_matches(',').trim_matches('"');
+        let section = section
+            .as_ref()
+            .unwrap_or_else(|| panic!("launcher table entry {key} outside any section"));
+        table
+            .entry(section.clone())
+            .or_default()
+            .insert(key.to_string(), env.to_string());
+    }
+    assert!(in_table, "TOML_KEY_ENVVAR table not found in launcher");
+    table
+}
+
+/// `.conf` keys kept as deprecated aliases of a renamed flag. The launcher
+/// must export the env name of the flag they alias.
+const CONF_KEY_ALIASES: &[(&str, &str)] = &[("datafusion-num-threads", "num-datafusion-threads")];
+
+fn canonical_conf_key(key: &str) -> &str {
+    CONF_KEY_ALIASES
+        .iter()
+        .find(|(alias, _)| *alias == key)
+        .map_or(key, |(_, canonical)| canonical)
+}
+
+/// The env name the launcher exports for a `.conf` key, mirroring
+/// `read_config_toml` in the launcher: explicit table entry (flavor
+/// overrides common), else `INFLUXDB3_` + SCREAMING_SNAKE of the key.
+fn launcher_env_for(
+    table: &HashMap<String, HashMap<String, String>>,
+    flavor: &str,
+    key: &str,
+) -> String {
+    table
+        .get(flavor)
+        .and_then(|m| m.get(key))
+        .or_else(|| table.get("common").and_then(|m| m.get(key)))
+        .cloned()
+        .unwrap_or_else(|| format!("INFLUXDB3_{}", key.replace('-', "_").to_uppercase()))
+}
+
+/// Collect `long name -> env name` for every clap arg (hidden included: the
+/// launcher exports whatever the `.conf` template names, hidden or not).
+fn extract_cli_env_names(cmd: &clap::Command, out: &mut HashMap<String, Option<String>>) {
+    for arg in cmd.get_arguments() {
+        if let Some(long) = arg.get_long() {
+            out.insert(
+                long.to_string(),
+                arg.get_env().map(|e| e.to_string_lossy().into_owned()),
+            );
+        }
+    }
+    for subcmd in cmd.get_subcommands() {
+        extract_cli_env_names(subcmd, out);
+    }
+}
+
+/// Every `.conf` template key must reach the binary through the launcher
+/// under the env name clap actually binds for that flag. A launcher entry
+/// that exports a deprecated alias makes every packaged start log an
+/// `env_compat` deprecation warning for a variable the user never set
+/// (#5465); one that exports an unbound name silently drops the setting
+/// (#4816).
+#[test]
+fn test_launcher_env_names_match_cli() {
+    use crate::commands::serve::Config;
+    use influxdb3_startup::env_compat::ENV_ALIASES;
+
+    let launcher_path = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../.circleci/packages/influxdb3/fs/usr/lib/influxdb3/influxdb3-launcher"
+    );
+    let config_path = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../.circleci/packages/influxdb3/fs/usr/share/influxdb3/influxdb3-core.conf"
+    );
+    let flavor = "core";
+
+    let launcher = std::fs::read_to_string(launcher_path)
+        .unwrap_or_else(|e| panic!("Failed to read launcher at {launcher_path}: {e}"));
+    let config = std::fs::read_to_string(config_path)
+        .unwrap_or_else(|e| panic!("Failed to read config file at {config_path}: {e}"));
+
+    let table = parse_launcher_env_table(&launcher);
+    let mut cli_env = HashMap::new();
+    extract_cli_env_names(&Config::command(), &mut cli_env);
+    let legacy: HashMap<&str, &str> = ENV_ALIASES.iter().map(|(new, old)| (*old, *new)).collect();
+
+    let mut keys: Vec<_> = extract_config_file_options(&config).into_iter().collect();
+    keys.sort();
+    let mut errors = Vec::new();
+    for key in keys {
+        let exported = launcher_env_for(&table, flavor, &key);
+        let Some(bound) = cli_env.get(canonical_conf_key(&key)) else {
+            // Covered by test_config_file_cli_option_drift.
+            continue;
+        };
+        // A flag may bind a legacy env primary that ENV_ALIASES maps a
+        // canonical INFLUXDB3_ name onto (the trogging/trace_exporters
+        // exception in docs/cli-conventions.md); the launcher must export
+        // the canonical name, which env_compat copies onto the primary.
+        let expected = bound
+            .as_deref()
+            .map(|b| legacy.get(b).copied().unwrap_or(b));
+        match expected {
+            Some(expected) if expected == exported => {}
+            Some(expected) => match legacy.get(exported.as_str()) {
+                Some(canonical) => errors.push(format!(
+                    "  - {key}: launcher exports {exported}, a deprecated alias of \
+                     {canonical} (every packaged start logs a deprecation warning)"
+                )),
+                None => errors.push(format!(
+                    "  - {key}: launcher exports {exported}, but the flag binds {expected} \
+                     (the setting is silently ignored, or read through a clap-level \
+                     deprecated alias that warns)"
+                )),
+            },
+            None => errors.push(format!(
+                "  - {key}: launcher exports {exported}, but the flag has no env binding \
+                 (the setting is silently ignored)"
+            )),
+        }
+    }
+
+    if !errors.is_empty() {
+        panic!(
+            "Launcher env names do not match the CLI ({launcher_path}):\n{}\n\n\
+             To fix: update TOML_KEY_ENVVAR in the launcher (or remove the entry when the \
+             key follows the INFLUXDB3_ + SCREAMING_SNAKE default) so it exports the env \
+             name the clap flag binds, and update the `(env: ...)` comment in {config_path}.",
+            errors.join("\n")
+        );
+    }
+}

--- a/influxdb3/src/help/serve_all.txt
+++ b/influxdb3/src/help/serve_all.txt
@@ -25,6 +25,8 @@ Examples:
 {}
   --node-id <NODE_ID>                          Node identifier used as prefix in object store file paths
                                                  [env: INFLUXDB3_NODE_ID=]
+  --node-id-from-env <VARNAME>                 Obtain the node id from the specified environment variable; conflicts with --node-id flag
+                                                 [env: INFLUXDB3_NODE_ID_FROM_ENV=]
   --object-store <STORE>                       Object storage to use
                                                  [possible values: memory, memory-throttled, file, s3, google, azure]
 
@@ -139,6 +141,8 @@ Examples:
                                                  [env: INFLUXDB3_OBJECT_STORE_MAX_RETRIES=]
   --object-store-retry-timeout <TIMEOUT>       Max retry timeout
                                                  [env: INFLUXDB3_OBJECT_STORE_RETRY_TIMEOUT=]
+  --object-store-request-timeout <TIMEOUT>     HTTP request timeout for object store requests [default: 30s]
+                                                 [env: INFLUXDB3_OBJECT_STORE_REQUEST_TIMEOUT=]
   --object-store-tls-allow-insecure            Skip TLS certificate verification for object storage.
                                                WARNING: This is insecure and should only be used for testing
                                                  [env: INFLUXDB3_OBJECT_STORE_TLS_ALLOW_INSECURE=]
@@ -206,6 +210,15 @@ Examples:
                                                    [env: INFLUXDB3_WAL_REPLAY_CONCURRENCY_LIMIT=]
   --snapshotted-wal-files-to-keep <N>            Number of snapshotted WAL files to retain [default: 300]
                                                    [env: INFLUXDB3_SNAPSHOTTED_WAL_FILES_TO_KEEP=]
+  --wal-replay-fail-on-error                     Fail startup on corrupt WAL files instead of skipping them
+                                                   [env: INFLUXDB3_WAL_REPLAY_FAIL_ON_ERROR=]
+  --snapshot-concurrency-limit <N>               Max concurrent snapshot persistence tasks; setting this too
+                                                 high can lead to OOM [default: number of CPUs]
+                                                   [env: INFLUXDB3_SNAPSHOT_CONCURRENCY_LIMIT=]
+  --checkpoint-interval <INTERVAL>               Interval between snapshot checkpoints, which aggregate
+                                                 snapshots into one file per month to speed up startup
+                                                 [default: disabled]
+                                                   [env: INFLUXDB3_CHECKPOINT_INTERVAL=]
 
 {}
   --last-cache-eviction-interval <INTERVAL>      Last-N-Value cache eviction interval [default: 10s]
@@ -215,6 +228,11 @@ Examples:
   --query-log-max-entries <N>                    Maximum number of entries in the query log [default: 1000]
                                                    [aliases: query-log-size]
                                                    [env: INFLUXDB3_QUERY_LOG_MAX_ENTRIES=]
+  --max-concurrent-queries <N>                   Maximum number of queries executing at once; further queries
+                                                 wait until a running query completes. Lower values provide
+                                                 backpressure during load spikes at the cost of queuing
+                                                   [default: effectively unlimited (~2^60)]
+                                                   [env: INFLUXDB3_MAX_CONCURRENT_QUERIES=]
   --query-file-limit <LIMIT>                     Max parquet files allowed in a query
                                                    [env: INFLUXDB3_QUERY_FILE_LIMIT=]
 

--- a/influxdb3/tests/server/write.rs
+++ b/influxdb3/tests/server/write.rs
@@ -807,3 +807,136 @@ async fn test_table_creation_with_special_characters_line_protocol_compatibility
     // Use insta snapshot to verify the table columns
     insta::assert_json_snapshot!("special_chars_table_columns", table_info);
 }
+/// Regression test for <https://github.com/influxdata/influxdb_pro/issues/5352> (EAR 7056):
+/// overwrites of the same (series key, timestamp) that share one write buffer chunk must
+/// resolve to the last acknowledged write, both in query results and in what
+/// `sort_dedupe_persist` bakes into the gen1 parquet file. Before the write buffer collapsed
+/// overwrites (`table_buffer.rs`), the duplicate rows tied on both dedup sort keys and an
+/// unstable sort picked an arbitrary survivor — this test failed with superseded versions
+/// persisted in every trial.
+///
+/// Each table's batch interleaves N series x M versions of the same (series, time) in one
+/// request, so every version lands in a single buffer chunk. The historical failure was
+/// input-deterministic (no RNG in the sort), so repetition only samples the space if the
+/// layout varies: each table uses a different (series x versions) shape as an independent
+/// trial.
+#[test_log::test(tokio::test)]
+async fn overwrite_last_write_wins_through_persistence() {
+    // Distinct layouts per table: same defect, different equal-key run sizes and
+    // positions, so each is an independent trial of the unstable sort.
+    const TRIALS: &[(usize, i64)] = &[(10, 12), (7, 15), (12, 9), (9, 20)];
+
+    // A fixed timestamp ~20 minutes in the past: old enough that the chunk is
+    // eligible for persistence as soon as a snapshot runs, and constant across
+    // the batch so every row of a series is a duplicate of the others.
+    let ts_ns = (std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("time after epoch")
+        .as_nanos() as i64)
+        - 20 * 60 * 1_000_000_000;
+
+    let server = TestServer::spawn().await;
+    let db_name = "repro_5352";
+
+    // Version-major interleave: every series gets v, then every series gets v+1, ...
+    // mirroring an ETL that rewrites a whole aggregate table each cycle.
+    let mut lp = String::new();
+    for (table, &(n_series, n_versions)) in TRIALS.iter().enumerate() {
+        for v in 0..n_versions {
+            for s in 0..n_series {
+                lp.push_str(&format!(
+                    "tbl_{table},probe=sensor_{s:04} v={}i {ts_ns}\n",
+                    1000 + v
+                ));
+            }
+        }
+    }
+    server
+        .write_lp_to_db(db_name, lp, Precision::Nanosecond)
+        .await
+        .expect("write overwrite batch");
+
+    // Wait until every table's chunk has been persisted, so the assertion checks the
+    // durable winner rather than racing the snapshot. Snapshots only run on new
+    // WAL activity, so each poll iteration writes a filler row (to its own table,
+    // at the current time) to drive the WAL forward until the probe tables'
+    // now-cold chunk is persisted.
+    for table in 0..TRIALS.len() {
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(30);
+        let mut filler = 0u64;
+        loop {
+            filler += 1;
+            server
+                .write_lp_to_db(
+                    db_name,
+                    format!("filler,f=a x={filler}i"),
+                    Precision::Nanosecond,
+                )
+                .await
+                .expect("write filler");
+            let resp = server
+                .api_v3_query_sql(&[
+                    ("db", db_name),
+                    (
+                        "q",
+                        &format!(
+                            "SELECT COUNT(*) AS n FROM system.parquet_files \
+                             WHERE table_name = 'tbl_{table}'"
+                        ),
+                    ),
+                    ("format", "json"),
+                ])
+                .await
+                .json::<Value>()
+                .await
+                .expect("query parquet_files");
+            if resp[0]["n"].as_i64().unwrap_or(0) > 0 {
+                break;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "tbl_{table} was not persisted within 30s"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        }
+    }
+
+    let mut failures = Vec::new();
+    for (table, &(n_series, n_versions)) in TRIALS.iter().enumerate() {
+        let want = 1000 + n_versions - 1;
+        let resp = server
+            .api_v3_query_sql(&[
+                ("db", db_name),
+                (
+                    "q",
+                    &format!("SELECT probe, v FROM tbl_{table} ORDER BY probe"),
+                ),
+                ("format", "json"),
+            ])
+            .await
+            .json::<Value>()
+            .await
+            .expect("query json");
+        let rows = resp.as_array().expect("json array response");
+        if rows.len() != n_series {
+            failures.push(format!(
+                "tbl_{table}: expected {n_series} rows after dedup, got {}",
+                rows.len()
+            ));
+        }
+        for row in rows {
+            let probe = row["probe"].as_str().unwrap_or("?");
+            let got = row["v"].as_i64().unwrap_or(-1);
+            if got != want {
+                failures.push(format!(
+                    "tbl_{table}/{probe}: persisted v={got}, want v={want} (last acknowledged write)"
+                ));
+            }
+        }
+    }
+    assert!(
+        failures.is_empty(),
+        "superseded versions won dedup and were persisted:\n{}",
+        failures.join("\n")
+    );
+}

--- a/influxdb3_authz/src/authorizer.rs
+++ b/influxdb3_authz/src/authorizer.rs
@@ -73,6 +73,16 @@ impl AuthProvider for TokenAuthenticatorAndAuthorizer {
         access_request: AccessRequest,
     ) -> Result<(), ResourceAuthorizationError> {
         let subject = subject.ok_or(ResourceAuthorizationError::Unauthorized)?;
+
+        // Role authoring and deletion are temporarily gated to admins only
+        if let AccessRequest::Role(RoleAction::Create | RoleAction::Update | RoleAction::Delete) =
+            access_request
+        {
+            return self
+                .authorize_action(Some(subject), AccessRequest::Admin)
+                .await;
+        }
+
         match subject {
             Subject::Token(token_id) => {
                 trace!(?token_id, ?access_request, "checking token access");

--- a/influxdb3_authz/src/authorizer/tests.rs
+++ b/influxdb3_authz/src/authorizer/tests.rs
@@ -1,14 +1,22 @@
 use std::sync::Arc;
 
 use authz::{Authorizer, Error as IoxError, Permission as IoxPermission, Resource};
-use influxdb3_id::{DbId, TokenId};
+use influxdb3_id::{DbId, TokenId, UserId};
 use iox_time::{MockProvider, Time};
 use sha2::Digest;
 
+use crate::role::role_permissions::{
+    DatabasePermission, RolePermission, SystemPermission, UserPermission,
+};
+use crate::role::{
+    DatabaseAction, Permission, Permissions, ResourceIdentifier, RoleAction, SystemAction,
+    SystemResource, UserAction,
+};
 use crate::{
     AccessRequest, AuthProvider, CatalogProvider, DatabaseActions, IdProvider,
-    ResourceAuthorizationError, TokenAuthenticator, TokenAuthenticatorAndAuthorizer, TokenInfo,
-    TokenPermissionProvider, TokenProvider,
+    ResourceAuthorizationError, Subject, SystemActions, SystemResourceIdentifier,
+    TokenAuthenticator, TokenAuthenticatorAndAuthorizer, TokenInfo, TokenPermissionProvider,
+    TokenProvider,
 };
 
 #[derive(Debug)]
@@ -832,11 +840,6 @@ async fn test_authorizer_multi_db_nonexistent_database() {
 
 #[test]
 fn user_describe_grant_confers_database_visibility_but_not_read() {
-    use crate::role::{
-        DatabaseAction, Permission, Permissions, ResourceIdentifier,
-        role_permissions::DatabasePermission,
-    };
-
     let perms = Permissions::new(vec![Permission::Database(DatabasePermission::new(
         DatabaseAction::Describe,
         ResourceIdentifier::All,
@@ -859,12 +862,6 @@ fn user_describe_grant_confers_database_visibility_but_not_read() {
 
 #[test]
 fn user_system_all_read_grant_allows_specific_resources() {
-    use crate::role::{
-        Permission, Permissions, ResourceIdentifier, SystemAction,
-        role_permissions::SystemPermission,
-    };
-    use crate::{SystemActions, SystemResourceIdentifier};
-
     let perms = Permissions::new(vec![Permission::System(SystemPermission::new(
         SystemAction::Read,
         ResourceIdentifier::All,
@@ -886,12 +883,6 @@ fn user_system_all_read_grant_allows_specific_resources() {
 
 #[test]
 fn user_system_specific_grant_only_allows_that_resource() {
-    use crate::role::{
-        Permission, Permissions, ResourceIdentifier, SystemAction, SystemResource,
-        role_permissions::SystemPermission,
-    };
-    use crate::{SystemActions, SystemResourceIdentifier};
-
     let perms = Permissions::new(vec![Permission::System(SystemPermission::new(
         SystemAction::Read,
         ResourceIdentifier::Identifier(SystemResource::Health),
@@ -911,9 +902,6 @@ fn user_system_specific_grant_only_allows_that_resource() {
 
 #[test]
 fn user_without_system_grant_denied() {
-    use crate::role::{Permissions, UserAction, role_permissions::UserPermission};
-    use crate::{SystemActions, SystemResourceIdentifier};
-
     let perms = Permissions::new(vec![crate::role::Permission::User(UserPermission::new(
         UserAction::Read,
     ))]);
@@ -927,12 +915,6 @@ fn user_without_system_grant_denied() {
 
 #[test]
 fn user_system_unknown_resource_id_denied() {
-    use crate::role::{
-        Permission, Permissions, ResourceIdentifier, SystemAction,
-        role_permissions::SystemPermission,
-    };
-    use crate::{SystemActions, SystemResourceIdentifier};
-
     let perms = Permissions::new(vec![Permission::System(SystemPermission::new(
         SystemAction::Read,
         ResourceIdentifier::All,
@@ -947,9 +929,6 @@ fn user_system_unknown_resource_id_denied() {
 
 #[test]
 fn user_system_admin_all_covers_system_access() {
-    use crate::role::{Permission, Permissions};
-    use crate::{SystemActions, SystemResourceIdentifier};
-
     let perms = Permissions::new(vec![Permission::AccountAdminAll]);
 
     assert!(super::check_user_system_access(
@@ -957,4 +936,78 @@ fn user_system_admin_all_covers_system_access() {
         SystemResourceIdentifier::from(SystemResourceIdentifier::HEALTH),
         SystemActions::from(SystemActions::READ),
     ));
+}
+
+#[test_log::test(tokio::test)]
+async fn role_authoring_is_admin_only() {
+    let time_provider = MockProvider::new(Time::from_timestamp_nanos(0));
+    let authenticator = TokenAuthenticator::new(
+        Arc::new(MockTokenProvider::new("sample-token", false)),
+        Arc::new(time_provider),
+    );
+    let authorizer = TokenAuthenticatorAndAuthorizer::new(
+        Arc::new(authenticator),
+        Arc::new(MockCatalogProvider(false)) as _,
+    );
+
+    // A non-admin user is denied role authoring for now -- even when it has
+    // role:*:create/update/delete permissions
+    // Temporarily grant these permissions just to verify the admin-only behavior.
+    let user = Subject::User {
+        user_id: UserId::from(1),
+        permissions: Permissions::new(vec![
+            Permission::Role(RolePermission::new(RoleAction::Create)),
+            Permission::Role(RolePermission::new(RoleAction::Update)),
+            Permission::Role(RolePermission::new(RoleAction::Delete)),
+        ]),
+    };
+
+    // Any authenticated subject can read roles; no Role:Read permission is required
+    authorizer
+        .authorize_action(Some(&user), AccessRequest::Role(RoleAction::Read))
+        .await
+        .expect("role read should be allowed for any authenticated user");
+
+    // Non-admin users should be denied role authoring actions
+    for action in [RoleAction::Create, RoleAction::Update, RoleAction::Delete] {
+        let err = authorizer
+            .authorize_action(Some(&user), AccessRequest::Role(action))
+            .await
+            .unwrap_err();
+        assert!(
+            matches!(err, ResourceAuthorizationError::Unauthorized),
+            "expected {action:?} denied for non-admin users"
+        );
+    }
+}
+
+#[test_log::test(tokio::test)]
+async fn role_authoring_allowed_for_admin_user() {
+    let time_provider = MockProvider::new(Time::from_timestamp_nanos(0));
+    let authenticator = TokenAuthenticator::new(
+        Arc::new(MockTokenProvider::new("sample-token", false)),
+        Arc::new(time_provider),
+    );
+    let authorizer = TokenAuthenticatorAndAuthorizer::new(
+        Arc::new(authenticator),
+        Arc::new(MockCatalogProvider(false)) as _,
+    );
+
+    let admin = Subject::User {
+        user_id: UserId::from(1),
+        permissions: Permissions::new(vec![Permission::AccountAdminAll]),
+    };
+
+    // Admin can take all role actions
+    for action in [
+        RoleAction::Create,
+        RoleAction::Update,
+        RoleAction::Delete,
+        RoleAction::Read,
+    ] {
+        authorizer
+            .authorize_action(Some(&admin), AccessRequest::Role(action))
+            .await
+            .unwrap_or_else(|e| panic!("admin should be allowed {action:?}: {e}"));
+    }
 }

--- a/influxdb3_clap_blocks/src/memory_size.rs
+++ b/influxdb3_clap_blocks/src/memory_size.rs
@@ -351,7 +351,13 @@ pub fn percent_of_total_mem_capped(percent: u8, cap_bytes: usize) -> usize {
 /// Threshold (as a fraction of detected process memory) at which configured
 /// memory reservations are considered close enough to the available total to
 /// warrant warning the operator.
-pub const MEMORY_RESERVATION_WARN_THRESHOLD: f64 = 0.90;
+///
+/// Must stay strictly above the sum of the shipped percentage defaults, which
+/// come to 90% (`--exec-mem-pool-size` 20% + `--file-cache-size` 20% +
+/// `--replica-max-buffer-size` 50%), with a byte of slack for the rounding
+/// difference between the two. Otherwise the recommended configuration warns
+/// about itself. Raising any of those defaults means raising this too.
+pub const MEMORY_RESERVATION_WARN_THRESHOLD: f64 = 0.91;
 
 /// Returns true when `reserved` is at or above
 /// [`MEMORY_RESERVATION_WARN_THRESHOLD`] of `detected`.

--- a/influxdb3_clap_blocks/src/memory_size/tests.rs
+++ b/influxdb3_clap_blocks/src/memory_size/tests.rs
@@ -193,8 +193,10 @@ fn test_should_warn_memory_reservations() {
     let total = 100;
     // Below threshold: no warn.
     assert!(!should_warn_memory_reservations(total, 89));
+    // Sum of the shipped percentage defaults: must stay quiet.
+    assert!(!should_warn_memory_reservations(total, 90));
     // At threshold: warn.
-    assert!(should_warn_memory_reservations(total, 90));
+    assert!(should_warn_memory_reservations(total, 91));
     // Above threshold but under detected total: warn.
     assert!(should_warn_memory_reservations(total, 95));
     // Over-committed (reserved > detected): warn.

--- a/influxdb3_processing_engine/Cargo.toml
+++ b/influxdb3_processing_engine/Cargo.toml
@@ -46,6 +46,7 @@ influxdb3_cache = { path = "../influxdb3_cache" }
 influxdb3_write = { path = "../influxdb3_write", features = [ "test_helpers" ] }
 iox_query.workspace = true
 metric.workspace = true
+mockito.workspace = true
 object_store.workspace = true
 parquet_file.workspace = true
 proptest = "1.0"

--- a/influxdb3_processing_engine/src/lib.rs
+++ b/influxdb3_processing_engine/src/lib.rs
@@ -119,6 +119,7 @@ pub struct ProcessingEngineManagerImpl {
     time_provider: Arc<dyn TimeProvider>,
     cache: Arc<Mutex<CacheStore>>,
     scheduler: scheduler::Scheduler,
+    worker: Arc<worker::local::PythonTriggerWorker>,
     /// Maximum concurrent invocations per `run_async` trigger; `NonZeroUsize::MAX`
     /// means unlimited.
     async_trigger_concurrency_limit: NonZeroUsize,
@@ -406,9 +407,12 @@ impl ProcessingEngineManagerImpl {
             plugin_shutdown: plugin_shutdown.clone(),
             plugin_trigger_invocation_registry: plugin_trigger_invocation_registry.clone(),
         });
-        let scheduler = scheduler::Scheduler::new(Arc::clone(&node_id), |scheduler| {
-            worker.register_scheduler(scheduler);
-            vec![worker]
+        let scheduler = scheduler::Scheduler::new(Arc::clone(&node_id), {
+            let worker = Arc::clone(&worker);
+            |scheduler| {
+                worker.register_scheduler(scheduler);
+                vec![worker as _]
+            }
         });
         let pem = Arc::new(Self {
             environment_manager: environment,
@@ -417,6 +421,7 @@ impl ProcessingEngineManagerImpl {
             query_endpoint,
             time_provider,
             scheduler,
+            worker,
             async_trigger_concurrency_limit,
             trigger_registry: Default::default(),
             cache,
@@ -840,6 +845,7 @@ impl ProcessingEngineManagerImpl {
         self.scheduler.shutdown_trigger(key).await;
         self.trigger_registry.write().await.remove_trigger(key);
         self.cache.lock().drop_trigger_cache(db_id, trigger_id);
+        self.worker.forget_trigger(key);
 
         Ok(())
     }
@@ -1340,6 +1346,8 @@ fn background_catalog_update(
                             .scheduler
                             .shutdown_triggers_for_db(*db_id)
                             .await;
+                        // must run after scheduler shutdown
+                        processing_engine_manager.worker.forget_all_for_db(*db_id);
                         if !hard_delete_pending {
                             processing_engine_manager
                                 .trigger_registry
@@ -1358,6 +1366,8 @@ fn background_catalog_update(
                             .scheduler
                             .shutdown_triggers_for_db(*db_id)
                             .await;
+                        // must run after scheduler shutdown
+                        processing_engine_manager.worker.forget_all_for_db(*db_id);
                         processing_engine_manager
                             .trigger_registry
                             .write()

--- a/influxdb3_processing_engine/src/tests.rs
+++ b/influxdb3_processing_engine/src/tests.rs
@@ -2090,6 +2090,112 @@ async fn test_hard_delete_removes_schedule_triggers() -> Result<(), Box<dyn std:
     Ok(())
 }
 
+/// Create `db_name` with a disabled trigger on `file_name` and seed the
+/// worker's plugin cache for it.
+async fn seed_worker_plugin_in_db(
+    pem: &Arc<ProcessingEngineManagerImpl>,
+    db_name: &str,
+    file_name: &str,
+) -> crate::scheduler::TriggerKey {
+    pem.catalog.create_database(db_name).await.unwrap();
+    let validated = pem.validate_plugin_filename(file_name).await.unwrap();
+    let trigger = pem
+        .catalog
+        .create_processing_engine_trigger(
+            db_name,
+            "cache_trigger",
+            validated,
+            ApiNodeSpec::All,
+            "every:1s",
+            TriggerSettings::default(),
+            &None,
+            true,
+        )
+        .await
+        .unwrap();
+    let key = trigger_key(
+        pem.catalog.db_schema(db_name).unwrap().id,
+        trigger.trigger_id,
+    );
+    pem.worker.load_plugin_for_test(key).await.unwrap();
+    key
+}
+
+/// #5358: soft delete must evict the worker's cached plugins for that db —
+/// immediately, even though the default hard delete is 72 h out — and only
+/// that db's.
+#[test_log::test(tokio::test)]
+async fn test_soft_delete_evicts_worker_plugin_cache() -> Result<(), Box<dyn std::error::Error>> {
+    let (pem, db_id, trigger_id, _cancel, file) = setup_db_with_trigger("schedule").await?;
+    let file_name = file
+        .path()
+        .file_name()
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .to_string();
+    let key = trigger_key(db_id, trigger_id);
+    pem.worker.load_plugin_for_test(key).await.unwrap();
+    let other_key = seed_worker_plugin_in_db(&pem, "other_db", &file_name).await;
+    assert_eq!(pem.worker.cached_keys().len(), 2);
+
+    // Plain delete: hard delete pending on the default (72 h) schedule.
+    pem.catalog
+        .soft_delete_database(
+            "test_db",
+            HardDeletionTime::Default,
+            DeletionScope::DataAndCatalog,
+        )
+        .await?;
+
+    // Catalog subscriptions are synchronous, so the handler has run.
+    assert_eq!(
+        pem.worker.cached_keys(),
+        vec![other_key],
+        "soft delete must evict the db's cached plugins and no others"
+    );
+
+    pem.catalog
+        .soft_delete_database(
+            "other_db",
+            HardDeletionTime::Default,
+            DeletionScope::DataAndCatalog,
+        )
+        .await?;
+    assert!(
+        pem.worker.cached_keys().is_empty(),
+        "no cached plugins should remain once every db is deleted"
+    );
+    Ok(())
+}
+
+/// #5358: a plugin cached after soft delete (straggler load) is swept when the
+/// hard delete fires.
+#[test_log::test(tokio::test)]
+async fn test_hard_delete_evicts_worker_plugin_cache() -> Result<(), Box<dyn std::error::Error>> {
+    let (pem, db_id, trigger_id, _cancel, _file) = setup_db_with_trigger("schedule").await?;
+    let key = trigger_key(db_id, trigger_id);
+
+    pem.catalog
+        .soft_delete_database(
+            "test_db",
+            HardDeletionTime::Now,
+            DeletionScope::DataAndCatalog,
+        )
+        .await?;
+
+    // Cache after the soft delete so the hard-delete handler must evict itself.
+    pem.worker.load_plugin_for_test(key).await.unwrap();
+    assert_eq!(pem.worker.cached_keys(), vec![key]);
+
+    pem.catalog.hard_delete_database(&db_id).await?;
+    assert!(
+        pem.worker.cached_keys().is_empty(),
+        "hard delete must evict the db's cached plugins"
+    );
+    Ok(())
+}
+
 /// Unit tests for the id-keyed trigger routing table. These exercise
 /// `TriggerRegistry` directly, without a catalog, to prove WAL and request
 /// routing are driven by `TriggerKey`.

--- a/influxdb3_processing_engine/src/worker/local.rs
+++ b/influxdb3_processing_engine/src/worker/local.rs
@@ -79,6 +79,7 @@ pub(crate) fn make_trigger_worker(context: TriggerWorkerContext) -> Arc<PythonTr
         plugin_shutdown: context.plugin_shutdown,
         plugin_trigger_invocation_registry: context.plugin_trigger_invocation_registry,
         plugins: Default::default(),
+        next_plugin_generation: Default::default(),
         active_work: Default::default(),
         schedulers: Default::default(),
     })
@@ -94,9 +95,16 @@ pub(crate) struct PythonTriggerWorker {
     cache: Arc<Mutex<CacheStore>>,
     plugin_shutdown: CancellationToken,
     plugin_trigger_invocation_registry: Option<Arc<PluginTriggerInvocationRegistry>>,
-    plugins: Mutex<HashMap<TriggerKey, Arc<TriggerPlugin>>>,
+    plugins: Mutex<HashMap<TriggerKey, PluginSlot>>,
+    next_plugin_generation: AtomicU64,
     active_work: ActiveWorkRegistry,
     schedulers: Mutex<HashMap<Arc<str>, Weak<dyn TriggerScheduler>>>,
+}
+
+#[derive(Debug)]
+struct PluginSlot {
+    generation: u64,
+    plugin: Option<Arc<TriggerPlugin>>,
 }
 
 impl Debug for PythonTriggerWorker {
@@ -184,11 +192,16 @@ impl PythonTriggerWorker {
             .ok_or_else(|| anyhow!("trigger not found: {key:?}"))?;
         let db_name = db_schema.name.to_string();
 
-        if let Some(plugin) = self.plugins.lock().get(&key).cloned()
-            && plugin.matches(&db_name, &trigger_definition)
-        {
-            return Ok(plugin);
-        }
+        let load_generation = {
+            let mut plugins = self.plugins.lock();
+            let slot = plugins.entry(key).or_insert_with(|| self.new_plugin_slot());
+            if let Some(plugin) = &slot.plugin
+                && plugin.matches(&db_name, &trigger_definition)
+            {
+                return Ok(Arc::clone(plugin));
+            }
+            slot.generation
+        };
 
         let plugin_code = Arc::new(
             read_plugin_code(
@@ -204,8 +217,53 @@ impl PythonTriggerWorker {
             plugin_code,
             self,
         ));
-        self.plugins.lock().insert(key, Arc::clone(&plugin));
+        let mut plugins = self.plugins.lock();
+        if let Some(slot) = plugins.get_mut(&key)
+            && slot.generation == load_generation
+        {
+            slot.plugin = Some(Arc::clone(&plugin));
+        }
         Ok(plugin)
+    }
+
+    fn new_plugin_slot(&self) -> PluginSlot {
+        PluginSlot {
+            generation: self.next_plugin_generation.fetch_add(1, Ordering::Relaxed),
+            plugin: None,
+        }
+    }
+
+    pub(crate) fn forget_trigger(&self, key: TriggerKey) {
+        let evicted = self.plugins.lock().remove(&key);
+        // dropped outside the lock
+        drop(evicted);
+    }
+
+    pub(crate) fn forget_all_for_db(&self, db_id: DbId) {
+        let evicted: Vec<_> = {
+            let mut plugins = self.plugins.lock();
+            plugins.extract_if(|key, _| key.db_id == db_id).collect()
+        };
+        // dropped outside the lock
+        drop(evicted);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn cached_keys(&self) -> Vec<TriggerKey> {
+        self.plugins
+            .lock()
+            .iter()
+            .filter(|(_, slot)| slot.plugin.is_some())
+            .map(|(key, _)| *key)
+            .collect()
+    }
+
+    #[cfg(test)]
+    pub(crate) async fn load_plugin_for_test(
+        &self,
+        key: TriggerKey,
+    ) -> Result<(), TriggerExecutionError> {
+        self.plugin_for_key(key).await.map(|_| ())
     }
 
     async fn execute_once(
@@ -676,5 +734,7 @@ impl TriggerWorker for PythonTriggerWorker {
     }
 }
 
+#[cfg(test)]
+pub(crate) mod test_support;
 #[cfg(test)]
 mod tests;

--- a/influxdb3_processing_engine/src/worker/local/test_support.rs
+++ b/influxdb3_processing_engine/src/worker/local/test_support.rs
@@ -1,0 +1,114 @@
+//! Shared fixtures for the worker's tests.
+
+use super::*;
+use crate::environment::TestManager;
+use crate::query::UnimplementedQueryEndpoint;
+use influxdb3_py_api::write::WriteAccumulator;
+use iox_time::{MockProvider, Time};
+use object_store::memory::InMemory;
+use std::path::PathBuf;
+use std::time::Duration;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+use tokio::sync::Notify;
+
+/// A [`TriggerScheduler`] that accepts every callback and records nothing.
+///
+/// The worker refuses work from a scheduler it cannot report back to, so tests
+/// that expect a submission to be accepted have to register one of these.
+pub(crate) struct NoopTriggerScheduler(pub(crate) Arc<str>);
+
+impl TriggerScheduler for NoopTriggerScheduler {
+    fn node_id(&self) -> Arc<str> {
+        Arc::clone(&self.0)
+    }
+
+    fn work_progressed(&self, _worker_node_id: Arc<str>, _work_id: TriggerWorkId) {}
+
+    fn work_finished(&self, _worker_node_id: Arc<str>, _result: TriggerWorkResult) {}
+}
+
+/// Build a worker backed by an in-memory catalog and object store.
+///
+/// `plugin_dir` is only needed by tests that resolve real plugin code.
+pub(crate) async fn test_worker_with_plugin_repo(
+    node_id: &str,
+    plugin_dir: Option<PathBuf>,
+    plugin_repo: Option<String>,
+) -> (Arc<PythonTriggerWorker>, Arc<Catalog>, CancellationToken) {
+    let time_provider: Arc<dyn TimeProvider> =
+        Arc::new(MockProvider::new(Time::from_timestamp_nanos(1)));
+    let cache = Arc::new(Mutex::new(CacheStore::new(
+        Arc::clone(&time_provider),
+        Duration::from_secs(10),
+    )));
+    let catalog = Catalog::new(
+        "test_host",
+        Arc::new(InMemory::new()),
+        Arc::clone(&time_provider),
+        Default::default(),
+    )
+    .await
+    .unwrap();
+    let plugin_shutdown = CancellationToken::new();
+
+    let worker = make_trigger_worker(TriggerWorkerContext {
+        environment_manager: ProcessingEngineEnvironmentManager {
+            plugin_dir,
+            virtual_env_location: None,
+            package_manager: Arc::new(TestManager),
+            plugin_dir_only: false,
+            plugin_repo,
+        },
+        catalog: Arc::clone(&catalog),
+        node_id: Arc::from(node_id),
+        write_endpoint: Arc::new(WriteAccumulator::default()),
+        query_endpoint: Arc::new(UnimplementedQueryEndpoint),
+        time_provider,
+        cache,
+        plugin_shutdown: plugin_shutdown.clone(),
+        plugin_trigger_invocation_registry: None,
+    });
+
+    (worker, catalog, plugin_shutdown)
+}
+
+/// An HTTP server serving one gated connection per body, sequentially, so a
+/// plugin load can be suspended mid-fetch at an exact point.
+///
+/// Returns the URL to use as the worker's plugin repo, a [`Notify`] that fires
+/// when a request has arrived, and a [`Notify`] the test signals to release
+/// the response.
+pub(crate) async fn gated_plugin_repo(
+    bodies: &'static [&'static str],
+) -> (String, Arc<Notify>, Arc<Notify>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let url = format!("http://{}", listener.local_addr().unwrap());
+    let request_arrived = Arc::new(Notify::new());
+    let release_response = Arc::new(Notify::new());
+    let arrived = Arc::clone(&request_arrived);
+    let release = Arc::clone(&release_response);
+    tokio::spawn(async move {
+        for body in bodies {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            let mut request = Vec::new();
+            let mut chunk = [0u8; 1024];
+            while !request.windows(4).any(|window| window == b"\r\n\r\n") {
+                let n = stream.read(&mut chunk).await.unwrap();
+                if n == 0 {
+                    break;
+                }
+                request.extend_from_slice(&chunk[..n]);
+            }
+            arrived.notify_one();
+            release.notified().await;
+            let response = format!(
+                "HTTP/1.1 200 OK\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{body}",
+                body.len(),
+            );
+            stream.write_all(response.as_bytes()).await.unwrap();
+            stream.shutdown().await.unwrap();
+        }
+    });
+    (url, request_arrived, release_response)
+}

--- a/influxdb3_processing_engine/src/worker/local/tests.rs
+++ b/influxdb3_processing_engine/src/worker/local/tests.rs
@@ -9,16 +9,225 @@ use std::io::Write as _;
 use std::time::Duration;
 use tempfile::NamedTempFile;
 
-struct NoopTriggerScheduler(Arc<str>);
+use super::test_support::{NoopTriggerScheduler, gated_plugin_repo, test_worker_with_plugin_repo};
 
-impl TriggerScheduler for NoopTriggerScheduler {
-    fn node_id(&self) -> Arc<str> {
-        Arc::clone(&self.0)
+async fn create_gh_trigger(catalog: &Arc<Catalog>) -> TriggerKey {
+    create_gh_trigger_in_db(catalog, "foo").await
+}
+
+async fn create_gh_trigger_in_db(catalog: &Arc<Catalog>, db_name: &str) -> TriggerKey {
+    catalog.create_database(db_name).await.unwrap();
+    let trigger_definition = catalog
+        .create_processing_engine_trigger(
+            db_name,
+            "test_trigger",
+            ValidPluginFilename::from_validated_name("gh:test/plugin.py"),
+            ApiNodeSpec::All,
+            "every:1s",
+            TriggerSettings::default(),
+            &None,
+            false,
+        )
+        .await
+        .unwrap();
+    TriggerKey {
+        db_id: catalog.db_schema(db_name).unwrap().id,
+        trigger_id: trigger_definition.trigger_id,
+    }
+}
+
+#[tokio::test]
+async fn forget_all_for_db_evicts_only_that_dbs_entries() {
+    let mut repo = mockito::Server::new_async().await;
+    let mock = repo
+        .mock("GET", "/test/plugin.py")
+        .with_body("# v1")
+        .expect(2)
+        .create_async()
+        .await;
+    let (worker, catalog, _shutdown) =
+        test_worker_with_plugin_repo("test_node", None, Some(repo.url())).await;
+    let key1 = create_gh_trigger_in_db(&catalog, "db_one").await;
+    let key2 = create_gh_trigger_in_db(&catalog, "db_two").await;
+    worker.plugin_for_key(key1).await.unwrap();
+    worker.plugin_for_key(key2).await.unwrap();
+    mock.assert_async().await;
+    assert_eq!(worker.plugins.lock().len(), 2);
+
+    worker.forget_all_for_db(key1.db_id);
+    {
+        let plugins = worker.plugins.lock();
+        assert!(!plugins.contains_key(&key1));
+        assert!(plugins.get(&key2).unwrap().plugin.is_some());
     }
 
-    fn work_progressed(&self, _worker_node_id: Arc<str>, _work_id: TriggerWorkId) {}
+    worker.forget_all_for_db(key2.db_id);
+    assert_eq!(
+        worker.plugins.lock().len(),
+        0,
+        "eviction must remove entries, not leave tombstones"
+    );
+}
 
-    fn work_finished(&self, _worker_node_id: Arc<str>, _result: TriggerWorkResult) {}
+#[tokio::test]
+async fn load_in_flight_across_a_db_eviction_is_not_cached() {
+    let (repo_url, request_arrived, release_response) = gated_plugin_repo(&["# stale"]).await;
+    let (worker, catalog, _shutdown) =
+        test_worker_with_plugin_repo("test_node", None, Some(repo_url)).await;
+    let key = create_gh_trigger(&catalog).await;
+
+    let load_worker = Arc::clone(&worker);
+    let load = tokio::spawn(async move { load_worker.plugin_for_key(key).await });
+    request_arrived.notified().await;
+    worker.forget_all_for_db(key.db_id);
+    release_response.notify_one();
+
+    let plugin = load.await.unwrap().unwrap();
+    assert_eq!(plugin.plugin_code.code().as_ref(), "# stale");
+    assert!(
+        !worker.plugins.lock().contains_key(&key),
+        "a db eviction must invalidate a load that was in flight"
+    );
+}
+
+/// Pins the per-db granularity for which a map-level epoch was rejected:
+/// evicting one db must not invalidate another db's in-flight load.
+#[tokio::test]
+async fn db_eviction_does_not_invalidate_another_dbs_in_flight_load() {
+    let (repo_url, request_arrived, release_response) =
+        gated_plugin_repo(&["# db1", "# db2"]).await;
+    let (worker, catalog, _shutdown) =
+        test_worker_with_plugin_repo("test_node", None, Some(repo_url)).await;
+    let key1 = create_gh_trigger_in_db(&catalog, "db_one").await;
+    let key2 = create_gh_trigger_in_db(&catalog, "db_two").await;
+
+    // db_one cached up front so the eviction has something to remove.
+    let load1 = {
+        let worker = Arc::clone(&worker);
+        tokio::spawn(async move { worker.plugin_for_key(key1).await })
+    };
+    request_arrived.notified().await;
+    release_response.notify_one();
+    load1.await.unwrap().unwrap();
+
+    // db_two's load is held mid-fetch across the db_one eviction.
+    let load2 = {
+        let worker = Arc::clone(&worker);
+        tokio::spawn(async move { worker.plugin_for_key(key2).await })
+    };
+    request_arrived.notified().await;
+    worker.forget_all_for_db(key1.db_id);
+    release_response.notify_one();
+
+    load2.await.unwrap().unwrap();
+    let plugins = worker.plugins.lock();
+    assert!(!plugins.contains_key(&key1));
+    assert!(
+        plugins.get(&key2).unwrap().plugin.is_some(),
+        "evicting db_one must not invalidate db_two's in-flight load"
+    );
+}
+
+#[tokio::test]
+async fn forget_trigger_evicts_cached_plugin_so_gh_source_is_refetched() {
+    let mut repo = mockito::Server::new_async().await;
+    let mock_v1 = repo
+        .mock("GET", "/test/plugin.py")
+        .with_body("# v1")
+        .expect(1)
+        .create_async()
+        .await;
+
+    let (worker, catalog, _shutdown) =
+        test_worker_with_plugin_repo("test_node", None, Some(repo.url())).await;
+    let key = create_gh_trigger(&catalog).await;
+
+    let first = worker.plugin_for_key(key).await.unwrap();
+    assert_eq!(first.plugin_code.code().as_ref(), "# v1");
+    mock_v1.assert_async().await;
+
+    let mock_v2 = repo
+        .mock("GET", "/test/plugin.py")
+        .with_body("# v2")
+        .expect(1)
+        .create_async()
+        .await;
+    worker.forget_trigger(key);
+
+    let second = worker.plugin_for_key(key).await.unwrap();
+    assert!(
+        !Arc::ptr_eq(&first, &second),
+        "eviction must rebuild the TriggerPlugin"
+    );
+    assert_eq!(second.plugin_code.code().as_ref(), "# v2");
+    mock_v2.assert_async().await;
+}
+
+#[tokio::test]
+async fn load_in_flight_across_an_eviction_is_not_cached() {
+    let (repo_url, request_arrived, release_response) = gated_plugin_repo(&["# stale"]).await;
+    let (worker, catalog, _shutdown) =
+        test_worker_with_plugin_repo("test_node", None, Some(repo_url)).await;
+    let key = create_gh_trigger(&catalog).await;
+
+    let load_worker = Arc::clone(&worker);
+    let load = tokio::spawn(async move { load_worker.plugin_for_key(key).await });
+    request_arrived.notified().await;
+    worker.forget_trigger(key);
+    release_response.notify_one();
+
+    // The load still hands its plugin to the (cancelled) work that wanted it,
+    // but must not re-cache source fetched before the trigger stopped.
+    let plugin = load.await.unwrap().unwrap();
+    assert_eq!(plugin.plugin_code.code().as_ref(), "# stale");
+    assert!(
+        !worker.plugins.lock().contains_key(&key),
+        "an eviction must invalidate a load that was in flight"
+    );
+}
+
+/// Guards the ABA hole that makes removal-based eviction safe: a slot
+/// recreated after an eviction gets a globally unique generation, so a load
+/// that reserved the *old* slot can never cache into the new one.
+#[tokio::test]
+async fn a_load_reserved_before_eviction_never_caches_into_a_recreated_slot() {
+    let (repo_url, request_arrived, release_response) =
+        gated_plugin_repo(&["# stale", "# fresh"]).await;
+    let (worker, catalog, _shutdown) =
+        test_worker_with_plugin_repo("test_node", None, Some(repo_url)).await;
+    let key = create_gh_trigger(&catalog).await;
+
+    let w1 = Arc::clone(&worker);
+    let l1 = tokio::spawn(async move { w1.plugin_for_key(key).await });
+    request_arrived.notified().await;
+    worker.forget_trigger(key);
+
+    // L2 recreates the slot, capturing its fresh generation under the map lock
+    // *before* its HTTP connection is accepted (the gated repo serves
+    // connections sequentially), so waiting for the slot to reappear orders
+    // L2's reservation ahead of L1's insert.
+    let w2 = Arc::clone(&worker);
+    let l2 = tokio::spawn(async move { w2.plugin_for_key(key).await });
+    while !worker.plugins.lock().contains_key(&key) {
+        tokio::task::yield_now().await;
+    }
+
+    release_response.notify_one();
+    let stale = l1.await.unwrap().unwrap();
+    assert_eq!(stale.plugin_code.code().as_ref(), "# stale");
+    assert!(
+        worker.plugins.lock().get(&key).unwrap().plugin.is_none(),
+        "a recreated slot must reject a load reserved before the eviction"
+    );
+
+    request_arrived.notified().await;
+    release_response.notify_one();
+    let fresh = l2.await.unwrap().unwrap();
+    assert_eq!(fresh.plugin_code.code().as_ref(), "# fresh");
+    assert!(
+        worker.plugins.lock().get(&key).unwrap().plugin.is_some(),
+        "the load that owns the recreated slot caches normally"
+    );
 }
 
 #[tokio::test]
@@ -88,6 +297,7 @@ async fn python_worker_reuses_cached_trigger_plugin_tracks_schedulers_and_drops_
         plugin_shutdown: CancellationToken::new(),
         plugin_trigger_invocation_registry: None,
         plugins: Default::default(),
+        next_plugin_generation: Default::default(),
         active_work: Default::default(),
         schedulers: Default::default(),
     });

--- a/influxdb3_startup/Cargo.toml
+++ b/influxdb3_startup/Cargo.toml
@@ -10,6 +10,11 @@ build = "Core"
 
 [dependencies]
 chrono.workspace = true
+observability_deps.workspace = true
+tokio.workspace = true
+
+[dev-dependencies]
+test_helpers = { path = "../core/test_helpers" }
 
 [lints]
 workspace = true

--- a/influxdb3_startup/src/lib.rs
+++ b/influxdb3_startup/src/lib.rs
@@ -1,9 +1,9 @@
 //! Startup utilities for InfluxDB 3.
 //!
-//! Provides functionality needed during early startup, before the tracing
-//! system is initialized:
+//! Provides functionality needed during node startup:
 //! - [`early_logging`]: Log-like output for pre-tracing startup messages
 //! - [`env_compat`]: Backwards-compatible environment variable aliasing
+//! - [`phase`]: Per-phase progress tracking for the serve path
 #![deny(rustdoc::broken_intra_doc_links, rustdoc::bare_urls, rust_2018_idioms)]
 #![warn(
     missing_debug_implementations,
@@ -13,3 +13,8 @@
 
 pub mod early_logging;
 pub mod env_compat;
+pub mod phase;
+
+pub use phase::{
+    NoopStartupPhaseObserver, PhaseGuard, StartupPhase, StartupPhaseObserver, StartupPhases,
+};

--- a/influxdb3_startup/src/phase.rs
+++ b/influxdb3_startup/src/phase.rs
@@ -1,0 +1,306 @@
+//! Phase tracking for node startup.
+//!
+//! [`StartupPhases`] issues one [`PhaseGuard`] per phase. The guard logs a start line when it is
+//! created and a completion line when the phase succeeds or fails. Completion events also feed a
+//! [`StartupPhaseObserver`] so they reach the service log; start lines go to tracing only, so do
+//! not rely on a service-log start event.
+//!
+//! Both destinations are deliberate. Tracing writes through line-buffered stdout, so a line reaches
+//! the file descriptor as it completes and survives a SIGKILL; the service log hands entries to a
+//! background writer thread, so an entry can still be in memory when the process dies. A node that
+//! is OOM-killed mid-phase keeps its tracing lines and may lose its service log entries, so the two
+//! are not redundant.
+
+use std::fmt::Debug;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use observability_deps::tracing::{error, info};
+// The startup path threads a `tokio::time::Instant` as its origin, so match that rather than
+// converting at every call site. It also keeps these durations honest under a paused test clock.
+use tokio::time::Instant;
+
+/// A named startup phase the enterprise serve path emits SLL events for.
+#[derive(Debug, Clone, Copy)]
+pub enum StartupPhase {
+    /// The throwaway catalog load `command` runs on the temporary runtime to look up the
+    /// instance id and the persisted storage mode. Finishes before logging is initialised, so it
+    /// is reported after the fact via `StartupPhases::report_completed`.
+    /// Success detail: `storage_mode=<parquet|pacha_tree>`.
+    TempCatalogLoad,
+    /// Licensing init on the temporary runtime. The span covers the whole licensing bootstrap,
+    /// including its own catalog access and onboarding telemetry, so boot wall-clock stays fully
+    /// attributed. Also reported after the fact; never reported on `no_license` builds.
+    /// Success detail: `licensed_cores=<n>`.
+    Licensing,
+    /// Load of the persisted catalog. Success detail: `uuid_<catalog uuid>`.
+    CatalogLoad,
+    /// Load (or first-boot create) of the persisted `EnterpriseConfig`.
+    /// Success detail: `loaded` or `created_default`.
+    EnterpriseConfig,
+    /// Background table-index-cache initialization on ingest-capable nodes. Runs concurrently
+    /// with later phases, so its lines interleave with theirs.
+    /// Success detail: `snapshots=<split> entries=<held>`.
+    TableIndexCache,
+    /// Load of compacted data: the producer's state on compact nodes, or the consumer's copy on
+    /// other modes when a compactor node is running.
+    /// Success detail: `tables=<n> generations=<n>`, plus ` retries=<n>` for the consumer.
+    CompactedDataLoad,
+    /// Restore of persisted snapshots into the write buffer. Success detail:
+    /// `checkpoints=<n> additional_snapshots=<n>`, `snapshots=<n>`, or `skipped`.
+    SnapshotRestore,
+    /// Replay of WAL files written since the last snapshot. Success detail:
+    /// `no_wal files=<n>` or `replayed_through_seq_<seq> files=<n>`.
+    WalReplay,
+    /// Binding the HTTP listener and, when configured, the internode listener.
+    /// Success detail: `internode_bound` or `http_only` (addresses stay out of the service log).
+    ListenerBind,
+    /// Creation of replicated buffers for every ingest peer on query-capable nodes.
+    /// Success detail: `peers=<n>`.
+    ReplicaBootstrap,
+    /// Warm-up of the last-value and distinct-value caches.
+    /// Success detail: `both_caches`, `lvc_only`, `dvc_only`, or `skipped`.
+    CacheWarm,
+    /// Registration of this node in the catalog. Success detail: `instance_<instance id>`.
+    NodeRegistration,
+    /// Processing engine setup and trigger start on process-capable nodes.
+    /// Success detail: `triggers_started`.
+    ProcessingEngine,
+    /// Terminal phase: the node is serving. See [`StartupPhases::ready`].
+    /// Detail: `listening` (the address is on the adjacent startup-time tracing line only).
+    Ready,
+}
+
+impl StartupPhase {
+    /// The snake_case name this phase carries on log lines and SLL events.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::TempCatalogLoad => "temp_catalog_load",
+            Self::Licensing => "licensing",
+            Self::CatalogLoad => "catalog_load",
+            Self::EnterpriseConfig => "enterprise_config",
+            Self::TableIndexCache => "table_index_cache",
+            Self::CompactedDataLoad => "compacted_data_load",
+            Self::SnapshotRestore => "snapshot_restore",
+            Self::WalReplay => "wal_replay",
+            Self::ListenerBind => "listener_bind",
+            Self::ReplicaBootstrap => "replica_bootstrap",
+            Self::CacheWarm => "cache_warm",
+            Self::NodeRegistration => "node_registration",
+            Self::ProcessingEngine => "processing_engine",
+            Self::Ready => "ready",
+        }
+    }
+}
+
+/// Subscriber for per-phase startup completion events. Fires once per
+/// phase per node boot. Success carries a per-phase `detail` summary;
+/// error carries a static `error_code` for the phase that failed.
+/// Node-scoped.
+pub trait StartupPhaseObserver: Send + Sync + Debug {
+    /// Called when `phase` completes successfully.
+    fn on_phase_success(&self, phase: StartupPhase, duration_ms: u64, detail: String);
+    /// Called when `phase` fails with `error_code`.
+    fn on_phase_error(&self, phase: StartupPhase, error_code: &'static str, duration_ms: u64);
+}
+
+/// No-op observer used when no subscriber is wired in.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct NoopStartupPhaseObserver;
+
+impl StartupPhaseObserver for NoopStartupPhaseObserver {
+    fn on_phase_success(&self, _: StartupPhase, _: u64, _: String) {}
+    fn on_phase_error(&self, _: StartupPhase, _: &'static str, _: u64) {}
+}
+
+/// Issues one [`PhaseGuard`] per startup phase.
+///
+/// `process_start` should be the same instant used to report total startup time, so that the
+/// `elapsed_total_ms` on every phase line is measured against one origin.
+#[derive(Debug, Clone)]
+pub struct StartupPhases {
+    observer: Arc<dyn StartupPhaseObserver>,
+    process_start: Instant,
+}
+
+impl StartupPhases {
+    /// Build a tracker that feeds `observer` and measures every `elapsed_total_ms` from
+    /// `process_start`.
+    pub fn new(observer: Arc<dyn StartupPhaseObserver>, process_start: Instant) -> Self {
+        Self {
+            observer,
+            process_start,
+        }
+    }
+
+    /// A tracker that discards every event, for tests and for paths with no subscriber.
+    ///
+    /// Each call takes its own origin, so `elapsed_total_ms` is only meaningful within one
+    /// instance. Production code builds one [`StartupPhases`] from the process start instant and
+    /// shares it, so that every phase measures against the same origin.
+    pub fn noop() -> Self {
+        Self::new(Arc::new(NoopStartupPhaseObserver), Instant::now())
+    }
+
+    /// Start `phase` and log what it is about to do.
+    ///
+    /// `plan` describes the work in terms already known at this point — counts, configured
+    /// concurrency — and is logged verbatim. Pass an empty string when there is nothing useful to
+    /// say up front. The guard must be finished with [`PhaseGuard::success`] or
+    /// [`PhaseGuard::error`]; dropping it without either logs the phase as incomplete.
+    pub fn begin(&self, phase: StartupPhase, plan: impl AsRef<str>) -> PhaseGuard<'_> {
+        let plan = plan.as_ref();
+        info!(
+            startup_phase = phase.as_str(),
+            elapsed_total_ms = self.elapsed_total_ms(),
+            plan,
+            "startup phase started"
+        );
+        PhaseGuard {
+            phases: self,
+            phase,
+            started: Instant::now(),
+            finished: AtomicBool::new(false),
+        }
+    }
+
+    /// Report a phase that already ran to completion, for work that ran before logging was
+    /// initialised (the temp-catalog load and licensing init run on a temporary runtime before
+    /// tracing exists). Emits the started and finished lines a [`PhaseGuard`] would have emitted,
+    /// using the recorded instants, and feeds the observer one success event.
+    ///
+    /// `started` may predate this tracker's origin: the origin stays tied to the reported total
+    /// startup time, so `elapsed_total_ms` saturates to zero instead of moving that origin.
+    /// Failures need no counterpart here — a failure in this pre-logging work aborts the boot
+    /// before any tracker exists.
+    pub fn report_completed(
+        &self,
+        phase: StartupPhase,
+        started: Instant,
+        finished: Instant,
+        detail: impl Into<String>,
+    ) {
+        let detail = detail.into();
+        info!(
+            startup_phase = phase.as_str(),
+            elapsed_total_ms = self.elapsed_total_ms_at(started),
+            plan = "",
+            "startup phase started"
+        );
+        let duration_ms = finished.saturating_duration_since(started).as_millis() as u64;
+        info!(
+            startup_phase = phase.as_str(),
+            duration_ms,
+            elapsed_total_ms = self.elapsed_total_ms_at(finished),
+            detail = detail.as_str(),
+            "startup phase finished"
+        );
+        self.observer.on_phase_success(phase, duration_ms, detail);
+    }
+
+    /// Report the terminal `ready` phase.
+    ///
+    /// Unlike the other phases this is a point event, not a span: its duration is the whole boot,
+    /// measured from the same origin as every `elapsed_total_ms` above it. Call it once, after the
+    /// last fallible setup step, so an aborted boot never reports ready.
+    pub fn ready(&self, detail: impl Into<String>) {
+        let detail = detail.into();
+        let duration_ms = self.elapsed_total_ms();
+        info!(
+            startup_phase = StartupPhase::Ready.as_str(),
+            duration_ms,
+            detail = detail.as_str(),
+            "startup finished"
+        );
+        self.observer
+            .on_phase_success(StartupPhase::Ready, duration_ms, detail);
+    }
+
+    fn elapsed_total_ms(&self) -> u64 {
+        self.process_start.elapsed().as_millis() as u64
+    }
+
+    /// Milliseconds from the origin to `at`, saturating to zero when `at` predates the origin.
+    fn elapsed_total_ms_at(&self, at: Instant) -> u64 {
+        at.saturating_duration_since(self.process_start).as_millis() as u64
+    }
+}
+
+/// One in-progress startup phase. See [`StartupPhases::begin`].
+#[derive(Debug)]
+pub struct PhaseGuard<'a> {
+    phases: &'a StartupPhases,
+    phase: StartupPhase,
+    started: Instant,
+    finished: AtomicBool,
+}
+
+impl PhaseGuard<'_> {
+    /// Record that the phase completed. `detail` is the machine-readable per-phase summary that
+    /// reaches the service log, and must contain no names, query text or other user data.
+    pub fn success(&self, detail: impl Into<String>) {
+        if self.finish() {
+            return;
+        }
+        let detail = detail.into();
+        let duration_ms = self.duration_ms();
+        info!(
+            startup_phase = self.phase.as_str(),
+            duration_ms,
+            elapsed_total_ms = self.phases.elapsed_total_ms(),
+            detail = detail.as_str(),
+            "startup phase finished"
+        );
+        self.phases
+            .observer
+            .on_phase_success(self.phase, duration_ms, detail);
+    }
+
+    /// Record that the phase failed. Takes `&self` so it composes with `inspect_err` ahead of the
+    /// `?` that propagates the original error.
+    pub fn error(&self, error_code: &'static str) {
+        if self.finish() {
+            return;
+        }
+        let duration_ms = self.duration_ms();
+        error!(
+            startup_phase = self.phase.as_str(),
+            duration_ms,
+            elapsed_total_ms = self.phases.elapsed_total_ms(),
+            error_code,
+            "startup phase failed"
+        );
+        self.phases
+            .observer
+            .on_phase_error(self.phase, error_code, duration_ms);
+    }
+
+    fn duration_ms(&self) -> u64 {
+        self.started.elapsed().as_millis() as u64
+    }
+
+    /// Mark the guard finished. Returns true if it was already finished, in which case the caller
+    /// must emit nothing: a phase reports exactly once.
+    fn finish(&self) -> bool {
+        self.finished.swap(true, Ordering::Relaxed)
+    }
+}
+
+impl Drop for PhaseGuard<'_> {
+    fn drop(&mut self) {
+        if *self.finished.get_mut() {
+            return;
+        }
+        // Reached when a phase returns early without reporting. Logged rather than ignored so the
+        // gap is visible instead of the phase silently never finishing.
+        error!(
+            startup_phase = self.phase.as_str(),
+            duration_ms = self.duration_ms(),
+            elapsed_total_ms = self.phases.elapsed_total_ms(),
+            "startup phase did not report an outcome"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/influxdb3_startup/src/phase/tests.rs
+++ b/influxdb3_startup/src/phase/tests.rs
@@ -1,0 +1,201 @@
+use std::sync::Mutex;
+
+use super::*;
+
+/// Records what reached the observer, so tests assert on emissions rather than log output.
+#[derive(Debug, Default)]
+struct RecordingObserver {
+    events: Mutex<Vec<Event>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Event {
+    Success {
+        phase: &'static str,
+        detail: String,
+    },
+    Error {
+        phase: &'static str,
+        code: &'static str,
+    },
+}
+
+impl RecordingObserver {
+    fn events(&self) -> Vec<Event> {
+        self.events.lock().unwrap().clone()
+    }
+}
+
+impl StartupPhaseObserver for RecordingObserver {
+    fn on_phase_success(&self, phase: StartupPhase, _duration_ms: u64, detail: String) {
+        self.events.lock().unwrap().push(Event::Success {
+            phase: phase.as_str(),
+            detail,
+        });
+    }
+
+    fn on_phase_error(&self, phase: StartupPhase, error_code: &'static str, _duration_ms: u64) {
+        self.events.lock().unwrap().push(Event::Error {
+            phase: phase.as_str(),
+            code: error_code,
+        });
+    }
+}
+
+fn phases() -> (Arc<RecordingObserver>, StartupPhases) {
+    let observer = Arc::new(RecordingObserver::default());
+    let phases = StartupPhases::new(
+        Arc::clone(&observer) as Arc<dyn StartupPhaseObserver>,
+        Instant::now(),
+    );
+    (observer, phases)
+}
+
+#[test]
+fn success_reports_once() {
+    let (observer, phases) = phases();
+    {
+        let guard = phases.begin(StartupPhase::CatalogLoad, "");
+        guard.success("uuid_abc");
+    }
+    assert_eq!(
+        observer.events(),
+        vec![Event::Success {
+            phase: "catalog_load",
+            detail: "uuid_abc".to_string(),
+        }]
+    );
+}
+
+#[test]
+fn error_reports_once() {
+    let (observer, phases) = phases();
+    {
+        let guard = phases.begin(StartupPhase::WalReplay, "");
+        guard.error("wal_replay_failed");
+    }
+    assert_eq!(
+        observer.events(),
+        vec![Event::Error {
+            phase: "wal_replay",
+            code: "wal_replay_failed",
+        }]
+    );
+}
+
+/// `inspect_err` calls `error` and the `?` that follows drops the guard. Drop must not turn that
+/// into a second event.
+#[test]
+fn error_then_drop_does_not_report_twice() {
+    let (observer, phases) = phases();
+    {
+        let guard = phases.begin(StartupPhase::SnapshotRestore, "");
+        let result: Result<(), &str> = Err("boom");
+        let _ = result.inspect_err(|_| guard.error("snapshot_restore_failed"));
+    }
+    assert_eq!(observer.events().len(), 1, "phase must report exactly once");
+}
+
+/// A phase that reports success and is then dropped must not also report an outcome from `Drop`.
+#[test]
+fn success_then_drop_does_not_report_twice() {
+    let (observer, phases) = phases();
+    {
+        let guard = phases.begin(StartupPhase::CacheWarm, "");
+        guard.success("skipped");
+    }
+    assert_eq!(observer.events().len(), 1, "phase must report exactly once");
+}
+
+/// Dropping without reporting is a bug at the call site. It logs, but must not fabricate a success
+/// or error event for the observer.
+#[test]
+fn drop_without_outcome_emits_no_observer_event() {
+    let (observer, phases) = phases();
+    {
+        let _guard = phases.begin(StartupPhase::NodeRegistration, "");
+    }
+    assert!(
+        observer.events().is_empty(),
+        "an unreported phase must not reach the observer"
+    );
+}
+
+/// A later phase must report a larger cumulative elapsed than an earlier one, since both measure
+/// against the same process origin.
+#[test]
+fn elapsed_total_is_monotonic_across_phases() {
+    let (_observer, phases) = phases();
+    let first = phases.elapsed_total_ms();
+    std::thread::sleep(std::time::Duration::from_millis(2));
+    let second = phases.elapsed_total_ms();
+    assert!(second >= first, "{second} should be >= {first}");
+}
+
+/// `report_completed` stands in for a whole begin/success pair, so it must feed the observer
+/// exactly one success event carrying the detail.
+#[test]
+fn report_completed_emits_one_success_event() {
+    let (observer, phases) = phases();
+    let started = Instant::now();
+    phases.report_completed(
+        StartupPhase::TempCatalogLoad,
+        started,
+        started + std::time::Duration::from_millis(3),
+        "storage_mode=parquet",
+    );
+    assert_eq!(
+        observer.events(),
+        vec![Event::Success {
+            phase: "temp_catalog_load",
+            detail: "storage_mode=parquet".to_string(),
+        }]
+    );
+}
+
+/// `report_completed` must emit the same started and finished lines a live guard would, and a
+/// span that predates the tracker origin must clamp `elapsed_total_ms` to zero rather than
+/// underflow — the pre-logging phases run before `startup_timer` exists.
+#[test]
+fn report_completed_logs_both_lines_and_clamps_before_origin() {
+    let capture = test_helpers::tracing::TracingCapture::new();
+    let (_observer, phases) = phases();
+    // The instants are fixed, so the 5 ms duration below is exact, not timing-dependent.
+    let origin = Instant::now();
+    let started = origin - std::time::Duration::from_millis(10);
+    let finished = origin - std::time::Duration::from_millis(5);
+    let phases = StartupPhases {
+        process_start: origin,
+        ..phases
+    };
+    phases.report_completed(
+        StartupPhase::Licensing,
+        started,
+        finished,
+        "licensed_cores=2",
+    );
+    let logs = capture.to_string();
+    let started_line = logs
+        .lines()
+        .find(|l| l.contains("startup phase started"))
+        .expect("a started line is logged");
+    assert!(
+        started_line.contains(r#"startup_phase = "licensing""#),
+        "{logs}"
+    );
+    assert!(started_line.contains("elapsed_total_ms = 0"), "{logs}");
+    let finished_line = logs
+        .lines()
+        .find(|l| l.contains("startup phase finished"))
+        .expect("a finished line is logged");
+    assert!(
+        finished_line.contains(r#"startup_phase = "licensing""#),
+        "{logs}"
+    );
+    assert!(finished_line.contains("duration_ms = 5"), "{logs}");
+    assert!(finished_line.contains("elapsed_total_ms = 0"), "{logs}");
+    assert!(
+        finished_line.contains(r#"detail = "licensed_cores=2""#),
+        "{logs}"
+    );
+}

--- a/influxdb3_write/Cargo.toml
+++ b/influxdb3_write/Cargo.toml
@@ -67,6 +67,7 @@ serde_json.workspace = true
 serde_with.workspace = true
 sha2.workspace = true
 snap.workspace = true
+siphasher.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 url.workspace = true
@@ -93,4 +94,8 @@ criterion.workspace = true
 
 [[bench]]
 name = "persisted_files_bench"
+harness = false
+
+[[bench]]
+name = "table_buffer_bench"
 harness = false

--- a/influxdb3_write/benches/table_buffer_bench.rs
+++ b/influxdb3_write/benches/table_buffer_bench.rs
@@ -1,0 +1,157 @@
+//! Write-buffer table buffer: insert cost and the per-query cost of producing
+//! batches, across overwrite mixes. The query-path number is what a point
+//! lookup against buffered data pays before DataFusion sees a row, so it is
+//! the one to watch when changing how superseded rows are handled.
+//!
+//! Scenarios (100k unique points, 3 fields incl. a string, one tag):
+//! - `none`:    no overwrites (append-only tables; the fast path)
+//! - `average`: 10% of points overwritten once
+//! - `heavy`:   every point overwritten once (50% of rows superseded)
+//! - `worst`:   every point overwritten three times (75% superseded)
+
+use std::hint::black_box;
+use std::sync::Arc;
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use influxdb3_catalog::catalog::{Catalog, TableDefinition};
+use influxdb3_types::DatabaseName;
+use influxdb3_wal::Row;
+use influxdb3_write::write_buffer::table_buffer::TableBuffer;
+use influxdb3_write::write_buffer::validator::WriteValidator;
+use influxdb3_write::{ChunkFilter, Precision};
+use iox_time::{MockProvider, Time};
+use object_store::memory::InMemory;
+
+const POINTS: usize = 100_000;
+const DB: &str = "bench-db";
+
+struct Workload {
+    name: &'static str,
+    /// Batches of rows in ingest order: the first holds the unique points,
+    /// each later one rewrites a slice of them.
+    batches: Vec<Vec<Row>>,
+    table_def: Arc<TableDefinition>,
+}
+
+fn lp(points: impl Iterator<Item = usize>, version: usize) -> String {
+    let mut s = String::with_capacity(POINTS * 64);
+    for i in points {
+        // Same tag set and timestamp per point; field values change per version.
+        s.push_str(&format!(
+            "tbl,sensor=s-{i} f={}.5,i={}i,s=\"v{version}-{i}\" 1000\n",
+            i % 1000,
+            i + version
+        ));
+    }
+    s
+}
+
+async fn rows(catalog: &Arc<Catalog>, lp: &str, ingest_sec: i64) -> Vec<Row> {
+    let db = DatabaseName::try_from(DB).unwrap();
+    WriteValidator::initialize(db, Arc::clone(catalog))
+        .unwrap()
+        .v1_parse_lines_and_catalog_updates(
+            lp,
+            false,
+            Time::from_timestamp_nanos(ingest_sec * 1_000_000_000),
+            Precision::Nanosecond,
+        )
+        .unwrap()
+        .commit_catalog_changes()
+        .await
+        .map(|r| r.unwrap_success())
+        .unwrap()
+        .into_inner()
+        .to_rows()
+}
+
+async fn workload(name: &'static str, overwrite_fraction: f64, passes: usize) -> Workload {
+    let catalog = Catalog::new(
+        "bench-node",
+        Arc::new(InMemory::new()),
+        Arc::new(MockProvider::new(Time::from_timestamp_nanos(0))),
+        Default::default(),
+    )
+    .await
+    .unwrap();
+    let mut batches = vec![rows(&catalog, &lp(0..POINTS, 0), 0).await];
+    let overwritten = (POINTS as f64 * overwrite_fraction) as usize;
+    for pass in 1..=passes {
+        batches.push(rows(&catalog, &lp(0..overwritten, pass), pass as i64).await);
+    }
+    let table_def = catalog
+        .db_schema(DB)
+        .unwrap()
+        .table_definition("tbl")
+        .unwrap();
+    Workload {
+        name,
+        batches,
+        table_def,
+    }
+}
+
+fn buffer(w: &Workload) -> TableBuffer {
+    let mut tb = TableBuffer::new();
+    for b in &w.batches {
+        tb.buffer_chunk(0, b);
+    }
+    tb
+}
+
+fn bench(c: &mut Criterion) {
+    let rt = tokio::runtime::Runtime::new().unwrap();
+    let workloads = rt.block_on(async {
+        vec![
+            workload("none", 0.0, 0).await,
+            workload("average", 0.1, 1).await,
+            workload("heavy", 1.0, 1).await,
+            workload("worst", 1.0, 3).await,
+        ]
+    });
+
+    // Insert: the whole workload buffered from scratch.
+    let mut g = c.benchmark_group("table_buffer/insert");
+    for w in &workloads {
+        let rows: usize = w.batches.iter().map(Vec::len).sum();
+        g.throughput(Throughput::Elements(rows as u64));
+        g.bench_with_input(BenchmarkId::from_parameter(w.name), w, |b, w| {
+            b.iter(|| black_box(buffer(w)))
+        });
+    }
+    g.finish();
+
+    // Query path: producing the batches a query scans.
+    let mut g = c.benchmark_group("table_buffer/record_batches");
+    for w in &workloads {
+        let tb = buffer(w);
+        let filter = ChunkFilter::new(&w.table_def, &[]).unwrap();
+        g.throughput(Throughput::Elements(POINTS as u64));
+        g.bench_with_input(BenchmarkId::from_parameter(w.name), &tb, |b, tb| {
+            b.iter(|| {
+                black_box(
+                    tb.partitioned_record_batches(Arc::clone(&w.table_def), &filter)
+                        .unwrap(),
+                )
+            })
+        });
+    }
+    g.finish();
+
+    // Persist path: the snapshot batch of the chunk.
+    let mut g = c.benchmark_group("table_buffer/snapshot");
+    for w in &workloads {
+        g.throughput(Throughput::Elements(POINTS as u64));
+        g.bench_with_input(BenchmarkId::from_parameter(w.name), w, |b, w| {
+            b.iter_batched(
+                || buffer(w),
+                |mut tb| black_box(tb.snapshot(Arc::clone(&w.table_def), i64::MAX)),
+                criterion::BatchSize::LargeInput,
+            )
+        });
+    }
+    g.finish();
+}
+
+criterion_group!(benches, bench);
+criterion_main!(benches);

--- a/influxdb3_write/src/write_buffer/queryable_buffer.rs
+++ b/influxdb3_write/src/write_buffer/queryable_buffer.rs
@@ -158,32 +158,51 @@ impl QueryableBuffer {
             return Ok(vec![]);
         };
 
-        Ok(table_buffer
+        let partitioned = table_buffer
             .partitioned_record_batches(Arc::clone(&table_def), buffer_filter)
-            .map_err(|e| DataFusionError::Execution(format!("error getting batches {e}")))?
-            .into_iter()
-            .map(|(gen_time, (ts_min_max, batches))| {
+            .map_err(|e| DataFusionError::Execution(format!("error getting batches {e}")))?;
+
+        let mut chunks: Vec<Arc<dyn QueryChunk>> = Vec::with_capacity(partitioned.len());
+        for (gen_time, buffered) in partitioned {
+            let partition_id = PartitionHashId::new(
+                data_types::TableId::new(table_def.table_id.get() as i64),
+                &PartitionKey::from(gen_time.to_string()),
+            );
+            // Snapshotting (frozen, pre-persist) batches rank strictly below
+            // live batches: an overwrite arriving while a snapshot's parquet
+            // files are being written lands in a live chunk and must win
+            // dedup against the frozen state deterministically.
+            let ranked = [
+                (
+                    buffered.snapshotting,
+                    buffered.snapshotting_min_max,
+                    i64::MAX - 1,
+                ),
+                (buffered.live, buffered.live_min_max, i64::MAX),
+            ];
+            for (batches, timestamp_min_max, order) in ranked {
+                if batches.is_empty() {
+                    continue;
+                }
                 let row_count = batches.iter().map(|b| b.num_rows()).sum::<usize>();
                 let chunk_stats = create_chunk_statistics(
                     Some(row_count),
                     influx_schema,
-                    Some(ts_min_max),
+                    timestamp_min_max,
                     &NoColumnRanges,
                 );
-                Arc::new(BufferChunk {
+                chunks.push(Arc::new(BufferChunk {
                     batches,
                     schema: influx_schema.clone(),
                     stats: Arc::new(chunk_stats),
-                    partition_id: PartitionHashId::new(
-                        data_types::TableId::new(0),
-                        &PartitionKey::from(gen_time.to_string()),
-                    ),
+                    partition_id: partition_id.clone(),
                     sort_key: None,
                     id: ChunkId::new(),
-                    chunk_order: ChunkOrder::new(i64::MAX),
-                }) as Arc<dyn QueryChunk>
-            })
-            .collect())
+                    chunk_order: ChunkOrder::new(order),
+                }) as Arc<dyn QueryChunk>);
+            }
+        }
+        Ok(chunks)
     }
 
     /// Update the caches managed by the database
@@ -351,7 +370,6 @@ impl QueryableBuffer {
             // persist the individual files, building the snapshot as we go
             let persisted_snapshot = Arc::new(Mutex::new(snapshot));
 
-            let persist_jobs_empty = persist_jobs.is_empty();
             let semaphore = Arc::new(Semaphore::new(parquet_snapshot_concurrency_limit.get()));
             let mut set = JoinSet::new();
             for persist_job in persist_jobs {
@@ -442,60 +460,45 @@ impl QueryableBuffer {
 
             set.join_all().await;
 
-            // persist the snapshot file - only if persist jobs are present or
-            // files have been removed due to retention policies.
-            // If persist_jobs is empty, then the parquet file wouldn't have been
-            // written out, so it's desirable to not write empty snapshot files.
+            // Always persist the snapshot manifest, even when it is empty.
             //
-            // How can persist jobs be empty even though a snapshot is triggered?
+            // The snapshot sequence number is minted eagerly at plan time in the
+            // WAL crate (`SnapshotTracker::increment_snapshot_sequence_number`) and
+            // embedded durably in the WAL file, so by the time we get here the
+            // number has already been spent. Consumers walk the sequence by exact
+            // key: the compactor point-GETs `marker + 1` and treats `NotFound` as
+            // "caught up", and enterprise read replicas block until each manifest
+            // appears. Skipping the write for an empty snapshot would leave a
+            // permanent hole that halts the compactor for this node and wedges
+            // those replicas (influxdb_pro#4827). An empty manifest is cheap and
+            // loads harmlessly, and it shares the same lifecycle as every other
+            // snapshot manifest (there is no separate cleanup path for it in OSS),
+            // so we always write it rather than leave a gap the consumers cannot
+            // distinguish from a failed persist.
             //
-            // When force snapshot is set, wal_periods (tracked by
-            // snapshot_tracker) will never be empty as a no-op is added. This
-            // means even though there is a wal period the query buffer might
-            // still be empty. The reason is, when snapshots are happening very
-            // close to each other (when force snapshot is set), they could get
-            // queued to run immediately one after the other as illustrated in
-            // example series of flushes and force snapshots below,
-            //
-            //   1 (only wal flush) // triggered by flush interval 1s
-            //   2 (snapshot)       // triggered by flush interval 1s
-            //   3 (force_snapshot) // triggered by mem check interval 10s
-            //   4 (force_snapshot) // triggered by mem check interval 10s
-            //
-            // Although the flush interval an mem check intervals aren't same
-            // there's a good chance under high memory pressure there will be
-            // a lot of overlapping.
-            //
-            // In this setup - after 2 (snapshot), we emptied wal buffer and as
-            // soon as snapshot is done, 3 will try to run the snapshot but wal
-            // buffer can be empty at this point, which means it adds a no-op.
-            // no-op has the current time which will be used as the
-            // end_time_marker. That would evict everything from query buffer, so
-            // when 4 (force snapshot) runs there's no data in the query
-            // buffer though it has a wal_period. When normal (i.e without
-            // force_snapshot) snapshot runs, snapshot_tracker will check if
-            // wal_periods are empty so it won't trigger a snapshot in the first
-            // place.
-            let removed_files_empty = persisted_snapshot.lock().removed_files.is_empty();
+            // A forced snapshot can legitimately find nothing to persist:
+            // `force_flush_buffer` adds a `WalOp::Noop` so a wal_period always
+            // exists, but back-to-back forced snapshots under memory pressure can
+            // drain the query buffer before the next one runs, leaving no persist
+            // jobs and no removed files while the sequence number has still been
+            // consumed.
             let persisted_snapshot = PersistedSnapshotVersion::V1(
                 Arc::into_inner(persisted_snapshot)
                     .expect("Should only have one strong reference")
                     .into_inner(),
             );
-            if !persist_jobs_empty || !removed_files_empty {
-                loop {
-                    match persister.persist_snapshot(&persisted_snapshot).await {
-                        Ok(_) => {
-                            let persisted_snapshot = Some(persisted_snapshot.clone());
-                            notify_snapshot_tx
-                                .send(persisted_snapshot)
-                                .expect("persisted snapshot notify tx should not be closed");
-                            break;
-                        }
-                        Err(e) => {
-                            error!(%e, "Error persisting snapshot, sleeping and retrying...");
-                            tokio::time::sleep(Duration::from_secs(1)).await;
-                        }
+            loop {
+                match persister.persist_snapshot(&persisted_snapshot).await {
+                    Ok(_) => {
+                        let persisted_snapshot = Some(persisted_snapshot.clone());
+                        notify_snapshot_tx
+                            .send(persisted_snapshot)
+                            .expect("persisted snapshot notify tx should not be closed");
+                        break;
+                    }
+                    Err(e) => {
+                        error!(%e, "Error persisting snapshot, sleeping and retrying...");
+                        tokio::time::sleep(Duration::from_secs(1)).await;
                     }
                 }
             }

--- a/influxdb3_write/src/write_buffer/table_buffer.rs
+++ b/influxdb3_write/src/write_buffer/table_buffer.rs
@@ -1,10 +1,13 @@
 //! The in memory buffer of a table that can be quickly added to and queried
 
+use arrow::array::builder::BooleanBufferBuilder;
 use arrow::array::{
-    Array, ArrayRef, BooleanBuilder, Float64Builder, Int64Builder, StringBuilder,
+    Array, ArrayRef, ArrowPrimitiveType, BooleanArray, BooleanBuilder, Float64Builder,
+    GenericByteBuilder, Int64Builder, PrimitiveArray, PrimitiveBuilder, StringArray, StringBuilder,
     StringDictionaryBuilder, TimestampNanosecondBuilder, UInt64Builder,
 };
-use arrow::datatypes::Int32Type;
+use arrow::buffer::{BooleanBuffer, Buffer, MutableBuffer, NullBuffer, OffsetBuffer, ScalarBuffer};
+use arrow::datatypes::{GenericStringType, Int32Type};
 use arrow::record_batch::RecordBatch;
 use data_types::TimestampMinMax;
 use hashbrown::{HashMap, HashSet};
@@ -15,6 +18,7 @@ use schema::{InfluxColumnType, InfluxFieldType, Schema, SchemaBuilder};
 use std::collections::BTreeMap;
 use std::collections::btree_map::Entry;
 use std::mem::size_of;
+use std::ops::Range;
 use std::sync::Arc;
 use thiserror::Error;
 
@@ -27,14 +31,78 @@ pub enum Error {
 
     #[error("Error creating record batch: {0}")]
     RecordBatchError(#[from] arrow::error::ArrowError),
+
+    #[error("row range {start}..{end} is out of bounds for a chunk of {row_count} rows")]
+    RowRangeOutOfBounds {
+        start: usize,
+        end: usize,
+        row_count: usize,
+    },
 }
 
 pub(crate) type Result<T, E = Error> = std::result::Result<T, E>;
 
 #[derive(Default)]
 pub struct TableBuffer {
-    chunk_time_to_chunks: BTreeMap<i64, Vec<MutableTableChunk>>,
+    chunk_time_to_chunks: BTreeMap<i64, ChunkTimeBuffer>,
     snapshotting_chunks: Vec<SnapshotChunk>,
+}
+
+/// All buffered chunks for one chunk_time (gen1 window) of a table, plus the
+/// overwrite index spanning them. A chunk_time usually holds one chunk; a
+/// var-column overflow splits it into several, and hoisting the index here
+/// keeps overwrite collapsing working across the split — including on WAL
+/// replay, where batch boundaries (and therefore split points) can differ
+/// from the original ingest.
+#[derive(Default)]
+struct ChunkTimeBuffer {
+    chunks: Vec<MutableTableChunk>,
+    /// Overwrite identity of each live row -> (chunk index, row index).
+    /// See [`row_key_for`].
+    row_key_to_index: HashMap<u128, (usize, usize)>,
+}
+
+impl ChunkTimeBuffer {
+    fn add_rows(&mut self, rows: &[Row]) {
+        let last = self.chunks.len() - 1;
+
+        // Reused across the batch's rows so overwrite-identity hashing does
+        // no per-row allocation.
+        let mut tag_scratch: Vec<(u16, &str)> = Vec::new();
+        let mut key_scratch: Vec<u8> = Vec::new();
+
+        for r in rows {
+            let row_key = row_key_for(r, &mut tag_scratch, &mut key_scratch);
+            let replaces = self.row_key_to_index.get(&row_key).copied();
+
+            let (earlier, target) = self.chunks.split_at_mut(last);
+            let target = &mut target[0];
+            let this_row = match replaces {
+                None => target.append_row(r, CarrySource::None),
+                Some((ci, ri)) if ci == last => {
+                    let idx = target.append_row(r, CarrySource::Local(ri));
+                    target.mark_superseded(ri);
+                    idx
+                }
+                Some((ci, ri)) => {
+                    let idx = target.append_row(r, CarrySource::Foreign(&earlier[ci], ri));
+                    earlier[ci].mark_superseded(ri);
+                    idx
+                }
+            };
+            self.row_key_to_index.insert(row_key, (last, this_row));
+        }
+    }
+}
+
+/// Where an appended row's missing fields are carried forward from
+enum CarrySource<'a> {
+    /// A fresh row
+    None,
+    /// An earlier row in the same chunk
+    Local(usize),
+    /// A row in an earlier split chunk of the same chunk_time
+    Foreign(&'a MutableTableChunk, usize),
 }
 
 impl TableBuffer {
@@ -43,7 +111,7 @@ impl TableBuffer {
     }
 
     pub fn buffer_chunk(&mut self, chunk_time: i64, rows: &[Row]) {
-        let chunks = self.chunk_time_to_chunks.entry(chunk_time).or_default();
+        let ctb = self.chunk_time_to_chunks.entry(chunk_time).or_default();
 
         let mut incoming_per_column = HashMap::new();
         for r in rows {
@@ -57,17 +125,17 @@ impl TableBuffer {
             }
         }
 
-        let needs_new_chunk = chunks.is_empty()
-            || chunks
+        let needs_new_chunk = ctb.chunks.is_empty()
+            || ctb
+                .chunks
                 .last()
                 .is_some_and(|c| c.would_exceed_limit_with(&incoming_per_column));
 
         if needs_new_chunk {
-            chunks.push(MutableTableChunk::new());
+            ctb.chunks.push(MutableTableChunk::new());
         }
 
-        let buffer_chunk = chunks.last_mut().unwrap();
-        buffer_chunk.add_rows(rows);
+        ctb.add_rows(rows);
     }
 
     /// Produce a partitioned set of record batches along with their min/max timestamp
@@ -82,8 +150,8 @@ impl TableBuffer {
         &self,
         table_def: Arc<TableDefinition>,
         filter: &ChunkFilter<'_>,
-    ) -> Result<HashMap<i64, (TimestampMinMax, Vec<RecordBatch>)>> {
-        let mut batches = HashMap::new();
+    ) -> Result<HashMap<i64, BufferedBatches>> {
+        let mut batches: HashMap<i64, BufferedBatches> = HashMap::new();
         let schema = table_def.schema.as_arrow();
         for sc in self.snapshotting_chunks.iter().filter(|sc| {
             filter.test_time_stamp_min_max(sc.timestamp_min_max.min, sc.timestamp_min_max.max)
@@ -101,23 +169,20 @@ impl TableBuffer {
                 .collect();
             let cols = cols?;
             let rb = RecordBatch::try_new(Arc::clone(&schema), cols)?;
-            let (ts, v) = batches
+            batches
                 .entry(sc.chunk_time)
-                .or_insert_with(|| (sc.timestamp_min_max, Vec::new()));
-            *ts = ts.union(&sc.timestamp_min_max);
-            v.push(rb);
+                .or_default()
+                .push_snapshotting(rb, sc.timestamp_min_max);
         }
-        for (t, chunks) in self.chunk_time_to_chunks.iter() {
-            for c in chunks
+        for (t, ctb) in self.chunk_time_to_chunks.iter() {
+            for c in ctb
+                .chunks
                 .iter()
                 .filter(|c| filter.test_time_stamp_min_max(c.timestamp_min, c.timestamp_max))
             {
                 let ts_min_max = TimestampMinMax::new(c.timestamp_min, c.timestamp_max);
-                let (ts, v) = batches
-                    .entry(*t)
-                    .or_insert_with(|| (ts_min_max, Vec::new()));
-                *ts = ts.union(&ts_min_max);
-                v.push(c.record_batch(Arc::clone(&table_def))?);
+                let rb = c.record_batch(Arc::clone(&table_def))?;
+                batches.entry(*t).or_default().push_live(rb, ts_min_max);
             }
         }
         Ok(batches)
@@ -129,7 +194,7 @@ impl TableBuffer {
         } else {
             self.chunk_time_to_chunks
                 .values()
-                .flatten()
+                .flat_map(|ctb| ctb.chunks.iter())
                 .map(|c| (c.timestamp_min, c.timestamp_max))
                 .fold((i64::MAX, i64::MIN), |(a_min, b_min), (a_max, b_max)| {
                     (a_min.min(b_min), a_max.max(b_max))
@@ -149,12 +214,14 @@ impl TableBuffer {
     pub fn computed_size(&self) -> usize {
         let mut size = size_of::<Self>();
 
-        for chunks in self.chunk_time_to_chunks.values() {
-            for c in chunks {
+        for ctb in self.chunk_time_to_chunks.values() {
+            for c in &ctb.chunks {
                 for builder in c.data.values() {
                     size += size_of::<ColumnId>() + size_of::<String>() + builder.size();
                 }
+                size += c.live.capacity() / 8;
             }
+            size += ctb.row_key_to_index.len() * (size_of::<u128>() + 2 * size_of::<usize>());
         }
 
         size
@@ -174,12 +241,23 @@ impl TableBuffer {
 
         let mut snapshot_chunks = Vec::new();
         for chunk_time in keys_to_remove {
-            let chunks = self.chunk_time_to_chunks.remove(&chunk_time).unwrap();
+            let chunks = self
+                .chunk_time_to_chunks
+                .remove(&chunk_time)
+                .unwrap()
+                .chunks;
             // A chunk_time can yield several chunks (a string/tag column crossing
             // the Arrow varchar limit splits one). The ordinal makes each chunk
             // individually addressable, both for its parquet path and for
             // `remove_snapshotting_chunk` once that parquet file exists.
             for (chunk_ordinal, chunk) in chunks.into_iter().enumerate() {
+                // Every row of an earlier split chunk can be superseded by
+                // overwrites landing in a later split; such a chunk has
+                // nothing to persist and would otherwise become an empty
+                // parquet file.
+                if chunk.superseded_count == chunk.row_count {
+                    continue;
+                }
                 let timestamp_min_max = chunk.timestamp_min_max();
                 let (schema, record_batch) = chunk.into_schema_record_batch(Arc::clone(&table_def));
 
@@ -224,6 +302,62 @@ impl TableBuffer {
     }
 }
 
+/// The queryable batches of one chunk_time, split by provenance so the
+/// consumer can rank them: `snapshotting` batches are frozen pre-persist
+/// state that must lose dedup against `live` batches, which can contain
+/// newer overwrites of the same points (arriving while the snapshot's
+/// parquet files are being written). Mixing them under one chunk order
+/// would make that dedup order-undefined.
+///
+/// Each provenance set carries its own time range so the chunks built from
+/// them get stats no looser than their actual batches.
+#[derive(Debug, Default)]
+pub struct BufferedBatches {
+    /// Frozen snapshot batches, already collapsed; rank below `live`.
+    pub snapshotting: Vec<RecordBatch>,
+    /// Time range covered by `snapshotting`; `None` when it is empty.
+    pub snapshotting_min_max: Option<TimestampMinMax>,
+    /// Batches from mutable chunks, collapsed as of this call.
+    pub live: Vec<RecordBatch>,
+    /// Time range covered by `live`; `None` when it is empty.
+    pub live_min_max: Option<TimestampMinMax>,
+}
+
+impl BufferedBatches {
+    fn push_snapshotting(&mut self, batch: RecordBatch, min_max: TimestampMinMax) {
+        self.snapshotting_min_max = Some(union_opt(self.snapshotting_min_max, min_max));
+        self.snapshotting.push(batch);
+    }
+
+    fn push_live(&mut self, batch: RecordBatch, min_max: TimestampMinMax) {
+        self.live_min_max = Some(union_opt(self.live_min_max, min_max));
+        self.live.push(batch);
+    }
+
+    /// Time range across both provenance sets; `None` when both are empty.
+    pub fn timestamp_min_max(&self) -> Option<TimestampMinMax> {
+        match (self.snapshotting_min_max, self.live_min_max) {
+            (Some(s), Some(l)) => Some(s.union(&l)),
+            (s, None) => s,
+            (None, l) => l,
+        }
+    }
+
+    /// All batches, snapshotting first. For consumers (and tests) that do
+    /// not rank by provenance.
+    pub fn combined(&self) -> Vec<RecordBatch> {
+        self.snapshotting
+            .iter()
+            .chain(self.live.iter())
+            .cloned()
+            .collect()
+    }
+}
+
+fn union_opt(cur: Option<TimestampMinMax>, next: TimestampMinMax) -> TimestampMinMax {
+    cur.map_or(next, |cur| cur.union(&next))
+}
+
 #[derive(Debug, Clone)]
 pub struct SnapshotChunk {
     pub(crate) chunk_time: i64,
@@ -248,7 +382,7 @@ impl std::fmt::Debug for TableBuffer {
         let (min_time, max_time, row_count) = self
             .chunk_time_to_chunks
             .values()
-            .flatten()
+            .flat_map(|ctb| ctb.chunks.iter())
             .map(|c| (c.timestamp_min, c.timestamp_max, c.row_count))
             .fold(
                 (i64::MAX, i64::MIN, 0),
@@ -256,7 +390,11 @@ impl std::fmt::Debug for TableBuffer {
                     (a_min.min(b_min), a_max.max(b_max), a_count + b_count)
                 },
             );
-        let chunk_count: usize = self.chunk_time_to_chunks.values().map(|v| v.len()).sum();
+        let chunk_count: usize = self
+            .chunk_time_to_chunks
+            .values()
+            .map(|ctb| ctb.chunks.len())
+            .sum();
         f.debug_struct("TableBuffer")
             .field("chunk_count", &chunk_count)
             .field("timestamp_min", &min_time)
@@ -266,12 +404,82 @@ impl std::fmt::Debug for TableBuffer {
     }
 }
 
+/// An append-only set of column builders holding buffered rows, with
+/// overwrite collapsing: a row that repeats an earlier row's (tag set,
+/// timestamp) supersedes it. The new row unions the field sets — fields the
+/// new row does not provide are carried forward from the replaced row — and
+/// the replaced row is masked out of every batch this chunk produces, so
+/// duplicate keys never reach query or persist dedup with an undefined
+/// order. Builders are never mutated in place; superseded rows stay in the
+/// builders and are skipped when a batch is produced ([`Self::materialize`]),
+/// in the same single pass that copies the builders into immutable arrays.
 struct MutableTableChunk {
     timestamp_min: i64,
     timestamp_max: i64,
     data: BTreeMap<ColumnId, Builder>,
     row_count: usize,
     string_bytes_per_column: HashMap<ColumnId, usize>,
+    /// One bit per row: set while the row is live, cleared once a later
+    /// duplicate supersedes it. Read directly by the materialization kernels.
+    live: BooleanBufferBuilder,
+    superseded_count: usize,
+    /// Lowest row index superseded since [`Self::reset_superseded_watermark`]
+    /// was last called (`None` if none). Lets a materialization cache tell
+    /// whether a cached prefix of this chunk is still valid without scanning
+    /// the mask; nothing consumes it yet.
+    superseded_since_watermark: Option<usize>,
+}
+
+/// Per-process random keys for the overwrite-identity hash below. Tag values
+/// are user-controlled, so the hash is keyed (SipHash is a PRF): without the
+/// keys, colliding tag sets cannot be constructed — the same reasoning that
+/// gives `PartitionHashId` a cryptographic hash for user-set partition keys.
+/// Fresh keys per process are fine because the index never leaves the process.
+static ROW_KEY_HASH_KEYS: std::sync::LazyLock<(u64, u64)> = std::sync::LazyLock::new(|| {
+    use std::hash::{BuildHasher, Hasher};
+    let entropy = std::collections::hash_map::RandomState::new();
+    let k0 = entropy.build_hasher().finish();
+    let mut h = entropy.build_hasher();
+    h.write_u64(!k0);
+    (k0, h.finish())
+});
+
+/// The overwrite identity of a row — its tag (column id, value) pairs sorted
+/// by column id, then its timestamp — reduced to a 128-bit keyed hash. Two
+/// rows with equal keys are treated as versions of the same point.
+///
+/// Hashing instead of storing the identity bytes keeps the per-row cost
+/// allocation-free (`tag_scratch` and `key_scratch` are reused across the
+/// rows of a batch). The trade-off is a hash-collision chance that two
+/// distinct points merge: at 128 bits the accidental probability is
+/// ~n²/2¹²⁸ for n buffered rows (~10⁻²⁵ even at 10M rows), and the keyed
+/// hash ([`ROW_KEY_HASH_KEYS`]) rules out constructed collisions.
+fn row_key_for<'a>(
+    row: &'a Row,
+    tag_scratch: &mut Vec<(u16, &'a str)>,
+    key_scratch: &mut Vec<u8>,
+) -> u128 {
+    use siphasher::sip128::Hasher128;
+    use std::hash::Hasher;
+
+    tag_scratch.clear();
+    tag_scratch.extend(row.fields.iter().filter_map(|f| match &f.value {
+        FieldData::Tag(v) => Some((f.id.get(), v.as_ref())),
+        _ => None,
+    }));
+    tag_scratch.sort_unstable_by_key(|(id, _)| *id);
+    key_scratch.clear();
+    for (id, v) in tag_scratch.iter() {
+        key_scratch.extend_from_slice(&id.to_be_bytes());
+        key_scratch.extend_from_slice(&(v.len() as u32).to_be_bytes());
+        key_scratch.extend_from_slice(v.as_bytes());
+    }
+    key_scratch.extend_from_slice(&row.time.to_be_bytes());
+
+    let (k0, k1) = *ROW_KEY_HASH_KEYS;
+    let mut hasher = siphasher::sip128::SipHasher13::new_with_keys(k0, k1);
+    hasher.write(key_scratch);
+    hasher.finish128().as_u128()
 }
 
 // Test infrastructure for configurable string size limit - thread-local for test isolation.
@@ -325,7 +533,42 @@ impl MutableTableChunk {
             data: Default::default(),
             row_count: 0,
             string_bytes_per_column: HashMap::new(),
+            live: BooleanBufferBuilder::new(0),
+            superseded_count: 0,
+            superseded_since_watermark: None,
         }
+    }
+
+    /// Mark `row` as replaced by a later duplicate.
+    fn mark_superseded(&mut self, row: usize) {
+        debug_assert!(self.live.get_bit(row), "row {row} superseded twice");
+        self.live.set_bit(row, false);
+        self.superseded_count += 1;
+        self.superseded_since_watermark =
+            Some(self.superseded_since_watermark.map_or(row, |w| w.min(row)));
+    }
+
+    /// See the `superseded_since_watermark` field.
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "read by a materialization cache that does not exist yet"
+        )
+    )]
+    pub(crate) fn superseded_watermark(&self) -> Option<usize> {
+        self.superseded_since_watermark
+    }
+
+    #[cfg_attr(
+        not(test),
+        expect(
+            dead_code,
+            reason = "reset by a materialization cache that does not exist yet"
+        )
+    )]
+    pub(crate) fn reset_superseded_watermark(&mut self) {
+        self.superseded_since_watermark = None;
     }
 
     fn would_exceed_limit_with(&self, incoming_per_column: &HashMap<ColumnId, usize>) -> bool {
@@ -342,16 +585,19 @@ impl MutableTableChunk {
 }
 
 impl MutableTableChunk {
-    fn add_rows(&mut self, rows: &[Row]) {
-        let new_row_count = rows.len();
-        // Capacity needed for builders created in this call.
-        // After this batch of rows, each builder will have exactly (self.row_count + new_row_count)
-        // entries for values and nulls.
-        // Using exact capacity avoids the default 1024-element allocation which may cause excessive
-        // memory usage when there are many chunks with few rows each in sparse time-series data.
-        let builder_capacity = self.row_count + new_row_count;
+    /// Append one row, returning its row index. `carry` names the row this
+    /// one replaces (if any) so fields the new row does not provide are
+    /// carried forward — from this chunk or from an earlier split chunk of
+    /// the same chunk_time. The caller (`ChunkTimeBuffer`) owns duplicate
+    /// detection and superseded marking.
+    fn append_row(&mut self, r: &Row, carry: CarrySource<'_>) -> usize {
+        let this_row = self.row_count;
+        // Exact capacity for builders created by this row avoids the default
+        // 1024-element allocation, which adds up across many small chunks in
+        // sparse time-series data.
+        let builder_capacity = this_row + 1;
 
-        for (row_index, r) in rows.iter().enumerate() {
+        {
             let mut value_added = HashSet::with_capacity(r.fields.len());
 
             for f in &r.fields {
@@ -366,7 +612,7 @@ impl MutableTableChunk {
                             let mut time_builder =
                                 TimestampNanosecondBuilder::with_capacity(builder_capacity);
                             // append nulls for all previous rows
-                            time_builder.append_nulls(row_index + self.row_count);
+                            time_builder.append_nulls(this_row);
                             Builder::Time(time_builder)
                         });
                         if let Builder::Time(b) = b {
@@ -385,7 +631,7 @@ impl MutableTableChunk {
                                 (builder_capacity * 64).min(1024),
                             );
                             // append nulls for all previous rows
-                            tag_builder.append_nulls(row_index + self.row_count);
+                            tag_builder.append_nulls(this_row);
                             e.insert(Builder::Tag(tag_builder));
                         }
                         let b = self.data.get_mut(&f.id).expect("tag builder should exist");
@@ -405,7 +651,7 @@ impl MutableTableChunk {
                                 (builder_capacity * 64).min(1024),
                             );
                             // append nulls for all previous rows
-                            string_builder.append_nulls(row_index + self.row_count);
+                            string_builder.append_nulls(this_row);
                             Builder::String(string_builder)
                         });
                         if let Builder::String(b) = b {
@@ -418,7 +664,7 @@ impl MutableTableChunk {
                         let b = self.data.entry(f.id).or_insert_with(|| {
                             let mut int_builder = Int64Builder::with_capacity(builder_capacity);
                             // append nulls for all previous rows
-                            int_builder.append_nulls(row_index + self.row_count);
+                            int_builder.append_nulls(this_row);
                             Builder::I64(int_builder)
                         });
                         if let Builder::I64(b) = b {
@@ -431,7 +677,7 @@ impl MutableTableChunk {
                         let b = self.data.entry(f.id).or_insert_with(|| {
                             let mut uint_builder = UInt64Builder::with_capacity(builder_capacity);
                             // append nulls for all previous rows
-                            uint_builder.append_nulls(row_index + self.row_count);
+                            uint_builder.append_nulls(this_row);
                             Builder::U64(uint_builder)
                         });
                         if let Builder::U64(b) = b {
@@ -444,7 +690,7 @@ impl MutableTableChunk {
                         let b = self.data.entry(f.id).or_insert_with(|| {
                             let mut float_builder = Float64Builder::with_capacity(builder_capacity);
                             // append nulls for all previous rows
-                            float_builder.append_nulls(row_index + self.row_count);
+                            float_builder.append_nulls(this_row);
                             Builder::F64(float_builder)
                         });
                         if let Builder::F64(b) = b {
@@ -457,7 +703,7 @@ impl MutableTableChunk {
                         let b = self.data.entry(f.id).or_insert_with(|| {
                             let mut bool_builder = BooleanBuilder::with_capacity(builder_capacity);
                             // append nulls for all previous rows
-                            bool_builder.append_nulls(row_index + self.row_count);
+                            bool_builder.append_nulls(this_row);
                             Builder::Bool(bool_builder)
                         });
                         if let Builder::Bool(b) = b {
@@ -470,15 +716,56 @@ impl MutableTableChunk {
                 }
             }
 
-            // add nulls for any columns not present
+            // Columns the row doesn't provide: an overwrite carries the
+            // replaced row's value forward (line protocol unions the field
+            // sets, conflicts favoring the new write); a fresh row gets null.
             for (column_id, builder) in &mut self.data {
                 if !value_added.contains(column_id) {
-                    builder.append_null();
+                    let copied_bytes = match &carry {
+                        CarrySource::None => {
+                            builder.append_null();
+                            0
+                        }
+                        CarrySource::Local(old) => {
+                            builder.append_copied(builder_read(builder, *old))
+                        }
+                        CarrySource::Foreign(src_chunk, old) => match src_chunk.data.get(column_id)
+                        {
+                            Some(src) => builder.append_copied(builder_read(src, *old)),
+                            None => {
+                                builder.append_null();
+                                0
+                            }
+                        },
+                    };
+                    if copied_bytes > 0 {
+                        *self.string_bytes_per_column.entry(*column_id).or_default() +=
+                            copied_bytes;
+                    }
+                }
+            }
+
+            // A foreign carry can reference columns this chunk has never
+            // seen (they were only ever written before the split). Create
+            // them so the union does not drop fields across the split.
+            if let CarrySource::Foreign(src_chunk, old) = &carry {
+                for (column_id, src) in &src_chunk.data {
+                    if !value_added.contains(column_id) && !self.data.contains_key(column_id) {
+                        let mut builder = src.new_null_prefilled(this_row);
+                        let copied_bytes = builder.append_copied(builder_read(src, *old));
+                        if copied_bytes > 0 {
+                            *self.string_bytes_per_column.entry(*column_id).or_default() +=
+                                copied_bytes;
+                        }
+                        self.data.insert(*column_id, builder);
+                    }
                 }
             }
         }
 
-        self.row_count += new_row_count;
+        self.live.append(true);
+        self.row_count += 1;
+        this_row
     }
 
     fn timestamp_min_max(&self) -> TimestampMinMax {
@@ -486,34 +773,95 @@ impl MutableTableChunk {
     }
 
     fn record_batch(&self, table_def: Arc<TableDefinition>) -> Result<RecordBatch> {
+        self.materialize(table_def, 0..self.row_count)
+    }
+
+    /// Produce the live rows of `rows` as an immutable batch in table-schema
+    /// order. Rows superseded by a later duplicate are skipped in the same
+    /// pass that copies the builders, so no consumer (query or persist) sees
+    /// two versions of one point from this chunk and no second copy is made
+    /// to hide them. A chunk with no superseded rows takes the plain
+    /// `finish_cloned` path.
+    pub(crate) fn materialize(
+        &self,
+        table_def: Arc<TableDefinition>,
+        rows: Range<usize>,
+    ) -> Result<RecordBatch> {
+        if rows.start > rows.end || rows.end > self.row_count {
+            return Err(Error::RowRangeOutOfBounds {
+                start: rows.start,
+                end: rows.end,
+                row_count: self.row_count,
+            });
+        }
         let schema = table_def.schema.as_arrow();
         let table_def = legacy::TableDefinition::new(table_def);
+        // The mask view and its runs are built once and shared by every column.
+        let live = self.live_rows(&rows);
 
         let mut cols = Vec::with_capacity(schema.fields().len());
-
         for f in schema.fields() {
             let column_def = table_def
                 .column_definition(f.name())
                 .expect("a valid column name");
-            let b = match self.data.get(&column_def.id) {
-                Some(b) => b.as_arrow(),
-                None => array_ref_nulls_for_type(column_def.data_type, self.row_count),
+            let col = match self.data.get(&column_def.id) {
+                Some(b) => self.column_for(b, &live)?,
+                None => array_ref_nulls_for_type(column_def.data_type, live.kept),
             };
-
-            cols.push(b);
+            cols.push(col);
         }
-
         Ok(RecordBatch::try_new(schema, cols)?)
     }
 
+    /// The live rows of `rows`: `None` runs when nothing in the chunk is
+    /// superseded (every row of the range is live).
+    fn live_rows(&self, rows: &Range<usize>) -> LiveRows {
+        if self.superseded_count == 0 {
+            LiveRows {
+                rows: rows.clone(),
+                kept: rows.len(),
+                runs: None,
+            }
+        } else {
+            LiveRows::masked(&self.live, rows)
+        }
+    }
+
+    /// The live rows of one builder as an immutable array.
+    fn column_for(&self, b: &Builder, live: &LiveRows) -> Result<ArrayRef> {
+        match &live.runs {
+            None => {
+                let arr = b.as_arrow();
+                Ok(if live.rows.len() == self.row_count {
+                    arr
+                } else {
+                    arr.slice(live.rows.start, live.rows.len())
+                })
+            }
+            Some(_) => b.as_arrow_kept(live),
+        }
+    }
+
     fn into_schema_record_batch(self, table_def: Arc<TableDefinition>) -> (Schema, RecordBatch) {
+        let live = self.live_rows(&(0..self.row_count));
+        let kept = live.kept;
+        let Self { data, .. } = self;
         let table_def = legacy::TableDefinition::new(table_def);
-        let mut cols = Vec::with_capacity(self.data.len());
+        let mut cols = Vec::with_capacity(data.len());
         let mut schema_builder = SchemaBuilder::new();
         let mut cols_in_batch = HashSet::new();
-        for (col_id, builder) in self.data.into_iter() {
+        for (col_id, mut builder) in data.into_iter() {
             cols_in_batch.insert(col_id);
-            let (col_type, col) = builder.into_influxcol_and_arrow();
+            let col_type = builder.influx_column_type();
+            // Superseded rows are skipped in the copy itself; with none, the
+            // builders are drained into the arrays without a copy.
+            let col = if live.runs.is_none() {
+                builder.finish()
+            } else {
+                builder
+                    .as_arrow_kept(&live)
+                    .expect("filtering superseded rows should never fail")
+            };
             schema_builder.influx_column(
                 table_def
                     .column_id_to_name(&col_id)
@@ -529,7 +877,7 @@ impl MutableTableChunk {
         for (col_id, col_def) in table_def.columns.iter() {
             if !cols_in_batch.contains(col_id) {
                 schema_builder.influx_column(col_def.name.as_ref(), col_def.data_type);
-                let col = array_ref_nulls_for_type(col_def.data_type, self.row_count);
+                let col = array_ref_nulls_for_type(col_def.data_type, kept);
 
                 cols.push(col);
             }
@@ -539,12 +887,107 @@ impl MutableTableChunk {
             .expect("should always be able to build schema");
         let arrow_schema = schema.as_arrow();
 
-        (
-            schema,
-            RecordBatch::try_new(arrow_schema, cols)
-                .expect("should always be able to build record batch"),
-        )
+        let batch = RecordBatch::try_new(arrow_schema, cols)
+            .expect("should always be able to build record batch");
+
+        (schema, batch)
     }
+}
+
+/// The live rows of one materialization, computed once and shared by every
+/// column of the batch.
+struct LiveRows {
+    rows: Range<usize>,
+    /// Number of live rows in `rows`.
+    kept: usize,
+    /// `None` when every row of `rows` is live. Otherwise the mask bits of
+    /// `rows` and its maximal runs of live rows as absolute row ranges:
+    /// copying run by run is what keeps the kernels at memcpy speed when
+    /// superseded rows are sparse or clustered, rather than a branch per row.
+    runs: Option<(BooleanBuffer, Vec<Range<usize>>)>,
+}
+
+impl LiveRows {
+    /// Read the `live` bits of `rows` (one copy of `rows.len() / 8` bytes).
+    fn masked(live: &BooleanBufferBuilder, rows: &Range<usize>) -> Self {
+        let bits = BooleanBuffer::new(Buffer::from(live.as_slice()), rows.start, rows.len());
+        let runs: Vec<Range<usize>> = bits
+            .set_slices()
+            .map(|(s, e)| rows.start + s..rows.start + e)
+            .collect();
+        Self {
+            rows: rows.clone(),
+            kept: bits.count_set_bits(),
+            runs: Some((bits, runs)),
+        }
+    }
+}
+
+/// Copy the validity bits of `runs` out of a builder's bitmap, or `None`
+/// when the builder has never seen a null.
+fn kept_nulls(validity: Option<&[u8]>, runs: &[Range<usize>], kept: usize) -> Option<NullBuffer> {
+    let validity = validity?;
+    let mut out = BooleanBufferBuilder::new(kept);
+    for r in runs {
+        out.append_packed_range(r.clone(), validity);
+    }
+    Some(NullBuffer::new(out.finish()))
+}
+
+/// Copy the live rows out of a primitive builder, one memcpy per run.
+fn kept_primitive<T: ArrowPrimitiveType>(
+    b: &PrimitiveBuilder<T>,
+    runs: &[Range<usize>],
+    kept: usize,
+) -> PrimitiveArray<T> {
+    let values = b.values_slice();
+    let mut out = MutableBuffer::with_capacity(kept * size_of::<T::Native>());
+    for r in runs {
+        out.extend_from_slice(&values[r.clone()]);
+    }
+    let values = ScalarBuffer::<T::Native>::new(out.into(), 0, kept);
+    PrimitiveArray::<T>::new(values, kept_nulls(b.validity_slice(), runs, kept))
+}
+
+/// Copy the live rows out of a boolean builder, one packed bit range per run.
+fn kept_bool(b: &BooleanBuilder, runs: &[Range<usize>], kept: usize) -> BooleanArray {
+    let values = b.values_slice();
+    let mut out = BooleanBufferBuilder::new(kept);
+    for r in runs {
+        out.append_packed_range(r.clone(), values);
+    }
+    BooleanArray::new(out.finish(), kept_nulls(b.validity_slice(), runs, kept))
+}
+
+/// Copy the live rows out of a string builder: one memcpy of bytes per run,
+/// offsets rebased as they are copied.
+fn kept_string(
+    b: &GenericByteBuilder<GenericStringType<i32>>,
+    runs: &[Range<usize>],
+    kept: usize,
+) -> StringArray {
+    let values = b.values_slice();
+    let offsets = b.offsets_slice();
+    let bytes: usize = runs
+        .iter()
+        .map(|r| (offsets[r.end] - offsets[r.start]) as usize)
+        .sum();
+    let mut out_values = MutableBuffer::with_capacity(bytes);
+    let mut out_offsets = Vec::<i32>::with_capacity(kept + 1);
+    out_offsets.push(0);
+    for r in runs {
+        let (first, last) = (offsets[r.start], offsets[r.end]);
+        out_values.extend_from_slice(&values[first as usize..last as usize]);
+        let rebase = out_offsets[out_offsets.len() - 1] - first;
+        out_offsets.extend(offsets[r.start + 1..=r.end].iter().map(|o| o + rebase));
+    }
+    // The bytes were written by a `StringBuilder`, so they are valid UTF-8 and
+    // the offsets are monotonic; `new` only re-checks that.
+    StringArray::new(
+        OffsetBuffer::new(ScalarBuffer::from(out_offsets)),
+        out_values.into(),
+        kept_nulls(b.validity_slice(), runs, kept),
+    )
 }
 
 fn array_ref_nulls_for_type(data_type: InfluxColumnType, len: usize) -> ArrayRef {
@@ -598,6 +1041,79 @@ impl std::fmt::Debug for MutableTableChunk {
     }
 }
 
+/// A value read out of a builder slot for carry-forward. Owned, so the
+/// source borrow ends before the (possibly same) destination is appended.
+enum CopiedValue {
+    Null,
+    Bool(bool),
+    I64(i64),
+    F64(f64),
+    U64(u64),
+    Time(i64),
+    String(String),
+}
+
+/// Read the value at `idx` from a builder. Tag columns read as null: a
+/// duplicate row carries the same tag set as the row it replaces, so a tag
+/// column missing from the new row was missing from the old one too.
+fn builder_read(b: &Builder, idx: usize) -> CopiedValue {
+    fn is_valid(validity: Option<&[u8]>, idx: usize) -> bool {
+        validity.is_none_or(|v| v[idx / 8] & (1 << (idx % 8)) != 0)
+    }
+    match b {
+        Builder::Bool(b) => {
+            if is_valid(b.validity_slice(), idx) {
+                CopiedValue::Bool(b.values_slice()[idx / 8] & (1 << (idx % 8)) != 0)
+            } else {
+                CopiedValue::Null
+            }
+        }
+        Builder::I64(b) => {
+            if is_valid(b.validity_slice(), idx) {
+                CopiedValue::I64(b.values_slice()[idx])
+            } else {
+                CopiedValue::Null
+            }
+        }
+        Builder::F64(b) => {
+            if is_valid(b.validity_slice(), idx) {
+                CopiedValue::F64(b.values_slice()[idx])
+            } else {
+                CopiedValue::Null
+            }
+        }
+        Builder::U64(b) => {
+            if is_valid(b.validity_slice(), idx) {
+                CopiedValue::U64(b.values_slice()[idx])
+            } else {
+                CopiedValue::Null
+            }
+        }
+        Builder::Time(b) => {
+            if is_valid(b.validity_slice(), idx) {
+                CopiedValue::Time(b.values_slice()[idx])
+            } else {
+                CopiedValue::Null
+            }
+        }
+        Builder::String(b) => {
+            if is_valid(b.validity_slice(), idx) {
+                let offsets = b.offsets_slice();
+                let start = offsets[idx] as usize;
+                let end = offsets[idx + 1] as usize;
+                CopiedValue::String(
+                    std::str::from_utf8(&b.values_slice()[start..end])
+                        .expect("buffered string values are valid utf8")
+                        .to_string(),
+                )
+            } else {
+                CopiedValue::Null
+            }
+        }
+        Builder::Tag(_) => CopiedValue::Null,
+    }
+}
+
 pub(super) enum Builder {
     Bool(BooleanBuilder),
     I64(Int64Builder),
@@ -633,31 +1149,113 @@ impl Builder {
         }
     }
 
-    fn into_influxcol_and_arrow(self) -> (InfluxColumnType, ArrayRef) {
-        match self {
-            Self::Bool(mut b) => (
-                InfluxColumnType::Field(InfluxFieldType::Boolean),
-                Arc::new(b.finish()),
-            ),
-            Self::I64(mut b) => (
-                InfluxColumnType::Field(InfluxFieldType::Integer),
-                Arc::new(b.finish()),
-            ),
-            Self::F64(mut b) => (
-                InfluxColumnType::Field(InfluxFieldType::Float),
-                Arc::new(b.finish()),
-            ),
-            Self::U64(mut b) => (
-                InfluxColumnType::Field(InfluxFieldType::UInteger),
-                Arc::new(b.finish()),
-            ),
-            Self::String(mut b) => (
-                InfluxColumnType::Field(InfluxFieldType::String),
-                Arc::new(b.finish()),
-            ),
-            Self::Tag(mut b) => (InfluxColumnType::Tag, Arc::new(b.finish())),
-            Self::Time(mut b) => (InfluxColumnType::Timestamp, Arc::new(b.finish())),
+    /// Append a previously read value (see [`builder_read`]), or null.
+    /// Returns the number of variable-length bytes appended, for the
+    /// caller's string-size accounting.
+    fn append_copied(&mut self, value: CopiedValue) -> usize {
+        match (self, value) {
+            (b, CopiedValue::Null) => {
+                b.append_null();
+                0
+            }
+            (Builder::Bool(b), CopiedValue::Bool(v)) => {
+                b.append_value(v);
+                0
+            }
+            (Builder::I64(b), CopiedValue::I64(v)) => {
+                b.append_value(v);
+                0
+            }
+            (Builder::F64(b), CopiedValue::F64(v)) => {
+                b.append_value(v);
+                0
+            }
+            (Builder::U64(b), CopiedValue::U64(v)) => {
+                b.append_value(v);
+                0
+            }
+            (Builder::Time(b), CopiedValue::Time(v)) => {
+                b.append_value(v);
+                0
+            }
+            (Builder::String(b), CopiedValue::String(v)) => {
+                let len = v.len();
+                b.append_value(v);
+                len
+            }
+            _ => panic!("unexpected field type"),
         }
+    }
+
+    /// An empty builder of the same variant as `self`, prefilled with
+    /// `rows` nulls. Used when a carry-forward references a column this
+    /// chunk has not seen yet.
+    fn new_null_prefilled(&self, rows: usize) -> Builder {
+        let mut b = match self {
+            Builder::Bool(_) => Builder::Bool(BooleanBuilder::with_capacity(rows + 1)),
+            Builder::I64(_) => Builder::I64(Int64Builder::with_capacity(rows + 1)),
+            Builder::F64(_) => Builder::F64(Float64Builder::with_capacity(rows + 1)),
+            Builder::U64(_) => Builder::U64(UInt64Builder::with_capacity(rows + 1)),
+            Builder::String(_) => Builder::String(StringBuilder::with_capacity(rows + 1, 1024)),
+            Builder::Tag(_) => Builder::Tag(StringDictionaryBuilder::new()),
+            Builder::Time(_) => Builder::Time(TimestampNanosecondBuilder::with_capacity(rows + 1)),
+        };
+        for _ in 0..rows {
+            b.append_null();
+        }
+        b
+    }
+
+    fn influx_column_type(&self) -> InfluxColumnType {
+        match self {
+            Self::Bool(_) => InfluxColumnType::Field(InfluxFieldType::Boolean),
+            Self::I64(_) => InfluxColumnType::Field(InfluxFieldType::Integer),
+            Self::F64(_) => InfluxColumnType::Field(InfluxFieldType::Float),
+            Self::U64(_) => InfluxColumnType::Field(InfluxFieldType::UInteger),
+            Self::String(_) => InfluxColumnType::Field(InfluxFieldType::String),
+            Self::Tag(_) => InfluxColumnType::Tag,
+            Self::Time(_) => InfluxColumnType::Timestamp,
+        }
+    }
+
+    /// Drain the builder into an immutable array without copying; the
+    /// builder is left empty.
+    fn finish(&mut self) -> ArrayRef {
+        match self {
+            Self::Bool(b) => Arc::new(b.finish()),
+            Self::I64(b) => Arc::new(b.finish()),
+            Self::F64(b) => Arc::new(b.finish()),
+            Self::U64(b) => Arc::new(b.finish()),
+            Self::String(b) => Arc::new(b.finish()),
+            Self::Tag(b) => Arc::new(b.finish()),
+            Self::Time(b) => Arc::new(b.finish()),
+        }
+    }
+
+    /// The live rows of `live.rows` as an immutable array, copied out of the
+    /// builder in a single pass that skips rows whose `live` bit is clear —
+    /// one bulk copy per run of live rows. Dictionary (tag) columns clone
+    /// their keys and dictionary and filter the keys, which is cheap relative
+    /// to a value column.
+    fn as_arrow_kept(&self, live: &LiveRows) -> Result<ArrayRef> {
+        let (bits, runs) = live
+            .runs
+            .as_ref()
+            .expect("as_arrow_kept is only called with a superseded-row mask");
+        let (rows, kept) = (&live.rows, live.kept);
+        Ok(match self {
+            Self::Tag(b) => {
+                let arr = b.finish_cloned().slice(rows.start, rows.len());
+                let mask = BooleanArray::new(bits.clone(), None);
+                arrow::compute::filter(&arr, &mask)?
+            }
+            Self::Bool(b) => Arc::new(kept_bool(b, runs, kept)),
+            Self::I64(b) => Arc::new(kept_primitive(b, runs, kept)),
+            Self::F64(b) => Arc::new(kept_primitive(b, runs, kept)),
+            Self::U64(b) => Arc::new(kept_primitive(b, runs, kept)),
+            Self::Time(b) => Arc::new(kept_primitive(b, runs, kept)),
+            Self::String(b) => Arc::new(kept_string(b, runs, kept)),
+        })
     }
 
     fn size(&self) -> usize {

--- a/influxdb3_write/src/write_buffer/table_buffer/tests.rs
+++ b/influxdb3_write/src/write_buffer/table_buffer/tests.rs
@@ -1,7 +1,7 @@
 use crate::{Precision, write_buffer::validator::WriteValidator};
 
 use super::*;
-use arrow_util::assert_batches_sorted_eq;
+use arrow_util::{assert_batches_eq, assert_batches_sorted_eq};
 use datafusion::prelude::{Expr, col, lit_timestamp_nano};
 use influxdb3_catalog::catalog::{Catalog, DatabaseSchema};
 use influxdb3_types::DatabaseName;
@@ -87,8 +87,12 @@ async fn test_partitioned_table_buffer_batches() {
 
     for t in 0..10 {
         let offset = t * 10;
-        let (ts_min_max, batches) = partitioned_batches.get(&offset).unwrap();
-        assert_eq!(TimestampMinMax::new(offset + 1, offset + 2), *ts_min_max);
+        let buffered = partitioned_batches.get(&offset).unwrap();
+        let batches = &buffered.combined();
+        assert_eq!(
+            Some(TimestampMinMax::new(offset + 1, offset + 2)),
+            buffered.timestamp_min_max()
+        );
         assert_batches_sorted_eq!(
             [
                 "+-----+--------------------------------+-----------+",
@@ -130,7 +134,7 @@ async fn test_computed_size_of_buffer() {
     table_buffer.buffer_chunk(0, &rows);
 
     let size = table_buffer.computed_size();
-    assert_eq!(size, 1251);
+    assert_eq!(size, 1427);
 }
 
 #[test]
@@ -226,7 +230,7 @@ async fn test_time_filters() {
             .partitioned_record_batches(Arc::clone(&table_def), &filter)
             .unwrap()
             .into_values()
-            .flat_map(|(_, batches)| batches)
+            .flat_map(|buffered| buffered.combined())
             .collect::<Vec<RecordBatch>>();
         assert_batches_sorted_eq!(t.expected_output, &batches);
     }
@@ -272,17 +276,41 @@ async fn test_chunk_splits_on_large_string_payload() {
     // Buffer first batch - chunk is empty, 0 + 50 <= 99, goes to chunk1
     // After: chunk1.string_bytes_per_column[val] = 50
     table_buffer.buffer_chunk(0, &rows1);
-    assert_eq!(table_buffer.chunk_time_to_chunks.get(&0).unwrap().len(), 1);
+    assert_eq!(
+        table_buffer
+            .chunk_time_to_chunks
+            .get(&0)
+            .unwrap()
+            .chunks
+            .len(),
+        1
+    );
 
     // Buffer second batch - predictive check: 50 + 50 = 100 > 99, triggers new chunk
     // After: chunk2.string_bytes_per_column[val] = 50
     table_buffer.buffer_chunk(0, &rows2);
-    assert_eq!(table_buffer.chunk_time_to_chunks.get(&0).unwrap().len(), 2);
+    assert_eq!(
+        table_buffer
+            .chunk_time_to_chunks
+            .get(&0)
+            .unwrap()
+            .chunks
+            .len(),
+        2
+    );
 
     // Buffer third batch - predictive check: 50 + 50 = 100 > 99, triggers new chunk
     // After: chunk3.string_bytes_per_column[val] = 50
     table_buffer.buffer_chunk(0, &rows3);
-    assert_eq!(table_buffer.chunk_time_to_chunks.get(&0).unwrap().len(), 3);
+    assert_eq!(
+        table_buffer
+            .chunk_time_to_chunks
+            .get(&0)
+            .unwrap()
+            .chunks
+            .len(),
+        3
+    );
 
     // Verify all data can be retrieved
     let batches = table_buffer
@@ -290,13 +318,13 @@ async fn test_chunk_splits_on_large_string_payload() {
         .unwrap();
 
     assert_eq!(batches.len(), 1); // 1 time partition
-    let (ts_min_max, record_batches) = batches.get(&0).unwrap();
-    assert_eq!(ts_min_max.min, 1);
-    assert_eq!(ts_min_max.max, 3);
-    assert_eq!(record_batches.len(), 3); // 3 chunks -> 3 record batches
+    let buffered = batches.get(&0).unwrap();
+    assert_eq!(buffered.timestamp_min_max().unwrap().min, 1);
+    assert_eq!(buffered.timestamp_min_max().unwrap().max, 3);
+    assert_eq!(buffered.live.len(), 3); // 3 chunks -> 3 record batches
 
     // Check total row count across all batches
-    let total_rows: usize = record_batches.iter().map(|rb| rb.num_rows()).sum();
+    let total_rows: usize = buffered.live.iter().map(|rb| rb.num_rows()).sum();
     assert_eq!(total_rows, 3);
 }
 
@@ -335,20 +363,52 @@ async fn test_chunk_accumulates_when_under_limit() {
 
     // First three writes should all go to the same chunk
     table_buffer.buffer_chunk(0, &rows1);
-    assert_eq!(table_buffer.chunk_time_to_chunks.get(&0).unwrap().len(), 1);
+    assert_eq!(
+        table_buffer
+            .chunk_time_to_chunks
+            .get(&0)
+            .unwrap()
+            .chunks
+            .len(),
+        1
+    );
 
     table_buffer.buffer_chunk(0, &rows2);
-    assert_eq!(table_buffer.chunk_time_to_chunks.get(&0).unwrap().len(), 1);
+    assert_eq!(
+        table_buffer
+            .chunk_time_to_chunks
+            .get(&0)
+            .unwrap()
+            .chunks
+            .len(),
+        1
+    );
 
     table_buffer.buffer_chunk(0, &rows3);
-    assert_eq!(table_buffer.chunk_time_to_chunks.get(&0).unwrap().len(), 1);
+    assert_eq!(
+        table_buffer
+            .chunk_time_to_chunks
+            .get(&0)
+            .unwrap()
+            .chunks
+            .len(),
+        1
+    );
 
     // Fourth write should trigger a new chunk
     table_buffer.buffer_chunk(0, &rows4);
-    assert_eq!(table_buffer.chunk_time_to_chunks.get(&0).unwrap().len(), 2);
+    assert_eq!(
+        table_buffer
+            .chunk_time_to_chunks
+            .get(&0)
+            .unwrap()
+            .chunks
+            .len(),
+        2
+    );
 
     // Verify chunk sizes: first chunk should have 3 rows, second chunk should have 1 row
-    let chunks = table_buffer.chunk_time_to_chunks.get(&0).unwrap();
+    let chunks = &table_buffer.chunk_time_to_chunks.get(&0).unwrap().chunks;
     assert_eq!(chunks[0].row_count, 3);
     assert_eq!(chunks[1].row_count, 1);
 
@@ -357,11 +417,11 @@ async fn test_chunk_accumulates_when_under_limit() {
         .partitioned_record_batches(Arc::clone(&table_def), &ChunkFilter::default())
         .unwrap();
 
-    let (ts_min_max, record_batches) = batches.get(&0).unwrap();
-    assert_eq!(ts_min_max.min, 1);
-    assert_eq!(ts_min_max.max, 4);
+    let buffered = batches.get(&0).unwrap();
+    assert_eq!(buffered.timestamp_min_max().unwrap().min, 1);
+    assert_eq!(buffered.timestamp_min_max().unwrap().max, 4);
 
-    let total_rows: usize = record_batches.iter().map(|rb| rb.num_rows()).sum();
+    let total_rows: usize = buffered.live.iter().map(|rb| rb.num_rows()).sum();
     assert_eq!(total_rows, 4);
 }
 
@@ -392,11 +452,35 @@ async fn test_chunk_splits_on_large_tag_payload() {
     let table_def = writer.db_schema().table_definition("tbl").unwrap();
     let mut table_buffer = TableBuffer::new();
     table_buffer.buffer_chunk(0, &rows1);
-    assert_eq!(table_buffer.chunk_time_to_chunks.get(&0).unwrap().len(), 1);
+    assert_eq!(
+        table_buffer
+            .chunk_time_to_chunks
+            .get(&0)
+            .unwrap()
+            .chunks
+            .len(),
+        1
+    );
     table_buffer.buffer_chunk(0, &rows2);
-    assert_eq!(table_buffer.chunk_time_to_chunks.get(&0).unwrap().len(), 2);
+    assert_eq!(
+        table_buffer
+            .chunk_time_to_chunks
+            .get(&0)
+            .unwrap()
+            .chunks
+            .len(),
+        2
+    );
     table_buffer.buffer_chunk(0, &rows3);
-    assert_eq!(table_buffer.chunk_time_to_chunks.get(&0).unwrap().len(), 3);
+    assert_eq!(
+        table_buffer
+            .chunk_time_to_chunks
+            .get(&0)
+            .unwrap()
+            .chunks
+            .len(),
+        3
+    );
 
     // Verify all data can be retrieved
     let batches = table_buffer
@@ -404,12 +488,12 @@ async fn test_chunk_splits_on_large_tag_payload() {
         .unwrap();
 
     assert_eq!(batches.len(), 1);
-    let (ts_min_max, record_batches) = batches.get(&0).unwrap();
-    assert_eq!(ts_min_max.min, 1);
-    assert_eq!(ts_min_max.max, 3);
-    assert_eq!(record_batches.len(), 3);
+    let buffered = batches.get(&0).unwrap();
+    assert_eq!(buffered.timestamp_min_max().unwrap().min, 1);
+    assert_eq!(buffered.timestamp_min_max().unwrap().max, 3);
+    assert_eq!(buffered.live.len(), 3);
 
-    let total_rows: usize = record_batches.iter().map(|rb| rb.num_rows()).sum();
+    let total_rows: usize = buffered.live.iter().map(|rb| rb.num_rows()).sum();
     assert_eq!(total_rows, 3);
 }
 
@@ -446,7 +530,15 @@ async fn test_remove_snapshotting_chunk_leaves_the_other_chunks_queryable() {
     table_buffer.buffer_chunk(0, &rows2);
     table_buffer.buffer_chunk(0, &rows3);
     table_buffer.buffer_chunk(0, &rows4);
-    assert_eq!(table_buffer.chunk_time_to_chunks.get(&0).unwrap().len(), 2);
+    assert_eq!(
+        table_buffer
+            .chunk_time_to_chunks
+            .get(&0)
+            .unwrap()
+            .chunks
+            .len(),
+        2
+    );
     // chunk_time 10: one chunk, the sibling gen1 block.
     table_buffer.buffer_chunk(10, &rows1);
 
@@ -466,10 +558,14 @@ async fn test_remove_snapshotting_chunk_leaves_the_other_chunks_queryable() {
             .unwrap();
         let mut counts: Vec<(i64, usize)> = batches
             .into_iter()
-            .map(|(chunk_time, (_, rbs))| {
+            .map(|(chunk_time, buffered)| {
                 (
                     chunk_time,
-                    rbs.iter().map(|rb| rb.num_rows()).sum::<usize>(),
+                    buffered
+                        .combined()
+                        .iter()
+                        .map(|rb| rb.num_rows())
+                        .sum::<usize>(),
                 )
             })
             .collect();
@@ -497,4 +593,465 @@ async fn test_remove_snapshotting_chunk_leaves_the_other_chunks_queryable() {
 
     table_buffer.remove_snapshotting_chunk(0, 1);
     assert!(queryable_rows(&table_buffer).is_empty());
+}
+
+/// Overwrites of the same (tag set, timestamp) collapse at buffer time
+/// (<https://github.com/influxdata/influxdb_pro/issues/5352>): the latest
+/// write wins, fields the overwrite does not provide are carried forward
+/// (field-set union), and superseded versions reach neither the query path
+/// nor the snapshot path.
+#[tokio::test]
+async fn test_overwrite_collapses_to_latest_write() {
+    let writer = TestWriter::new().await;
+
+    // Interleave versions across series in single and separate batches, and
+    // include a partial overwrite (v2 of u1 omits `w`, which v1 provided).
+    let rows_a = writer
+        .write_to_rows(
+            "tbl,t=u1 v=1i,w=10i 1000\n\
+             tbl,t=u2 v=1i 1000\n\
+             tbl,t=u1 v=2i 1000",
+            0,
+        )
+        .await;
+    let rows_b = writer
+        .write_to_rows("tbl,t=u2 v=2i 1000\ntbl,t=u1 v=3i 1000", 1)
+        .await;
+
+    let table_def = writer.db_schema().table_definition("tbl").unwrap();
+    let mut table_buffer = TableBuffer::new();
+    table_buffer.buffer_chunk(0, &rows_a);
+    table_buffer.buffer_chunk(0, &rows_b);
+
+    let expected = [
+        "+----+-----------------------------+---+----+",
+        "| t  | time                        | v | w  |",
+        "+----+-----------------------------+---+----+",
+        "| u1 | 1970-01-01T00:00:00.000001Z | 3 | 10 |",
+        "| u2 | 1970-01-01T00:00:00.000001Z | 2 |    |",
+        "+----+-----------------------------+---+----+",
+    ];
+
+    // Query path: one row per series, latest values, unioned fields.
+    let partitioned_batches = table_buffer
+        .partitioned_record_batches(Arc::clone(&table_def), &ChunkFilter::default())
+        .unwrap();
+    let batches = partitioned_batches.get(&0).unwrap().combined();
+    assert_batches_sorted_eq!(expected, &batches);
+
+    // Snapshot (persist) path: the batch handed to persistence is already
+    // collapsed, so a superseded version can never be written to parquet.
+    // (Snapshot batches order columns by column id, so time comes last.)
+    let snapshot_chunks = table_buffer.snapshot(Arc::clone(&table_def), i64::MAX);
+    assert_eq!(1, snapshot_chunks.len());
+    assert_batches_sorted_eq!(
+        [
+            "+----+---+----+-----------------------------+",
+            "| t  | v | w  | time                        |",
+            "+----+---+----+-----------------------------+",
+            "| u1 | 3 | 10 | 1970-01-01T00:00:00.000001Z |",
+            "| u2 | 2 |    | 1970-01-01T00:00:00.000001Z |",
+            "+----+---+----+-----------------------------+",
+        ],
+        &[snapshot_chunks[0].record_batch.clone()]
+    );
+}
+
+/// Overwrite collapsing spans var-column chunk splits
+/// (<https://github.com/influxdata/influxdb_pro/issues/5352>): the overwrite
+/// index is per chunk_time, so a row whose earlier version lives in a
+/// previous split chunk still supersedes it, and fields the overwrite does
+/// not provide are carried across the split — including columns the new
+/// chunk has never seen.
+#[tokio::test]
+async fn test_overwrite_collapses_across_chunk_split() {
+    let _guard = VarColMaxGuard::new(100);
+    let writer = TestWriter::new().await;
+
+    // 60 bytes of string payload per batch: batch 1 fits (60 <= 100), batch
+    // 2 would exceed (60 + 60 > 100) and opens a second chunk.
+    let s60 = "x".repeat(60);
+    let rows1 = writer
+        .write_to_rows(format!("tbl,t=u1 v=1i,w=10i,s=\"{s60}\" 1000"), 0)
+        .await;
+    // Overwrite of the same (tag set, time) lands in the split chunk and
+    // omits `w`, which must be carried over from the superseded row in the
+    // earlier chunk.
+    let rows2 = writer
+        .write_to_rows(format!("tbl,t=u1 v=2i,s=\"{s60}\" 1000"), 1)
+        .await;
+
+    let table_def = writer.db_schema().table_definition("tbl").unwrap();
+    let mut table_buffer = TableBuffer::new();
+    table_buffer.buffer_chunk(0, &rows1);
+    table_buffer.buffer_chunk(0, &rows2);
+    assert_eq!(
+        table_buffer
+            .chunk_time_to_chunks
+            .get(&0)
+            .unwrap()
+            .chunks
+            .len(),
+        2,
+        "payload should have split the chunk"
+    );
+
+    let partitioned_batches = table_buffer
+        .partitioned_record_batches(Arc::clone(&table_def), &ChunkFilter::default())
+        .unwrap();
+    let batches = partitioned_batches.get(&0).unwrap().combined();
+    let total_rows: usize = batches.iter().map(|rb| rb.num_rows()).sum();
+    assert_eq!(total_rows, 1, "superseded version must be masked out");
+    assert_batches_sorted_eq!(
+        [
+            "+--------------------------------------------------------------+----+-----------------------------+---+----+",
+            "| s                                                            | t  | time                        | v | w  |",
+            "+--------------------------------------------------------------+----+-----------------------------+---+----+",
+            &format!("| {s60} | u1 | 1970-01-01T00:00:00.000001Z | 2 | 10 |"),
+            "+--------------------------------------------------------------+----+-----------------------------+---+----+",
+        ],
+        &batches
+    );
+}
+
+/// A split chunk whose every row was superseded by overwrites in a later
+/// split has nothing left to persist: snapshot must skip it rather than emit
+/// an empty parquet file, while the surviving chunk keeps its ordinal.
+#[tokio::test]
+async fn test_snapshot_skips_fully_superseded_split_chunk() {
+    let _guard = VarColMaxGuard::new(100);
+    let writer = TestWriter::new().await;
+
+    let s60 = "x".repeat(60);
+    let rows1 = writer
+        .write_to_rows(format!("tbl,t=u1 v=1i,s=\"{s60}\" 1000"), 0)
+        .await;
+    let rows2 = writer
+        .write_to_rows(format!("tbl,t=u1 v=2i,s=\"{s60}\" 1000"), 1)
+        .await;
+
+    let table_def = writer.db_schema().table_definition("tbl").unwrap();
+    let mut table_buffer = TableBuffer::new();
+    table_buffer.buffer_chunk(0, &rows1);
+    table_buffer.buffer_chunk(0, &rows2);
+    assert_eq!(
+        table_buffer
+            .chunk_time_to_chunks
+            .get(&0)
+            .unwrap()
+            .chunks
+            .len(),
+        2,
+        "payload should have split the chunk"
+    );
+
+    let snapshot_chunks = table_buffer.snapshot(Arc::clone(&table_def), i64::MAX);
+    assert_eq!(
+        snapshot_chunks.len(),
+        1,
+        "the fully superseded first split must not become a snapshot chunk"
+    );
+    assert_eq!(snapshot_chunks[0].chunk_ordinal, 1);
+    assert_eq!(snapshot_chunks[0].record_batch.num_rows(), 1);
+    // Persist batches carry columns in column-id order.
+    assert_batches_eq!(
+        [
+            "+----+---+--------------------------------------------------------------+-----------------------------+",
+            "| t  | v | s                                                            | time                        |",
+            "+----+---+--------------------------------------------------------------+-----------------------------+",
+            &format!("| u1 | 2 | {s60} | 1970-01-01T00:00:00.000001Z |"),
+            "+----+---+--------------------------------------------------------------+-----------------------------+",
+        ],
+        &[snapshot_chunks[0].record_batch.clone()]
+    );
+}
+
+/// An overwrite arriving while a snapshot's parquet files are being written
+/// lands in a live chunk and is reported separately from the frozen
+/// snapshotting batches, so the consumer can rank the frozen state below it
+/// and dedup deterministically (live wins).
+#[tokio::test]
+async fn test_snapshotting_and_live_batches_are_separated() {
+    let writer = TestWriter::new().await;
+    let rows_v1 = writer.write_to_rows("tbl,t=u1 v=1i 1000", 0).await;
+    let rows_v2 = writer.write_to_rows("tbl,t=u1 v=2i 1000", 1).await;
+
+    let table_def = writer.db_schema().table_definition("tbl").unwrap();
+    let mut table_buffer = TableBuffer::new();
+    table_buffer.buffer_chunk(0, &rows_v1);
+    let snapshot_chunks = table_buffer.snapshot(Arc::clone(&table_def), i64::MAX);
+    assert_eq!(1, snapshot_chunks.len());
+
+    // v2 arrives mid-persist: it goes to a fresh live chunk.
+    table_buffer.buffer_chunk(0, &rows_v2);
+
+    let partitioned_batches = table_buffer
+        .partitioned_record_batches(Arc::clone(&table_def), &ChunkFilter::default())
+        .unwrap();
+    let buffered = partitioned_batches.get(&0).unwrap();
+    assert_eq!(buffered.snapshotting.len(), 1);
+    assert_eq!(buffered.live.len(), 1);
+    assert_eq!(buffered.snapshotting[0].num_rows(), 1);
+    assert_eq!(buffered.live[0].num_rows(), 1);
+}
+
+/// Each provenance set reports its own time range, so the chunk built from
+/// the frozen snapshotting batches does not advertise times only present in
+/// live batches (and vice versa).
+#[tokio::test]
+async fn test_buffered_batches_track_per_provenance_time_ranges() {
+    let writer = TestWriter::new().await;
+    let rows_v1 = writer.write_to_rows("tbl,t=u1 v=1i 1000", 0).await;
+    let rows_v2 = writer.write_to_rows("tbl,t=u1 v=2i 2000", 1).await;
+
+    let table_def = writer.db_schema().table_definition("tbl").unwrap();
+    let mut table_buffer = TableBuffer::new();
+    table_buffer.buffer_chunk(0, &rows_v1);
+    let snapshot_chunks = table_buffer.snapshot(Arc::clone(&table_def), i64::MAX);
+    assert_eq!(1, snapshot_chunks.len());
+    table_buffer.buffer_chunk(0, &rows_v2);
+
+    let partitioned_batches = table_buffer
+        .partitioned_record_batches(Arc::clone(&table_def), &ChunkFilter::default())
+        .unwrap();
+    let buffered = partitioned_batches.get(&0).unwrap();
+    assert_eq!(
+        buffered.snapshotting_min_max,
+        Some(TimestampMinMax::new(1000, 1000))
+    );
+    assert_eq!(
+        buffered.live_min_max,
+        Some(TimestampMinMax::new(2000, 2000))
+    );
+    assert_eq!(
+        buffered.timestamp_min_max(),
+        Some(TimestampMinMax::new(1000, 2000))
+    );
+}
+
+// --- fused superseded-row masking -------------------------------------------
+
+/// Overwrites across every column type: the produced batch carries exactly the
+/// live rows, with carried-forward fields and nulls intact, for booleans,
+/// integers, unsigned, floats, strings, tags and time alike.
+#[tokio::test]
+async fn test_record_batch_masks_superseded_rows_for_every_column_type() {
+    let writer = TestWriter::new().await;
+    let rows = writer
+        .write_to_rows(
+            "tbl,t=a b=true,i=1i,u=2u,f=1.5,s=\"one\" 1000\n\
+             tbl,t=b i=3i 1000\n\
+             tbl,t=a s=\"three\" 2000",
+            0,
+        )
+        .await;
+    // Overwrite the first two points: new values for some fields, the rest
+    // carried forward from the superseded rows.
+    let overwrites = writer
+        .write_to_rows(
+            "tbl,t=a i=9i,b=false 1000\n\
+             tbl,t=b u=7u 1000",
+            1,
+        )
+        .await;
+
+    let table_def = writer.db_schema().table_definition("tbl").unwrap();
+    let mut table_buffer = TableBuffer::new();
+    table_buffer.buffer_chunk(0, &rows);
+    table_buffer.buffer_chunk(0, &overwrites);
+    let chunk = &table_buffer.chunk_time_to_chunks.get(&0).unwrap().chunks[0];
+    assert_eq!(chunk.row_count, 5);
+    assert_eq!(chunk.superseded_count, 2);
+
+    let batch = chunk.record_batch(Arc::clone(&table_def)).unwrap();
+    assert_batches_sorted_eq!(
+        [
+            "+-------+-----+---+-------+---+-----------------------------+---+",
+            "| b     | f   | i | s     | t | time                        | u |",
+            "+-------+-----+---+-------+---+-----------------------------+---+",
+            "|       |     |   | three | a | 1970-01-01T00:00:00.000002Z |   |",
+            "|       |     | 3 |       | b | 1970-01-01T00:00:00.000001Z | 7 |",
+            "| false | 1.5 | 9 | one   | a | 1970-01-01T00:00:00.000001Z | 2 |",
+            "+-------+-----+---+-------+---+-----------------------------+---+",
+        ],
+        &[batch]
+    );
+}
+
+/// `materialize` takes a row range: rows outside it are not produced, and
+/// superseded rows inside it are still masked out.
+#[tokio::test]
+async fn test_materialize_range_selects_rows_and_masks_superseded() {
+    let writer = TestWriter::new().await;
+    let rows = writer
+        .write_to_rows(
+            "tbl,t=a v=1i 1000\ntbl,t=b v=2i 1000\ntbl,t=c v=3i 1000\ntbl,t=d v=4i 1000",
+            0,
+        )
+        .await;
+    let overwrite = writer.write_to_rows("tbl,t=b v=20i 1000", 1).await;
+
+    let table_def = writer.db_schema().table_definition("tbl").unwrap();
+    let mut table_buffer = TableBuffer::new();
+    table_buffer.buffer_chunk(0, &rows);
+    table_buffer.buffer_chunk(0, &overwrite);
+    let chunk = &table_buffer.chunk_time_to_chunks.get(&0).unwrap().chunks[0];
+
+    // Rows 1..4 are b (superseded), c, d.
+    let batch = chunk.materialize(Arc::clone(&table_def), 1..4).unwrap();
+    assert_eq!(batch.num_rows(), 2);
+    assert_batches_sorted_eq!(
+        [
+            "+---+-----------------------------+---+",
+            "| t | time                        | v |",
+            "+---+-----------------------------+---+",
+            "| c | 1970-01-01T00:00:00.000001Z | 3 |",
+            "| d | 1970-01-01T00:00:00.000001Z | 4 |",
+            "+---+-----------------------------+---+",
+        ],
+        &[batch]
+    );
+    // The tail alone: the replacement row.
+    let tail = chunk.materialize(Arc::clone(&table_def), 4..5).unwrap();
+    assert_eq!(tail.num_rows(), 1);
+    // The whole chunk equals `record_batch`.
+    let whole = chunk.materialize(Arc::clone(&table_def), 0..5).unwrap();
+    assert_eq!(whole.num_rows(), 4);
+}
+
+#[tokio::test]
+async fn test_materialize_rejects_out_of_bounds_range() {
+    let writer = TestWriter::new().await;
+    let rows = writer.write_to_rows("tbl,t=a v=1i 1000", 0).await;
+    let table_def = writer.db_schema().table_definition("tbl").unwrap();
+    let mut table_buffer = TableBuffer::new();
+    table_buffer.buffer_chunk(0, &rows);
+    let chunk = &table_buffer.chunk_time_to_chunks.get(&0).unwrap().chunks[0];
+
+    let err = chunk
+        .materialize(Arc::clone(&table_def), 0..2)
+        .expect_err("end past row_count must be rejected");
+    assert!(
+        matches!(
+            err,
+            Error::RowRangeOutOfBounds {
+                start: 0,
+                end: 2,
+                row_count: 1
+            }
+        ),
+        "{err:?}"
+    );
+    let err = chunk
+        .materialize(Arc::clone(&table_def), std::ops::Range { start: 1, end: 0 })
+        .expect_err("inverted range must be rejected");
+    assert!(matches!(err, Error::RowRangeOutOfBounds { .. }), "{err:?}");
+}
+
+/// A range that covers only superseded rows yields an empty batch that still
+/// carries the table schema.
+#[tokio::test]
+async fn test_materialize_fully_superseded_range_is_empty_with_schema() {
+    let writer = TestWriter::new().await;
+    let rows = writer.write_to_rows("tbl,t=a v=1i 1000", 0).await;
+    let overwrite = writer.write_to_rows("tbl,t=a v=2i 1000", 1).await;
+    let table_def = writer.db_schema().table_definition("tbl").unwrap();
+    let mut table_buffer = TableBuffer::new();
+    table_buffer.buffer_chunk(0, &rows);
+    table_buffer.buffer_chunk(0, &overwrite);
+    let chunk = &table_buffer.chunk_time_to_chunks.get(&0).unwrap().chunks[0];
+
+    let batch = chunk.materialize(Arc::clone(&table_def), 0..1).unwrap();
+    assert_eq!(batch.num_rows(), 0);
+    assert_eq!(batch.schema(), table_def.schema.as_arrow());
+}
+
+/// The watermark is the lowest row index superseded since it was last reset,
+/// for a future materialization cache to tell whether a cached prefix is stale.
+#[tokio::test]
+async fn test_superseded_watermark_tracks_lowest_row_since_reset() {
+    let writer = TestWriter::new().await;
+    let rows = writer
+        .write_to_rows(
+            "tbl,t=a v=1i 1000\ntbl,t=b v=2i 1000\ntbl,t=c v=3i 1000\ntbl,t=d v=4i 1000",
+            0,
+        )
+        .await;
+    let ow_c = writer.write_to_rows("tbl,t=c v=30i 1000", 1).await;
+    let ow_a = writer.write_to_rows("tbl,t=a v=10i 1000", 2).await;
+    let ow_d = writer.write_to_rows("tbl,t=d v=40i 1000", 3).await;
+
+    let mut table_buffer = TableBuffer::new();
+    table_buffer.buffer_chunk(0, &rows);
+    let chunk = |tb: &TableBuffer| {
+        tb.chunk_time_to_chunks.get(&0).unwrap().chunks[0].superseded_watermark()
+    };
+    assert_eq!(chunk(&table_buffer), None, "nothing superseded yet");
+
+    table_buffer.buffer_chunk(0, &ow_c);
+    assert_eq!(chunk(&table_buffer), Some(2));
+    table_buffer.buffer_chunk(0, &ow_a);
+    assert_eq!(chunk(&table_buffer), Some(0), "lower row wins");
+
+    table_buffer
+        .chunk_time_to_chunks
+        .get_mut(&0)
+        .unwrap()
+        .chunks[0]
+        .reset_superseded_watermark();
+    assert_eq!(chunk(&table_buffer), None);
+    table_buffer.buffer_chunk(0, &ow_d);
+    assert_eq!(
+        chunk(&table_buffer),
+        Some(3),
+        "only supersedes since the reset count"
+    );
+}
+
+/// The persist path and the query path agree on which rows survive: the
+/// snapshot batch of a chunk with superseded rows holds the same rows as its
+/// query batch.
+#[tokio::test]
+async fn test_snapshot_batch_matches_query_batch_with_superseded_rows() {
+    let writer = TestWriter::new().await;
+    let rows = writer
+        .write_to_rows(
+            "tbl,t=a v=1i,s=\"x\" 1000\ntbl,t=b v=2i 1000\ntbl,t=c v=3i,s=\"z\" 1000",
+            0,
+        )
+        .await;
+    let overwrites = writer
+        .write_to_rows("tbl,t=a v=10i 1000\ntbl,t=c s=\"zz\" 1000", 1)
+        .await;
+    let table_def = writer.db_schema().table_definition("tbl").unwrap();
+    let mut table_buffer = TableBuffer::new();
+    table_buffer.buffer_chunk(0, &rows);
+    table_buffer.buffer_chunk(0, &overwrites);
+
+    let query_batch = table_buffer.chunk_time_to_chunks.get(&0).unwrap().chunks[0]
+        .record_batch(Arc::clone(&table_def))
+        .unwrap();
+    let snapshot = table_buffer.snapshot(Arc::clone(&table_def), i64::MAX);
+    assert_eq!(snapshot.len(), 1);
+    let persist_batch = snapshot[0].record_batch.clone();
+
+    // Same columns (persist is column-id ordered, query is schema ordered).
+    let project = |b: &RecordBatch| {
+        let idx: Vec<usize> = ["s", "t", "time", "v"]
+            .iter()
+            .map(|n| b.schema().index_of(n).unwrap())
+            .collect();
+        b.project(&idx).unwrap()
+    };
+    let expected = [
+        "+----+---+-----------------------------+----+",
+        "| s  | t | time                        | v  |",
+        "+----+---+-----------------------------+----+",
+        "| x  | a | 1970-01-01T00:00:00.000001Z | 10 |",
+        "|    | b | 1970-01-01T00:00:00.000001Z | 2  |",
+        "| zz | c | 1970-01-01T00:00:00.000001Z | 3  |",
+        "+----+---+-----------------------------+----+",
+    ];
+    assert_batches_sorted_eq!(expected, &[project(&query_batch)]);
+    assert_batches_sorted_eq!(expected, &[project(&persist_batch)]);
 }

--- a/influxdb3_write/src/write_buffer/tests.rs
+++ b/influxdb3_write/src/write_buffer/tests.rs
@@ -803,6 +803,144 @@ async fn catalog_snapshots_only_if_updated() {
     verify_snapshot_count(3, &write_buffer.persister).await;
 }
 
+/// Drive a snapshot and wait for it to finish, returning the sequence number the
+/// tracker handed out.
+async fn force_snapshot(write_buffer: &Arc<WriteBufferImpl>) -> SnapshotSequenceNumber {
+    let (snapshot_done, snapshot_info, snapshot_permit) = write_buffer
+        .wal
+        .force_flush_buffer()
+        .await
+        .expect("a forced flush always produces a snapshot");
+    snapshot_done.await.expect("snapshot completes");
+    write_buffer
+        .wal
+        .cleanup_snapshot(snapshot_info, snapshot_permit)
+        .await;
+    snapshot_info.snapshot_sequence_number
+}
+
+/// A forced snapshot over an empty buffer still consumes a sequence number, so its
+/// manifest must be written -- empty, but present -- rather than skipped. Skipping
+/// would leave a hole a sequential consumer cannot tell apart from a failed persist
+/// (influxdb_pro#4827).
+#[tokio::test]
+async fn forced_empty_snapshot_writes_manifest() {
+    let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let (write_buffer, _ctx, _time_provider) = setup(
+        Time::from_timestamp_nanos(0),
+        Arc::clone(&object_store),
+        WalConfig {
+            gen1_duration: Gen1Duration::new_1m(),
+            max_write_buffer_size: 100,
+            flush_interval: Duration::from_millis(5),
+            // high enough that the tracker never snapshots on its own; every
+            // snapshot below is driven explicitly
+            snapshot_size: 100,
+            ..Default::default()
+        },
+    )
+    .await;
+
+    // seq 1 holds data, so it gets a normal manifest
+    do_writes(
+        "test_db",
+        write_buffer.as_ref(),
+        &[TestWrite {
+            lp: "cpu bar=1",
+            time_seconds: 10,
+        }],
+    )
+    .await;
+    let first = force_snapshot(&write_buffer).await;
+    assert_eq!(first, SnapshotSequenceNumber::new(1));
+
+    // nothing was written since, so this forced snapshot drains an empty buffer
+    let empty = force_snapshot(&write_buffer).await;
+    assert_eq!(empty, SnapshotSequenceNumber::new(2));
+
+    // the manifest for the empty sequence exists at its exact key and carries the
+    // empty-snapshot sentinels
+    let path = SnapshotInfoFilePath::new("test_host", empty);
+    let bytes = object_store
+        .get(&path)
+        .await
+        .expect("the empty snapshot must still write a manifest")
+        .bytes()
+        .await
+        .unwrap();
+    let snapshot: PersistedSnapshot = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(snapshot.snapshot_sequence_number, empty);
+    assert!(snapshot.databases.is_empty());
+    assert_eq!(snapshot.row_count, 0);
+    assert_eq!(snapshot.min_time, i64::MAX);
+    assert_eq!(snapshot.max_time, i64::MIN);
+}
+
+/// Density invariant: a workload mixing normal snapshots with a forced-empty
+/// snapshot must leave a contiguous run of sequence numbers in object store with no
+/// gaps. This is what keeps the compactor and read replicas from stalling on a hole
+/// (influxdb_pro#4827).
+#[tokio::test]
+async fn snapshot_sequence_has_no_holes() {
+    let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let (write_buffer, _ctx, _time_provider) = setup(
+        Time::from_timestamp_nanos(0),
+        Arc::clone(&object_store),
+        WalConfig {
+            gen1_duration: Gen1Duration::new_1m(),
+            max_write_buffer_size: 100,
+            flush_interval: Duration::from_millis(5),
+            snapshot_size: 100,
+            ..Default::default()
+        },
+    )
+    .await;
+
+    // 1: data -> normal manifest
+    do_writes(
+        "test_db",
+        write_buffer.as_ref(),
+        &[TestWrite {
+            lp: "cpu bar=1",
+            time_seconds: 10,
+        }],
+    )
+    .await;
+    let first = force_snapshot(&write_buffer).await;
+
+    // 2: drained buffer -> forced-empty snapshot
+    let empty = force_snapshot(&write_buffer).await;
+
+    // 3: data again -> normal manifest
+    do_writes(
+        "test_db",
+        write_buffer.as_ref(),
+        &[TestWrite {
+            lp: "cpu bar=2",
+            time_seconds: 20,
+        }],
+    )
+    .await;
+    let third = force_snapshot(&write_buffer).await;
+
+    assert_eq!(first, SnapshotSequenceNumber::new(1));
+    assert_eq!(empty, SnapshotSequenceNumber::new(2));
+    assert_eq!(third, SnapshotSequenceNumber::new(3));
+
+    let mut persisted: Vec<u64> = write_buffer
+        .persister
+        .load_snapshots(1000)
+        .await
+        .unwrap()
+        .iter()
+        .map(|PersistedSnapshotVersion::V1(s)| s.snapshot_sequence_number.as_u64())
+        .collect();
+    persisted.sort_unstable();
+    assert_eq!(persisted, vec![1, 2, 3]);
+
+    assert_snapshot_sequence_has_no_holes(&object_store, "test_host").await;
+}
+
 /// Check that when a WriteBuffer is initialized with existing snapshot files, that newly
 /// generated snapshot files use the next sequence number.
 #[tokio::test]
@@ -1933,7 +2071,7 @@ async fn test_check_mem_and_force_snapshot() {
     let total_buffer_size_bytes_after = write_buffer.buffer.get_total_size_bytes();
     debug!(?total_buffer_size_bytes_after, "total buffer size");
     assert!(total_buffer_size_bytes_before > total_buffer_size_bytes_after);
-    assert_dbs_not_empty_in_snapshot_file(&obj_store, "test_host").await;
+    assert_snapshot_sequence_has_no_holes(&obj_store, "test_host").await;
 
     let total_buffer_size_bytes_before = total_buffer_size_bytes_after;
     debug!("2nd snapshot..");
@@ -1958,17 +2096,18 @@ async fn test_check_mem_and_force_snapshot() {
     // the query buffer. But when there's nothing evicted then the min/max stays
     // the same as what they were initialized to i64::MAX/i64::MIN respectively.
     //
-    // This however does not stop loading the data into memory as no empty
-    // parquet files are written out. But this test recreates that issue and checks
-    // object store directly to make sure inconsistent snapshot file isn't written
-    // out in the first place
+    // This empty snapshot still consumes a sequence number, so its manifest must
+    // be written out even though it holds no databases. Skipping it would leave a
+    // hole in the sequence that stalls the compactor and read replicas
+    // (influxdb_pro#4827). The assertion below checks object store directly to
+    // confirm the sequence stays contiguous.
     check_mem_and_force_snapshot(&Arc::clone(&write_buffer), 50).await;
     let total_buffer_size_bytes_after = write_buffer.buffer.get_total_size_bytes();
     // no other writes so nothing can be snapshotted, so mem should stay same
     assert!(total_buffer_size_bytes_before == total_buffer_size_bytes_after);
 
     drop(write_buffer);
-    assert_dbs_not_empty_in_snapshot_file(&obj_store, "test_host").await;
+    assert_snapshot_sequence_has_no_holes(&obj_store, "test_host").await;
 
     // dropping write_buffer does not kill any background task (like snapshot which does a
     // WAL file cleanup) which means when we start the buffer again it sees the WAL file but
@@ -1990,7 +2129,7 @@ async fn test_check_mem_and_force_snapshot() {
     )
     .await;
 
-    assert_dbs_not_empty_in_snapshot_file(&obj_store, "test_host").await;
+    assert_snapshot_sequence_has_no_holes(&obj_store, "test_host").await;
     drop(write_buffer_after_restart);
 
     tokio::time::sleep(Duration::from_millis(10)).await;
@@ -2008,7 +2147,7 @@ async fn test_check_mem_and_force_snapshot() {
         },
     )
     .await;
-    assert_dbs_not_empty_in_snapshot_file(&obj_store, "test_host").await;
+    assert_snapshot_sequence_has_no_holes(&obj_store, "test_host").await;
 }
 
 #[test_log::test(tokio::test)]
@@ -2941,25 +3080,57 @@ async fn get_table_batches_from_query_buffer(
     batches
 }
 
-async fn assert_dbs_not_empty_in_snapshot_file(obj_store: &Arc<dyn ObjectStore>, host: &str) {
+/// Every snapshot sequence number the tracker hands out must land a manifest in
+/// object store, so the persisted sequences form a contiguous run with no gaps.
+/// A skipped (empty) snapshot leaves a hole that a sequential consumer -- the
+/// compactor point-GETting `marker + 1`, or a read replica waiting on the next
+/// manifest -- cannot distinguish from a failed persist, so it stalls forever
+/// (influxdb_pro#4827).
+///
+/// Snapshots persist on a background task, so this polls until the set of manifests
+/// stops changing before asserting contiguity.
+async fn assert_snapshot_sequence_has_no_holes(obj_store: &Arc<dyn ObjectStore>, host: &str) {
     let from = Path::from(format!("{host}/snapshots/"));
-    let file_paths = load_files_from_obj_store(obj_store, &from).await;
-    debug!(?file_paths, "obj store snapshots");
-    for file_path in file_paths {
-        let bytes = obj_store
-            .get(&file_path)
-            .await
-            .unwrap()
-            .bytes()
-            .await
-            .unwrap();
-        let persisted_snapshot: PersistedSnapshot = serde_json::from_slice(&bytes).unwrap();
-        // dbs not empty
-        assert!(!persisted_snapshot.databases.is_empty());
-        // min and max times aren't defaults
-        assert!(persisted_snapshot.min_time != i64::MAX);
-        assert!(persisted_snapshot.max_time != i64::MIN);
+    let mut sequences: Vec<u64> = Vec::new();
+    let mut stable_checks = 0;
+    for _ in 0..40 {
+        let file_paths = load_files_from_obj_store(obj_store, &from).await;
+        let mut observed = Vec::with_capacity(file_paths.len());
+        for file_path in file_paths {
+            let bytes = obj_store
+                .get(&file_path)
+                .await
+                .unwrap()
+                .bytes()
+                .await
+                .unwrap();
+            let persisted_snapshot: PersistedSnapshot = serde_json::from_slice(&bytes).unwrap();
+            observed.push(persisted_snapshot.snapshot_sequence_number.as_u64());
+        }
+        observed.sort_unstable();
+        if !observed.is_empty() && observed == sequences {
+            stable_checks += 1;
+            if stable_checks > 3 {
+                break;
+            }
+        } else {
+            stable_checks = 0;
+            sequences = observed;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
     }
+    debug!(?sequences, "obj store snapshot sequences");
+    assert!(
+        !sequences.is_empty(),
+        "expected at least one persisted snapshot manifest"
+    );
+    let min = *sequences.first().unwrap();
+    let max = *sequences.last().unwrap();
+    let expected: Vec<u64> = (min..=max).collect();
+    assert_eq!(
+        sequences, expected,
+        "snapshot sequence has a hole (a consumed sequence number with no manifest)"
+    );
 }
 
 async fn load_files_from_obj_store(object_store: &Arc<dyn ObjectStore>, path: &Path) -> Vec<Path> {


### PR DESCRIPTION

Source: 6ee8b0e752e7dbe25b01eeceaf1bb1d9b107ff3a

Commits:
- `6ee8b0e752` chore: update versions to 3.11.4 (influxdata/influxdb_pro#5647)
- `33bcf30b18` feat(startup): route startup phases through one tracker for logging (influxdata/influxdb_pro#5385) (influxdata/influxdb_pro#5614)
- `1019f247d0` fix: user privilege escalation with custom role authoring (influxdata/influxdb_pro#4819) (influxdata/influxdb_pro#5627)
- `4766c1db01` fix(snapshot): always persist the snapshot manifest, even when empty (influxdata/influxdb_pro#4862) (influxdata/influxdb_pro#5625)
- `69016e66b5` fix(py): update to 3.13.15-20260901 for latest security fixes (influxdata/influxdb_pro#5581) (influxdata/influxdb_pro#5622)
- `4ea0139035` fix: 3.11.4 backport for EAR 7062/7056/CLI fixes (influxdata/influxdb_pro#5591)
- `9545610c03` fix(pe): backport worker plugin-cache eviction fixes to 3.11 (influxdata/influxdb_pro#5364, influxdata/influxdb_pro#5386, influxdata/influxdb_pro#5388, influxdata/influxdb_pro#5464) (influxdata/influxdb_pro#5578)

Co-authored-by: Cannon Palms <cpalms@influxdata.com>
Co-authored-by: caterryan <caterryan1@gmail.com>
Co-authored-by: praveen-influx <pkumar@influxdata.com>
Co-authored-by: Reid Kaufmann <73494261+reidkaufmann@users.noreply.github.com>