### PR TITLE
chore(sync): influxdb_pro 2026-09-04 (3.9)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,6 @@ executors:
     working_directory: /tmp/workspace/<< pipeline.id >>
 
 orbs:
-  aws-s3: circleci/aws-s3@2.0.0
   rust: circleci/rust@1.6.1
 
 # Unlike when a commit is pushed to a branch, CircleCI does not automatically
@@ -146,10 +145,10 @@ parameters:
   # Consistent environment setup for Python Build Standalone
   PBS_DATE:
     type: string
-    default: "20260610"
+    default: "20260901"
   PBS_VERSION:
     type: string
-    default: "3.13.14"
+    default: "3.13.15"
 
 # Consistent Cargo environment configuration
 cargo_env: &cargo_env
@@ -653,22 +652,23 @@ jobs:
       #   - snapshots
       destination:
         type: string
+    environment:
+      # Newer awscli/boto3 send CRC32 checksum headers that Cloudflare R2
+      # rejects unless checksum calculation is limited to when required.
+      AWS_REQUEST_CHECKSUM_CALCULATION: when_required
     steps:
       - attach_workspace:
           at: /tmp/workspace
-      - aws-s3/sync:
-          arguments:             --acl public-read
-          aws-region:            RELEASE_AWS_REGION
-          aws-access-key-id:     RELEASE_AWS_ACCESS_KEY_ID
-          aws-secret-access-key: RELEASE_AWS_SECRET_ACCESS_KEY
-          from:                  /tmp/workspace/artifacts
-          to:                    s3://dl.influxdata.com/influxdb/<< parameters.destination >>
       - run:
+          name: Upload artifacts to R2
           command: |
-            export AWS_REGION="${RELEASE_AWS_REGION}"
+            pip install --quiet awscli
             export AWS_ACCESS_KEY_ID="${RELEASE_AWS_ACCESS_KEY_ID}"
             export AWS_SECRET_ACCESS_KEY="${RELEASE_AWS_SECRET_ACCESS_KEY}"
-            aws cloudfront create-invalidation --distribution-id "${RELEASE_ARTIFACTS_CLOUDFRONT}" --paths '/influxdb/<< parameters.destination >>/*'
+            aws s3 sync /tmp/workspace/artifacts \
+              "s3://dl-influxdata-com/influxdb/<< parameters.destination >>" \
+              --endpoint-url "${AWS_ENDPOINT_URL_S3}" \
+              --region auto
 
   build-docker:
     parameters:

--- a/.circleci/packages/influxdb3/fs/usr/share/influxdb3/influxdb3-core.conf
+++ b/.circleci/packages/influxdb3/fs/usr/share/influxdb3/influxdb3-core.conf
@@ -36,6 +36,12 @@
 # Default: 0.0.0.0:8181 (env: INFLUXDB3_HTTP_BIND_ADDR)
 #http-bind="0.0.0.0:8181"
 
+# Maximum time to wait for active connections to drain during shutdown.
+# Remaining connections are forcibly closed when the timeout expires. Set to
+# 0s to close connections immediately.
+# Default: 30s (env: INFLUXDB3_SHUTDOWN_TIMEOUT)
+#shutdown-timeout="30s"
+
 # Logs: filter directive
 # Default: info,iox_query::query_log=warn,influxdb3_query_executor::core=warn
 # (env: LOG_FILTER)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -144,7 +144,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -155,7 +155,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -444,7 +444,7 @@ dependencies = [
 
 [[package]]
 name = "arrow_util"
-version = "3.9.11"
+version = "3.9.13"
 dependencies = [
  "ahash 0.8.12",
  "arrow",
@@ -541,7 +541,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "authz"
-version = "3.9.11"
+version = "3.9.13"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -655,7 +655,7 @@ dependencies = [
 
 [[package]]
 name = "backoff"
-version = "3.9.11"
+version = "3.9.13"
 dependencies = [
  "rand 0.9.2",
  "snafu 0.9.0",
@@ -1069,7 +1069,7 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "catalog_cache"
-version = "3.9.11"
+version = "3.9.13"
 dependencies = [
  "bytes",
  "criterion 0.8.2",
@@ -1207,7 +1207,7 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "client_util"
-version = "3.9.11"
+version = "3.9.13"
 dependencies = [
  "http 1.4.0",
  "iox_http_util",
@@ -1785,7 +1785,7 @@ dependencies = [
 
 [[package]]
 name = "data_types"
-version = "3.9.11"
+version = "3.9.13"
 dependencies = [
  "arrow",
  "arrow-buffer",
@@ -2518,7 +2518,7 @@ dependencies = [
 
 [[package]]
 name = "datafusion_util"
-version = "3.9.11"
+version = "3.9.13"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -2602,7 +2602,7 @@ dependencies = [
 
 [[package]]
 name = "dml"
-version = "3.9.11"
+version = "3.9.13"
 dependencies = [
  "arrow_util",
  "data_types",
@@ -2709,12 +2709,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "error_reporting"
-version = "3.9.11"
+version = "3.9.13"
 dependencies = [
  "datafusion",
  "snafu 0.9.0",
@@ -2744,7 +2744,7 @@ dependencies = [
 
 [[package]]
 name = "executor"
-version = "3.9.11"
+version = "3.9.13"
 dependencies = [
  "futures",
  "metric",
@@ -2825,7 +2825,7 @@ dependencies = [
 
 [[package]]
 name = "flightsql"
-version = "3.9.11"
+version = "3.9.13"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -3032,7 +3032,7 @@ dependencies = [
 
 [[package]]
 name = "futures_test_utils"
-version = "3.9.11"
+version = "3.9.13"
 dependencies = [
  "clap",
  "futures",
@@ -3043,7 +3043,7 @@ dependencies = [
 
 [[package]]
 name = "generated_types"
-version = "3.9.11"
+version = "3.9.13"
 dependencies = [
  "bytes",
  "pbjson",
@@ -3165,9 +3165,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "a9f37a958b41b3b19ee2707c06439c0e9e547e847223eb791ecb0cb821c65e27"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3427,7 +3427,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.13",
+ "h2 0.4.16",
  "http 1.4.0",
  "http-body 1.0.1",
  "httparse",
@@ -3692,7 +3692,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb2_client"
-version = "3.9.11"
+version = "3.9.13"
 dependencies = [
  "bytes",
  "futures",
@@ -3711,7 +3711,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3"
-version = "3.9.11"
+version = "3.9.13"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3762,6 +3762,7 @@ dependencies = [
  "num_cpus",
  "object_store",
  "object_store_metrics",
+ "object_store_utils",
  "observability_deps",
  "owo-colors",
  "panic_logging",
@@ -3801,7 +3802,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_authz"
-version = "3.9.11"
+version = "3.9.13"
 dependencies = [
  "async-trait",
  "authz",
@@ -3818,7 +3819,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_cache"
-version = "3.9.11"
+version = "3.9.13"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3853,7 +3854,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_catalog"
-version = "3.9.11"
+version = "3.9.13"
 dependencies = [
  "anyhow",
  "arrow",
@@ -3905,7 +3906,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_clap_blocks"
-version = "3.9.11"
+version = "3.9.13"
 dependencies = [
  "async-trait",
  "bytes",
@@ -3942,7 +3943,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_client"
-version = "3.9.11"
+version = "3.9.13"
 dependencies = [
  "bytes",
  "hashbrown 0.14.5",
@@ -3962,7 +3963,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_commands"
-version = "3.9.11"
+version = "3.9.13"
 dependencies = [
  "anyhow",
  "clap",
@@ -3981,7 +3982,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_id"
-version = "3.9.11"
+version = "3.9.13"
 dependencies = [
  "indexmap 2.13.0",
  "serde",
@@ -3991,7 +3992,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_internal_api"
-version = "3.9.11"
+version = "3.9.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4012,7 +4013,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_load_generator"
-version = "3.9.11"
+version = "3.9.13"
 dependencies = [
  "anyhow",
  "bytes",
@@ -4041,7 +4042,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_process"
-version = "3.9.11"
+version = "3.9.13"
 dependencies = [
  "iox_time",
  "uuid",
@@ -4049,7 +4050,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_processing_engine"
-version = "3.9.11"
+version = "3.9.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4094,7 +4095,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_py_api"
-version = "3.9.11"
+version = "3.9.13"
 dependencies = [
  "anyhow",
  "arrow-array",
@@ -4122,7 +4123,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_query_executor"
-version = "3.9.11"
+version = "3.9.13"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4172,7 +4173,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_server"
-version = "3.9.11"
+version = "3.9.13"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4255,7 +4256,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_shutdown"
-version = "3.9.11"
+version = "3.9.13"
 dependencies = [
  "futures",
  "futures-util",
@@ -4270,14 +4271,17 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_startup"
-version = "3.9.11"
+version = "3.9.13"
 dependencies = [
  "chrono",
+ "observability_deps",
+ "test_helpers",
+ "tokio",
 ]
 
 [[package]]
 name = "influxdb3_sys_events"
-version = "3.9.11"
+version = "3.9.13"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4296,7 +4300,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_system_tables"
-version = "3.9.11"
+version = "3.9.13"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -4328,7 +4332,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_telemetry"
-version = "3.9.11"
+version = "3.9.13"
 dependencies = [
  "futures",
  "futures-util",
@@ -4349,7 +4353,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_test_helpers"
-version = "3.9.11"
+version = "3.9.13"
 dependencies = [
  "async-trait",
  "bytes",
@@ -4362,7 +4366,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_types"
-version = "3.9.11"
+version = "3.9.13"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4382,7 +4386,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_wal"
-version = "3.9.11"
+version = "3.9.13"
 dependencies = [
  "async-trait",
  "bitcode",
@@ -4397,7 +4401,9 @@ dependencies = [
  "influxdb3_id",
  "influxdb3_shutdown",
  "iox_time",
+ "metric",
  "object_store",
+ "object_store_utils",
  "observability_deps",
  "parking_lot",
  "schema",
@@ -4410,7 +4416,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb3_write"
-version = "3.9.11"
+version = "3.9.13"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4479,7 +4485,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb_influxql_parser"
-version = "3.9.11"
+version = "3.9.13"
 dependencies = [
  "assert_matches",
  "chrono",
@@ -4496,7 +4502,7 @@ dependencies = [
 
 [[package]]
 name = "influxdb_iox_client"
-version = "3.9.11"
+version = "3.9.13"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -4525,7 +4531,7 @@ dependencies = [
 
 [[package]]
 name = "ingester_query_grpc"
-version = "3.9.11"
+version = "3.9.13"
 dependencies = [
  "base64 0.22.1",
  "data_types",
@@ -4582,7 +4588,7 @@ checksum = "06432fb54d3be7964ecd3649233cddf80db2832f47fec34c01f65b3d9d774983"
 
 [[package]]
 name = "iox_http"
-version = "3.9.11"
+version = "3.9.13"
 dependencies = [
  "assert_matches",
  "async-trait",
@@ -4602,7 +4608,7 @@ dependencies = [
 
 [[package]]
 name = "iox_http_util"
-version = "3.9.11"
+version = "3.9.13"
 dependencies = [
  "futures",
  "http 1.4.0",
@@ -4613,7 +4619,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query"
-version = "3.9.11"
+version = "3.9.13"
 dependencies = [
  "arrow",
  "arrow_util",
@@ -4662,7 +4668,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query_influxql"
-version = "3.9.11"
+version = "3.9.13"
 dependencies = [
  "arrow",
  "assert_matches",
@@ -4689,7 +4695,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query_influxql_rewrite"
-version = "3.9.11"
+version = "3.9.13"
 dependencies = [
  "influxdb_influxql_parser",
  "thiserror 2.0.18",
@@ -4697,7 +4703,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query_params"
-version = "3.9.11"
+version = "3.9.13"
 dependencies = [
  "arrow",
  "assert_matches",
@@ -4711,7 +4717,7 @@ dependencies = [
 
 [[package]]
 name = "iox_query_udf"
-version = "3.9.11"
+version = "3.9.13"
 dependencies = [
  "datafusion-udf-wasm-host",
  "datafusion-udf-wasm-query",
@@ -4722,7 +4728,7 @@ dependencies = [
 
 [[package]]
 name = "iox_system_tables"
-version = "3.9.11"
+version = "3.9.13"
 dependencies = [
  "arrow",
  "async-trait",
@@ -4732,7 +4738,7 @@ dependencies = [
 
 [[package]]
 name = "iox_time"
-version = "3.9.11"
+version = "3.9.13"
 dependencies = [
  "chrono",
  "parking_lot",
@@ -4741,7 +4747,7 @@ dependencies = [
 
 [[package]]
 name = "iox_v1_query_api"
-version = "3.9.11"
+version = "3.9.13"
 dependencies = [
  "anyhow",
  "arrow",
@@ -4802,7 +4808,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4855,7 +4861,7 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jemalloc_stats"
-version = "3.9.11"
+version = "3.9.13"
 dependencies = [
  "snafu 0.9.0",
  "tikv-jemalloc-ctl",
@@ -5000,7 +5006,7 @@ dependencies = [
 
 [[package]]
 name = "linear_buffer"
-version = "3.9.11"
+version = "3.9.13"
 
 [[package]]
 name = "linux-raw-sys"
@@ -5044,7 +5050,7 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "logfmt"
-version = "3.9.11"
+version = "3.9.13"
 dependencies = [
  "humantime",
  "parking_lot",
@@ -5152,14 +5158,14 @@ dependencies = [
 
 [[package]]
 name = "metric"
-version = "3.9.11"
+version = "3.9.13"
 dependencies = [
  "parking_lot",
 ]
 
 [[package]]
 name = "metric_exporters"
-version = "3.9.11"
+version = "3.9.13"
 dependencies = [
  "metric",
  "mockito",
@@ -5284,7 +5290,7 @@ checksum = "9252111cf132ba0929b6f8e030cac2a24b507f3a4d6db6fb2896f27b354c714b"
 
 [[package]]
 name = "mutable_batch"
-version = "3.9.11"
+version = "3.9.13"
 dependencies = [
  "arrow",
  "arrow_util",
@@ -5302,7 +5308,7 @@ dependencies = [
 
 [[package]]
 name = "mutable_batch_lp"
-version = "3.9.11"
+version = "3.9.13"
 dependencies = [
  "arrow_util",
  "assert_matches",
@@ -5318,7 +5324,7 @@ dependencies = [
 
 [[package]]
 name = "mutable_batch_pb"
-version = "3.9.11"
+version = "3.9.13"
 dependencies = [
  "arrow_util",
  "criterion 0.8.2",
@@ -5556,7 +5562,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_limit"
-version = "3.9.11"
+version = "3.9.13"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5568,7 +5574,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_mem_cache"
-version = "3.9.11"
+version = "3.9.13"
 dependencies = [
  "async-trait",
  "bincode",
@@ -5595,7 +5601,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_metrics"
-version = "3.9.11"
+version = "3.9.13"
 dependencies = [
  "async-trait",
  "bloom2",
@@ -5620,7 +5626,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_mock"
-version = "3.9.11"
+version = "3.9.13"
 dependencies = [
  "async-trait",
  "bytes",
@@ -5634,7 +5640,7 @@ dependencies = [
 
 [[package]]
 name = "object_store_size_hinting"
-version = "3.9.11"
+version = "3.9.13"
 dependencies = [
  "chrono",
  "http 1.4.0",
@@ -5644,20 +5650,22 @@ dependencies = [
 
 [[package]]
 name = "object_store_utils"
-version = "3.9.11"
+version = "3.9.13"
 dependencies = [
  "async-trait",
  "backon",
  "bytes",
  "futures",
+ "metric",
  "object_store",
  "observability_deps",
  "tokio",
+ "uuid",
 ]
 
 [[package]]
 name = "observability_deps"
-version = "3.9.11"
+version = "3.9.13"
 dependencies = [
  "tracing",
 ]
@@ -5722,7 +5730,7 @@ dependencies = [
 
 [[package]]
 name = "panic_logging"
-version = "3.9.11"
+version = "3.9.13"
 dependencies = [
  "metric",
  "test_helpers",
@@ -5797,7 +5805,7 @@ dependencies = [
 
 [[package]]
 name = "parquet_file"
-version = "3.9.11"
+version = "3.9.13"
 dependencies = [
  "arrow",
  "arrow_util",
@@ -5826,7 +5834,7 @@ dependencies = [
 
 [[package]]
 name = "partition"
-version = "3.9.11"
+version = "3.9.13"
 dependencies = [
  "arrow",
  "assert_matches",
@@ -6123,7 +6131,7 @@ dependencies = [
 
 [[package]]
 name = "predicate"
-version = "3.9.11"
+version = "3.9.13"
 dependencies = [
  "arrow",
  "async-trait",
@@ -6469,7 +6477,7 @@ dependencies = [
 
 [[package]]
 name = "query_functions"
-version = "3.9.11"
+version = "3.9.13"
 dependencies = [
  "arrow",
  "chrono",
@@ -6551,7 +6559,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6808,7 +6816,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-util",
- "h2 0.4.13",
+ "h2 0.4.16",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
@@ -7013,7 +7021,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7152,7 +7160,7 @@ dependencies = [
 
 [[package]]
 name = "schema"
-version = "3.9.11"
+version = "3.9.13"
 dependencies = [
  "arrow",
  "base64 0.22.1",
@@ -7335,7 +7343,7 @@ dependencies = [
 
 [[package]]
 name = "service_common"
-version = "3.9.11"
+version = "3.9.13"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -7349,7 +7357,7 @@ dependencies = [
 
 [[package]]
 name = "service_grpc_flight"
-version = "3.9.11"
+version = "3.9.13"
 dependencies = [
  "arrow",
  "arrow-flight",
@@ -7416,7 +7424,7 @@ dependencies = [
 
 [[package]]
 name = "sharder"
-version = "3.9.11"
+version = "3.9.13"
 dependencies = [
  "criterion 0.8.2",
  "data_types",
@@ -7558,7 +7566,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7938,7 +7946,7 @@ dependencies = [
 
 [[package]]
 name = "table_batch"
-version = "3.9.11"
+version = "3.9.13"
 dependencies = [
  "arrow_util",
  "bitvec",
@@ -7982,7 +7990,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8024,7 +8032,7 @@ dependencies = [
 
 [[package]]
 name = "test_helpers"
-version = "3.9.11"
+version = "3.9.13"
 dependencies = [
  "async-trait",
  "dotenvy",
@@ -8043,7 +8051,7 @@ dependencies = [
 
 [[package]]
 name = "test_helpers_authz"
-version = "3.9.11"
+version = "3.9.13"
 dependencies = [
  "futures",
  "generated_types",
@@ -8316,7 +8324,7 @@ dependencies = [
 
 [[package]]
 name = "tokio_metrics_bridge"
-version = "3.9.11"
+version = "3.9.13"
 dependencies = [
  "metric",
  "parking_lot",
@@ -8325,7 +8333,7 @@ dependencies = [
 
 [[package]]
 name = "tokio_watchdog"
-version = "3.9.11"
+version = "3.9.13"
 dependencies = [
  "metric",
  "test_helpers",
@@ -8402,7 +8410,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "flate2",
- "h2 0.4.13",
+ "h2 0.4.16",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
@@ -8548,7 +8556,7 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tower_trailer"
-version = "3.9.11"
+version = "3.9.13"
 dependencies = [
  "futures",
  "http 1.4.0",
@@ -8560,7 +8568,7 @@ dependencies = [
 
 [[package]]
 name = "trace"
-version = "3.9.11"
+version = "3.9.13"
 dependencies = [
  "chrono",
  "parking_lot",
@@ -8570,7 +8578,7 @@ dependencies = [
 
 [[package]]
 name = "trace_exporters"
-version = "3.9.11"
+version = "3.9.13"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8587,7 +8595,7 @@ dependencies = [
 
 [[package]]
 name = "trace_http"
-version = "3.9.11"
+version = "3.9.13"
 dependencies = [
  "bytes",
  "futures",
@@ -8682,7 +8690,7 @@ dependencies = [
 
 [[package]]
 name = "tracker"
-version = "3.9.11"
+version = "3.9.13"
 dependencies = [
  "futures",
  "hashbrown 0.14.5",
@@ -8702,7 +8710,7 @@ dependencies = [
 
 [[package]]
 name = "trogging"
-version = "3.9.11"
+version = "3.9.13"
 dependencies = [
  "clap",
  "logfmt",
@@ -9710,15 +9718,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -9750,28 +9749,11 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
+ "windows_i686_gnullvm",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link 0.2.1",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -9805,12 +9787,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9821,12 +9797,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -9841,22 +9811,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -9871,12 +9829,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9887,12 +9839,6 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -9907,12 +9853,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9923,12 +9863,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,7 +125,7 @@ exclude = [
 #
 # For porting to the actual OSS repo (influxdb), this would need to change to `-nightly`, i.e., by
 # stripping the `-oss`.
-version = "3.9.11"
+version = "3.9.13"
 authors = ["InfluxData OSS Developers"]
 edition = "2024"
 license = "MIT OR Apache-2.0"

--- a/core/iox_time/src/lib.rs
+++ b/core/iox_time/src/lib.rs
@@ -21,18 +21,22 @@ pub struct Time(DateTime<Utc>);
 impl Add<Duration> for Time {
     type Output = Self;
 
+    /// Saturates at [`Time::MAX`]: a std [`Duration`] can exceed chrono's
+    /// representable range, so overflow is reachable from user-supplied
+    /// durations and must not panic. Use [`Time::checked_add`] to detect it.
     fn add(self, rhs: Duration) -> Self::Output {
-        let duration = chrono::Duration::from_std(rhs).unwrap();
-        Self(self.0 + duration)
+        self.checked_add(rhs).unwrap_or(Self::MAX)
     }
 }
 
 impl Sub<Duration> for Time {
     type Output = Self;
 
+    /// Saturates at [`Time::MIN`]: a std [`Duration`] can exceed chrono's
+    /// representable range, so overflow is reachable from user-supplied
+    /// durations and must not panic. Use [`Time::checked_sub`] to detect it.
     fn sub(self, rhs: Duration) -> Self::Output {
-        let duration = chrono::Duration::from_std(rhs).unwrap();
-        Self(self.0 - duration)
+        self.checked_sub(rhs).unwrap_or(Self::MIN)
     }
 }
 
@@ -685,6 +689,13 @@ mod test {
         assert!(chrono::Duration::from_std(duration).is_err());
         assert!(time.checked_add(duration).is_none());
         assert!(time.checked_sub(duration).is_none());
+
+        // The Add/Sub operators saturate instead of panicking, both when the
+        // duration exceeds chrono's range and when the result would overflow.
+        assert_eq!(time + duration, Time::MAX);
+        assert_eq!(time - duration, Time::MIN);
+        assert_eq!(Time::MAX + Duration::from_nanos(1), Time::MAX);
+        assert_eq!(Time::MIN - Duration::from_nanos(1), Time::MIN);
     }
 
     #[test]

--- a/deny.toml
+++ b/deny.toml
@@ -87,6 +87,23 @@ ignore = [
     # upstream datafusion-udf-wasm bump.
     "RUSTSEC-2026-0188",
     #
+    # wasmtime 41.0.4 stores can mix up type indices between engines
+    # (https://rustsec.org/advisories/RUSTSEC-2026-0222). Same transitive path via
+    # datafusion-udf-wasm; only reachable if a Wasm UDF is loaded, and UDFs are
+    # disabled by default (udfs_enabled = false). The 41.x line has no patched
+    # release. The fix requires wasmtime >=46.0.2, which needs an upstream
+    # datafusion-udf-wasm bump to a DataFusion 52 rev.
+    "RUSTSEC-2026-0222",
+    #
+    # wasmtime 41.0.4 filesystem sandbox escape when paths or symlinks contain
+    # trailing slashes (https://rustsec.org/advisories/RUSTSEC-2026-0269). Same
+    # transitive path via datafusion-udf-wasm; only reachable if a Wasm UDF is
+    # loaded with WASI filesystem preopens granted, and UDFs are disabled by
+    # default (udfs_enabled = false). The 41.x line has no patched release. The
+    # fix requires wasmtime >=46.0.3, which needs an upstream datafusion-udf-wasm
+    # bump.
+    "RUSTSEC-2026-0269",
+    #
     # TODO: update wasmtime-wasi via datafusion-udf-wasm to a patched version (>=45.0.3; >=46.0.1 is also fixed)
 
     # rand unsoundness: only reachable with rand's `log` feature plus a custom logger

--- a/influxdb3/Cargo.toml
+++ b/influxdb3/Cargo.toml
@@ -52,6 +52,7 @@ influxdb3_telemetry = { path = "../influxdb3_telemetry" }
 influxdb3_types = { path = "../influxdb3_types" }
 influxdb3_wal = { path = "../influxdb3_wal" }
 influxdb3_write = { path = "../influxdb3_write" }
+object_store_utils = { path = "../object_store_utils" }
 
 # Crates.io dependencies
 anyhow.workspace = true

--- a/influxdb3/src/commands/serve.rs
+++ b/influxdb3/src/commands/serve.rs
@@ -53,6 +53,7 @@ use iox_time::{SystemProvider, TimeProvider};
 use metric::U64Gauge;
 use object_store::ObjectStore;
 use object_store_metrics::ObjectStoreMetrics;
+use object_store_utils::SelfVerifyingCreateStore;
 use observability_deps::tracing::*;
 use panic_logging::SendPanicsToTracing;
 use parquet_file::storage::{ParquetStorage, StorageId};
@@ -224,6 +225,18 @@ pub struct Config {
         action,
     )]
     pub http_bind_address: SocketAddr,
+
+    /// Maximum time to wait for active connections to drain during shutdown.
+    ///
+    /// When the timeout expires, remaining connections are forcibly closed. A value of `0s`
+    /// skips the graceful drain and closes connections immediately.
+    #[clap(
+        long = "shutdown-timeout",
+        env = "INFLUXDB3_SHUTDOWN_TIMEOUT",
+        default_value = "30s",
+        action
+    )]
+    pub shutdown_timeout: humantime::Duration,
 
     /// Enable admin token recovery endpoint on the specified address.
     /// Use flag alone for default address (127.0.0.1:8182) or provide a custom address.
@@ -794,6 +807,21 @@ pub async fn command(config: Config, user_params: HashMap<String, String>) -> Re
         .make_object_store_with_metrics(&metrics)
         .map_err(Error::ObjectStoreParsing)?;
 
+    // The WAL tags its conditional creates so it can recognise its own object
+    // when a retried PUT collides with its own hidden success. This layer sits
+    // innermost so the read-back reaches the real store, not the cache. A
+    // backend that discards object metadata has nowhere to carry the tag, so it
+    // is left unwrapped and keeps the un-verified behaviour.
+    let object_store: Arc<dyn ObjectStore> = if config
+        .object_store_config
+        .object_store
+        .supports_object_metadata()
+    {
+        Arc::new(SelfVerifyingCreateStore::new(object_store, &metrics))
+    } else {
+        object_store
+    };
+
     // setup metrics'd object store:
     let object_store: Arc<dyn ObjectStore> = Arc::new(ObjectStoreMetrics::new(
         object_store,
@@ -1181,6 +1209,7 @@ pub async fn command(config: Config, user_params: HashMap<String, String>) -> Re
             cert_file: cert_file.clone(),
             key_file: key_file.clone(),
             tls_minimum_version: (&config.tls_minimum_version).into(),
+            shutdown_timeout: *config.shutdown_timeout,
         })
     });
 
@@ -1192,6 +1221,7 @@ pub async fn command(config: Config, user_params: HashMap<String, String>) -> Re
         cert_file,
         key_file,
         tls_minimum_version: (&config.tls_minimum_version).into(),
+        shutdown_timeout: *config.shutdown_timeout,
     });
 
     // There are two different select! macros - tokio::select and futures::select

--- a/influxdb3/src/commands/serve/cli_params.rs
+++ b/influxdb3/src/commands/serve/cli_params.rs
@@ -31,6 +31,7 @@ const NON_SENSITIVE_PARAMS: &[&str] = &[
     "node-id-from-env",
     "cluster-id",
     "http-bind",
+    "shutdown-timeout",
     "max-http-request-size",
     "object-store",
     "data-dir",

--- a/influxdb3/src/help/serve.txt
+++ b/influxdb3/src/help/serve.txt
@@ -25,6 +25,11 @@ Examples
 {}
   --http-bind <ADDR>               Address for HTTP API requests [default: 0.0.0.0:8181]
                                     [env: INFLUXDB3_HTTP_BIND_ADDR=]
+  --shutdown-timeout <DURATION>    Maximum time to wait for active connections to drain during
+                                   shutdown. Remaining connections are forcibly closed when the
+                                   timeout expires. Set to 0s to close connections immediately.
+                                    [default: 30s]
+                                    [env: INFLUXDB3_SHUTDOWN_TIMEOUT=]
   --log-filter <FILTER>            Logs: filter directive
                                     [default: info,iox_query::query_log=warn,influxdb3_query_executor::query_planner=warn]
                                     [env: INFLUXDB3_LOG_FILTER=]

--- a/influxdb3/src/help/serve_all.txt
+++ b/influxdb3/src/help/serve_all.txt
@@ -31,6 +31,11 @@ Examples:
 {}
   --http-bind <ADDR>                           Address for HTTP API requests [default: 0.0.0.0:8181]
                                                  [env: INFLUXDB3_HTTP_BIND_ADDR=]
+  --shutdown-timeout <DURATION>                Maximum time to wait for active connections to drain during
+                                               shutdown. Remaining connections are forcibly closed when the
+                                               timeout expires. Set to 0s to close connections immediately.
+                                                 [default: 30s]
+                                                 [env: INFLUXDB3_SHUTDOWN_TIMEOUT=]
   --log-filter <FILTER>                        Logs: filter directive
                                                  [default: info,iox_query::query_log=warn,
                                                   influxdb3_query_executor::query_planner=warn]

--- a/influxdb3_clap_blocks/src/object_store.rs
+++ b/influxdb3_clap_blocks/src/object_store.rs
@@ -1192,6 +1192,20 @@ impl ObjectStoreType {
             Self::Azure => "azure",
         }
     }
+
+    /// Whether the backend retains user-defined object metadata, which gates
+    /// nonce-tagged conditional creates.
+    pub fn supports_object_metadata(&self) -> bool {
+        match self {
+            // `InMemory` keeps the attributes it was given, and
+            // `ThrottledStore` passes them through to it.
+            Self::Memory | Self::MemoryThrottled => true,
+            // `LocalFileSystem` rejects a put carrying any attributes.
+            Self::File => false,
+            // User-defined metadata headers on the object.
+            Self::S3 | Self::Google | Self::Azure => true,
+        }
+    }
 }
 
 /// The `object_store::signer::Signer` trait is implemented for AWS and local file systems, so when

--- a/influxdb3_server/src/lib.rs
+++ b/influxdb3_server/src/lib.rs
@@ -31,10 +31,11 @@ use influxdb3_authz::AuthProvider;
 use influxdb3_catalog::catalog::Catalog;
 use influxdb3_process::build_version_string;
 use influxdb3_telemetry::store::TelemetryStore;
-use observability_deps::tracing::{error, info, trace, warn};
+use observability_deps::tracing::{error, info, warn};
 use std::fmt::Debug;
 use std::path::PathBuf;
 use std::sync::{Arc, LazyLock};
+use std::time::Duration;
 use thiserror::Error;
 use tokio::io::AsyncWriteExt;
 use tokio::net::TcpListener;
@@ -143,6 +144,7 @@ pub struct CreateServerArgs<'a> {
     pub cert_file: Option<PathBuf>,
     pub key_file: Option<PathBuf>,
     pub tls_minimum_version: &'a [&'static SupportedProtocolVersion],
+    pub shutdown_timeout: Duration,
 }
 
 #[derive(Debug)]
@@ -154,6 +156,7 @@ pub struct Server<'a> {
     key_file: Option<PathBuf>,
     cert_file: Option<PathBuf>,
     tls_minimum_version: &'a [&'static SupportedProtocolVersion],
+    shutdown_timeout: Duration,
 }
 
 impl<'a> Server<'a> {
@@ -166,6 +169,7 @@ impl<'a> Server<'a> {
             cert_file,
             key_file,
             tls_minimum_version,
+            shutdown_timeout,
         }: CreateServerArgs<'a>,
     ) -> Self {
         Self {
@@ -176,6 +180,7 @@ impl<'a> Server<'a> {
             key_file,
             cert_file,
             tls_minimum_version,
+            shutdown_timeout,
         }
     }
 
@@ -374,6 +379,8 @@ pub async fn serve(
     paths_without_authz: &'static Vec<&'static str>,
     tcp_listener_file_path: Option<PathBuf>,
 ) -> Result<()> {
+    let shutdown_timeout = server.shutdown_timeout;
+
     // Create trace layers for HTTP and gRPC
     let http_trace_layer = server.create_http_trace_layer();
     let grpc_trace_layer = server.create_grpc_trace_layer();
@@ -533,15 +540,30 @@ pub async fn serve(
         }
     }
 
-    // This explicit select! is needed for graceful shutdown
-    trace!("Starting graceful shutdown, waiting for connections to close");
-    tokio::select! {
-        _ = graceful.shutdown() => {
-            info!("All connections closed gracefully");
-        }
-        _ = tokio::time::sleep(tokio::time::Duration::from_secs(30)) => {
-            info!("Graceful shutdown timed out after 30 seconds");
-        }
+    let connection_count = graceful.count();
+    if shutdown_timeout.is_zero() {
+        info!(
+            connection_count,
+            "shutdown timeout is 0s; skipping connection drain"
+        );
+        return Ok(());
+    }
+    info!(
+        connection_count,
+        ?shutdown_timeout,
+        "waiting for connections to drain"
+    );
+    if tokio::time::timeout(shutdown_timeout, graceful.shutdown())
+        .await
+        .is_err()
+    {
+        warn!(
+            connection_count,
+            ?shutdown_timeout,
+            "graceful connection drain timed out; forcing shutdown"
+        );
+    } else {
+        info!("all connections closed gracefully");
     }
 
     Ok(())

--- a/influxdb3_server/src/tests.rs
+++ b/influxdb3_server/src/tests.rs
@@ -1454,6 +1454,7 @@ async fn setup_server(start_time: i64) -> (String, CancellationToken, Arc<dyn Wr
         cert_file: None,
         key_file: None,
         tls_minimum_version: TLS_MIN_VERSION,
+        shutdown_timeout: std::time::Duration::from_secs(30),
     });
     let shutdown = frontend_shutdown.clone();
     let paths = EMPTY_PATHS.get_or_init(std::vec::Vec::new);

--- a/influxdb3_startup/Cargo.toml
+++ b/influxdb3_startup/Cargo.toml
@@ -10,6 +10,11 @@ build = "Core"
 
 [dependencies]
 chrono.workspace = true
+observability_deps = { path = "../core/observability_deps" }
+tokio.workspace = true
+
+[dev-dependencies]
+test_helpers = { path = "../core/test_helpers" }
 
 [lints]
 workspace = true

--- a/influxdb3_startup/src/lib.rs
+++ b/influxdb3_startup/src/lib.rs
@@ -1,9 +1,9 @@
 //! Startup utilities for InfluxDB 3.
 //!
-//! Provides functionality needed during early startup, before the tracing
-//! system is initialized:
+//! Provides functionality needed during node startup:
 //! - [`early_logging`]: Log-like output for pre-tracing startup messages
 //! - [`env_compat`]: Backwards-compatible environment variable aliasing
+//! - [`phase`]: Per-phase progress tracking for the serve path
 #![deny(rustdoc::broken_intra_doc_links, rustdoc::bare_urls, rust_2018_idioms)]
 #![warn(
     missing_debug_implementations,
@@ -13,3 +13,8 @@
 
 pub mod early_logging;
 pub mod env_compat;
+pub mod phase;
+
+pub use phase::{
+    NoopStartupPhaseObserver, PhaseGuard, StartupPhase, StartupPhaseObserver, StartupPhases,
+};

--- a/influxdb3_startup/src/phase.rs
+++ b/influxdb3_startup/src/phase.rs
@@ -1,0 +1,306 @@
+//! Phase tracking for node startup.
+//!
+//! [`StartupPhases`] issues one [`PhaseGuard`] per phase. The guard logs a start line when it is
+//! created and a completion line when the phase succeeds or fails. Completion events also feed a
+//! [`StartupPhaseObserver`] so they reach the service log; start lines go to tracing only, so do
+//! not rely on a service-log start event.
+//!
+//! Both destinations are deliberate. Tracing writes through line-buffered stdout, so a line reaches
+//! the file descriptor as it completes and survives a SIGKILL; the service log hands entries to a
+//! background writer thread, so an entry can still be in memory when the process dies. A node that
+//! is OOM-killed mid-phase keeps its tracing lines and may lose its service log entries, so the two
+//! are not redundant.
+
+use std::fmt::Debug;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use observability_deps::tracing::{error, info};
+// The startup path threads a `tokio::time::Instant` as its origin, so match that rather than
+// converting at every call site. It also keeps these durations honest under a paused test clock.
+use tokio::time::Instant;
+
+/// A named startup phase the enterprise serve path emits SLL events for.
+#[derive(Debug, Clone, Copy)]
+pub enum StartupPhase {
+    /// The throwaway catalog load `command` runs on the temporary runtime to look up the
+    /// instance id and the persisted storage mode. Finishes before logging is initialised, so it
+    /// is reported after the fact via `StartupPhases::report_completed`.
+    /// Success detail: `storage_mode=<parquet|pacha_tree>`.
+    TempCatalogLoad,
+    /// Licensing init on the temporary runtime. The span covers the whole licensing bootstrap,
+    /// including its own catalog access and onboarding telemetry, so boot wall-clock stays fully
+    /// attributed. Also reported after the fact; never reported on `no_license` builds.
+    /// Success detail: `licensed_cores=<n>`.
+    Licensing,
+    /// Load of the persisted catalog. Success detail: `uuid_<catalog uuid>`.
+    CatalogLoad,
+    /// Load (or first-boot create) of the persisted `EnterpriseConfig`.
+    /// Success detail: `loaded` or `created_default`.
+    EnterpriseConfig,
+    /// Background table-index-cache initialization on ingest-capable nodes. Runs concurrently
+    /// with later phases, so its lines interleave with theirs.
+    /// Success detail: `snapshots=<split> entries=<held>`.
+    TableIndexCache,
+    /// Load of compacted data: the producer's state on compact nodes, or the consumer's copy on
+    /// other modes when a compactor node is running.
+    /// Success detail: `tables=<n> generations=<n>`, plus ` retries=<n>` for the consumer.
+    CompactedDataLoad,
+    /// Restore of persisted snapshots into the write buffer. Success detail:
+    /// `checkpoints=<n> additional_snapshots=<n>`, `snapshots=<n>`, or `skipped`.
+    SnapshotRestore,
+    /// Replay of WAL files written since the last snapshot. Success detail:
+    /// `no_wal files=<n>` or `replayed_through_seq_<seq> files=<n>`.
+    WalReplay,
+    /// Binding the HTTP listener and, when configured, the internode listener.
+    /// Success detail: `internode_bound` or `http_only` (addresses stay out of the service log).
+    ListenerBind,
+    /// Creation of replicated buffers for every ingest peer on query-capable nodes.
+    /// Success detail: `peers=<n>`.
+    ReplicaBootstrap,
+    /// Warm-up of the last-value and distinct-value caches.
+    /// Success detail: `both_caches`, `lvc_only`, `dvc_only`, or `skipped`.
+    CacheWarm,
+    /// Registration of this node in the catalog. Success detail: `instance_<instance id>`.
+    NodeRegistration,
+    /// Processing engine setup and trigger start on process-capable nodes.
+    /// Success detail: `triggers_started`.
+    ProcessingEngine,
+    /// Terminal phase: the node is serving. See [`StartupPhases::ready`].
+    /// Detail: `listening` (the address is on the adjacent startup-time tracing line only).
+    Ready,
+}
+
+impl StartupPhase {
+    /// The snake_case name this phase carries on log lines and SLL events.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::TempCatalogLoad => "temp_catalog_load",
+            Self::Licensing => "licensing",
+            Self::CatalogLoad => "catalog_load",
+            Self::EnterpriseConfig => "enterprise_config",
+            Self::TableIndexCache => "table_index_cache",
+            Self::CompactedDataLoad => "compacted_data_load",
+            Self::SnapshotRestore => "snapshot_restore",
+            Self::WalReplay => "wal_replay",
+            Self::ListenerBind => "listener_bind",
+            Self::ReplicaBootstrap => "replica_bootstrap",
+            Self::CacheWarm => "cache_warm",
+            Self::NodeRegistration => "node_registration",
+            Self::ProcessingEngine => "processing_engine",
+            Self::Ready => "ready",
+        }
+    }
+}
+
+/// Subscriber for per-phase startup completion events. Fires once per
+/// phase per node boot. Success carries a per-phase `detail` summary;
+/// error carries a static `error_code` for the phase that failed.
+/// Node-scoped.
+pub trait StartupPhaseObserver: Send + Sync + Debug {
+    /// Called when `phase` completes successfully.
+    fn on_phase_success(&self, phase: StartupPhase, duration_ms: u64, detail: String);
+    /// Called when `phase` fails with `error_code`.
+    fn on_phase_error(&self, phase: StartupPhase, error_code: &'static str, duration_ms: u64);
+}
+
+/// No-op observer used when no subscriber is wired in.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct NoopStartupPhaseObserver;
+
+impl StartupPhaseObserver for NoopStartupPhaseObserver {
+    fn on_phase_success(&self, _: StartupPhase, _: u64, _: String) {}
+    fn on_phase_error(&self, _: StartupPhase, _: &'static str, _: u64) {}
+}
+
+/// Issues one [`PhaseGuard`] per startup phase.
+///
+/// `process_start` should be the same instant used to report total startup time, so that the
+/// `elapsed_total_ms` on every phase line is measured against one origin.
+#[derive(Debug, Clone)]
+pub struct StartupPhases {
+    observer: Arc<dyn StartupPhaseObserver>,
+    process_start: Instant,
+}
+
+impl StartupPhases {
+    /// Build a tracker that feeds `observer` and measures every `elapsed_total_ms` from
+    /// `process_start`.
+    pub fn new(observer: Arc<dyn StartupPhaseObserver>, process_start: Instant) -> Self {
+        Self {
+            observer,
+            process_start,
+        }
+    }
+
+    /// A tracker that discards every event, for tests and for paths with no subscriber.
+    ///
+    /// Each call takes its own origin, so `elapsed_total_ms` is only meaningful within one
+    /// instance. Production code builds one [`StartupPhases`] from the process start instant and
+    /// shares it, so that every phase measures against the same origin.
+    pub fn noop() -> Self {
+        Self::new(Arc::new(NoopStartupPhaseObserver), Instant::now())
+    }
+
+    /// Start `phase` and log what it is about to do.
+    ///
+    /// `plan` describes the work in terms already known at this point — counts, configured
+    /// concurrency — and is logged verbatim. Pass an empty string when there is nothing useful to
+    /// say up front. The guard must be finished with [`PhaseGuard::success`] or
+    /// [`PhaseGuard::error`]; dropping it without either logs the phase as incomplete.
+    pub fn begin(&self, phase: StartupPhase, plan: impl AsRef<str>) -> PhaseGuard<'_> {
+        let plan = plan.as_ref();
+        info!(
+            startup_phase = phase.as_str(),
+            elapsed_total_ms = self.elapsed_total_ms(),
+            plan,
+            "startup phase started"
+        );
+        PhaseGuard {
+            phases: self,
+            phase,
+            started: Instant::now(),
+            finished: AtomicBool::new(false),
+        }
+    }
+
+    /// Report a phase that already ran to completion, for work that ran before logging was
+    /// initialised (the temp-catalog load and licensing init run on a temporary runtime before
+    /// tracing exists). Emits the started and finished lines a [`PhaseGuard`] would have emitted,
+    /// using the recorded instants, and feeds the observer one success event.
+    ///
+    /// `started` may predate this tracker's origin: the origin stays tied to the reported total
+    /// startup time, so `elapsed_total_ms` saturates to zero instead of moving that origin.
+    /// Failures need no counterpart here — a failure in this pre-logging work aborts the boot
+    /// before any tracker exists.
+    pub fn report_completed(
+        &self,
+        phase: StartupPhase,
+        started: Instant,
+        finished: Instant,
+        detail: impl Into<String>,
+    ) {
+        let detail = detail.into();
+        info!(
+            startup_phase = phase.as_str(),
+            elapsed_total_ms = self.elapsed_total_ms_at(started),
+            plan = "",
+            "startup phase started"
+        );
+        let duration_ms = finished.saturating_duration_since(started).as_millis() as u64;
+        info!(
+            startup_phase = phase.as_str(),
+            duration_ms,
+            elapsed_total_ms = self.elapsed_total_ms_at(finished),
+            detail = detail.as_str(),
+            "startup phase finished"
+        );
+        self.observer.on_phase_success(phase, duration_ms, detail);
+    }
+
+    /// Report the terminal `ready` phase.
+    ///
+    /// Unlike the other phases this is a point event, not a span: its duration is the whole boot,
+    /// measured from the same origin as every `elapsed_total_ms` above it. Call it once, after the
+    /// last fallible setup step, so an aborted boot never reports ready.
+    pub fn ready(&self, detail: impl Into<String>) {
+        let detail = detail.into();
+        let duration_ms = self.elapsed_total_ms();
+        info!(
+            startup_phase = StartupPhase::Ready.as_str(),
+            duration_ms,
+            detail = detail.as_str(),
+            "startup finished"
+        );
+        self.observer
+            .on_phase_success(StartupPhase::Ready, duration_ms, detail);
+    }
+
+    fn elapsed_total_ms(&self) -> u64 {
+        self.process_start.elapsed().as_millis() as u64
+    }
+
+    /// Milliseconds from the origin to `at`, saturating to zero when `at` predates the origin.
+    fn elapsed_total_ms_at(&self, at: Instant) -> u64 {
+        at.saturating_duration_since(self.process_start).as_millis() as u64
+    }
+}
+
+/// One in-progress startup phase. See [`StartupPhases::begin`].
+#[derive(Debug)]
+pub struct PhaseGuard<'a> {
+    phases: &'a StartupPhases,
+    phase: StartupPhase,
+    started: Instant,
+    finished: AtomicBool,
+}
+
+impl PhaseGuard<'_> {
+    /// Record that the phase completed. `detail` is the machine-readable per-phase summary that
+    /// reaches the service log, and must contain no names, query text or other user data.
+    pub fn success(&self, detail: impl Into<String>) {
+        if self.finish() {
+            return;
+        }
+        let detail = detail.into();
+        let duration_ms = self.duration_ms();
+        info!(
+            startup_phase = self.phase.as_str(),
+            duration_ms,
+            elapsed_total_ms = self.phases.elapsed_total_ms(),
+            detail = detail.as_str(),
+            "startup phase finished"
+        );
+        self.phases
+            .observer
+            .on_phase_success(self.phase, duration_ms, detail);
+    }
+
+    /// Record that the phase failed. Takes `&self` so it composes with `inspect_err` ahead of the
+    /// `?` that propagates the original error.
+    pub fn error(&self, error_code: &'static str) {
+        if self.finish() {
+            return;
+        }
+        let duration_ms = self.duration_ms();
+        error!(
+            startup_phase = self.phase.as_str(),
+            duration_ms,
+            elapsed_total_ms = self.phases.elapsed_total_ms(),
+            error_code,
+            "startup phase failed"
+        );
+        self.phases
+            .observer
+            .on_phase_error(self.phase, error_code, duration_ms);
+    }
+
+    fn duration_ms(&self) -> u64 {
+        self.started.elapsed().as_millis() as u64
+    }
+
+    /// Mark the guard finished. Returns true if it was already finished, in which case the caller
+    /// must emit nothing: a phase reports exactly once.
+    fn finish(&self) -> bool {
+        self.finished.swap(true, Ordering::Relaxed)
+    }
+}
+
+impl Drop for PhaseGuard<'_> {
+    fn drop(&mut self) {
+        if *self.finished.get_mut() {
+            return;
+        }
+        // Reached when a phase returns early without reporting. Logged rather than ignored so the
+        // gap is visible instead of the phase silently never finishing.
+        error!(
+            startup_phase = self.phase.as_str(),
+            duration_ms = self.duration_ms(),
+            elapsed_total_ms = self.phases.elapsed_total_ms(),
+            "startup phase did not report an outcome"
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/influxdb3_startup/src/phase/tests.rs
+++ b/influxdb3_startup/src/phase/tests.rs
@@ -1,0 +1,201 @@
+use std::sync::Mutex;
+
+use super::*;
+
+/// Records what reached the observer, so tests assert on emissions rather than log output.
+#[derive(Debug, Default)]
+struct RecordingObserver {
+    events: Mutex<Vec<Event>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Event {
+    Success {
+        phase: &'static str,
+        detail: String,
+    },
+    Error {
+        phase: &'static str,
+        code: &'static str,
+    },
+}
+
+impl RecordingObserver {
+    fn events(&self) -> Vec<Event> {
+        self.events.lock().unwrap().clone()
+    }
+}
+
+impl StartupPhaseObserver for RecordingObserver {
+    fn on_phase_success(&self, phase: StartupPhase, _duration_ms: u64, detail: String) {
+        self.events.lock().unwrap().push(Event::Success {
+            phase: phase.as_str(),
+            detail,
+        });
+    }
+
+    fn on_phase_error(&self, phase: StartupPhase, error_code: &'static str, _duration_ms: u64) {
+        self.events.lock().unwrap().push(Event::Error {
+            phase: phase.as_str(),
+            code: error_code,
+        });
+    }
+}
+
+fn phases() -> (Arc<RecordingObserver>, StartupPhases) {
+    let observer = Arc::new(RecordingObserver::default());
+    let phases = StartupPhases::new(
+        Arc::clone(&observer) as Arc<dyn StartupPhaseObserver>,
+        Instant::now(),
+    );
+    (observer, phases)
+}
+
+#[test]
+fn success_reports_once() {
+    let (observer, phases) = phases();
+    {
+        let guard = phases.begin(StartupPhase::CatalogLoad, "");
+        guard.success("uuid_abc");
+    }
+    assert_eq!(
+        observer.events(),
+        vec![Event::Success {
+            phase: "catalog_load",
+            detail: "uuid_abc".to_string(),
+        }]
+    );
+}
+
+#[test]
+fn error_reports_once() {
+    let (observer, phases) = phases();
+    {
+        let guard = phases.begin(StartupPhase::WalReplay, "");
+        guard.error("wal_replay_failed");
+    }
+    assert_eq!(
+        observer.events(),
+        vec![Event::Error {
+            phase: "wal_replay",
+            code: "wal_replay_failed",
+        }]
+    );
+}
+
+/// `inspect_err` calls `error` and the `?` that follows drops the guard. Drop must not turn that
+/// into a second event.
+#[test]
+fn error_then_drop_does_not_report_twice() {
+    let (observer, phases) = phases();
+    {
+        let guard = phases.begin(StartupPhase::SnapshotRestore, "");
+        let result: Result<(), &str> = Err("boom");
+        let _ = result.inspect_err(|_| guard.error("snapshot_restore_failed"));
+    }
+    assert_eq!(observer.events().len(), 1, "phase must report exactly once");
+}
+
+/// A phase that reports success and is then dropped must not also report an outcome from `Drop`.
+#[test]
+fn success_then_drop_does_not_report_twice() {
+    let (observer, phases) = phases();
+    {
+        let guard = phases.begin(StartupPhase::CacheWarm, "");
+        guard.success("skipped");
+    }
+    assert_eq!(observer.events().len(), 1, "phase must report exactly once");
+}
+
+/// Dropping without reporting is a bug at the call site. It logs, but must not fabricate a success
+/// or error event for the observer.
+#[test]
+fn drop_without_outcome_emits_no_observer_event() {
+    let (observer, phases) = phases();
+    {
+        let _guard = phases.begin(StartupPhase::NodeRegistration, "");
+    }
+    assert!(
+        observer.events().is_empty(),
+        "an unreported phase must not reach the observer"
+    );
+}
+
+/// A later phase must report a larger cumulative elapsed than an earlier one, since both measure
+/// against the same process origin.
+#[test]
+fn elapsed_total_is_monotonic_across_phases() {
+    let (_observer, phases) = phases();
+    let first = phases.elapsed_total_ms();
+    std::thread::sleep(std::time::Duration::from_millis(2));
+    let second = phases.elapsed_total_ms();
+    assert!(second >= first, "{second} should be >= {first}");
+}
+
+/// `report_completed` stands in for a whole begin/success pair, so it must feed the observer
+/// exactly one success event carrying the detail.
+#[test]
+fn report_completed_emits_one_success_event() {
+    let (observer, phases) = phases();
+    let started = Instant::now();
+    phases.report_completed(
+        StartupPhase::TempCatalogLoad,
+        started,
+        started + std::time::Duration::from_millis(3),
+        "storage_mode=parquet",
+    );
+    assert_eq!(
+        observer.events(),
+        vec![Event::Success {
+            phase: "temp_catalog_load",
+            detail: "storage_mode=parquet".to_string(),
+        }]
+    );
+}
+
+/// `report_completed` must emit the same started and finished lines a live guard would, and a
+/// span that predates the tracker origin must clamp `elapsed_total_ms` to zero rather than
+/// underflow — the pre-logging phases run before `startup_timer` exists.
+#[test]
+fn report_completed_logs_both_lines_and_clamps_before_origin() {
+    let capture = test_helpers::tracing::TracingCapture::new();
+    let (_observer, phases) = phases();
+    // The instants are fixed, so the 5 ms duration below is exact, not timing-dependent.
+    let origin = Instant::now();
+    let started = origin - std::time::Duration::from_millis(10);
+    let finished = origin - std::time::Duration::from_millis(5);
+    let phases = StartupPhases {
+        process_start: origin,
+        ..phases
+    };
+    phases.report_completed(
+        StartupPhase::Licensing,
+        started,
+        finished,
+        "licensed_cores=2",
+    );
+    let logs = capture.to_string();
+    let started_line = logs
+        .lines()
+        .find(|l| l.contains("startup phase started"))
+        .expect("a started line is logged");
+    assert!(
+        started_line.contains(r#"startup_phase = "licensing""#),
+        "{logs}"
+    );
+    assert!(started_line.contains("elapsed_total_ms = 0"), "{logs}");
+    let finished_line = logs
+        .lines()
+        .find(|l| l.contains("startup phase finished"))
+        .expect("a finished line is logged");
+    assert!(
+        finished_line.contains(r#"startup_phase = "licensing""#),
+        "{logs}"
+    );
+    assert!(finished_line.contains("duration_ms = 5"), "{logs}");
+    assert!(finished_line.contains("elapsed_total_ms = 0"), "{logs}");
+    assert!(
+        finished_line.contains(r#"detail = "licensed_cores=2""#),
+        "{logs}"
+    );
+}

--- a/influxdb3_wal/Cargo.toml
+++ b/influxdb3_wal/Cargo.toml
@@ -16,6 +16,7 @@ schema = { path = "../core/schema" }
 # Local Crates
 influxdb3_id = { path = "../influxdb3_id" }
 influxdb3_shutdown = { path = "../influxdb3_shutdown" }
+object_store_utils = { path = "../object_store_utils" }
 
 # crates.io dependencies
 async-trait.workspace = true
@@ -40,4 +41,6 @@ large-strings = ["influxdb-line-protocol/large-strings"]
 workspace = true
 
 [dev-dependencies]
+metric = { path = "../core/metric" }
+object_store_utils = { path = "../object_store_utils", features = ["test-helpers"] }
 test-log.workspace = true

--- a/influxdb3_wal/src/object_store.rs
+++ b/influxdb3_wal/src/object_store.rs
@@ -11,7 +11,8 @@ use hashbrown::HashMap;
 use influxdb3_shutdown::{CancellationToken, ShutdownToken};
 use iox_time::TimeProvider;
 use object_store::path::{Path, PathPart};
-use object_store::{ObjectStore, PutMode, PutOptions, PutPayload};
+use object_store::{ObjectStore, PutPayload};
+use object_store_utils::{PutNonce, SelfVerifyingCreate};
 use observability_deps::tracing::{debug, error, info, trace, warn};
 use std::time::{Duration, Instant};
 use std::{str::FromStr, sync::Arc};
@@ -335,6 +336,9 @@ impl WalObjectStore {
         let data = crate::serialize::serialize_to_file_bytes(&wal_contents)
             .expect("unable to serialize wal contents into bytes for file");
         let data = Bytes::from(data);
+        // One nonce per WAL file, minted outside the retry loop below so that
+        // every attempt at this file carries the same one.
+        let nonce = PutNonce::generate();
 
         let mut retry_count = 0;
 
@@ -345,27 +349,26 @@ impl WalObjectStore {
                 .put_opts(
                     &wal_path,
                     PutPayload::from_bytes(data.clone()),
-                    PutOptions {
-                        mode: PutMode::Create,
-                        ..Default::default()
-                    },
+                    SelfVerifyingCreate::with_nonce(nonce.clone()).put_options(),
                 )
                 .await
             {
                 Ok(_) => {
                     break;
                 }
-                // In the event that the WAL file has already been written, we want to stop the
-                // process. This would be due to someone running multiple processes with the same
-                // `--node-id` simultaneously. Whether that is intentional or not, we have to stop
-                // the process so that either the other running process can take over, or so that
-                // the operator can intervene and correct the state of their object store.
+                // A WAL file already exists at this path and is not one of this writer's own
+                // retries. The likeliest cause is a second process running with the same
+                // `--node-id`. Whatever the cause we stop, so that the other process can take
+                // over or the operator can correct the state of the object store.
                 Err(object_store::Error::AlreadyExists { path, source }) => {
                     error!(
                         path,
                         ?source,
-                        "invoking shutdown after attempt to persist a WAL file \
-                        that already exists on the object store"
+                        "invoking shutdown: a WAL file this process was writing already exists \
+                        on the object store; check for another process running with the same \
+                        --node-id. Where write verification is active, a store that discards \
+                        object metadata or a WAL file left by an older build can produce the \
+                        same result"
                     );
                     // update the state on the wal buffer so that new writes are not
                     // accepted:

--- a/influxdb3_wal/src/object_store/tests.rs
+++ b/influxdb3_wal/src/object_store/tests.rs
@@ -7,6 +7,7 @@ use indexmap::IndexMap;
 use influxdb3_id::{ColumnId, DbId, TableId};
 use iox_time::{MockProvider, Time};
 use object_store::memory::InMemory;
+use object_store_utils::{LostResponseError, LostResponseStore, SelfVerifyingCreateStore};
 use std::any::Any;
 use tokio::sync::oneshot::Receiver;
 
@@ -891,4 +892,133 @@ impl WalFileNotifier for TestNotifier {
     fn as_any(&self) -> &dyn Any {
         self
     }
+}
+
+/// Build a WAL over `inner` wrapped in the verifying layer.
+fn verifying_wal_over(inner: Arc<dyn ObjectStore>) -> (WalObjectStore, CancellationToken) {
+    let registry = metric::Registry::new();
+    wal_over(Arc::new(SelfVerifyingCreateStore::new(inner, &registry)))
+}
+
+/// Build a WAL over `object_store`, returning the WAL and the shutdown token it
+/// will cancel if it decides a foreign writer holds the path.
+fn wal_over(object_store: Arc<dyn ObjectStore>) -> (WalObjectStore, CancellationToken) {
+    let time_provider: Arc<dyn TimeProvider> =
+        Arc::new(MockProvider::new(Time::from_timestamp_nanos(0)));
+    let notifier: Arc<dyn WalFileNotifier> = Arc::new(TestNotifier::default());
+    let shutdown = CancellationToken::new();
+    let wal = WalObjectStore::new_without_replay(
+        time_provider,
+        object_store,
+        "my_host",
+        notifier,
+        WalConfig {
+            max_write_buffer_size: 100,
+            flush_interval: Duration::from_secs(1),
+            snapshot_size: 2,
+            gen1_duration: Gen1Duration::new_1m(),
+            ..Default::default()
+        },
+        None,
+        None,
+        &[],
+        1,
+        shutdown.clone(),
+    );
+    (wal, shutdown)
+}
+
+/// A single write op, enough to fill the WAL buffer so a flush persists a file.
+fn op() -> WalOp {
+    WalOp::Write(WriteBatch {
+        catalog_sequence: 0,
+        database_id: DbId::from(0),
+        database_name: "db1".into(),
+        table_chunks: IndexMap::from([(
+            TableId::from(0),
+            TableChunks {
+                min_time: 1,
+                max_time: 1,
+                chunk_time_to_chunk: HashMap::from([(
+                    0,
+                    TableChunk {
+                        rows: vec![Row {
+                            time: 1,
+                            fields: vec![
+                                Field {
+                                    id: ColumnId::from(0),
+                                    value: FieldData::Integer(1),
+                                },
+                                Field {
+                                    id: ColumnId::from(1),
+                                    value: FieldData::Timestamp(1),
+                                },
+                            ],
+                        }],
+                    },
+                )]),
+            },
+        )])
+        .into(),
+        min_time_ns: 1,
+        max_time_ns: 1,
+    })
+}
+
+/// The bug from EAR 7005: the PUT is applied, the response is lost, the
+/// client's own retry gets 412. The node must not shut down.
+#[tokio::test]
+async fn own_lost_put_response_is_not_a_duplicate_writer() {
+    let inner = Arc::new(LostResponseStore::new(Arc::new(InMemory::new())));
+    let (wal, shutdown) = verifying_wal_over(Arc::clone(&inner) as _);
+
+    wal.write_ops_unconfirmed(vec![op()]).await.unwrap();
+    inner.lose_next_put_response_with(LostResponseError::AlreadyExists);
+
+    let flushed = wal.flush_buffer(true).await;
+
+    assert!(!shutdown.is_cancelled(), "node shut down on its own write");
+    assert!(
+        flushed.is_some(),
+        "flush reported failure for a durable write"
+    );
+}
+
+/// Control: without the verifying layer, the same scenario still shuts the node
+/// down. This proves the test above detects the bug, and that a store left
+/// unwrapped is unchanged.
+#[tokio::test]
+async fn an_unwrapped_store_still_shuts_down_on_a_lost_put_response() {
+    let inner = Arc::new(LostResponseStore::new(Arc::new(InMemory::new())));
+    let (wal, shutdown) = wal_over(Arc::clone(&inner) as _);
+
+    wal.write_ops_unconfirmed(vec![op()]).await.unwrap();
+    inner.lose_next_put_response_with(LostResponseError::AlreadyExists);
+
+    let flushed = wal.flush_buffer(true).await;
+
+    assert!(shutdown.is_cancelled());
+    assert!(flushed.is_none());
+}
+
+/// The WAL's own 100x retry loop re-issues the create. A nonce minted per
+/// `put_opts` call would be fresh on the second attempt and read the first
+/// attempt's nonce as foreign; a nonce minted per WAL file covers it.
+#[tokio::test]
+async fn outer_retry_loop_is_covered_by_the_per_file_nonce() {
+    let inner = Arc::new(LostResponseStore::new(Arc::new(InMemory::new())));
+    let (wal, shutdown) = verifying_wal_over(Arc::clone(&inner) as _);
+
+    wal.write_ops_unconfirmed(vec![op()]).await.unwrap();
+    // First attempt lands but returns a retryable error, so the WAL's own loop
+    // re-enters put_opts; the second attempt collides with attempt one.
+    inner.lose_next_put_response_with(LostResponseError::Generic);
+
+    let flushed = wal.flush_buffer(true).await;
+
+    assert!(
+        !shutdown.is_cancelled(),
+        "outer-loop retry shut the node down"
+    );
+    assert!(flushed.is_some());
 }

--- a/influxdb3_write/Cargo.toml
+++ b/influxdb3_write/Cargo.toml
@@ -75,6 +75,7 @@ regex.workspace = true
 [dev-dependencies]
 # Core Crates
 arrow_util = { path = "../core/arrow_util" }
+object_store_utils = { path = "../object_store_utils", features = ["test-helpers"] }
 query_functions = { path = "../core/query_functions" }
 test_helpers = { path = "../core/test_helpers" }
 

--- a/influxdb3_write/src/persister.rs
+++ b/influxdb3_write/src/persister.rs
@@ -34,9 +34,9 @@ use futures_util::stream::{FuturesOrdered, StreamExt};
 use influxdb3_cache::parquet_cache::ParquetFileDataToCache;
 use influxdb3_wal::SnapshotSequenceNumber;
 use iox_time::TimeProvider;
-use object_store::ObjectStore;
 use object_store::path::Path as ObjPath;
-use object_store_utils::AdaptivePutExt;
+use object_store::{ObjectMeta, ObjectStore};
+use object_store_utils::{AdaptiveGetExt, AdaptivePutExt};
 use observability_deps::tracing::{debug, error, info, trace, warn};
 use parking_lot::RwLock;
 use parquet::arrow::ArrowWriter;
@@ -98,6 +98,13 @@ pub const DEFAULT_OBJECT_STORE_URL: &str = "iox://influxdb3/";
 const MAX_CONCURRENT_CHECKPOINT_LOADS: usize = 10;
 /// Number of checkpoints to retain per month when cleaning up (latest + previous for safety)
 const CHECKPOINTS_TO_RETAIN_PER_MONTH: usize = 2;
+/// Default number of snapshot manifests fetched concurrently during startup
+/// restore. Matches the default object-store connection limit so small
+/// manifests keep loading at full concurrency (no startup regression); large
+/// manifests fan out into ranged GETs that share that same connection-limit
+/// semaphore, so peak in-flight requests are bounded regardless. The effective
+/// limit is capped by the object-store connection limit at startup.
+pub const DEFAULT_MAX_CONCURRENT_SNAPSHOT_LOADS: usize = 64;
 
 /// Cached checkpoint with its file index for efficient incremental updates.
 ///
@@ -130,6 +137,8 @@ pub struct Persister {
     last_checkpoint_time: RwLock<Option<Instant>>,
     /// Cached checkpoint for the current month to avoid reloading from object store.
     cached_checkpoint: RwLock<Option<CachedCheckpoint>>,
+    /// Max snapshot manifests fetched concurrently during startup restore.
+    snapshot_load_concurrency: usize,
 }
 
 impl Persister {
@@ -156,7 +165,15 @@ impl Persister {
             checkpoint_interval,
             last_checkpoint_time: RwLock::new(None),
             cached_checkpoint: RwLock::new(None),
+            snapshot_load_concurrency: DEFAULT_MAX_CONCURRENT_SNAPSHOT_LOADS,
         }
+    }
+
+    /// Override the number of snapshot manifests fetched concurrently during
+    /// startup restore. Defaults to [`DEFAULT_MAX_CONCURRENT_SNAPSHOT_LOADS`].
+    pub fn with_snapshot_load_concurrency(mut self, concurrency: usize) -> Self {
+        self.snapshot_load_concurrency = concurrency.max(1);
+        self
     }
 
     /// Get the Object Store URL
@@ -199,7 +216,7 @@ impl Persister {
             node_identifier_prefix = %self.node_identifier_prefix,
             "load_snapshots: starting"
         );
-        let mut futures = FuturesOrdered::new();
+        let mut fetches = Vec::new();
         let mut offset: Option<ObjPath> = None;
 
         while most_recent_n > 0 {
@@ -244,9 +261,15 @@ impl Persister {
             async fn get_snapshot(
                 location: ObjPath,
                 last_modified: DateTime<Utc>,
+                object_size: u64,
                 object_store: Arc<dyn ObjectStore>,
             ) -> Result<(usize, PersistedSnapshotVersion)> {
-                let bytes = object_store.get(&location).await?.bytes().await?;
+                // Manifests can be multi-GiB; get_adaptive chunks large
+                // reads. Size is known from list(), so pass it to skip a
+                // HEAD.
+                let bytes = object_store
+                    .get_adaptive(&location, Some(object_size))
+                    .await?;
                 let size = bytes.len();
                 let mut snapshot: PersistedSnapshotVersion = serde_json::from_slice(&bytes)?;
                 match &mut snapshot {
@@ -260,9 +283,10 @@ impl Persister {
 
             trace!(count = end, "load_snapshots: queueing snapshot fetches");
             for item in &list[0..end] {
-                futures.push_back(get_snapshot(
+                fetches.push(get_snapshot(
                     item.location.clone(),
                     item.last_modified,
+                    item.size,
                     Arc::clone(&self.object_store),
                 ));
             }
@@ -277,14 +301,24 @@ impl Persister {
             offset = Some(list[end - 1].location.clone());
         }
 
+        // Fetch with bounded concurrency: each in-flight manifest holds a
+        // reassembly buffer, so an unbounded fan-out over many (potentially
+        // multi-GiB) manifests can exhaust memory at startup. buffered() keeps
+        // at most snapshot_load_concurrency requests in flight while preserving
+        // input order.
         trace!(
-            pending_fetches = futures.len(),
+            pending_fetches = fetches.len(),
+            snapshot_load_concurrency = self.snapshot_load_concurrency,
             "load_snapshots: fetching snapshot contents"
         );
-        let mut results = Vec::new();
+        let results_with_size: Vec<(usize, PersistedSnapshotVersion)> =
+            futures_util::stream::iter(fetches)
+                .buffered(self.snapshot_load_concurrency)
+                .try_collect()
+                .await?;
+        let mut results = Vec::with_capacity(results_with_size.len());
         let mut total_bytes = 0usize;
-        while let Some(result) = futures.next().await {
-            let (size, snapshot) = result?;
+        for (size, snapshot) in results_with_size {
             total_bytes += size;
             results.push(snapshot);
         }
@@ -554,7 +588,7 @@ impl Persister {
     pub async fn list_latest_checkpoints_per_month(
         &self,
         min_sequence: Option<SnapshotSequenceNumber>,
-    ) -> Result<Vec<ObjPath>> {
+    ) -> Result<Vec<ObjectMeta>> {
         debug!(
             node_identifier_prefix = %self.node_identifier_prefix,
             ?min_sequence,
@@ -564,18 +598,16 @@ impl Persister {
         let checkpoint_dir = SnapshotCheckpointPath::dir(&self.node_identifier_prefix);
         let mut checkpoint_list = self.object_store.list(Some(&checkpoint_dir));
 
-        // Collect all checkpoint paths
-        let mut paths_by_month: HashMap<YearMonth, Vec<ObjPath>> = HashMap::new();
+        // Collect all checkpoint metas (kept whole so the size from the LIST is
+        // threaded to the loader, letting it size the read without a HEAD).
+        let mut metas_by_month: HashMap<YearMonth, Vec<ObjectMeta>> = HashMap::new();
 
         while let Some(item) = checkpoint_list.next().await {
             match item {
                 Ok(meta) => {
                     let path_str = meta.location.as_ref();
                     if let Some(year_month) = SnapshotCheckpointPath::parse_year_month(path_str) {
-                        paths_by_month
-                            .entry(year_month)
-                            .or_default()
-                            .push(meta.location);
+                        metas_by_month.entry(year_month).or_default().push(meta);
                     }
                 }
                 Err(e) => {
@@ -589,12 +621,12 @@ impl Persister {
         }
 
         // For each month, select only the latest checkpoint
-        let mut result: Vec<(YearMonth, ObjPath)> = paths_by_month
+        let mut result: Vec<(YearMonth, ObjectMeta)> = metas_by_month
             .into_iter()
-            .map(|(month, mut paths)| {
-                paths.sort();
+            .map(|(month, mut metas)| {
+                metas.sort_by(|a, b| a.location.cmp(&b.location));
                 // First path after sorting is the latest due to inverted sequence numbers
-                (month, paths.into_iter().next().unwrap())
+                (month, metas.into_iter().next().unwrap())
             })
             .collect();
 
@@ -605,9 +637,9 @@ impl Persister {
             let min_seq_u64 = min_seq.as_u64();
             let with_seqs: Vec<_> = result
                 .iter()
-                .filter_map(|(month, path)| {
-                    SnapshotCheckpointPath::parse_sequence_number(path.as_ref())
-                        .map(|seq| (*month, path.clone(), seq.as_u64()))
+                .filter_map(|(month, meta)| {
+                    SnapshotCheckpointPath::parse_sequence_number(meta.location.as_ref())
+                        .map(|seq| (*month, meta.clone(), seq.as_u64()))
                 })
                 .collect();
 
@@ -626,7 +658,7 @@ impl Persister {
                         .map(|(_, _, next_seq)| *next_seq >= min_seq_u64)
                         .unwrap_or(false)
                 })
-                .map(|(_, (month, path, _))| (*month, path.clone()))
+                .map(|(_, (month, meta, _))| (*month, meta.clone()))
                 .collect();
 
             debug!(
@@ -636,37 +668,41 @@ impl Persister {
             );
         }
 
-        let paths: Vec<ObjPath> = result.into_iter().map(|(_, path)| path).collect();
+        let metas: Vec<ObjectMeta> = result.into_iter().map(|(_, meta)| meta).collect();
 
         debug!(
-            count = paths.len(),
+            count = metas.len(),
             "list_latest_checkpoints_per_month: completed"
         );
-        Ok(paths)
+        Ok(metas)
     }
 
-    /// Loads checkpoints from the given paths.
+    /// Loads checkpoints from the given object metas.
     ///
-    /// Use with paths returned from `list_latest_checkpoints_per_month()`.
+    /// Use with the metas returned from `list_latest_checkpoints_per_month()`.
     /// Limits concurrency to avoid overwhelming the object store.
     pub async fn load_checkpoints(
         &self,
-        paths: Vec<ObjPath>,
+        metas: Vec<ObjectMeta>,
     ) -> Result<Vec<PersistedSnapshotCheckpointVersion>> {
-        debug!(count = paths.len(), "load_checkpoints: starting");
+        debug!(count = metas.len(), "load_checkpoints: starting");
 
         let semaphore = Arc::new(Semaphore::new(MAX_CONCURRENT_CHECKPOINT_LOADS));
         let mut futures = FuturesOrdered::new();
 
-        for path in paths {
+        for meta in metas {
             let object_store = Arc::clone(&self.object_store);
             let semaphore = Arc::clone(&semaphore);
-            let path_clone = path.clone();
 
             futures.push_back(async move {
                 let _permit = semaphore.acquire().await.expect("semaphore not closed");
-                trace!(path = %path_clone, "loading checkpoint");
-                let bytes = object_store.get(&path_clone).await?.bytes().await?;
+                trace!(path = %meta.location, "loading checkpoint");
+                // Checkpoints merge a month of snapshots and are the most likely
+                // to be multi-GiB; get_adaptive chunks large reads. The size is
+                // known from the prior list(), so pass it to skip size discovery.
+                let bytes = object_store
+                    .get_adaptive(&meta.location, Some(meta.size))
+                    .await?;
                 let checkpoint: PersistedSnapshotCheckpointVersion =
                     serde_json::from_slice(&bytes)?;
                 Result::<_, PersisterError>::Ok(checkpoint)

--- a/influxdb3_write/src/persister/tests.rs
+++ b/influxdb3_write/src/persister/tests.rs
@@ -486,7 +486,7 @@ async fn test_persist_and_load_checkpoint_roundtrip() {
         .await
         .unwrap();
     assert_eq!(paths.len(), 1);
-    assert!(paths[0].as_ref().contains("2025-01"));
+    assert!(paths[0].location.as_ref().contains("2025-01"));
 
     // Load it back
     let loaded = persister.load_checkpoints(paths).await.unwrap();
@@ -1221,4 +1221,45 @@ async fn test_checkpoint_cleanup_only_affects_specified_month() {
 
     // Now both should have 2
     assert_eq!(count_checkpoints_for_month(&persister, &feb_2025).await, 2);
+}
+
+#[tokio::test]
+async fn load_snapshots_bounds_fetch_concurrency() {
+    use object_store_utils::TestObjectStore;
+    use std::sync::Arc as StdArc;
+
+    // Persist more snapshots than the concurrency bound onto an InMemory store.
+    let inner = StdArc::new(InMemory::new());
+    let seed = Persister::new(
+        StdArc::clone(&inner) as _,
+        "test_host",
+        StdArc::new(MockProvider::new(Time::from_timestamp_nanos(0))) as _,
+        None,
+    );
+    let n = 24usize;
+    for seq in 1..=n as u64 {
+        seed.persist_snapshot(&PersistedSnapshotVersion::V1(create_test_snapshot(seq)))
+            .await
+            .unwrap();
+    }
+
+    // Wrap the store so each get() is tracked and delayed enough to overlap,
+    // making the peak concurrency observable.
+    let tracking = StdArc::new(TestObjectStore::new(inner).with_latency_ms(Some(20), None));
+    let k = 4usize;
+    let persister = Persister::new(
+        StdArc::clone(&tracking) as _,
+        "test_host",
+        StdArc::new(MockProvider::new(Time::from_timestamp_nanos(0))) as _,
+        None,
+    )
+    .with_snapshot_load_concurrency(k);
+
+    let loaded = persister.load_snapshots(n).await.unwrap();
+    assert_eq!(loaded.len(), n, "all snapshots should load");
+    assert!(
+        tracking.max_in_flight_gets() <= k,
+        "peak concurrent gets {} exceeded the bound {k}",
+        tracking.max_in_flight_gets()
+    );
 }

--- a/influxdb3_write/src/write_buffer/queryable_buffer.rs
+++ b/influxdb3_write/src/write_buffer/queryable_buffer.rs
@@ -308,7 +308,6 @@ impl QueryableBuffer {
             // persist the individual files, building the snapshot as we go
             let persisted_snapshot = Arc::new(Mutex::new(snapshot));
 
-            let persist_jobs_empty = persist_jobs.is_empty();
             let semaphore = Arc::new(Semaphore::new(parquet_snapshot_concurrency_limit.get()));
             let mut set = JoinSet::new();
             for persist_job in persist_jobs {
@@ -392,60 +391,45 @@ impl QueryableBuffer {
 
             set.join_all().await;
 
-            // persist the snapshot file - only if persist jobs are present or
-            // files have been removed due to retention policies.
-            // If persist_jobs is empty, then the parquet file wouldn't have been
-            // written out, so it's desirable to not write empty snapshot files.
+            // Always persist the snapshot manifest, even when it is empty.
             //
-            // How can persist jobs be empty even though a snapshot is triggered?
+            // The snapshot sequence number is minted eagerly at plan time in the
+            // WAL crate (`SnapshotTracker::increment_snapshot_sequence_number`) and
+            // embedded durably in the WAL file, so by the time we get here the
+            // number has already been spent. Consumers walk the sequence by exact
+            // key: the compactor point-GETs `marker + 1` and treats `NotFound` as
+            // "caught up", and enterprise read replicas block until each manifest
+            // appears. Skipping the write for an empty snapshot would leave a
+            // permanent hole that halts the compactor for this node and wedges
+            // those replicas (influxdb_pro#4827). An empty manifest is cheap and
+            // loads harmlessly, and it shares the same lifecycle as every other
+            // snapshot manifest (there is no separate cleanup path for it in OSS),
+            // so we always write it rather than leave a gap the consumers cannot
+            // distinguish from a failed persist.
             //
-            // When force snapshot is set, wal_periods (tracked by
-            // snapshot_tracker) will never be empty as a no-op is added. This
-            // means even though there is a wal period the query buffer might
-            // still be empty. The reason is, when snapshots are happening very
-            // close to each other (when force snapshot is set), they could get
-            // queued to run immediately one after the other as illustrated in
-            // example series of flushes and force snapshots below,
-            //
-            //   1 (only wal flush) // triggered by flush interval 1s
-            //   2 (snapshot)       // triggered by flush interval 1s
-            //   3 (force_snapshot) // triggered by mem check interval 10s
-            //   4 (force_snapshot) // triggered by mem check interval 10s
-            //
-            // Although the flush interval an mem check intervals aren't same
-            // there's a good chance under high memory pressure there will be
-            // a lot of overlapping.
-            //
-            // In this setup - after 2 (snapshot), we emptied wal buffer and as
-            // soon as snapshot is done, 3 will try to run the snapshot but wal
-            // buffer can be empty at this point, which means it adds a no-op.
-            // no-op has the current time which will be used as the
-            // end_time_marker. That would evict everything from query buffer, so
-            // when 4 (force snapshot) runs there's no data in the query
-            // buffer though it has a wal_period. When normal (i.e without
-            // force_snapshot) snapshot runs, snapshot_tracker will check if
-            // wal_periods are empty so it won't trigger a snapshot in the first
-            // place.
-            let removed_files_empty = persisted_snapshot.lock().removed_files.is_empty();
+            // A forced snapshot can legitimately find nothing to persist:
+            // `force_flush_buffer` adds a `WalOp::Noop` so a wal_period always
+            // exists, but back-to-back forced snapshots under memory pressure can
+            // drain the query buffer before the next one runs, leaving no persist
+            // jobs and no removed files while the sequence number has still been
+            // consumed.
             let persisted_snapshot = PersistedSnapshotVersion::V1(
                 Arc::into_inner(persisted_snapshot)
                     .expect("Should only have one strong reference")
                     .into_inner(),
             );
-            if !persist_jobs_empty || !removed_files_empty {
-                loop {
-                    match persister.persist_snapshot(&persisted_snapshot).await {
-                        Ok(_) => {
-                            let persisted_snapshot = Some(persisted_snapshot.clone());
-                            notify_snapshot_tx
-                                .send(persisted_snapshot)
-                                .expect("persisted snapshot notify tx should not be closed");
-                            break;
-                        }
-                        Err(e) => {
-                            error!(%e, "Error persisting snapshot, sleeping and retrying...");
-                            tokio::time::sleep(Duration::from_secs(1)).await;
-                        }
+            loop {
+                match persister.persist_snapshot(&persisted_snapshot).await {
+                    Ok(_) => {
+                        let persisted_snapshot = Some(persisted_snapshot.clone());
+                        notify_snapshot_tx
+                            .send(persisted_snapshot)
+                            .expect("persisted snapshot notify tx should not be closed");
+                        break;
+                    }
+                    Err(e) => {
+                        error!(%e, "Error persisting snapshot, sleeping and retrying...");
+                        tokio::time::sleep(Duration::from_secs(1)).await;
                     }
                 }
             }

--- a/influxdb3_write/src/write_buffer/tests.rs
+++ b/influxdb3_write/src/write_buffer/tests.rs
@@ -821,6 +821,144 @@ async fn catalog_snapshots_only_if_updated() {
     verify_snapshot_count(3, &write_buffer.persister).await;
 }
 
+/// Drive a snapshot and wait for it to finish, returning the sequence number the
+/// tracker handed out.
+async fn force_snapshot(write_buffer: &Arc<WriteBufferImpl>) -> SnapshotSequenceNumber {
+    let (snapshot_done, snapshot_info, snapshot_permit) = write_buffer
+        .wal
+        .force_flush_buffer()
+        .await
+        .expect("a forced flush always produces a snapshot");
+    snapshot_done.await.expect("snapshot completes");
+    write_buffer
+        .wal
+        .cleanup_snapshot(snapshot_info, snapshot_permit)
+        .await;
+    snapshot_info.snapshot_sequence_number
+}
+
+/// A forced snapshot over an empty buffer still consumes a sequence number, so its
+/// manifest must be written -- empty, but present -- rather than skipped. Skipping
+/// would leave a hole a sequential consumer cannot tell apart from a failed persist
+/// (influxdb_pro#4827).
+#[tokio::test]
+async fn forced_empty_snapshot_writes_manifest() {
+    let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let (write_buffer, _ctx, _time_provider) = setup(
+        Time::from_timestamp_nanos(0),
+        Arc::clone(&object_store),
+        WalConfig {
+            gen1_duration: Gen1Duration::new_1m(),
+            max_write_buffer_size: 100,
+            flush_interval: Duration::from_millis(5),
+            // high enough that the tracker never snapshots on its own; every
+            // snapshot below is driven explicitly
+            snapshot_size: 100,
+            ..Default::default()
+        },
+    )
+    .await;
+
+    // seq 1 holds data, so it gets a normal manifest
+    do_writes(
+        "test_db",
+        write_buffer.as_ref(),
+        &[TestWrite {
+            lp: "cpu bar=1",
+            time_seconds: 10,
+        }],
+    )
+    .await;
+    let first = force_snapshot(&write_buffer).await;
+    assert_eq!(first, SnapshotSequenceNumber::new(1));
+
+    // nothing was written since, so this forced snapshot drains an empty buffer
+    let empty = force_snapshot(&write_buffer).await;
+    assert_eq!(empty, SnapshotSequenceNumber::new(2));
+
+    // the manifest for the empty sequence exists at its exact key and carries the
+    // empty-snapshot sentinels
+    let path = SnapshotInfoFilePath::new("test_host", empty);
+    let bytes = object_store
+        .get(&path)
+        .await
+        .expect("the empty snapshot must still write a manifest")
+        .bytes()
+        .await
+        .unwrap();
+    let snapshot: PersistedSnapshot = serde_json::from_slice(&bytes).unwrap();
+    assert_eq!(snapshot.snapshot_sequence_number, empty);
+    assert!(snapshot.databases.is_empty());
+    assert_eq!(snapshot.row_count, 0);
+    assert_eq!(snapshot.min_time, i64::MAX);
+    assert_eq!(snapshot.max_time, i64::MIN);
+}
+
+/// Density invariant: a workload mixing normal snapshots with a forced-empty
+/// snapshot must leave a contiguous run of sequence numbers in object store with no
+/// gaps. This is what keeps the compactor and read replicas from stalling on a hole
+/// (influxdb_pro#4827).
+#[tokio::test]
+async fn snapshot_sequence_has_no_holes() {
+    let object_store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let (write_buffer, _ctx, _time_provider) = setup(
+        Time::from_timestamp_nanos(0),
+        Arc::clone(&object_store),
+        WalConfig {
+            gen1_duration: Gen1Duration::new_1m(),
+            max_write_buffer_size: 100,
+            flush_interval: Duration::from_millis(5),
+            snapshot_size: 100,
+            ..Default::default()
+        },
+    )
+    .await;
+
+    // 1: data -> normal manifest
+    do_writes(
+        "test_db",
+        write_buffer.as_ref(),
+        &[TestWrite {
+            lp: "cpu bar=1",
+            time_seconds: 10,
+        }],
+    )
+    .await;
+    let first = force_snapshot(&write_buffer).await;
+
+    // 2: drained buffer -> forced-empty snapshot
+    let empty = force_snapshot(&write_buffer).await;
+
+    // 3: data again -> normal manifest
+    do_writes(
+        "test_db",
+        write_buffer.as_ref(),
+        &[TestWrite {
+            lp: "cpu bar=2",
+            time_seconds: 20,
+        }],
+    )
+    .await;
+    let third = force_snapshot(&write_buffer).await;
+
+    assert_eq!(first, SnapshotSequenceNumber::new(1));
+    assert_eq!(empty, SnapshotSequenceNumber::new(2));
+    assert_eq!(third, SnapshotSequenceNumber::new(3));
+
+    let mut persisted: Vec<u64> = write_buffer
+        .persister
+        .load_snapshots(1000)
+        .await
+        .unwrap()
+        .iter()
+        .map(|PersistedSnapshotVersion::V1(s)| s.snapshot_sequence_number.as_u64())
+        .collect();
+    persisted.sort_unstable();
+    assert_eq!(persisted, vec![1, 2, 3]);
+
+    assert_snapshot_sequence_has_no_holes(&object_store, "test_host").await;
+}
+
 /// Check that when a WriteBuffer is initialized with existing snapshot files, that newly
 /// generated snapshot files use the next sequence number.
 #[tokio::test]
@@ -1899,7 +2037,7 @@ async fn test_check_mem_and_force_snapshot() {
     let total_buffer_size_bytes_after = write_buffer.buffer.get_total_size_bytes();
     debug!(?total_buffer_size_bytes_after, "total buffer size");
     assert!(total_buffer_size_bytes_before > total_buffer_size_bytes_after);
-    assert_dbs_not_empty_in_snapshot_file(&obj_store, "test_host").await;
+    assert_snapshot_sequence_has_no_holes(&obj_store, "test_host").await;
 
     let total_buffer_size_bytes_before = total_buffer_size_bytes_after;
     debug!("2nd snapshot..");
@@ -1924,17 +2062,18 @@ async fn test_check_mem_and_force_snapshot() {
     // the query buffer. But when there's nothing evicted then the min/max stays
     // the same as what they were initialized to i64::MAX/i64::MIN respectively.
     //
-    // This however does not stop loading the data into memory as no empty
-    // parquet files are written out. But this test recreates that issue and checks
-    // object store directly to make sure inconsistent snapshot file isn't written
-    // out in the first place
+    // This empty snapshot still consumes a sequence number, so its manifest must
+    // be written out even though it holds no databases. Skipping it would leave a
+    // hole in the sequence that stalls the compactor and read replicas
+    // (influxdb_pro#4827). The assertion below checks object store directly to
+    // confirm the sequence stays contiguous.
     check_mem_and_force_snapshot(&Arc::clone(&write_buffer), 50).await;
     let total_buffer_size_bytes_after = write_buffer.buffer.get_total_size_bytes();
     // no other writes so nothing can be snapshotted, so mem should stay same
     assert!(total_buffer_size_bytes_before == total_buffer_size_bytes_after);
 
     drop(write_buffer);
-    assert_dbs_not_empty_in_snapshot_file(&obj_store, "test_host").await;
+    assert_snapshot_sequence_has_no_holes(&obj_store, "test_host").await;
 
     // dropping write_buffer does not kill any background task (like snapshot which does a
     // WAL file cleanup) which means when we start the buffer again it sees the WAL file but
@@ -1956,7 +2095,7 @@ async fn test_check_mem_and_force_snapshot() {
     )
     .await;
 
-    assert_dbs_not_empty_in_snapshot_file(&obj_store, "test_host").await;
+    assert_snapshot_sequence_has_no_holes(&obj_store, "test_host").await;
     drop(write_buffer_after_restart);
 
     tokio::time::sleep(Duration::from_millis(10)).await;
@@ -1974,7 +2113,7 @@ async fn test_check_mem_and_force_snapshot() {
         },
     )
     .await;
-    assert_dbs_not_empty_in_snapshot_file(&obj_store, "test_host").await;
+    assert_snapshot_sequence_has_no_holes(&obj_store, "test_host").await;
 }
 
 #[test_log::test(tokio::test)]
@@ -2908,25 +3047,57 @@ async fn get_table_batches_from_query_buffer(
     batches
 }
 
-async fn assert_dbs_not_empty_in_snapshot_file(obj_store: &Arc<dyn ObjectStore>, host: &str) {
+/// Every snapshot sequence number the tracker hands out must land a manifest in
+/// object store, so the persisted sequences form a contiguous run with no gaps.
+/// A skipped (empty) snapshot leaves a hole that a sequential consumer -- the
+/// compactor point-GETting `marker + 1`, or a read replica waiting on the next
+/// manifest -- cannot distinguish from a failed persist, so it stalls forever
+/// (influxdb_pro#4827).
+///
+/// Snapshots persist on a background task, so this polls until the set of manifests
+/// stops changing before asserting contiguity.
+async fn assert_snapshot_sequence_has_no_holes(obj_store: &Arc<dyn ObjectStore>, host: &str) {
     let from = Path::from(format!("{host}/snapshots/"));
-    let file_paths = load_files_from_obj_store(obj_store, &from).await;
-    debug!(?file_paths, "obj store snapshots");
-    for file_path in file_paths {
-        let bytes = obj_store
-            .get(&file_path)
-            .await
-            .unwrap()
-            .bytes()
-            .await
-            .unwrap();
-        let persisted_snapshot: PersistedSnapshot = serde_json::from_slice(&bytes).unwrap();
-        // dbs not empty
-        assert!(!persisted_snapshot.databases.is_empty());
-        // min and max times aren't defaults
-        assert!(persisted_snapshot.min_time != i64::MAX);
-        assert!(persisted_snapshot.max_time != i64::MIN);
+    let mut sequences: Vec<u64> = Vec::new();
+    let mut stable_checks = 0;
+    for _ in 0..40 {
+        let file_paths = load_files_from_obj_store(obj_store, &from).await;
+        let mut observed = Vec::with_capacity(file_paths.len());
+        for file_path in file_paths {
+            let bytes = obj_store
+                .get(&file_path)
+                .await
+                .unwrap()
+                .bytes()
+                .await
+                .unwrap();
+            let persisted_snapshot: PersistedSnapshot = serde_json::from_slice(&bytes).unwrap();
+            observed.push(persisted_snapshot.snapshot_sequence_number.as_u64());
+        }
+        observed.sort_unstable();
+        if !observed.is_empty() && observed == sequences {
+            stable_checks += 1;
+            if stable_checks > 3 {
+                break;
+            }
+        } else {
+            stable_checks = 0;
+            sequences = observed;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
     }
+    debug!(?sequences, "obj store snapshot sequences");
+    assert!(
+        !sequences.is_empty(),
+        "expected at least one persisted snapshot manifest"
+    );
+    let min = *sequences.first().unwrap();
+    let max = *sequences.last().unwrap();
+    let expected: Vec<u64> = (min..=max).collect();
+    assert_eq!(
+        sequences, expected,
+        "snapshot sequence has a hole (a consumed sequence number with no manifest)"
+    );
 }
 
 async fn load_files_from_obj_store(object_store: &Arc<dyn ObjectStore>, path: &Path) -> Vec<Path> {

--- a/object_store_utils/Cargo.toml
+++ b/object_store_utils/Cargo.toml
@@ -10,6 +10,7 @@ test-helpers = ["tokio"]
 
 [dependencies]
 # core deps
+metric = { path = "../core/metric" }
 observability_deps = { path = "../core/observability_deps" }
 
 # crates.io deps
@@ -19,6 +20,7 @@ bytes.workspace = true
 futures.workspace = true
 object_store.workspace = true
 tokio = { workspace = true, optional = true }
+uuid.workspace = true
 
 [dev-dependencies]
 tokio.workspace = true

--- a/object_store_utils/src/adaptive_get.rs
+++ b/object_store_utils/src/adaptive_get.rs
@@ -1,0 +1,406 @@
+//! Adaptive GET for object store: ranged/chunked reads for large objects,
+//! single-part GET for small ones.
+
+use bytes::{Bytes, BytesMut};
+use object_store::{ObjectStore, path::Path};
+use std::num::{NonZeroU64, NonZeroUsize};
+
+/// Object size at or below which [`AdaptiveGetExt::get_adaptive`] issues a
+/// single [`ObjectStore::get`]; strictly above, it chunks into
+/// [`DEFAULT_GET_CHUNK_SIZE`] ranged reads.
+///
+/// Set higher than the chunk size: a single GET has no protocol overhead, so
+/// chunking only pays off once one GET risks exceeding the per-request HTTP
+/// timeout (`--object-store-request-timeout`, default 30s) and would restart
+/// the whole download from byte 0 — the multi-GiB case.
+pub const SINGLE_GET_THRESHOLD: NonZeroU64 =
+    const { NonZeroU64::new(128 * 1024 * 1024).expect("single-GET threshold must be non-zero") };
+
+/// Range size for the chunked branch (16 MiB), matching
+/// `object_store_utils::DEFAULT_MULTIPART_CHUNK_SIZE`. Sized to sit well under
+/// the 30s per-request HTTP timeout so each ranged GET has ample budget.
+pub const DEFAULT_GET_CHUNK_SIZE: NonZeroU64 =
+    const { NonZeroU64::new(16 * 1024 * 1024).expect("default get chunk size must be non-zero") };
+
+/// Number of [`DEFAULT_GET_CHUNK_SIZE`] ranged GETs the chunked branch issues
+/// concurrently per batch. Bounds both in-flight requests and the transient
+/// memory held on top of the reassembly buffer to
+/// `MAX_CHUNKS_PER_BATCH * DEFAULT_GET_CHUNK_SIZE` (here 8 * 16 MiB = 128 MiB)
+/// instead of buffering every chunk of a multi-GiB object at once, which would
+/// roughly double peak RSS.
+pub const MAX_CHUNKS_PER_BATCH: NonZeroUsize =
+    const { NonZeroUsize::new(8).expect("max chunks per batch must be non-zero") };
+
+/// Extension trait that adds a size-gated `get_adaptive` method to any
+/// [`ObjectStore`] implementation.
+///
+/// At or below [`SINGLE_GET_THRESHOLD`] it does a single [`ObjectStore::get`]
+/// (unchanged behavior); above, it fetches [`DEFAULT_GET_CHUNK_SIZE`] chunks via
+/// per-chunk [`ObjectStore::get_range`] ([`MAX_CHUNKS_PER_BATCH`] at a time) and
+/// concatenates them. This is the read-side counterpart to `put_adaptive`: each
+/// chunk gets its own request-timeout and retry budget, so a transient failure
+/// retries one range rather than restarting a whole-object GET from byte 0.
+/// (`get_range`, not `get_ranges`, which would coalesce the contiguous ranges
+/// back into one request.)
+///
+/// `size` is the object's byte length. Pass `Some` when the caller already
+/// knows it (e.g. from a prior `list()` / `ObjectMeta`) to skip size discovery;
+/// pass `None` to have the method discover it with a ranged GET of the first
+/// chunk (which also returns the whole object in one request when it is small).
+///
+/// # Correctness
+///
+/// The chunked branch reads the object across multiple requests, so it assumes
+/// the object is immutable for the duration of the read. Snapshot manifests and
+/// checkpoints are write-once (a new sequence number is a new path), so this
+/// holds for their load paths.
+#[async_trait::async_trait]
+pub trait AdaptiveGetExt: ObjectStore {
+    /// Size-gated GET using [`SINGLE_GET_THRESHOLD`] / [`DEFAULT_GET_CHUNK_SIZE`].
+    async fn get_adaptive(
+        &self,
+        path: &Path,
+        size: Option<u64>,
+    ) -> Result<Bytes, object_store::Error> {
+        get_adaptive_impl(
+            self,
+            path,
+            size,
+            SINGLE_GET_THRESHOLD,
+            DEFAULT_GET_CHUNK_SIZE,
+            MAX_CHUNKS_PER_BATCH,
+        )
+        .await
+    }
+}
+
+impl<T: ObjectStore + ?Sized> AdaptiveGetExt for T {}
+
+/// The underlying implementation, taking explicit `threshold` / `chunk_size`
+/// for test coverage at small sizes. Production callers should use
+/// [`AdaptiveGetExt::get_adaptive`], which bakes in the defaults.
+pub(crate) async fn get_adaptive_impl<S: ObjectStore + ?Sized>(
+    store: &S,
+    path: &Path,
+    size: Option<u64>,
+    threshold: NonZeroU64,
+    chunk_size: NonZeroU64,
+    max_chunks_per_batch: NonZeroUsize,
+) -> Result<Bytes, object_store::Error> {
+    let chunk = chunk_size.get();
+
+    // `first_chunk` holds the leading chunk when size discovery fetched it (the
+    // size=None path), so the range walk can reuse it instead of re-fetching.
+    let (size, first_chunk): (u64, Option<Bytes>) = match size {
+        Some(size) => (size, None),
+        None => {
+            // Discover the size with a ranged get_opts rather than a HEAD:
+            // GetResult.meta.size is the object's *total* size, so one request
+            // yields both the size and the first chunk's bytes. Avoids HEAD,
+            // which on S3 has no error response body and is opaque on failure
+            // (influxdata/influxdb_pro#4423). Range one chunk (not the whole
+            // threshold) so this request stays within the per-request timeout.
+            let options = object_store::GetOptions {
+                range: Some((0..chunk).into()),
+                ..Default::default()
+            };
+            let result = store.get_opts(path, options).await?;
+            let size = result.meta.size;
+            let bytes = result.bytes().await?;
+            if size <= chunk {
+                // The object fits in the first chunk — return it, one request.
+                return Ok(bytes);
+            }
+            (size, Some(bytes))
+        }
+    };
+
+    // Up to the threshold a single GET fits the timeout budget and is cheaper
+    // than several — but only if discovery didn't already fetch the first chunk.
+    // If it did, fall through to the range walk, which reuses that chunk and
+    // fetches only the remainder rather than re-downloading the whole object.
+    if size <= threshold.get() && first_chunk.is_none() {
+        return store.get(path).await?.bytes().await;
+    }
+
+    // Reassembly buffer is contiguous (callers use serde_json::from_slice); a
+    // checked cast surfaces objects larger than usize on 32-bit rather than
+    // truncating the capacity.
+    let capacity = usize::try_from(size).map_err(|_| object_store::Error::Generic {
+        store: "adaptive_get",
+        source: format!("object size {size} exceeds addressable memory on this platform").into(),
+    })?;
+
+    // If size discovery already fetched range 0, seed the buffer with it and
+    // start the range walk at the second chunk to avoid re-fetching.
+    let first_offset = if first_chunk.is_some() { chunk } else { 0 };
+    let ranges: Vec<std::ops::Range<u64>> = (first_offset..size)
+        .step_by(chunk as usize)
+        .map(|offset| offset..(offset + chunk).min(size))
+        .collect();
+
+    // Per-chunk get_range, NOT get_ranges: get_ranges coalesces ranges within
+    // OBJECT_STORE_COALESCE_DEFAULT (1 MiB), so our contiguous ranges would
+    // merge back into one whole-object GET, re-exposing the timeout cliff this
+    // path avoids. Guarded by the test
+    // `chunked_branch_issues_one_get_range_per_chunk_not_coalesced`. Batching
+    // bounds concurrency and holds at most one batch on top of the buffer.
+    let mut buf = BytesMut::with_capacity(capacity);
+    if let Some(first) = first_chunk {
+        buf.extend_from_slice(&first);
+    }
+    for batch in ranges.chunks(max_chunks_per_batch.get()) {
+        let parts = futures::future::try_join_all(
+            batch
+                .iter()
+                .map(|range| store.get_range(path, range.clone())),
+        )
+        .await?;
+        for part in parts {
+            buf.extend_from_slice(&part);
+        }
+    }
+    Ok(buf.freeze())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_object_store::{ErrorConfig, OperationKind, TestObjectStore};
+    use object_store::memory::InMemory;
+    use std::sync::Arc;
+
+    #[derive(Copy, Clone, Debug)]
+    enum Branch {
+        SingleGet,
+        Chunked,
+    }
+
+    fn nz(n: u64) -> NonZeroU64 {
+        NonZeroU64::new(n).unwrap()
+    }
+
+    fn nzu(n: usize) -> NonZeroUsize {
+        NonZeroUsize::new(n).unwrap()
+    }
+
+    /// Assert that `get_adaptive_impl` routes a `payload`-sized object through
+    /// `expected` AND returns the bytes intact.
+    ///
+    /// Wraps `InMemory` in a `TestObjectStore` that fails on the *opposite*
+    /// branch's operation, mirroring `adaptive_put`'s `assert_branch`: if the
+    /// code under test takes the expected branch the failure predicate never
+    /// fires; if it takes the wrong branch the failure surfaces as an error and
+    /// the test fails. Guards against a silent flip of the `<=` comparison that
+    /// a round-trip-only test (indifferent `InMemory`) would not catch.
+    async fn assert_branch(
+        label: &str,
+        payload: Bytes,
+        threshold: NonZeroU64,
+        chunk_size: NonZeroU64,
+        expected: Branch,
+    ) {
+        let inner: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let path = Path::from(label);
+        inner.put(&path, payload.clone().into()).await.unwrap();
+
+        let fail_kind = match expected {
+            // Single-GET branch must not touch the ranged path.
+            Branch::SingleGet => OperationKind::GetRange,
+            // Chunked branch must not issue a whole-object GET.
+            Branch::Chunked => OperationKind::Get,
+        };
+        let test_store = TestObjectStore::new(inner)
+            .with_error_config(ErrorConfig::PercentageError(100.0))
+            .with_failure_predicate(move |ctx| ctx.kind == fail_kind);
+
+        let size = Some(payload.len() as u64);
+        // Large batch: branch-routing tests don't care about batching.
+        let got = get_adaptive_impl(&test_store, &path, size, threshold, chunk_size, nzu(1024))
+            .await
+            .unwrap_or_else(|e| {
+                panic!("{label}: get_adaptive took the wrong branch (expected {expected:?}): {e}")
+            });
+
+        assert_eq!(
+            test_store.get_injected_failure_count(),
+            0,
+            "{label}: get_adaptive touched the {fail_kind:?} path (expected {expected:?})",
+        );
+        assert_eq!(got, payload, "{label}: round-trip mismatch");
+    }
+
+    #[tokio::test]
+    async fn small_object_takes_single_get_branch() {
+        assert_branch(
+            "small",
+            Bytes::from(vec![1u8; 100]),
+            nz(1024),
+            nz(256),
+            Branch::SingleGet,
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn exact_threshold_takes_single_get_branch() {
+        // An object of exactly the threshold stays on the single-GET fast path.
+        assert_branch(
+            "exact",
+            Bytes::from(vec![2u8; 1024]),
+            nz(1024),
+            nz(256),
+            Branch::SingleGet,
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn above_threshold_takes_chunked_branch() {
+        // threshold+1 crosses into the ranged path.
+        assert_branch(
+            "above",
+            Bytes::from(vec![3u8; 1025]),
+            nz(1024),
+            nz(256),
+            Branch::Chunked,
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn chunked_branch_reassembles_multiple_chunks_intact() {
+        // 1000 bytes / 256-byte chunks -> 4 ranges (256,256,256,232); the
+        // reassembled bytes must equal the original exactly.
+        let payload: Bytes = (0..1000u32).map(|i| i as u8).collect::<Vec<u8>>().into();
+        assert_branch("multi", payload, nz(512), nz(256), Branch::Chunked).await;
+    }
+
+    #[tokio::test]
+    async fn size_none_small_object_served_by_ranged_get_no_head() {
+        // Size unknown + object smaller than one chunk: a single get_range of
+        // the first chunk returns the whole object (short read), so no HEAD is
+        // issued. A store that fails HEAD must still succeed.
+        let inner: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let path = Path::from("small-none");
+        let payload = Bytes::from(vec![7u8; 50]);
+        inner.put(&path, payload.clone().into()).await.unwrap();
+
+        let head_fails = TestObjectStore::new(inner)
+            .with_error_config(ErrorConfig::PercentageError(100.0))
+            .with_failure_predicate(|ctx| ctx.kind == OperationKind::Head);
+        // chunk=256 > payload=50, so the ranged GET short-reads the whole object.
+        let got = get_adaptive_impl(&head_fails, &path, None, nz(1024), nz(256), nzu(4))
+            .await
+            .expect("small object with size=None must not require a HEAD");
+        assert_eq!(got, payload);
+        assert_eq!(
+            head_fails.get_injected_failure_count(),
+            0,
+            "size=None small-object path must not issue a HEAD"
+        );
+    }
+
+    #[tokio::test]
+    async fn size_none_large_object_discovers_size_without_head() {
+        // Size unknown + object larger than one chunk: the first ranged GET
+        // (get_opts) yields the object's true size via GetResult.meta, so the
+        // impl learns the size AND the first chunk in one request and never
+        // issues a HEAD (a foot-gun on S3, see #4423). Result byte-identical.
+        let payload: Bytes = (0..1000u32).map(|i| i as u8).collect::<Vec<u8>>().into();
+        let inner: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let path = Path::from("large-none");
+        inner.put(&path, payload.clone().into()).await.unwrap();
+        // Fail any HEAD so the test proves the discovery path avoids it.
+        let store = TestObjectStore::new(inner)
+            .with_error_config(ErrorConfig::PercentageError(100.0))
+            .with_failure_predicate(|ctx| ctx.kind == OperationKind::Head);
+
+        // threshold=500 < size(1000) -> chunked; chunk=100 -> first get_opts
+        // returns a full 100-byte chunk plus meta.size=1000.
+        let got = get_adaptive_impl(&store, &path, None, nz(500), nz(100), nzu(4))
+            .await
+            .expect("size discovery for a large object must not require a HEAD");
+        assert_eq!(got, payload);
+        assert_eq!(
+            store.get_injected_failure_count(),
+            0,
+            "size=None large-object path must not issue a HEAD"
+        );
+    }
+
+    #[tokio::test]
+    async fn size_none_midsize_object_reuses_first_chunk_no_full_get() {
+        // Size unknown + object between one chunk and the threshold (chunk <
+        // size <= threshold): discovery already fetched the first chunk via
+        // get_opts, so the impl must fetch only the remainder and concat, NOT
+        // re-download the whole object with a plain get() (which would waste the
+        // prefetched chunk). Fail whole-object Get to prove it is not used.
+        let payload: Bytes = (0..300u32).map(|i| i as u8).collect::<Vec<u8>>().into();
+        let inner: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let path = Path::from("midsize-none");
+        inner.put(&path, payload.clone().into()).await.unwrap();
+        let store = TestObjectStore::new(inner)
+            .with_error_config(ErrorConfig::PercentageError(100.0))
+            .with_failure_predicate(|ctx| {
+                matches!(ctx.kind, OperationKind::Get | OperationKind::Head)
+            });
+
+        // chunk=100, threshold=500 -> size(300) is in (100, 500]: threshold
+        // branch, but discovery already holds bytes 0..100.
+        let got = get_adaptive_impl(&store, &path, None, nz(500), nz(100), nzu(4))
+            .await
+            .expect("mid-size size=None path must not issue a whole-object get or HEAD");
+        assert_eq!(got, payload);
+        assert_eq!(
+            store.get_injected_failure_count(),
+            0,
+            "mid-size size=None path must reuse the prefetched chunk, not re-get the whole object"
+        );
+    }
+
+    #[tokio::test]
+    async fn chunked_branch_issues_one_get_range_per_chunk_not_coalesced() {
+        // 1000 bytes / 100-byte chunks -> 10 contiguous ranges. The impl must
+        // issue 10 separate get_range requests (one per chunk), NOT a single
+        // get_ranges: object_store's get_ranges coalesces adjacent ranges (gap
+        // <= 1 MiB) and would merge all 10 back into one whole-object GET,
+        // defeating chunking and re-exposing the request-timeout cliff.
+        //
+        // Fail on GetRanges so any coalescing path surfaces as an error, and
+        // count the per-chunk get_range calls (the only op in this branch).
+        let payload: Bytes = (0..1000u32).map(|i| i as u8).collect::<Vec<u8>>().into();
+        let inner: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let path = Path::from("perchunk");
+        inner.put(&path, payload.clone().into()).await.unwrap();
+        let store = TestObjectStore::new(inner)
+            .with_error_config(ErrorConfig::PercentageError(100.0))
+            .with_failure_predicate(|ctx| ctx.kind == OperationKind::GetRanges);
+
+        let got = get_adaptive_impl(
+            &store,
+            &path,
+            Some(payload.len() as u64),
+            nz(500), // threshold < size -> chunked
+            nz(100), // chunk size -> 10 ranges
+            nzu(4),  // batches of 4 (concurrency/memory bound), still 10 get_range total
+        )
+        .await
+        .unwrap_or_else(|e| {
+            panic!("chunked read must not use the coalescing get_ranges path: {e}")
+        });
+
+        assert_eq!(got, payload, "reassembly across batches must be intact");
+        assert_eq!(
+            store.get_injected_failure_count(),
+            0,
+            "chunked read touched the coalescing get_ranges path",
+        );
+        assert_eq!(
+            store.get_call_count(),
+            10,
+            "expected 10 per-chunk get_range calls, got {}",
+            store.get_call_count()
+        );
+    }
+}

--- a/object_store_utils/src/cas_test_stores.rs
+++ b/object_store_utils/src/cas_test_stores.rs
@@ -1,0 +1,309 @@
+//! Object-store wrappers for exercising compare-and-swap / conditional-put
+//! logic (ambiguous-success retries, version-keyed backends, transient errors).
+
+use std::sync::Arc;
+
+use object_store::ObjectStore;
+
+/// Which error a lost response surfaces as. A `PutMode::Create` collision
+/// reaches the caller as `AlreadyExists`; `PutMode::Update` as `Precondition`;
+/// a dropped connection on a committed write as `Generic`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LostResponseError {
+    Precondition,
+    AlreadyExists,
+    Generic,
+}
+
+/// Store wrapper simulating an ambiguous conditional-put success: the write
+/// lands on the inner store, but the caller receives a failure — as happens
+/// when the client's internal retry layer re-sends a PUT whose response was
+/// lost and collides with its own earlier success.
+#[derive(Debug)]
+pub struct LostResponseStore {
+    inner: Arc<dyn ObjectStore>,
+    lose_next_put_response: std::sync::Mutex<Option<LostResponseError>>,
+    collision_shape: std::sync::Mutex<Option<LostResponseError>>,
+    last_get: std::sync::Mutex<Option<(Option<object_store::GetRange>, bool)>>,
+}
+
+/// The error a lost response, or a reshaped collision, surfaces as.
+fn lost_response_error(
+    error: LostResponseError,
+    location: &object_store::path::Path,
+) -> object_store::Error {
+    match error {
+        LostResponseError::Precondition => object_store::Error::Precondition {
+            path: location.to_string(),
+            source: "simulated lost response + retry collision".into(),
+        },
+        LostResponseError::AlreadyExists => object_store::Error::AlreadyExists {
+            path: location.to_string(),
+            source: "simulated lost response + retry collision".into(),
+        },
+        LostResponseError::Generic => object_store::Error::Generic {
+            store: "LostResponseStore",
+            source: "simulated lost response on a committed write".into(),
+        },
+    }
+}
+
+impl LostResponseStore {
+    pub fn new(inner: Arc<dyn ObjectStore>) -> Self {
+        Self {
+            inner,
+            lose_next_put_response: std::sync::Mutex::new(None),
+            collision_shape: std::sync::Mutex::new(None),
+            last_get: std::sync::Mutex::new(None),
+        }
+    }
+
+    /// Report every `PutMode::Create` collision as `error`, as Azure does when
+    /// an `If-None-Match: *` put comes back 412 rather than 409.
+    pub fn report_collisions_as(&self, error: LostResponseError) {
+        *self.collision_shape.lock().expect("lock not poisoned") = Some(error);
+    }
+
+    /// The `range` and `head` of the most recent `get_opts`, for pinning the
+    /// shape of a read-back.
+    pub fn last_get(&self) -> Option<(Option<object_store::GetRange>, bool)> {
+        self.last_get.lock().expect("lock not poisoned").clone()
+    }
+
+    /// Lose the next put response as a `Precondition`, the shape a
+    /// `PutMode::Update` collision takes.
+    pub fn lose_next_put_response(&self) {
+        self.lose_next_put_response_with(LostResponseError::Precondition);
+    }
+
+    pub fn lose_next_put_response_with(&self, error: LostResponseError) {
+        *self
+            .lose_next_put_response
+            .lock()
+            .expect("lock not poisoned") = Some(error);
+    }
+}
+
+impl std::fmt::Display for LostResponseStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "LostResponseStore({})", self.inner)
+    }
+}
+
+#[async_trait::async_trait]
+impl ObjectStore for LostResponseStore {
+    async fn put_opts(
+        &self,
+        location: &object_store::path::Path,
+        payload: object_store::PutPayload,
+        opts: object_store::PutOptions,
+    ) -> object_store::Result<object_store::PutResult> {
+        let result = match self.inner.put_opts(location, payload, opts).await {
+            Ok(result) => result,
+            Err(e @ object_store::Error::AlreadyExists { .. }) => {
+                let shape = *self.collision_shape.lock().expect("lock not poisoned");
+                return Err(shape.map_or(e, |shape| lost_response_error(shape, location)));
+            }
+            Err(e) => return Err(e),
+        };
+        // The write landed, but the caller sees the failure its own retry got.
+        let taken = self
+            .lose_next_put_response
+            .lock()
+            .expect("lock not poisoned")
+            .take();
+        match taken {
+            Some(error) => Err(lost_response_error(error, location)),
+            None => Ok(result),
+        }
+    }
+
+    async fn put_multipart_opts(
+        &self,
+        location: &object_store::path::Path,
+        opts: object_store::PutMultipartOptions,
+    ) -> object_store::Result<Box<dyn object_store::MultipartUpload>> {
+        self.inner.put_multipart_opts(location, opts).await
+    }
+
+    async fn get_opts(
+        &self,
+        location: &object_store::path::Path,
+        options: object_store::GetOptions,
+    ) -> object_store::Result<object_store::GetResult> {
+        *self.last_get.lock().expect("lock not poisoned") =
+            Some((options.range.clone(), options.head));
+        self.inner.get_opts(location, options).await
+    }
+
+    async fn delete(&self, location: &object_store::path::Path) -> object_store::Result<()> {
+        self.inner.delete(location).await
+    }
+
+    fn list(
+        &self,
+        prefix: Option<&object_store::path::Path>,
+    ) -> futures::stream::BoxStream<'static, object_store::Result<object_store::ObjectMeta>> {
+        self.inner.list(prefix)
+    }
+
+    fn list_with_delimiter<'life0, 'life1, 'async_trait>(
+        &'life0 self,
+        prefix: Option<&'life1 object_store::path::Path>,
+    ) -> std::pin::Pin<
+        Box<
+            dyn std::future::Future<Output = object_store::Result<object_store::ListResult>>
+                + Send
+                + 'async_trait,
+        >,
+    >
+    where
+        'life0: 'async_trait,
+        'life1: 'async_trait,
+        Self: 'async_trait,
+    {
+        self.inner.list_with_delimiter(prefix)
+    }
+
+    async fn copy(
+        &self,
+        from: &object_store::path::Path,
+        to: &object_store::path::Path,
+    ) -> object_store::Result<()> {
+        self.inner.copy(from, to).await
+    }
+
+    async fn copy_if_not_exists(
+        &self,
+        from: &object_store::path::Path,
+        to: &object_store::path::Path,
+    ) -> object_store::Result<()> {
+        self.inner.copy_if_not_exists(from, to).await
+    }
+}
+
+/// Store wrapper simulating a version-keyed backend like GCS: a conditional
+/// `Update` put must carry an object `version` (GCS sends it as
+/// `x-goog-if-generation-match` and returns `MissingVersion` when it is
+/// absent), and every read/write surfaces a fresh version. Code under test must
+/// capture and pass this version through, or every conditional `Update` after
+/// the first `Create` fails against a version-keyed store.
+#[derive(Debug)]
+pub struct VersionKeyedStore {
+    inner: Arc<dyn ObjectStore>,
+    version: std::sync::atomic::AtomicU64,
+}
+
+impl VersionKeyedStore {
+    pub fn new(inner: Arc<dyn ObjectStore>) -> Self {
+        Self {
+            inner,
+            version: std::sync::atomic::AtomicU64::new(0),
+        }
+    }
+
+    fn current_version(&self) -> String {
+        self.version
+            .load(std::sync::atomic::Ordering::SeqCst)
+            .to_string()
+    }
+}
+
+impl std::fmt::Display for VersionKeyedStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "VersionKeyedStore({})", self.inner)
+    }
+}
+
+#[async_trait::async_trait]
+impl ObjectStore for VersionKeyedStore {
+    async fn put_opts(
+        &self,
+        location: &object_store::path::Path,
+        payload: object_store::PutPayload,
+        opts: object_store::PutOptions,
+    ) -> object_store::Result<object_store::PutResult> {
+        if let object_store::PutMode::Update(uv) = &opts.mode
+            && uv.version.is_none()
+        {
+            // GCS keys conditional updates on the object generation and
+            // rejects the put outright when it is missing.
+            return Err(object_store::Error::Generic {
+                store: "VersionKeyedStore",
+                source: "conditional update requires an object version (MissingVersion)".into(),
+            });
+        }
+        let result = self.inner.put_opts(location, payload, opts).await?;
+        let version = self
+            .version
+            .fetch_add(1, std::sync::atomic::Ordering::SeqCst)
+            + 1;
+        Ok(object_store::PutResult {
+            e_tag: result.e_tag,
+            version: Some(version.to_string()),
+        })
+    }
+
+    async fn put_multipart_opts(
+        &self,
+        location: &object_store::path::Path,
+        opts: object_store::PutMultipartOptions,
+    ) -> object_store::Result<Box<dyn object_store::MultipartUpload>> {
+        self.inner.put_multipart_opts(location, opts).await
+    }
+
+    async fn get_opts(
+        &self,
+        location: &object_store::path::Path,
+        options: object_store::GetOptions,
+    ) -> object_store::Result<object_store::GetResult> {
+        let mut result = self.inner.get_opts(location, options).await?;
+        result.meta.version = Some(self.current_version());
+        Ok(result)
+    }
+
+    async fn delete(&self, location: &object_store::path::Path) -> object_store::Result<()> {
+        self.inner.delete(location).await
+    }
+
+    fn list(
+        &self,
+        prefix: Option<&object_store::path::Path>,
+    ) -> futures::stream::BoxStream<'static, object_store::Result<object_store::ObjectMeta>> {
+        self.inner.list(prefix)
+    }
+
+    fn list_with_delimiter<'life0, 'life1, 'async_trait>(
+        &'life0 self,
+        prefix: Option<&'life1 object_store::path::Path>,
+    ) -> std::pin::Pin<
+        Box<
+            dyn std::future::Future<Output = object_store::Result<object_store::ListResult>>
+                + Send
+                + 'async_trait,
+        >,
+    >
+    where
+        'life0: 'async_trait,
+        'life1: 'async_trait,
+        Self: 'async_trait,
+    {
+        self.inner.list_with_delimiter(prefix)
+    }
+
+    async fn copy(
+        &self,
+        from: &object_store::path::Path,
+        to: &object_store::path::Path,
+    ) -> object_store::Result<()> {
+        self.inner.copy(from, to).await
+    }
+
+    async fn copy_if_not_exists(
+        &self,
+        from: &object_store::path::Path,
+        to: &object_store::path::Path,
+    ) -> object_store::Result<()> {
+        self.inner.copy_if_not_exists(from, to).await
+    }
+}

--- a/object_store_utils/src/lib.rs
+++ b/object_store_utils/src/lib.rs
@@ -7,9 +7,26 @@ pub use retryable_object_store::set_default_retry_params;
 mod adaptive_put;
 pub use adaptive_put::{AdaptivePutExt, DEFAULT_MULTIPART_CHUNK_SIZE};
 
+mod adaptive_get;
+pub use adaptive_get::{
+    AdaptiveGetExt, DEFAULT_GET_CHUNK_SIZE, MAX_CHUNKS_PER_BATCH, SINGLE_GET_THRESHOLD,
+};
+
+mod self_verifying_create;
+pub use self_verifying_create::{
+    CONFLICT_METRIC_NAME, NonceCheck, PUT_NONCE_METADATA_KEY, PutNonce, SELF_WRITE_METRIC_NAME,
+    SelfVerifyingCreate, SelfVerifyingCreateStore, UNTAGGED_CONFLICT_METRIC_NAME,
+    UNVERIFIED_CONFLICT_METRIC_NAME, nonce_check,
+};
+
 #[cfg(any(feature = "test-helpers", test))]
 mod test_object_store;
 #[cfg(any(feature = "test-helpers", test))]
 pub use test_object_store::{
     ErrorConfig, ErrorType, OperationContext, OperationKind, TestObjectStore,
 };
+
+#[cfg(any(feature = "test-helpers", test))]
+mod cas_test_stores;
+#[cfg(any(feature = "test-helpers", test))]
+pub use cas_test_stores::{LostResponseError, LostResponseStore, VersionKeyedStore};

--- a/object_store_utils/src/retryable_object_store.rs
+++ b/object_store_utils/src/retryable_object_store.rs
@@ -244,6 +244,12 @@ pub trait RetryableObjectStore: ObjectStore {
         .await
     }
 
+    /// Put with retries, skipping the errors a retry cannot change.
+    ///
+    /// `NotFound`, `Precondition`, and `AlreadyExists` are returned on the first
+    /// attempt: a conditional put that lost the race loses it identically on
+    /// every retry, so retrying only delays the caller. Setting
+    /// [`RetryParams::when`] replaces this predicate rather than adding to it.
     async fn put_opts_with_retries(
         &self,
         path: &Path,
@@ -262,7 +268,9 @@ pub trait RetryableObjectStore: ObjectStore {
             Some(|err| {
                 !matches!(
                     err,
-                    ObjectStoreError::NotFound { .. } | ObjectStoreError::Precondition { .. }
+                    ObjectStoreError::NotFound { .. }
+                        | ObjectStoreError::Precondition { .. }
+                        | ObjectStoreError::AlreadyExists { .. }
                 )
             }),
             || async { store.put_opts(path, payload.clone(), options.clone()).await },

--- a/object_store_utils/src/retryable_object_store/tests.rs
+++ b/object_store_utils/src/retryable_object_store/tests.rs
@@ -253,6 +253,44 @@ async fn put_opts_precondition_not_retried() {
     );
 }
 
+// Ensures put_opts surfaces AlreadyExists errors without retrying.
+#[tokio::test]
+async fn put_opts_already_exists_not_retried() {
+    let inner: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let path = Path::from("catalog/0001.json");
+    inner
+        .put(&path, PutPayload::from("theirs"))
+        .await
+        .expect("setup: direct put to InMemory should succeed");
+
+    let concrete_store = Arc::new(TestObjectStore::new(Arc::clone(&inner)));
+    let test_store: Arc<dyn ObjectStore> = Arc::clone(&concrete_store) as _;
+
+    concrete_store.reset_call_count();
+
+    let result = test_store
+        .put_opts_with_retries(
+            &path,
+            PutPayload::from("ours"),
+            PutOptions::from(PutMode::Create),
+            "already exists put_opts".to_string(),
+            test_retry_params(4),
+        )
+        .await;
+
+    assert!(matches!(
+        result,
+        Err(ObjectStoreError::AlreadyExists { .. })
+    ));
+    // A conditional create that lost the race loses it identically on every
+    // attempt. Callers passing max_retries: usize::MAX spin forever.
+    assert_eq!(
+        concrete_store.get_call_count(),
+        1,
+        "AlreadyExists failures should not be retried"
+    );
+}
+
 #[tokio::test]
 async fn list_with_retries() {
     let inner: Arc<dyn ObjectStore> = Arc::new(InMemory::new());

--- a/object_store_utils/src/self_verifying_create.rs
+++ b/object_store_utils/src/self_verifying_create.rs
@@ -1,0 +1,417 @@
+//! Nonce-tagged conditional creates, so a writer can recognise its own object
+//! when a retried `PutMode::Create` collides with its own hidden success.
+//!
+//! Background and the reasoning behind each choice: influxdata/influxdb_pro#4776.
+
+use std::ops::Range;
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use bytes::Bytes;
+use futures::stream::BoxStream;
+use metric::{Registry, U64Counter};
+use object_store::{
+    Attribute, Attributes, GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta,
+    ObjectStore, PutMode, PutMultipartOptions, PutOptions, PutPayload, PutResult, Result,
+    path::Path,
+};
+use observability_deps::tracing::{debug, warn};
+
+use crate::{RetryParams, RetryableObjectStore};
+
+/// Object metadata key carrying the writer's nonce.
+///
+/// Lowercase and underscore-separated: Azure requires metadata names to be
+/// valid C# identifiers, and S3 and GCS store keys lowercased.
+pub const PUT_NONCE_METADATA_KEY: &str = "influxdb3_put_nonce";
+
+/// Identifies one logical write. Stable across a caller's own retries when the
+/// caller mints it outside its retry loop.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PutNonce(String);
+
+impl PutNonce {
+    pub fn generate() -> Self {
+        Self(uuid::Uuid::new_v4().to_string())
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+/// Marks a `PutMode::Create` as verifiable against whatever object is already
+/// at the path. Placed in `PutOptions::extensions`, so a store built without
+/// the verifying layer drops it and behaves as it always has.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct SelfVerifyingCreate {
+    nonce: Option<PutNonce>,
+}
+
+impl SelfVerifyingCreate {
+    /// Verify against a caller-owned nonce. Minting it outside the caller's
+    /// retry loop is what extends coverage to that loop.
+    pub fn with_nonce(nonce: PutNonce) -> Self {
+        Self { nonce: Some(nonce) }
+    }
+
+    /// Verify against a nonce minted per call, covering only the object store
+    /// client's internal retries.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn put_options(self) -> PutOptions {
+        let mut opts = PutOptions::from(PutMode::Create);
+        opts.extensions.insert(self);
+        opts
+    }
+
+    pub(crate) fn into_nonce(self) -> PutNonce {
+        self.nonce.unwrap_or_else(PutNonce::generate)
+    }
+}
+
+/// Verdict on the nonce stored against an existing object.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NonceCheck {
+    /// The stored nonce is ours: this is our own write.
+    Ours,
+    /// A different nonce: another writer holds the path.
+    Foreign,
+    /// No nonce at all. Cannot be distinguished from a foreign writer that
+    /// does not tag, an older build, or a store that discards metadata.
+    Absent,
+}
+
+pub fn nonce_check(attributes: &Attributes, nonce: &PutNonce) -> NonceCheck {
+    match attributes.get(&Attribute::Metadata(PUT_NONCE_METADATA_KEY.into())) {
+        None => NonceCheck::Absent,
+        Some(stored) if stored.as_ref() == nonce.as_str() => NonceCheck::Ours,
+        Some(_) => NonceCheck::Foreign,
+    }
+}
+
+pub const SELF_WRITE_METRIC_NAME: &str = "influxdb3_conditional_create_self_write_verified";
+pub const CONFLICT_METRIC_NAME: &str = "influxdb3_conditional_create_conflict_confirmed";
+pub const UNTAGGED_CONFLICT_METRIC_NAME: &str = "influxdb3_conditional_create_conflict_untagged";
+pub const UNVERIFIED_CONFLICT_METRIC_NAME: &str =
+    "influxdb3_conditional_create_conflict_unverified";
+
+/// Recorders are taken at construction so every series exists from startup,
+/// reading as zero until something is recorded to it.
+#[derive(Debug)]
+struct SelfVerifyMetrics {
+    self_writes: U64Counter,
+    conflicts: U64Counter,
+    untagged_conflicts: U64Counter,
+    unverified_conflicts: U64Counter,
+}
+
+impl SelfVerifyMetrics {
+    fn new(registry: &Registry) -> Self {
+        Self {
+            self_writes: registry
+                .register_metric::<U64Counter>(
+                    SELF_WRITE_METRIC_NAME,
+                    "conditional creates that failed but were confirmed to be this writer's own object",
+                )
+                .recorder(&[]),
+            conflicts: registry
+                .register_metric::<U64Counter>(
+                    CONFLICT_METRIC_NAME,
+                    "conditional creates that failed against an object carrying another writer's nonce",
+                )
+                .recorder(&[]),
+            untagged_conflicts: registry
+                .register_metric::<U64Counter>(
+                    UNTAGGED_CONFLICT_METRIC_NAME,
+                    "conditional creates that failed against an object carrying no nonce",
+                )
+                .recorder(&[]),
+            unverified_conflicts: registry
+                .register_metric::<U64Counter>(
+                    UNVERIFIED_CONFLICT_METRIC_NAME,
+                    "conditional creates that failed and could not be read back to check the nonce",
+                )
+                .recorder(&[]),
+        }
+    }
+}
+
+/// Read-back attempts inside one verification, covering a transient failure on
+/// the GET without waiting out a lasting one.
+const READ_BACK_ATTEMPTS: usize = 3;
+
+fn read_back_retry_params() -> RetryParams {
+    RetryParams {
+        max_retries: READ_BACK_ATTEMPTS - 1,
+        min_delay: Duration::from_millis(50),
+        max_delay: Duration::from_millis(500),
+        ..Default::default()
+    }
+}
+
+/// Report a collision as `AlreadyExists` whatever shape the backend gave it,
+/// so a caller that keys on that variant sees it on every backend.
+fn conflict(location: &Path, source: object_store::Error) -> object_store::Error {
+    object_store::Error::AlreadyExists {
+        path: location.to_string(),
+        source: Box::new(source),
+    }
+}
+
+#[derive(Debug)]
+pub struct SelfVerifyingCreateStore {
+    inner: Arc<dyn ObjectStore>,
+    metrics: SelfVerifyMetrics,
+}
+
+impl SelfVerifyingCreateStore {
+    pub fn new(inner: Arc<dyn ObjectStore>, registry: &Registry) -> Self {
+        Self {
+            inner,
+            metrics: SelfVerifyMetrics::new(registry),
+        }
+    }
+
+    /// Decide whether the object already at `location` is our own write.
+    async fn verify(
+        &self,
+        location: &Path,
+        nonce: &PutNonce,
+        collision: object_store::Error,
+    ) -> Result<PutResult> {
+        // Metadata only: the nonce rides in the object's attributes, and a
+        // ranged read is rejected outright against a zero-length object.
+        let opts = GetOptions {
+            head: true,
+            ..Default::default()
+        };
+
+        let existing = match self
+            .inner
+            .get_opts_with_retries(
+                location,
+                opts,
+                format!("verifying conditional create for {location}"),
+                read_back_retry_params(),
+            )
+            .await
+        {
+            Ok(existing) => existing,
+            Err(source) => {
+                // There is some special handling of NotFound here; if we are doing verification in
+                // this method, it is because we encoutered a 412/409 error when doing a PUT, i.e.,
+                // the object we tried to create reported as already exists.
+                //
+                // How would a NotFound arise when doing this GET request? Perhaps:
+                // - the object was persisted, then deleted due to a snapshot; that is not likely,
+                //   since the snapshot-triggered deletion gives some grace period before deleting,
+                //   but it is one conceivable way in which a NotFound could be encountered here.
+                // - a NotFound is improperly reported by the store due to cosmic anomoly or act of
+                //   God.
+                //
+                // The special handling is a difference in warning message to distinguish the
+                // underlying error when viewing the logs. For *all* errors in this scenario, we
+                // return AlreadyExists. The effect of this would be that the verification fails.
+                //
+                // For example, in the Parquet WAL, this would be treated as another process having
+                // persisted a WAL file in place of the current process, and the current process
+                // would exit. That outcome is appropriate (terminating the process) as allowing it
+                // to continue (and continue ingesting/persisting WAL) could lead to undefined
+                // behaviour or data corruption/loss; in which case, having the control plane
+                // restart the node (or if there _actually is_ another process running in place of
+                // this one, just letting the node shutdown) is better.
+                self.metrics.unverified_conflicts.inc(1);
+                if matches!(source, object_store::Error::NotFound { .. }) {
+                    warn!(
+                        %location,
+                        %source,
+                        "attempt to verify object after write conflict failed: the object was \
+                         gone before it could be checked; another process may have already \
+                         written and removed it"
+                    );
+                } else {
+                    warn!(
+                        %location,
+                        %source,
+                        "attempt to verify object after write conflict failed: the object \
+                         could not be fetched"
+                    );
+                }
+                return Err(object_store::Error::AlreadyExists {
+                    path: location.to_string(),
+                    source: format!(
+                        "write conflict ({collision}), and the attempt to verify the object \
+                         failed: {source}"
+                    )
+                    .into(),
+                });
+            }
+        };
+
+        match nonce_check(&existing.attributes, nonce) {
+            NonceCheck::Ours => {
+                self.metrics.self_writes.inc(1);
+                debug!(
+                    %location,
+                    "conditional create reported a conflict against this writer's own object; \
+                     the write is durable, treating as success"
+                );
+                Ok(PutResult {
+                    e_tag: existing.meta.e_tag.clone(),
+                    version: existing.meta.version.clone(),
+                })
+            }
+            NonceCheck::Foreign => {
+                self.metrics.conflicts.inc(1);
+                warn!(
+                    %location,
+                    "conditional create reported a conflict against an object carrying another \
+                     writer's nonce"
+                );
+                Err(conflict(location, collision))
+            }
+            NonceCheck::Absent => {
+                self.metrics.untagged_conflicts.inc(1);
+                warn!(
+                    %location,
+                    "conditional create reported a conflict against an object carrying no nonce; \
+                     the store may not retain object metadata, or the object predates tagging"
+                );
+                Err(conflict(location, collision))
+            }
+        }
+    }
+}
+
+impl std::fmt::Display for SelfVerifyingCreateStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "SelfVerifyingCreateStore({})", self.inner)
+    }
+}
+
+#[async_trait]
+impl ObjectStore for SelfVerifyingCreateStore {
+    async fn put(&self, location: &Path, payload: PutPayload) -> Result<PutResult> {
+        self.inner.put(location, payload).await
+    }
+
+    async fn put_opts(
+        &self,
+        location: &Path,
+        payload: PutPayload,
+        mut opts: PutOptions,
+    ) -> Result<PutResult> {
+        let Some(marker) = opts.extensions.remove::<SelfVerifyingCreate>() else {
+            return self.inner.put_opts(location, payload, opts).await;
+        };
+
+        // The marker only means anything on a create. Any other mode may be
+        // writing over an object this writer created earlier, so its nonce
+        // would still be at the path and a lost race would read back as ours.
+        if !matches!(opts.mode, PutMode::Create) {
+            return self.inner.put_opts(location, payload, opts).await;
+        }
+
+        let nonce = marker.into_nonce();
+        opts.attributes.insert(
+            Attribute::Metadata(PUT_NONCE_METADATA_KEY.into()),
+            nonce.as_str().to_string().into(),
+        );
+
+        match self.inner.put_opts(location, payload, opts).await {
+            // A conditional create that collided. Backends disagree on the
+            // shape: S3 and GCS translate the 412 into `AlreadyExists`, Azure
+            // passes the status through, so an `If-None-Match: *` collision
+            // there arrives as `Precondition` (412) or `AlreadyExists` (409).
+            // Within a marked create all three mean the same thing.
+            Err(
+                e @ (object_store::Error::AlreadyExists { .. }
+                | object_store::Error::Precondition { .. }
+                | object_store::Error::NotModified { .. }),
+            ) => self.verify(location, &nonce, e).await,
+            other => other,
+        }
+    }
+
+    async fn put_multipart(&self, location: &Path) -> Result<Box<dyn MultipartUpload>> {
+        self.inner.put_multipart(location).await
+    }
+
+    async fn put_multipart_opts(
+        &self,
+        location: &Path,
+        opts: PutMultipartOptions,
+    ) -> Result<Box<dyn MultipartUpload>> {
+        self.inner.put_multipart_opts(location, opts).await
+    }
+
+    async fn get(&self, location: &Path) -> Result<GetResult> {
+        self.inner.get(location).await
+    }
+
+    async fn get_opts(&self, location: &Path, options: GetOptions) -> Result<GetResult> {
+        self.inner.get_opts(location, options).await
+    }
+
+    async fn get_range(&self, location: &Path, range: Range<u64>) -> Result<Bytes> {
+        self.inner.get_range(location, range).await
+    }
+
+    async fn get_ranges(&self, location: &Path, ranges: &[Range<u64>]) -> Result<Vec<Bytes>> {
+        self.inner.get_ranges(location, ranges).await
+    }
+
+    async fn head(&self, location: &Path) -> Result<ObjectMeta> {
+        self.inner.head(location).await
+    }
+
+    async fn delete(&self, location: &Path) -> Result<()> {
+        self.inner.delete(location).await
+    }
+
+    fn delete_stream<'a>(
+        &'a self,
+        locations: BoxStream<'a, Result<Path>>,
+    ) -> BoxStream<'a, Result<Path>> {
+        self.inner.delete_stream(locations)
+    }
+
+    fn list(&self, prefix: Option<&Path>) -> BoxStream<'static, Result<ObjectMeta>> {
+        self.inner.list(prefix)
+    }
+
+    fn list_with_offset(
+        &self,
+        prefix: Option<&Path>,
+        offset: &Path,
+    ) -> BoxStream<'static, Result<ObjectMeta>> {
+        self.inner.list_with_offset(prefix, offset)
+    }
+
+    async fn list_with_delimiter(&self, prefix: Option<&Path>) -> Result<ListResult> {
+        self.inner.list_with_delimiter(prefix).await
+    }
+
+    async fn copy(&self, from: &Path, to: &Path) -> Result<()> {
+        self.inner.copy(from, to).await
+    }
+
+    async fn rename(&self, from: &Path, to: &Path) -> Result<()> {
+        self.inner.rename(from, to).await
+    }
+
+    async fn copy_if_not_exists(&self, from: &Path, to: &Path) -> Result<()> {
+        self.inner.copy_if_not_exists(from, to).await
+    }
+
+    async fn rename_if_not_exists(&self, from: &Path, to: &Path) -> Result<()> {
+        self.inner.rename_if_not_exists(from, to).await
+    }
+}
+
+#[cfg(test)]
+mod tests;

--- a/object_store_utils/src/self_verifying_create/tests.rs
+++ b/object_store_utils/src/self_verifying_create/tests.rs
@@ -1,0 +1,492 @@
+use super::*;
+use crate::cas_test_stores::{LostResponseError, LostResponseStore};
+use crate::test_object_store::{ErrorConfig, OperationKind, TestObjectStore};
+use metric::Metric;
+use object_store::UpdateVersion;
+use object_store::memory::InMemory;
+
+#[test]
+fn metadata_key_is_portable_across_providers() {
+    // Azure metadata names must be valid C# identifiers.
+    assert!(!PUT_NONCE_METADATA_KEY.contains('-'));
+    assert_eq!(
+        PUT_NONCE_METADATA_KEY,
+        PUT_NONCE_METADATA_KEY.to_lowercase()
+    );
+    assert!(PUT_NONCE_METADATA_KEY.starts_with(|c: char| c.is_ascii_alphabetic()));
+    assert!(
+        PUT_NONCE_METADATA_KEY
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_')
+    );
+}
+
+#[test]
+fn generated_nonces_differ() {
+    assert_ne!(PutNonce::generate(), PutNonce::generate());
+}
+
+#[test]
+fn put_options_carry_the_marker_and_create_mode() {
+    let nonce = PutNonce::generate();
+    let opts = SelfVerifyingCreate::with_nonce(nonce.clone()).put_options();
+
+    assert!(matches!(opts.mode, PutMode::Create));
+    assert!(
+        opts.attributes.is_empty(),
+        "the layer adds attributes, not the caller"
+    );
+
+    let marker = opts
+        .extensions
+        .get::<SelfVerifyingCreate>()
+        .expect("marker present");
+    assert_eq!(marker.clone().into_nonce(), nonce);
+}
+
+#[test]
+fn marker_without_a_nonce_mints_one() {
+    let a = SelfVerifyingCreate::new().into_nonce();
+    let b = SelfVerifyingCreate::new().into_nonce();
+    assert_ne!(a, b);
+}
+
+#[test]
+fn nonce_check_classifies_all_three_cases() {
+    let ours = PutNonce::generate();
+    let theirs = PutNonce::generate();
+
+    let mut attrs = Attributes::new();
+    assert_eq!(nonce_check(&attrs, &ours), NonceCheck::Absent);
+
+    attrs.insert(
+        Attribute::Metadata(PUT_NONCE_METADATA_KEY.into()),
+        theirs.as_str().to_string().into(),
+    );
+    assert_eq!(nonce_check(&attrs, &ours), NonceCheck::Foreign);
+
+    attrs.insert(
+        Attribute::Metadata(PUT_NONCE_METADATA_KEY.into()),
+        ours.as_str().to_string().into(),
+    );
+    assert_eq!(nonce_check(&attrs, &ours), NonceCheck::Ours);
+}
+
+fn store() -> (Arc<LostResponseStore>, SelfVerifyingCreateStore, Registry) {
+    let inner = Arc::new(LostResponseStore::new(Arc::new(InMemory::new())));
+    let registry = Registry::new();
+    let layer = SelfVerifyingCreateStore::new(Arc::clone(&inner) as _, &registry);
+    (inner, layer, registry)
+}
+
+fn count(registry: &Registry, name: &'static str) -> u64 {
+    registry
+        .get_instrument::<Metric<U64Counter>>(name)
+        .expect("counter registered")
+        .get_observer(&metric::Attributes::from(&[]))
+        .expect("series registered at construction")
+        .fetch()
+}
+
+#[tokio::test]
+async fn lost_response_on_a_marked_create_reports_success() {
+    let (inner, layer, _registry) = store();
+    let path = Path::from("wal/0001.wal");
+    inner.lose_next_put_response_with(LostResponseError::AlreadyExists);
+
+    let result = layer
+        .put_opts(
+            &path,
+            PutPayload::from_static(b"wal bytes"),
+            SelfVerifyingCreate::with_nonce(PutNonce::generate()).put_options(),
+        )
+        .await;
+
+    assert!(
+        result.is_ok(),
+        "own write reported as a conflict: {result:?}"
+    );
+}
+
+/// S3 and GCS translate a conditional-create 412 into `AlreadyExists`;
+/// Azure passes the status through, so the same collision arrives as
+/// `Precondition`. Both must be verified, or the fix is S3/GCS-only.
+#[tokio::test]
+async fn precondition_on_a_marked_create_is_also_verified() {
+    for shape in [
+        LostResponseError::Precondition,
+        LostResponseError::AlreadyExists,
+    ] {
+        let (inner, layer, _registry) = store();
+        inner.lose_next_put_response_with(shape);
+
+        let result = layer
+            .put_opts(
+                &Path::from("wal/0001.wal"),
+                PutPayload::from_static(b"wal bytes"),
+                SelfVerifyingCreate::with_nonce(PutNonce::generate()).put_options(),
+            )
+            .await;
+
+        assert!(
+            result.is_ok(),
+            "own write reported as a conflict for {shape:?}: {result:?}"
+        );
+    }
+}
+
+/// Pins the read-back shape: the nonce lives in the object's metadata, and
+/// asking for a range of an object of unknown length can fail on its own.
+#[tokio::test]
+async fn read_back_is_metadata_only() {
+    let (inner, layer, _registry) = store();
+    inner.lose_next_put_response_with(LostResponseError::AlreadyExists);
+
+    layer
+        .put_opts(
+            &Path::from("wal/0001.wal"),
+            PutPayload::from_static(b"wal bytes"),
+            SelfVerifyingCreate::with_nonce(PutNonce::generate()).put_options(),
+        )
+        .await
+        .unwrap();
+
+    let (range, head) = inner.last_get().expect("the layer read the object back");
+    assert!(head, "read-back requested the object body");
+    assert_eq!(range, None);
+}
+
+/// A ranged read-back is rejected against a zero-length object, so an empty
+/// object at the path would leave every collision unverifiable.
+#[tokio::test]
+async fn a_zero_length_object_is_verified() {
+    let (inner, layer, _registry) = store();
+    inner.lose_next_put_response_with(LostResponseError::AlreadyExists);
+
+    let result = layer
+        .put_opts(
+            &Path::from("wal/0001.wal"),
+            PutPayload::new(),
+            SelfVerifyingCreate::with_nonce(PutNonce::generate()).put_options(),
+        )
+        .await;
+
+    assert!(
+        result.is_ok(),
+        "own zero-length write reported as a conflict: {result:?}"
+    );
+}
+
+/// Azure surfaces an `If-None-Match: *` collision as `Precondition`, which
+/// a caller keying its fail-stop on `AlreadyExists` would never see.
+#[tokio::test]
+async fn a_confirmed_conflict_is_reported_as_already_exists_on_every_backend() {
+    for shape in [
+        LostResponseError::Precondition,
+        LostResponseError::AlreadyExists,
+    ] {
+        let (inner, layer, registry) = store();
+        inner.report_collisions_as(shape);
+        let path = Path::from("wal/0001.wal");
+
+        // A different writer gets there first, tagging with its own nonce.
+        layer
+            .put_opts(
+                &path,
+                PutPayload::from_static(b"theirs"),
+                SelfVerifyingCreate::with_nonce(PutNonce::generate()).put_options(),
+            )
+            .await
+            .unwrap();
+
+        let result = layer
+            .put_opts(
+                &path,
+                PutPayload::from_static(b"ours"),
+                SelfVerifyingCreate::with_nonce(PutNonce::generate()).put_options(),
+            )
+            .await;
+
+        assert!(
+            matches!(result, Err(object_store::Error::AlreadyExists { .. })),
+            "collision shaped as {shape:?} was not normalised: {result:?}"
+        );
+        assert_eq!(count(&registry, CONFLICT_METRIC_NAME), 1);
+    }
+}
+
+#[tokio::test]
+async fn counters_separate_self_writes_from_conflicts() {
+    let (inner, layer, registry) = store();
+
+    // Every series exists from construction, so a healthy node exports
+    // zeroes rather than nothing at all.
+    assert_eq!(count(&registry, SELF_WRITE_METRIC_NAME), 0);
+    assert_eq!(count(&registry, CONFLICT_METRIC_NAME), 0);
+    assert_eq!(count(&registry, UNTAGGED_CONFLICT_METRIC_NAME), 0);
+    assert_eq!(count(&registry, UNVERIFIED_CONFLICT_METRIC_NAME), 0);
+
+    // Our own write, seen as a collision.
+    let ours = Path::from("wal/0001.wal");
+    inner.lose_next_put_response_with(LostResponseError::AlreadyExists);
+    layer
+        .put_opts(
+            &ours,
+            PutPayload::from_static(b"ours"),
+            SelfVerifyingCreate::with_nonce(PutNonce::generate()).put_options(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(count(&registry, SELF_WRITE_METRIC_NAME), 1);
+    assert_eq!(count(&registry, CONFLICT_METRIC_NAME), 0);
+
+    // Someone else's object at a second path.
+    let theirs = Path::from("wal/0002.wal");
+    layer
+        .put_opts(
+            &theirs,
+            PutPayload::from_static(b"theirs"),
+            SelfVerifyingCreate::with_nonce(PutNonce::generate()).put_options(),
+        )
+        .await
+        .unwrap();
+    layer
+        .put_opts(
+            &theirs,
+            PutPayload::from_static(b"ours"),
+            SelfVerifyingCreate::with_nonce(PutNonce::generate()).put_options(),
+        )
+        .await
+        .unwrap_err();
+
+    assert_eq!(count(&registry, SELF_WRITE_METRIC_NAME), 1);
+    assert_eq!(count(&registry, CONFLICT_METRIC_NAME), 1);
+
+    // An object nobody tagged, at a third path.
+    let untagged = Path::from("wal/0003.wal");
+    inner
+        .put(&untagged, PutPayload::from_static(b"pre-upgrade"))
+        .await
+        .unwrap();
+    layer
+        .put_opts(
+            &untagged,
+            PutPayload::from_static(b"ours"),
+            SelfVerifyingCreate::with_nonce(PutNonce::generate()).put_options(),
+        )
+        .await
+        .unwrap_err();
+
+    assert_eq!(count(&registry, CONFLICT_METRIC_NAME), 1);
+    assert_eq!(count(&registry, UNTAGGED_CONFLICT_METRIC_NAME), 1);
+    assert_eq!(count(&registry, UNVERIFIED_CONFLICT_METRIC_NAME), 0);
+}
+
+#[tokio::test]
+async fn a_genuine_conflict_still_reports_already_exists() {
+    let (_inner, layer, _registry) = store();
+    let path = Path::from("wal/0001.wal");
+
+    // A different writer gets there first, tagging with its own nonce.
+    layer
+        .put_opts(
+            &path,
+            PutPayload::from_static(b"theirs"),
+            SelfVerifyingCreate::with_nonce(PutNonce::generate()).put_options(),
+        )
+        .await
+        .unwrap();
+
+    let result = layer
+        .put_opts(
+            &path,
+            PutPayload::from_static(b"ours"),
+            SelfVerifyingCreate::with_nonce(PutNonce::generate()).put_options(),
+        )
+        .await;
+
+    assert!(matches!(
+        result,
+        Err(object_store::Error::AlreadyExists { .. })
+    ));
+}
+
+#[tokio::test]
+async fn an_untagged_object_reports_already_exists() {
+    let (inner, layer, _registry) = store();
+    let path = Path::from("wal/0001.wal");
+    inner
+        .put(&path, PutPayload::from_static(b"pre-upgrade"))
+        .await
+        .unwrap();
+
+    let result = layer
+        .put_opts(
+            &path,
+            PutPayload::from_static(b"ours"),
+            SelfVerifyingCreate::with_nonce(PutNonce::generate()).put_options(),
+        )
+        .await;
+
+    assert!(matches!(
+        result,
+        Err(object_store::Error::AlreadyExists { .. })
+    ));
+}
+
+/// A store built without the layer drops the marker: it writes no
+/// attributes, so a `LocalFileSystem` would still accept the put, and a
+/// collision reaches the caller as the backend shaped it.
+#[tokio::test]
+async fn an_unwrapped_store_ignores_the_marker() {
+    let inner = LostResponseStore::new(Arc::new(InMemory::new()));
+    let path = Path::from("wal/0001.wal");
+    inner.lose_next_put_response_with(LostResponseError::AlreadyExists);
+
+    let result = inner
+        .put_opts(
+            &path,
+            PutPayload::from_static(b"wal bytes"),
+            SelfVerifyingCreate::with_nonce(PutNonce::generate()).put_options(),
+        )
+        .await;
+
+    assert!(matches!(
+        result,
+        Err(object_store::Error::AlreadyExists { .. })
+    ));
+
+    let stored = inner.get(&path).await.unwrap();
+    assert!(stored.attributes.is_empty());
+}
+
+#[tokio::test]
+async fn an_unmarked_create_is_forwarded_untouched() {
+    let (inner, layer, _registry) = store();
+    let path = Path::from("wal/0001.wal");
+
+    layer
+        .put_opts(
+            &path,
+            PutPayload::from_static(b"plain"),
+            PutOptions::from(PutMode::Create),
+        )
+        .await
+        .unwrap();
+
+    let stored = inner.get(&path).await.unwrap();
+    assert!(stored.attributes.is_empty());
+}
+
+/// Read-backs the layer cannot perform must not soften a collision: a
+/// caller that fail-stops on a duplicate writer would otherwise retry
+/// forever while a second writer holds the path.
+#[tokio::test]
+async fn a_failed_read_back_reports_already_exists() {
+    let lost = Arc::new(LostResponseStore::new(Arc::new(InMemory::new())));
+    let unreadable = Arc::new(
+        TestObjectStore::new(Arc::clone(&lost) as _)
+            .with_error_config(ErrorConfig::PercentageError(100.0))
+            .with_failure_predicate(|ctx| matches!(ctx.kind, OperationKind::GetOpts)),
+    );
+    let registry = Registry::new();
+    let layer = SelfVerifyingCreateStore::new(unreadable as _, &registry);
+
+    lost.lose_next_put_response_with(LostResponseError::AlreadyExists);
+
+    let result = layer
+        .put_opts(
+            &Path::from("wal/0001.wal"),
+            PutPayload::from_static(b"wal bytes"),
+            SelfVerifyingCreate::with_nonce(PutNonce::generate()).put_options(),
+        )
+        .await;
+
+    assert!(
+        matches!(result, Err(object_store::Error::AlreadyExists { .. })),
+        "unverifiable conflict was softened: {result:?}"
+    );
+    assert_eq!(count(&registry, UNVERIFIED_CONFLICT_METRIC_NAME), 1);
+    assert_eq!(count(&registry, CONFLICT_METRIC_NAME), 0);
+}
+
+#[tokio::test]
+async fn a_read_back_that_fails_once_is_retried() {
+    let lost = Arc::new(LostResponseStore::new(Arc::new(InMemory::new())));
+    let flaky = Arc::new(
+        TestObjectStore::new(Arc::clone(&lost) as _)
+            .with_error_config(ErrorConfig::FirstCallFails)
+            .with_failure_predicate(|ctx| matches!(ctx.kind, OperationKind::GetOpts)),
+    );
+    let registry = Registry::new();
+    let layer = SelfVerifyingCreateStore::new(flaky as _, &registry);
+
+    lost.lose_next_put_response_with(LostResponseError::AlreadyExists);
+
+    let result = layer
+        .put_opts(
+            &Path::from("wal/0001.wal"),
+            PutPayload::from_static(b"wal bytes"),
+            SelfVerifyingCreate::with_nonce(PutNonce::generate()).put_options(),
+        )
+        .await;
+
+    assert!(
+        result.is_ok(),
+        "a transient read-back failure was not retried: {result:?}"
+    );
+    assert_eq!(count(&registry, SELF_WRITE_METRIC_NAME), 1);
+    assert_eq!(count(&registry, UNVERIFIED_CONFLICT_METRIC_NAME), 0);
+}
+
+#[tokio::test]
+async fn a_marked_overwrite_is_forwarded_untouched() {
+    let (inner, layer, _registry) = store();
+    let path = Path::from("wal/0001.wal");
+
+    let mut opts = PutOptions::from(PutMode::Overwrite);
+    opts.extensions
+        .insert(SelfVerifyingCreate::with_nonce(PutNonce::generate()));
+    layer
+        .put_opts(&path, PutPayload::from_static(b"plain"), opts)
+        .await
+        .unwrap();
+
+    let stored = inner.get(&path).await.unwrap();
+    assert!(stored.attributes.is_empty());
+}
+
+/// A conditional update that loses its race is a lost race, even where the
+/// object at the path carries this writer's nonce from an earlier create.
+#[tokio::test]
+async fn a_marked_update_that_loses_is_not_verified() {
+    let (_inner, layer, registry) = store();
+    let path = Path::from("wal/0001.wal");
+    let nonce = PutNonce::generate();
+
+    layer
+        .put_opts(
+            &path,
+            PutPayload::from_static(b"ours"),
+            SelfVerifyingCreate::with_nonce(nonce.clone()).put_options(),
+        )
+        .await
+        .unwrap();
+
+    let mut opts = PutOptions::from(PutMode::Update(UpdateVersion {
+        e_tag: Some("stale".to_string()),
+        version: None,
+    }));
+    opts.extensions
+        .insert(SelfVerifyingCreate::with_nonce(nonce));
+    let result = layer
+        .put_opts(&path, PutPayload::from_static(b"newer"), opts)
+        .await;
+
+    assert!(
+        matches!(result, Err(object_store::Error::Precondition { .. })),
+        "a lost update was verified as this writer's own object: {result:?}"
+    );
+    assert_eq!(count(&registry, SELF_WRITE_METRIC_NAME), 0);
+}


### PR DESCRIPTION

Source: a58f6542130f52f9b05d6a62a017029ef8829410

Commits:
- `a58f654213` chore: update versions to 3.9.13 (influxdata/influxdb_pro#5648)
- `ab21ce9f9b` fix(snapshot): always persist the snapshot manifest, even when empty (influxdata/influxdb_pro#4862) (influxdata/influxdb_pro#5626)
- `8c3ea99ed6` fix(wal): stop shutting down when a conditional PUT retry hits its own write (influxdata/influxdb_pro#5127) (influxdata/influxdb_pro#5624)
- `cbefd4900e` feat(startup): route startup phases through one tracker for logging (cherry-pick influxdata/influxdb_pro#5385) (influxdata/influxdb_pro#5607)
- `2d0992cd55` fix(py): update to 3.13.15-20260901 for latest security fixes (influxdata/influxdb_pro#5581) (influxdata/influxdb_pro#5621)
- `090f227f76` chore(audit): fix cargo-deny failures on 3.9 (RUSTSEC-2026-0258, RUSTSEC-2026-0269) (influxdata/influxdb_pro#5608)
- `5769b591f9` fix(parquet): read manifests/checkpoints via size-gated get_adaptive (influxdata/influxdb_pro#5011) (influxdata/influxdb_pro#5265)
- `94d6bba27d` chore(ci): push release artifacts to Cloudflare R2 instead of AWS S3 (influxdata/influxdb_pro#5045)
- `ac783991a9` chore: fix cargo-audit failure due to RUSTSEC-2026-0222 (influxdata/influxdb_pro#4971)
- `8a0ec98b8f` fix(iox_time): saturate Time add/sub instead of panicking on overflow (influxdata/influxdb_pro#4988)
- `96044afaf6` chore: update versions to 3.9.12 (influxdata/influxdb_pro#4785)
- `d6d21a77b0` fix: bound graceful connection drain during shutdown (influxdata/influxdb_pro#4780) (influxdata/influxdb_pro#4783)

Co-authored-by: Cannon Palms <cpalms@influxdata.com>
Co-authored-by: Lili Cosic <cosiclili@gmail.com>
Co-authored-by: Phil Bracikowski <13472206+philjb@users.noreply.github.com>
Co-authored-by: praveen-influx <pkumar@influxdata.com>
Co-authored-by: Tim Yocum <tim@yocum.org>